### PR TITLE
Transfer emilevauge/traefik to containous/traefik

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Step 0 : FROM golang:1.5
  ---> 8c6473912976
 Step 1 : RUN go get github.com/Masterminds/glide
 [...]
-docker run --rm  -v "/var/run/docker.sock:/var/run/docker.sock" -it -e OS_ARCH_ARG -e OS_PLATFORM_ARG -e TESTFLAGS -v "/home/emile/dev/go/src/github.com/emilevauge/traefik/"dist":/go/src/github.com/emilevauge/traefik/"dist"" "traefik-dev:no-more-godep-ever" ./script/make.sh generate binary
+docker run --rm  -v "/var/run/docker.sock:/var/run/docker.sock" -it -e OS_ARCH_ARG -e OS_PLATFORM_ARG -e TESTFLAGS -v "/home/emile/dev/go/src/github.com/containous/traefik/"dist":/go/src/github.com/containous/traefik/"dist"" "traefik-dev:no-more-godep-ever" ./script/make.sh generate binary
 ---> Making bundle: generate (in .)
 removed 'gen.go'
 
@@ -66,13 +66,13 @@ integration test using the `test-integration` target.
 $ make test-unit
 docker build -t "traefik-dev:your-feature-branch" -f build.Dockerfile .
 # […]
-docker run --rm -it -e OS_ARCH_ARG -e OS_PLATFORM_ARG -e TESTFLAGS -v "/home/vincent/src/github/vdemeester/traefik/dist:/go/src/github.com/emilevauge/traefik/dist" "traefik-dev:your-feature-branch" ./script/make.sh generate test-unit
+docker run --rm -it -e OS_ARCH_ARG -e OS_PLATFORM_ARG -e TESTFLAGS -v "/home/vincent/src/github/vdemeester/traefik/dist:/go/src/github.com/containous/traefik/dist" "traefik-dev:your-feature-branch" ./script/make.sh generate test-unit
 ---> Making bundle: generate (in .)
 removed 'gen.go'
 
 ---> Making bundle: test-unit (in .)
 + go test -cover -coverprofile=cover.out .
-ok      github.com/emilevauge/traefik   0.005s  coverage: 4.1% of statements
+ok      github.com/containous/traefik   0.005s  coverage: 4.1% of statements
 
 Test success
 ```

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Emile Vauge, emile@vauge.com
+Copyright (c) 2016 Containous SAS, Emile Vauge, emile@vauge.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,12 @@ TRAEFIK_ENVS := \
 SRCS = $(shell git ls-files '*.go' | grep -v '^external/')
 
 BIND_DIR := "dist"
-TRAEFIK_MOUNT := -v "$(CURDIR)/$(BIND_DIR):/go/src/github.com/emilevauge/traefik/$(BIND_DIR)"
+TRAEFIK_MOUNT := -v "$(CURDIR)/$(BIND_DIR):/go/src/github.com/containous/traefik/$(BIND_DIR)"
 
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 TRAEFIK_DEV_IMAGE := traefik-dev$(if $(GIT_BRANCH),:$(GIT_BRANCH))
 REPONAME := $(shell echo $(REPO) | tr '[:upper:]' '[:lower:]')
-TRAEFIK_IMAGE := $(if $(REPONAME),$(REPONAME),"emilevauge/traefik")
+TRAEFIK_IMAGE := $(if $(REPONAME),$(REPONAME),"containous/traefik")
 INTEGRATION_OPTS := $(if $(MAKE_DOCKER_HOST),-e "DOCKER_HOST=$(MAKE_DOCKER_HOST)", -v "/var/run/docker.sock:/var/run/docker.sock")
 
 DOCKER_RUN_TRAEFIK := docker run $(INTEGRATION_OPTS) -it $(TRAEFIK_ENVS) $(TRAEFIK_MOUNT) "$(TRAEFIK_DEV_IMAGE)"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![Træfɪk](http://traefik.github.io/traefik.logo.svg  "Træfɪk")
 ___
 
-[![Build Status](https://travis-ci.org/emilevauge/traefik.svg?branch=master)](https://travis-ci.org/emilevauge/traefik)
-[![License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/EmileVauge/traefik/blob/master/LICENSE.md)
+[![Build Status](https://travis-ci.org/containous/traefik.svg?branch=master)](https://travis-ci.org/containous/traefik)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/containous/traefik/blob/master/LICENSE.md)
 [![Join the chat at https://traefik.herokuapp.com](https://img.shields.io/badge/style-register-green.svg?style=social&label=Slack)](https://traefik.herokuapp.com)
 [![Twitter](https://img.shields.io/twitter/follow/traefikproxy.svg?style=social)](https://twitter.com/intent/follow?screen_name=traefikproxy)
 
@@ -24,7 +24,7 @@ It supports several backends ([Docker :whale:](https://www.docker.com/), [Mesos/
 - Circuit breakers on backends
 - Round Robin, rebalancer load-balancers
 - Rest Metrics
-- Tiny docker image included [![Image Layers](https://badge.imagelayers.io/emilevauge/traefik:latest.svg)](https://imagelayers.io/?images=emilevauge/traefik:latest 'Image Layers')
+- Tiny docker image included [![Image Layers](https://badge.imagelayers.io/containous/traefik:latest.svg)](https://imagelayers.io/?images=containous/traefik:latest)
 - SSL backends support
 - SSL frontend support
 - Clean AngularJS Web UI
@@ -53,7 +53,7 @@ You can access to a simple HTML frontend of Træfik.
 
 ## Quick start
 
-- The simple way: grab the latest binary from the [releases](https://github.com/emilevauge/traefik/releases) page and just run it with the [sample configuration file](https://raw.githubusercontent.com/EmileVauge/traefik/master/traefik.sample.toml):
+- The simple way: grab the latest binary from the [releases](https://github.com/containous/traefik/releases) page and just run it with the [sample configuration file](https://raw.githubusercontent.com/containous/traefik/master/traefik.sample.toml):
 
 ```shell
 ./traefik -c traefik.toml
@@ -62,13 +62,13 @@ You can access to a simple HTML frontend of Træfik.
 - Use the tiny Docker image:
 
 ```shell
-docker run -d -p 8080:8080 -p 80:80 -v $PWD/traefik.toml:/etc/traefik/traefik.toml emilevauge/traefik
+docker run -d -p 8080:8080 -p 80:80 -v $PWD/traefik.toml:/etc/traefik/traefik.toml containous/traefik
 ```
 
 - From sources:
 
 ```shell
-git clone https://github.com/emilevauge/traefik
+git clone https://github.com/containous/traefik
 ```
 
 ## Documentation
@@ -106,3 +106,4 @@ software products.
 [![Asteris](docs/img/asteris.logo.png)](https://aster.is)
 
 Founded in 2014, Asteris creates next-generation infrastructure software for the modern datacenter. Asteris writes software that makes it easy for companies to implement continuous delivery and realtime data pipelines. We support the HashiCorp stack, along with Kubernetes, Apache Mesos, Spark and Kafka. We're core committers on mantl.io, consul-cli and mesos-consul.
+.

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -21,9 +21,9 @@ RUN set -ex; \
 # Set the default Docker to be run
 RUN ln -s /usr/local/bin/docker-${DOCKER_VERSION} /usr/local/bin/docker
 
-WORKDIR /go/src/github.com/emilevauge/traefik
+WORKDIR /go/src/github.com/containous/traefik
 
 COPY glide.yaml glide.yaml
 RUN glide up --quick
 
-COPY . /go/src/github.com/emilevauge/traefik
+COPY . /go/src/github.com/containous/traefik

--- a/cmd.go
+++ b/cmd.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/emilevauge/traefik/middlewares"
-	"github.com/emilevauge/traefik/provider"
+	"github.com/containous/traefik/middlewares"
+	"github.com/containous/traefik/provider"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"net/http"

--- a/configuration.go
+++ b/configuration.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/emilevauge/traefik/provider"
-	"github.com/emilevauge/traefik/types"
+	"github.com/containous/traefik/provider"
+	"github.com/containous/traefik/types"
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/viper"
 )

--- a/docs/index.md
+++ b/docs/index.md
@@ -1107,7 +1107,7 @@ Percentage of the requests served within a certain time (ms)
 ```sh
 docker run -d -l traefik.backend=test1 -l traefik.frontend.rule=Host -l traefik.frontend.value=test1.docker.localhost emilevauge/whoami
 docker run -d -l traefik.backend=test1 -l traefik.frontend.rule=Host -l traefik.frontend.value=test1.docker.localhost emilevauge/whoami
-docker run -d -p 8080:8080 -p 80:80 -v $PWD/traefik.toml:/traefik.toml -v /var/run/docker.sock:/var/run/docker.sock emilevauge/traefik
+docker run -d -p 8080:8080 -p 80:80 -v $PWD/traefik.toml:/traefik.toml -v /var/run/docker.sock:/var/run/docker.sock containous/traefik
 $ ab -n 20000 -c 20  -r http://test1.docker.localhost/
 This is ApacheBench, Version 2.3 <$Revision: 1528965 $>
 Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"text/template"
 
+	"github.com/containous/traefik/integration/utils"
 	"github.com/docker/libcompose/docker"
 	"github.com/docker/libcompose/project"
-	"github.com/emilevauge/traefik/integration/utils"
 
 	checker "github.com/vdemeester/shakers"
 	check "gopkg.in/check.v1"

--- a/provider/boltdb.go
+++ b/provider/boltdb.go
@@ -1,9 +1,9 @@
 package provider
 
 import (
+	"github.com/containous/traefik/types"
 	"github.com/docker/libkv/store"
 	"github.com/docker/libkv/store/boltdb"
-	"github.com/emilevauge/traefik/types"
 )
 
 // BoltDb holds configurations of the BoltDb provider.

--- a/provider/consul.go
+++ b/provider/consul.go
@@ -1,9 +1,9 @@
 package provider
 
 import (
+	"github.com/containous/traefik/types"
 	"github.com/docker/libkv/store"
 	"github.com/docker/libkv/store/consul"
-	"github.com/emilevauge/traefik/types"
 )
 
 // Consul holds configurations of the Consul provider.

--- a/provider/consul_catalog.go
+++ b/provider/consul_catalog.go
@@ -8,7 +8,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/cenkalti/backoff"
-	"github.com/emilevauge/traefik/types"
+	"github.com/containous/traefik/types"
 	"github.com/hashicorp/consul/api"
 )
 

--- a/provider/consul_catalog_test.go
+++ b/provider/consul_catalog_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/emilevauge/traefik/types"
+	"github.com/containous/traefik/types"
 	"github.com/hashicorp/consul/api"
 )
 

--- a/provider/docker.go
+++ b/provider/docker.go
@@ -11,7 +11,7 @@ import (
 	"github.com/BurntSushi/ty/fun"
 	log "github.com/Sirupsen/logrus"
 	"github.com/cenkalti/backoff"
-	"github.com/emilevauge/traefik/types"
+	"github.com/containous/traefik/types"
 	"github.com/fsouza/go-dockerclient"
 )
 

--- a/provider/docker_test.go
+++ b/provider/docker_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/emilevauge/traefik/types"
+	"github.com/containous/traefik/types"
 	"github.com/fsouza/go-dockerclient"
 )
 

--- a/provider/etcd.go
+++ b/provider/etcd.go
@@ -1,9 +1,9 @@
 package provider
 
 import (
+	"github.com/containous/traefik/types"
 	"github.com/docker/libkv/store"
 	"github.com/docker/libkv/store/etcd"
-	"github.com/emilevauge/traefik/types"
 )
 
 // Etcd holds configurations of the Etcd provider.

--- a/provider/file.go
+++ b/provider/file.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	log "github.com/Sirupsen/logrus"
-	"github.com/emilevauge/traefik/types"
+	"github.com/containous/traefik/types"
 	"gopkg.in/fsnotify.v1"
 )
 

--- a/provider/kv.go
+++ b/provider/kv.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/BurntSushi/ty/fun"
 	log "github.com/Sirupsen/logrus"
+	"github.com/containous/traefik/types"
 	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
-	"github.com/emilevauge/traefik/types"
 )
 
 // Kv holds common configurations of key-value providers.

--- a/provider/marathon.go
+++ b/provider/marathon.go
@@ -10,7 +10,7 @@ import (
 	"crypto/tls"
 	"github.com/BurntSushi/ty/fun"
 	log "github.com/Sirupsen/logrus"
-	"github.com/emilevauge/traefik/types"
+	"github.com/containous/traefik/types"
 	"github.com/gambol99/go-marathon"
 	"net/http"
 )

--- a/provider/marathon_test.go
+++ b/provider/marathon_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"errors"
-	"github.com/emilevauge/traefik/mocks"
-	"github.com/emilevauge/traefik/types"
+	"github.com/containous/traefik/mocks"
+	"github.com/containous/traefik/types"
 	"github.com/gambol99/go-marathon"
 	"github.com/stretchr/testify/mock"
 )

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -7,8 +7,8 @@ import (
 	"text/template"
 
 	"github.com/BurntSushi/toml"
-	"github.com/emilevauge/traefik/autogen"
-	"github.com/emilevauge/traefik/types"
+	"github.com/containous/traefik/autogen"
+	"github.com/containous/traefik/types"
 )
 
 // Provider defines methods of a provider.

--- a/provider/zk.go
+++ b/provider/zk.go
@@ -1,9 +1,9 @@
 package provider
 
 import (
+	"github.com/containous/traefik/types"
 	"github.com/docker/libkv/store"
 	"github.com/docker/libkv/store/zookeeper"
-	"github.com/emilevauge/traefik/types"
 )
 
 // Zookepper holds configurations of the Zookepper provider.

--- a/script/.validate
+++ b/script/.validate
@@ -4,7 +4,7 @@ if [ -z "$VALIDATE_UPSTREAM" ]; then
 	# this is kind of an expensive check, so let's not do this twice if we
 	# are running more than one validate bundlescript
 
-	VALIDATE_REPO='https://github.com/emilevauge/traefik.git'
+	VALIDATE_REPO='https://github.com/containous/traefik.git'
 	VALIDATE_BRANCH='master'
 
         # Should not be needed for now O:)

--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -14,13 +14,7 @@ sudo mv ghr /usr/bin/ghr
 sudo chmod +x /usr/bin/ghr
 
 # github release and tag
-ghr -t $GITHUB_TOKEN -u emilevauge -r traefik --prerelease ${VERSION} dist/
-
-# create docker image emilevauge/traefik
-docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-docker push ${REPO,,}:latest
-docker tag ${REPO,,}:latest ${REPO,,}:${VERSION}
-docker push ${REPO,,}:${VERSION}
+ghr -t $GITHUB_TOKEN -u containous -r traefik --prerelease ${VERSION} dist/
 
 # update traefik-library-image repo (official Docker image)
 git config --global user.email "emile@vauge.com"
@@ -34,6 +28,13 @@ git add -A
 echo $VERSION | git commit --file -
 echo $VERSION | git tag -a $VERSION --file -
 git push --follow-tags -u origin master
+
+# create docker image emilevauge/traefik (compatibility)
+docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+docker push ${REPO,,}:latest
+docker tag ${REPO,,}:latest ${REPO,,}:${VERSION}
+docker push ${REPO,,}:${VERSION}
+
 cd ..
 rm -Rf traefik-library-image/
 

--- a/server.go
+++ b/server.go
@@ -10,9 +10,9 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/codegangsta/negroni"
-	"github.com/emilevauge/traefik/middlewares"
-	"github.com/emilevauge/traefik/provider"
-	"github.com/emilevauge/traefik/types"
+	"github.com/containous/traefik/middlewares"
+	"github.com/containous/traefik/provider"
+	"github.com/containous/traefik/types"
 	"github.com/gorilla/mux"
 	"github.com/mailgun/manners"
 	"github.com/mailgun/oxy/cbreaker"

--- a/web.go
+++ b/web.go
@@ -7,9 +7,9 @@ import (
 	"net/http"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/containous/traefik/autogen"
+	"github.com/containous/traefik/types"
 	"github.com/elazarl/go-bindata-assetfs"
-	"github.com/emilevauge/traefik/autogen"
-	"github.com/emilevauge/traefik/types"
 	"github.com/gorilla/mux"
 	"github.com/thoas/stats"
 	"github.com/unrolled/render"

--- a/webui/src/index.html
+++ b/webui/src/index.html
@@ -39,7 +39,7 @@
               </ul>
               <ul class="nav navbar-nav navbar-right">
                 <li>
-                  <a href="https://github.com/EmileVauge/traefik/blob/master/docs/index.md" target="_blank">Documentation</a>
+                  <a href="https://github.com/containous/traefik/blob/master/docs/index.md" target="_blank">Documentation</a>
                 </li>
                 <li>
                   <a href="http://traefik.io" target="_blank"><span class="traefik-blue">traefik.io</span></a>


### PR DESCRIPTION
This PR finalizes transfer from repo `emilevauge/traefik` to `containous/traefik`.
As I created a [company](https://containo.us) to continue to develop Traefik, I transferred the project to an organization repo.