### PR TITLE
Re-enable the 'routes' middleware and add CNAME flattening

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -16,8 +16,10 @@ type GlobalConfiguration struct {
 	GraceTimeOut              int64
 	AccessLogsFile            string
 	TraefikLogsFile           string
+	ResolveConf               string
 	Certificates              []Certificate
 	LogLevel                  string
+	ResolvConf                string
 	ProvidersThrottleDuration time.Duration
 	Docker                    *provider.Docker
 	File                      *provider.File
@@ -41,6 +43,7 @@ func NewGlobalConfiguration() *GlobalConfiguration {
 	// default values
 	globalConfiguration.Port = ":80"
 	globalConfiguration.GraceTimeOut = 10
+	globalConfiguration.ResolveConf = "/etc/resolv.conf"
 	globalConfiguration.LogLevel = "ERROR"
 	globalConfiguration.ProvidersThrottleDuration = time.Duration(2 * time.Second)
 

--- a/configuration.go
+++ b/configuration.go
@@ -16,7 +16,6 @@ type GlobalConfiguration struct {
 	GraceTimeOut              int64
 	AccessLogsFile            string
 	TraefikLogsFile           string
-	ResolveConf               string
 	Certificates              []Certificate
 	LogLevel                  string
 	ResolvConf                string
@@ -39,15 +38,15 @@ type Certificate struct {
 
 // NewGlobalConfiguration returns a GlobalConfiguration with default values.
 func NewGlobalConfiguration() *GlobalConfiguration {
-	globalConfiguration := new(GlobalConfiguration)
+	globalConfiguration := GlobalConfiguration{}
 	// default values
 	globalConfiguration.Port = ":80"
 	globalConfiguration.GraceTimeOut = 10
-	globalConfiguration.ResolveConf = "/etc/resolv.conf"
+	globalConfiguration.ResolvConf = "/etc/resolv.conf"
 	globalConfiguration.LogLevel = "ERROR"
 	globalConfiguration.ProvidersThrottleDuration = time.Duration(2 * time.Second)
 
-	return globalConfiguration
+	return &globalConfiguration
 }
 
 // LoadFileConfig returns a GlobalConfiguration from reading the specified file (a toml file).

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,9 @@
 package: main
 import:
+  - package: github.com/stvp/go-udp-testing
+    ref: abcd331ec306600e2c71d73841152e78cce727f5
+  - package: github.com/karlseguin/ccache
+    ref:     74754c77cc65b05221301d2d4365fa1812b54926
   - package: github.com/coreos/go-etcd
     ref:     cc90c7b091275e606ad0ca7102a23fb2072f3f5e
     subpackages:

--- a/integration/cname_test.go
+++ b/integration/cname_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"net"
+	"net/http"
+	"os/exec"
+	"sync"
+	"time"
+    "github.com/miekg/dns"
+
+	checker "github.com/vdemeester/shakers"
+	check "gopkg.in/check.v1"
+)
+
+func (s *CNameSuite) TestSimpleConfiguration(c *check.C) {
+    // Start traefik with a specific resolve.conf configuration
+	cmd := exec.Command(traefikBinary, "fixtures/cname/cname.toml")
+	err := cmd.Start()
+	c.Assert(err, checker.IsNil)
+	defer cmd.Process.Kill()
+
+    //
+    name := "notthere.localhost"
+    url := "http://" + name + ":80"
+
+    dns.HandleFunc(name, CnameServer)
+    defer dns.HandleRemove(name)
+
+    // Run our own DNS server to serve the cname record we want
+    server, _, err := runLocalUDPServer("127.0.0.1:0")
+    if err != nil {
+        c.Fatalf("unable to run test server: %v", err)
+    }
+    defer server.Shutdown()
+
+	time.Sleep(1000 * time.Millisecond)
+	resp, err := http.Get(url)
+
+	// Expected a 404 as we did not configure anything
+	c.Assert(err, checker.IsNil)
+	c.Assert(resp.StatusCode, checker.Equals, 404)
+}
+
+
+func CnameServer(w dns.ResponseWriter, req *dns.Msg) {
+  m := new(dns.Msg)
+  m.SetReply(req)
+
+  m.Extra = make([]dns.RR, 1)
+  m.Extra[0] = &dns.CNAME{Hdr: dns.RR_Header{Name: m.Question[0].Name, Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 0}, Target: "test.localhost"}
+  w.WriteMsg(m)
+
+}
+
+func runLocalUDPServer(laddr string) (*dns.Server, string, error) {
+	pc, err := net.ListenPacket("udp", laddr)
+	if err != nil {
+		return nil, "", err
+	}
+	server := &dns.Server{PacketConn: pc, ReadTimeout: time.Hour, WriteTimeout: time.Hour}
+
+	waitLock := sync.Mutex{}
+	waitLock.Lock()
+	server.NotifyStartedFunc = waitLock.Unlock
+
+	go func() {
+		server.ActivateAndServe()
+		pc.Close()
+	}()
+
+	waitLock.Lock()
+	return server, pc.LocalAddr().String(), nil
+}

--- a/integration/cname_test.go
+++ b/integration/cname_test.go
@@ -20,7 +20,7 @@ func (s *CNameSuite) TestSimpleConfiguration(c *check.C) {
 	defer cmd.Process.Kill()
 
 	//
-	name := "notthere.localhost"
+	name := "localhost"
 	url := "http://" + name + ":80"
 
 	dns.HandleFunc(name, CnameServer)

--- a/integration/fixtures/cname/cname.toml
+++ b/integration/fixtures/cname/cname.toml
@@ -1,0 +1,32 @@
+# Reverse proxy nameserver config
+#
+# Optional
+# ResolveConf: "/etc/resolv.conf"
+#
+resolvConf= "fixtures/cname/resolv.conf"
+
+#
+# LogLevel
+logLevel = "DEBUG"
+
+[file]
+
+# rules
+[backends]
+  [backends.backend1]
+    [backends.backend2.LoadBalancer]
+      method = "drr"
+    [backends.backend2.servers.server1]
+    url = "http://172.17.0.4:80"
+    weight = 1
+    [backends.backend2.servers.server2]
+    url = "http://172.17.0.5:80"
+    weight = 2
+
+[frontends]
+  [frontends.frontend1]
+  backend = "backend1"
+    [frontends.frontend1.routes.test_1]
+    rule = "Host"
+    value = "test.localhost"
+

--- a/integration/fixtures/cname/resolv.conf
+++ b/integration/fixtures/cname/resolv.conf
@@ -1,0 +1,3 @@
+# blah blah
+domain hsd1.ca.comcast.net.
+nameserver 127.0.0.1:0

--- a/integration/fixtures/cname/resolv.conf
+++ b/integration/fixtures/cname/resolv.conf
@@ -1,3 +1,3 @@
 # blah blah
-domain hsd1.ca.comcast.net.
+domain tsd1.ca.comcast.net.
 nameserver 127.0.0.1:0

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -29,6 +29,7 @@ func init() {
 	check.Suite(&DockerSuite{})
 	check.Suite(&ConsulSuite{})
 	check.Suite(&MarathonSuite{})
+	check.Suite(&CNameSuite{})
 }
 
 var traefikBinary = "../dist/traefik"
@@ -41,6 +42,16 @@ func (s *FileSuite) SetUpSuite(c *check.C) {
 
 	s.composeProject.Up()
 }
+
+// CName test suites
+type CNameSuite struct{ BaseSuite }
+
+func (s *CNameSuite) SetUpSuite(c *check.C) {
+	s.createComposeProject(c, "cname")
+
+	s.composeProject.Up()
+}
+
 
 // Consul test suites (using libcompose)
 type ConsulSuite struct{ BaseSuite }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -47,11 +47,10 @@ func (s *FileSuite) SetUpSuite(c *check.C) {
 type CNameSuite struct{ BaseSuite }
 
 func (s *CNameSuite) SetUpSuite(c *check.C) {
-	s.createComposeProject(c, "cname")
+	s.createComposeProject(c, "file")
 
 	s.composeProject.Up()
 }
-
 
 // Consul test suites (using libcompose)
 type ConsulSuite struct{ BaseSuite }

--- a/middlewares/routes.go
+++ b/middlewares/routes.go
@@ -3,33 +3,33 @@ package middlewares
 import (
 	"encoding/json"
 	"log"
-	"time"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/gorilla/mux"
-    "github.com/miekg/dns"
-     "github.com/karlseguin/ccache"
+	"github.com/karlseguin/ccache"
+	"github.com/miekg/dns"
 )
 
 // Routes holds the gorilla mux routes (for the API & co).
 // It also does CNAME flattening, so Traefik can handle requests that come from other domains that use
 // Traefik as the canonical domain
 type Routes struct {
-	router *mux.Router
-    dnsCache *ccache.Cache
-    dnsClient *dns.Client
-    nameServerAddress string
+	router            *mux.Router
+	dnsCache          *ccache.Cache
+	dnsClient         *dns.Client
+	nameServerAddress string
 }
 
 // NewRoutes return a Routes based on the given router.
 func NewRoutes(router *mux.Router, resolvConf string) *Routes {
-    config, err := dns.ClientConfigFromFile(resolvConf)
-    if err != nil {
+	config, err := dns.ClientConfigFromFile(resolvConf)
+	if err != nil {
 		log.Fatal("Error reading resolv.conf file. Could not configure nameservers: ", err)
-    }
-    nameServerAddress := net.JoinHostPort(config.Servers[0], config.Port)
-    dnsCache := ccache.New(ccache.Configure().MaxSize(1000).ItemsToPrune(100))
+	}
+	nameServerAddress := net.JoinHostPort(config.Servers[0], config.Port)
+	dnsCache := ccache.New(ccache.Configure().MaxSize(1000).ItemsToPrune(100))
 	return &Routes{router, dnsCache, new(dns.Client), nameServerAddress}
 }
 
@@ -38,42 +38,42 @@ func (router *Routes) ServeHTTP(rw http.ResponseWriter, r *http.Request, next ht
 	if router.router.Match(r, &routeMatch) {
 		json, _ := json.Marshal(routeMatch.Handler)
 		log.Println("Request match route ", json)
-    } else {
-        host := router.dnsCache.Get(r.Host)
-        if (host == nil || host.TTL() < 0) {
-            newName, ttl, err := router.lookupCNAME(r.Host)
-            if err == nil {
-                if newName != nil {
-                    router.dnsCache.Set(r.Host, newName, ttl)
-                } else {
-                    router.dnsCache.Set(r.Host, nil, 60 * time.Second) // 60 second TTL for domains with no CNAME
-                }
-            }
-        }
-        if (host != nil) {
-            r.Host = host.Value().(string) // Rewrite the host header
-        }
-    }
+	} else {
+		host := router.dnsCache.Get(r.Host)
+		if host == nil || host.TTL() < 0 {
+			newName, ttl, err := router.lookupCNAME(r.Host)
+			if err == nil {
+				if newName != nil {
+					router.dnsCache.Set(r.Host, newName, ttl)
+				} else {
+					router.dnsCache.Set(r.Host, nil, 60*time.Second) // 60 second TTL for domains with no CNAME
+				}
+			}
+		}
+		if host != nil {
+			r.Host = host.Value().(string) // Rewrite the host header
+		}
+	}
 	next(rw, r)
 }
 
 func (router *Routes) lookupCNAME(host string) (*string, time.Duration, error) {
-    m := new(dns.Msg)
-    m.SetQuestion(dns.Fqdn(host), dns.TypeCNAME)
-    m.RecursionDesired = true
+	m := new(dns.Msg)
+	m.SetQuestion(dns.Fqdn(host), dns.TypeCNAME)
+	m.RecursionDesired = true
 
-    r, _, err := router.dnsClient.Exchange(m, router.nameServerAddress)
-    if r == nil {
-        log.Println("DNS lookup failed for %s: %s\n", host, err.Error())
-        return nil, 0, err
-    }
-    if r.Rcode != dns.RcodeSuccess {
-        log.Println("Invalid answer in CNAME query for %s\n", host)
-        return nil, 0, err
-    }
-    // Stuff must be in the answer section
-    for _, ans := range r.Answer {
-        return &ans.Header().Name, time.Duration(ans.Header().Ttl) * time.Second, nil
-    }
-    return nil, 0, nil
+	r, _, err := router.dnsClient.Exchange(m, router.nameServerAddress)
+	if r == nil {
+		log.Println("DNS lookup failed for %s: %s\n", host, err.Error())
+		return nil, 0, err
+	}
+	if r.Rcode != dns.RcodeSuccess {
+		log.Println("Invalid answer in CNAME query for %s\n", host)
+		return nil, 0, err
+	}
+	// Stuff must be in the answer section
+	for _, ans := range r.Answer {
+		return &ans.Header().Name, time.Duration(ans.Header().Ttl) * time.Second, nil
+	}
+	return nil, 0, nil
 }

--- a/middlewares/routes.go
+++ b/middlewares/routes.go
@@ -3,19 +3,34 @@ package middlewares
 import (
 	"encoding/json"
 	"log"
+	"time"
+	"net"
 	"net/http"
 
 	"github.com/gorilla/mux"
+    "github.com/miekg/dns"
+     "github.com/karlseguin/ccache"
 )
 
 // Routes holds the gorilla mux routes (for the API & co).
+// It also does CNAME flattening, so Traefik can handle requests that come from other domains that use
+// Traefik as the canonical domain
 type Routes struct {
 	router *mux.Router
+    dnsCache *ccache.Cache
+    dnsClient *dns.Client
+    nameServerAddress string
 }
 
 // NewRoutes return a Routes based on the given router.
-func NewRoutes(router *mux.Router) *Routes {
-	return &Routes{router}
+func NewRoutes(router *mux.Router, resolvConf string) *Routes {
+    config, err := dns.ClientConfigFromFile(resolvConf)
+    if err != nil {
+		log.Fatal("Error reading resolv.conf file. Could not configure nameservers: ", err)
+    }
+    nameServerAddress := net.JoinHostPort(config.Servers[0], config.Port)
+    dnsCache := ccache.New(ccache.Configure().MaxSize(1000).ItemsToPrune(100))
+	return &Routes{router, dnsCache, new(dns.Client), nameServerAddress}
 }
 
 func (router *Routes) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
@@ -23,6 +38,42 @@ func (router *Routes) ServeHTTP(rw http.ResponseWriter, r *http.Request, next ht
 	if router.router.Match(r, &routeMatch) {
 		json, _ := json.Marshal(routeMatch.Handler)
 		log.Println("Request match route ", json)
-	}
+    } else {
+        host := router.dnsCache.Get(r.Host)
+        if (host == nil || host.TTL() < 0) {
+            newName, ttl, err := router.lookupCNAME(r.Host)
+            if err == nil {
+                if newName != nil {
+                    router.dnsCache.Set(r.Host, newName, ttl)
+                } else {
+                    router.dnsCache.Set(r.Host, nil, 60 * time.Second) // 60 second TTL for domains with no CNAME
+                }
+            }
+        }
+        if (host != nil) {
+            r.Host = host.Value().(string) // Rewrite the host header
+        }
+    }
 	next(rw, r)
+}
+
+func (router *Routes) lookupCNAME(host string) (*string, time.Duration, error) {
+    m := new(dns.Msg)
+    m.SetQuestion(dns.Fqdn(host), dns.TypeCNAME)
+    m.RecursionDesired = true
+
+    r, _, err := router.dnsClient.Exchange(m, router.nameServerAddress)
+    if r == nil {
+        log.Println("DNS lookup failed for %s: %s\n", host, err.Error())
+        return nil, 0, err
+    }
+    if r.Rcode != dns.RcodeSuccess {
+        log.Println("Invalid answer in CNAME query for %s\n", host)
+        return nil, 0, err
+    }
+    // Stuff must be in the answer section
+    for _, ans := range r.Answer {
+        return &ans.Header().Name, time.Duration(ans.Header().Ttl) * time.Second, nil
+    }
+    return nil, 0, nil
 }

--- a/middlewares/routes.go
+++ b/middlewares/routes.go
@@ -2,7 +2,7 @@ package middlewares
 
 import (
 	"encoding/json"
-	"log"
+	log "github.com/Sirupsen/logrus"
 	"net"
 	"net/http"
 	"time"

--- a/traefik.go
+++ b/traefik.go
@@ -204,7 +204,7 @@ func main() {
 
 	var er error
 	serverLock.Lock()
-	srv, er = prepareServer(configurationRouter, globalConfiguration, nil, loggerMiddleware, metrics)
+	srv, er = prepareServer(configurationRouter, globalConfiguration, nil, loggerMiddleware, middlewares.NewRoutes(configurationRouter, globalConfiguration.ResolvConf), metrics)
 	if er != nil {
 		log.Fatal("Error preparing server: ", er)
 	}


### PR DESCRIPTION
If we fail to find a matching route, we'll first fetch the DNS records for the route and check for CNAMEs, then we check the route list for those CNAME's. With this feature, Traefik will be able to properly route requests sent to domains with CNAMEs pointed at addresses that resolve to Traefik -- a common pattern in PaaS implementations.