### PR TITLE
Use event stream API instead of event subscriptions

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -126,7 +126,6 @@ func init() {
 	traefikCmd.PersistentFlags().StringVar(&arguments.Marathon.Filename, "marathon.filename", "", "Override default configuration template. For advanced users :)")
 	traefikCmd.PersistentFlags().StringVar(&arguments.Marathon.Endpoint, "marathon.endpoint", "http://127.0.0.1:8080", "Marathon server endpoint. You can also specify multiple endpoint for Marathon")
 	traefikCmd.PersistentFlags().StringVar(&arguments.Marathon.Domain, "marathon.domain", "", "Default domain used")
-	traefikCmd.PersistentFlags().StringVar(&arguments.Marathon.NetworkInterface, "marathon.networkInterface", "eth0", "Network interface used to call Marathon web services. Needed in case of multiple network interfaces")
 
 	traefikCmd.PersistentFlags().BoolVar(&arguments.consul, "consul", false, "Enable Consul backend")
 	traefikCmd.PersistentFlags().BoolVar(&arguments.Consul.Watch, "consul.watch", true, "Watch provider")

--- a/docs/index.md
+++ b/docs/index.md
@@ -151,7 +151,6 @@ Flags:
       --marathon.domain string               Default domain used
       --marathon.endpoint string             Marathon server endpoint. You can also specify multiple endpoint for Marathon (default "http://127.0.0.1:8080")
       --marathon.filename string             Override default configuration template. For advanced users :)
-      --marathon.networkInterface string     Network interface used to call Marathon web services. Needed in case of multiple network interfaces (default "eth0")
       --marathon.watch                       Watch provider (default true)
       --maxIdleConnsPerHost int              If non-zero, controls the maximum idle (keep-alive) to keep per-host.  If zero, DefaultMaxIdleConnsPerHost is used
       --providersThrottleDuration duration   Backends throttle duration: minimum duration between 2 events from providers before applying a new configuration. It avoids unnecessary reloads if multiples events are sent in a short amount of time. (default 2s)
@@ -639,12 +638,6 @@ Træfɪk can be configured to use Marathon as a backend configuration:
 # Required
 #
 endpoint = "http://127.0.0.1:8080"
-
-# Network interface used to call Marathon web services. Needed in case of multiple network interfaces.
-# Optional
-# Default: "eth0"
-#
-networkInterface = "eth0"
 
 # Enable watch Marathon changes
 #

--- a/provider/marathon.go
+++ b/provider/marathon.go
@@ -17,13 +17,12 @@ import (
 
 // Marathon holds configuration of the Marathon provider.
 type Marathon struct {
-	BaseProvider     `mapstructure:",squash"`
-	Endpoint         string
-	Domain           string
-	NetworkInterface string
-	Basic            *MarathonBasic
-	TLS              *tls.Config
-	marathonClient   marathon.Marathon
+	BaseProvider   `mapstructure:",squash"`
+	Endpoint       string
+	Domain         string
+	Basic          *MarathonBasic
+	TLS            *tls.Config
+	marathonClient marathon.Marathon
 }
 
 // MarathonBasic holds basic authentication specific configurations
@@ -42,7 +41,7 @@ type lightMarathonClient interface {
 func (provider *Marathon) Provide(configurationChan chan<- types.ConfigMessage) error {
 	config := marathon.NewDefaultConfig()
 	config.URL = provider.Endpoint
-	config.EventsInterface = provider.NetworkInterface
+	config.EventsTransport = marathon.EventsTransportSSE
 	if provider.Basic != nil {
 		config.HTTPBasicAuthUser = provider.Basic.HTTPBasicAuthUser
 		config.HTTPBasicPassword = provider.Basic.HTTPBasicPassword
@@ -61,7 +60,7 @@ func (provider *Marathon) Provide(configurationChan chan<- types.ConfigMessage) 
 	update := make(marathon.EventsChannel, 5)
 	if provider.Watch {
 		if err := client.AddEventsListener(update, marathon.EVENTS_APPLICATIONS); err != nil {
-			log.Errorf("Failed to register for subscriptions, %s", err)
+			log.Errorf("Failed to register for events, %s", err)
 		} else {
 			go func() {
 				for {

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -206,12 +206,6 @@
 #
 # endpoint = "http://127.0.0.1:8080"
 
-# Network interface used to call Marathon web services. Needed in case of multiple network interfaces.
-# Optional
-# Default: "eth0"
-#
-# networkInterface = "eth0"
-
 # Enable watch Marathon changes
 #
 # Optional


### PR DESCRIPTION
as mentioned in https://github.com/containous/traefik/issues/210#issuecomment-190917703

From the docs here https://github.com/gambol99/go-marathon#event-stream doesn't look like anything else is needed to change across APIs