### PR TITLE
Fix docker network

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -57,7 +57,7 @@ import:
   - package: github.com/flynn/go-shlex
     ref:     3f9db97f856818214da2e1057f8ad84803971cff
   - package: github.com/fsouza/go-dockerclient
-    ref:     0239034d42f665efa17fd77c39f891c2f9f32922
+    ref:     a49c8269a6899cae30da1f8a4b82e0ce945f9967
   - package: github.com/boltdb/bolt
     ref:     51f99c862475898df9773747d3accd05a7ca33c1
   - package: gopkg.in/mgo.v2

--- a/provider/docker_test.go
+++ b/provider/docker_test.go
@@ -676,7 +676,11 @@ func TestDockerLoadDockerConfig(t *testing.T) {
 						Ports: map[docker.Port][]docker.PortBinding{
 							"80/tcp": {},
 						},
-						IPAddress: "127.0.0.1",
+						Networks: map[string]docker.ContainerNetwork{
+							"bridgde": {
+								IPAddress: "127.0.0.1",
+							},
+						},
 					},
 				},
 			},
@@ -718,7 +722,11 @@ func TestDockerLoadDockerConfig(t *testing.T) {
 						Ports: map[docker.Port][]docker.PortBinding{
 							"80/tcp": {},
 						},
-						IPAddress: "127.0.0.1",
+						Networks: map[string]docker.ContainerNetwork{
+							"bridgde": {
+								IPAddress: "127.0.0.1",
+							},
+						},
 					},
 				},
 				{
@@ -732,7 +740,11 @@ func TestDockerLoadDockerConfig(t *testing.T) {
 						Ports: map[docker.Port][]docker.PortBinding{
 							"80/tcp": {},
 						},
-						IPAddress: "127.0.0.1",
+						Networks: map[string]docker.ContainerNetwork{
+							"bridgde": {
+								IPAddress: "127.0.0.1",
+							},
+						},
 					},
 				},
 			},

--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -31,9 +31,9 @@ git push --follow-tags -u origin master
 
 # create docker image emilevauge/traefik (compatibility)
 docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-docker push ${REPO,,}:latest
-docker tag ${REPO,,}:latest ${REPO,,}:${VERSION}
-docker push ${REPO,,}:${VERSION}
+docker push emilevauge/traefik:latest
+docker tag emilevauge/traefik:latest emilevauge/traefik:${VERSION}
+docker push emilevauge/traefik:${VERSION}
 
 cd ..
 rm -Rf traefik-library-image/

--- a/templates/docker.tmpl
+++ b/templates/docker.tmpl
@@ -1,6 +1,6 @@
 [backends]{{range .Containers}}
     [backends.backend-{{getBackend .}}.servers.server-{{.Name | replace "/" "" | replace "." "-"}}]
-    url = "{{getProtocol .}}://{{.NetworkSettings.IPAddress}}:{{getPort .}}"
+    url = "{{getProtocol .}}://{{range $i := .NetworkSettings.Networks}}{{if $i}}{{.IPAddress}}{{end}}{{end}}:{{getPort .}}"
     weight = {{getWeight .}}
 {{end}}
 


### PR DESCRIPTION
This PR fixes docker network management using `NetworkSettings.Networks` instead of `NetworkSettings.IPAddress`.
Fixes #226 