### PR TITLE
add retries request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ traefik.toml
 *.test
 vendor/
 static/
+glide.lock

--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ It supports several backends ([Docker :whale:](https://www.docker.com/), [Mesos/
 
 ## Features
 
+- It's fast
 - No dependency hell, single binary made with go
 - Simple json Rest API
 - Simple TOML file configuration
 - Multiple backends supported: Docker, Mesos/Marathon, Consul, Etcd, and more to come
 - Watchers for backends, can listen change in backends to apply a new configuration automatically
 - Hot-reloading of configuration. No need to restart the process
-- Graceful shutdown http connections during hot-reloads
+- Graceful shutdown http connections
 - Circuit breakers on backends
 - Round Robin, rebalancer load-balancers
 - Rest Metrics

--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
-
 <p align="center">
 <img src="http://traefik.github.io/traefik.logo.svg" alt="Træfɪk" title="Træfɪk" />
 </p>
 
 [![Build Status](https://travis-ci.org/containous/traefik.svg?branch=master)](https://travis-ci.org/containous/traefik)
-[![License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/containous/traefik/blob/master/LICENSE.md)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/containous/traefik/blob/master/LICENSE.md)
 [![Join the chat at https://traefik.herokuapp.com](https://img.shields.io/badge/style-register-green.svg?style=social&label=Slack)](https://traefik.herokuapp.com)
 [![Twitter](https://img.shields.io/twitter/follow/traefikproxy.svg?style=social)](https://twitter.com/intent/follow?screen_name=traefikproxy)
 
 
 
 Træfɪk is a modern HTTP reverse proxy and load balancer made to deploy microservices with ease.
-It supports several backends ([Docker :whale:](https://www.docker.com/), [Mesos/Marathon](https://mesosphere.github.io/marathon/), [Consul](https://www.consul.io/), [Etcd](https://coreos.com/etcd/), [Zookeeper](https://zookeeper.apache.org), [BoltDB](https://github.com/boltdb/bolt), Rest API, file...) to manage its configuration automatically and dynamically.
+It supports several backends ([Docker :whale:](https://www.docker.com/), [Swarm :whale: :whale:](https://docs.docker.com/swarm), [Mesos/Marathon](https://mesosphere.github.io/marathon/), [Mesos/Marathon](https://mesosphere.github.io/marathon/), [Consul](https://www.consul.io/), [Etcd](https://coreos.com/etcd/), [Zookeeper](https://zookeeper.apache.org), [BoltDB](https://github.com/boltdb/bolt), Rest API, file...) to manage its configuration automatically and dynamically.
 
 
 ## Features
@@ -33,6 +32,7 @@ It supports several backends ([Docker :whale:](https://www.docker.com/), [Mesos/
 - Clean AngularJS Web UI
 - Websocket support
 - HTTP/2 support
+- Retry request if network error
 
 ## Demo
 

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -24,6 +24,6 @@ RUN ln -s /usr/local/bin/docker-${DOCKER_VERSION} /usr/local/bin/docker
 WORKDIR /go/src/github.com/containous/traefik
 
 COPY glide.yaml glide.yaml
-RUN glide up --quick
+RUN glide up
 
 COPY . /go/src/github.com/containous/traefik

--- a/configuration.go
+++ b/configuration.go
@@ -21,10 +21,11 @@ type GlobalConfiguration struct {
 	AccessLogsFile            string
 	TraefikLogsFile           string
 	LogLevel                  string
-	EntryPoints               EntryPoints
-	DefaultEntryPoints        DefaultEntryPoints
 	ProvidersThrottleDuration time.Duration
 	MaxIdleConnsPerHost       int
+	Retry                     *Retry
+	EntryPoints               EntryPoints
+	DefaultEntryPoints        DefaultEntryPoints
 	Docker                    *provider.Docker
 	File                      *provider.File
 	Web                       *WebProvider
@@ -34,6 +35,12 @@ type GlobalConfiguration struct {
 	Etcd                      *provider.Etcd
 	Zookeeper                 *provider.Zookepper
 	Boltdb                    *provider.BoltDb
+}
+
+// Retry contains request retry config
+type Retry struct {
+	Attempts int
+	MaxMem   int64
 }
 
 // DefaultEntryPoints holds default entry points

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
-![Træfɪk](http://traefik.github.io/traefik.logo.svg "Træfɪk")
-___
-
+<p align="center">
+<img src="http://traefik.github.io/traefik.logo.svg" alt="Træfɪk" title="Træfɪk" />
+</p>
 
 # <a id="top"></a> Documentation
 
@@ -177,46 +177,6 @@ Use "traefik [command] --help" for more information about a command.
 # Global configuration
 ################################################################
 
-# Entrypoints definition
-#
-# Optional
-# Default:
-# [entryPoints]
-#   [entryPoints.http]
-#   address = ":80"
-#
-# To redirect an http entrypoint to an https entrypoint (with SNI support):
-# [entryPoints]
-#   [entryPoints.http]
-#   address = ":80"
-#     [entryPoints.http.redirect]
-#       entryPoint = "https"
-#   [entryPoints.https]
-#   address = ":443"
-#     [entryPoints.https.tls]
-#       [[entryPoints.https.tls.certificates]]
-#       CertFile = "integration/fixtures/https/snitest.com.cert"
-#       KeyFile = "integration/fixtures/https/snitest.com.key"
-#       [[entryPoints.https.tls.certificates]]
-#       CertFile = "integration/fixtures/https/snitest.org.cert"
-#       KeyFile = "integration/fixtures/https/snitest.org.key"
-#
-# To redirect an entrypoint rewriting the URL:
-# [entryPoints]
-#   [entryPoints.http]
-#   address = ":80"
-#     [entryPoints.http.redirect]
-#       regex = "^http://localhost/(.*)"
-#       replacement = "http://mydomain/$1"
-
-# Entrypoints to be used by frontends that do not specify any entrypoint.
-# Each frontend can specify its own entrypoints.
-#
-# Optional
-# Default: ["http"]
-#
-# defaultEntryPoints = ["http", "https"]
-
 # Timeout in seconds.
 # Duration to give active requests a chance to finish during hot-reloads
 #
@@ -262,6 +222,66 @@ Use "traefik [command] --help" for more information about a command.
 #
 # MaxIdleConnsPerHost = 200
 
+# Entrypoints to be used by frontends that do not specify any entrypoint.
+# Each frontend can specify its own entrypoints.
+#
+# Optional
+# Default: ["http"]
+#
+# defaultEntryPoints = ["http", "https"]
+
+# Entrypoints definition
+#
+# Optional
+# Default:
+# [entryPoints]
+#   [entryPoints.http]
+#   address = ":80"
+#
+# To redirect an http entrypoint to an https entrypoint (with SNI support):
+# [entryPoints]
+#   [entryPoints.http]
+#   address = ":80"
+#     [entryPoints.http.redirect]
+#       entryPoint = "https"
+#   [entryPoints.https]
+#   address = ":443"
+#     [entryPoints.https.tls]
+#       [[entryPoints.https.tls.certificates]]
+#       CertFile = "integration/fixtures/https/snitest.com.cert"
+#       KeyFile = "integration/fixtures/https/snitest.com.key"
+#       [[entryPoints.https.tls.certificates]]
+#       CertFile = "integration/fixtures/https/snitest.org.cert"
+#       KeyFile = "integration/fixtures/https/snitest.org.key"
+#
+# To redirect an entrypoint rewriting the URL:
+# [entryPoints]
+#   [entryPoints.http]
+#   address = ":80"
+#     [entryPoints.http.redirect]
+#       regex = "^http://localhost/(.*)"
+#       replacement = "http://mydomain/$1"
+
+
+# Enable retry sending request if network error
+#
+# Optional
+#
+# [retry]
+
+# Number of attempts
+#
+# Optional
+# Default: (number servers in backend) -1
+#
+# attempts = 3
+
+# Sets the maximum request body to be stored in memory in Mo
+#
+# Optional
+# Default: 2
+#
+# maxMem = 3
 ```
 
 

--- a/glide.yaml
+++ b/glide.yaml
@@ -164,4 +164,4 @@ import:
   - package: github.com/google/go-querystring/query
   - package: github.com/vulcand/vulcand/plugin/rewrite
   - package: github.com/stretchr/testify/mock
-
+  - package: github.com/mailgun/multibuf

--- a/middlewares/handlerSwitcher.go
+++ b/middlewares/handlerSwitcher.go
@@ -1,0 +1,40 @@
+package middlewares
+
+import (
+	"github.com/gorilla/mux"
+	"net/http"
+	"sync"
+)
+
+// HandlerSwitcher allows hot switching of http.ServeMux
+type HandlerSwitcher struct {
+	handler     *mux.Router
+	handlerLock *sync.Mutex
+}
+
+// NewHandlerSwitcher builds a new instance of HandlerSwitcher
+func NewHandlerSwitcher(newHandler *mux.Router) (hs *HandlerSwitcher) {
+	return &HandlerSwitcher{
+		handler:     newHandler,
+		handlerLock: &sync.Mutex{},
+	}
+}
+
+func (hs *HandlerSwitcher) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	hs.handlerLock.Lock()
+	handlerBackup := hs.handler
+	hs.handlerLock.Unlock()
+	handlerBackup.ServeHTTP(rw, r)
+}
+
+// GetHandler returns the current http.ServeMux
+func (hs *HandlerSwitcher) GetHandler() (newHandler *mux.Router) {
+	return hs.handler
+}
+
+// UpdateHandler safely updates the current http.ServeMux with a new one
+func (hs *HandlerSwitcher) UpdateHandler(newHandler *mux.Router) {
+	hs.handlerLock.Lock()
+	hs.handler = newHandler
+	defer hs.handlerLock.Unlock()
+}

--- a/server.go
+++ b/server.go
@@ -443,7 +443,7 @@ func (server *Server) loadEntryPointConfig(entryPointName string, entryPoint *En
 	if len(entryPoint.Redirect.EntryPoint) > 0 {
 		regex = "^(?:https?:\\/\\/)?([\\da-z\\.-]+)(?::\\d+)(.*)$"
 		if server.globalConfiguration.EntryPoints[entryPoint.Redirect.EntryPoint] == nil {
-			return nil, errors.New("Unkown entrypoint " + entryPoint.Redirect.EntryPoint)
+			return nil, errors.New("Unknown entrypoint " + entryPoint.Redirect.EntryPoint)
 		}
 		protocol := "http"
 		if server.globalConfiguration.EntryPoints[entryPoint.Redirect.EntryPoint].TLS != nil {

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -2,46 +2,6 @@
 # Global configuration
 ################################################################
 
-# Entrypoints definition
-#
-# Optional
-# Default:
-# [entryPoints]
-#   [entryPoints.http]
-#   address = ":80"
-#
-# To redirect an http entrypoint to an https entrypoint (with SNI support):
-# [entryPoints]
-#   [entryPoints.http]
-#   address = ":80"
-#     [entryPoints.http.redirect]
-#       entryPoint = "https"
-#   [entryPoints.https]
-#   address = ":443"
-#     [entryPoints.https.tls]
-#       [[entryPoints.https.tls.certificates]]
-#       CertFile = "integration/fixtures/https/snitest.com.cert"
-#       KeyFile = "integration/fixtures/https/snitest.com.key"
-#       [[entryPoints.https.tls.certificates]]
-#       CertFile = "integration/fixtures/https/snitest.org.cert"
-#       KeyFile = "integration/fixtures/https/snitest.org.key"
-#
-# To redirect an entrypoint rewriting the URL:
-# [entryPoints]
-#   [entryPoints.http]
-#   address = ":80"
-#     [entryPoints.http.redirect]
-#       regex = "^http://localhost/(.*)"
-#       replacement = "http://mydomain/$1"
-
-# Entrypoints to be used by frontends that do not specify any entrypoint.
-# Each frontend can specify its own entrypoints.
-#
-# Optional
-# Default: ["http"]
-#
-# defaultEntryPoints = ["http", "https"]
-
 # Timeout in seconds.
 # Duration to give active requests a chance to finish during hot-reloads
 #
@@ -87,6 +47,65 @@
 #
 # MaxIdleConnsPerHost = 200
 
+# Entrypoints to be used by frontends that do not specify any entrypoint.
+# Each frontend can specify its own entrypoints.
+#
+# Optional
+# Default: ["http"]
+#
+# defaultEntryPoints = ["http", "https"]
+
+# Entrypoints definition
+#
+# Optional
+# Default:
+# [entryPoints]
+#   [entryPoints.http]
+#   address = ":80"
+#
+# To redirect an http entrypoint to an https entrypoint (with SNI support):
+# [entryPoints]
+#   [entryPoints.http]
+#   address = ":80"
+#     [entryPoints.http.redirect]
+#       entryPoint = "https"
+#   [entryPoints.https]
+#   address = ":443"
+#     [entryPoints.https.tls]
+#       [[entryPoints.https.tls.certificates]]
+#       CertFile = "integration/fixtures/https/snitest.com.cert"
+#       KeyFile = "integration/fixtures/https/snitest.com.key"
+#       [[entryPoints.https.tls.certificates]]
+#       CertFile = "integration/fixtures/https/snitest.org.cert"
+#       KeyFile = "integration/fixtures/https/snitest.org.key"
+#
+# To redirect an entrypoint rewriting the URL:
+# [entryPoints]
+#   [entryPoints.http]
+#   address = ":80"
+#     [entryPoints.http.redirect]
+#       regex = "^http://localhost/(.*)"
+#       replacement = "http://mydomain/$1"
+
+# Enable retry sending request if network error
+#
+# Optional
+#
+# [retry]
+
+# Number of attempts
+#
+# Optional
+# Default: (number servers in backend) -1
+#
+# attempts = 3
+
+# Sets the maximum request body to be stored in memory in Mo
+#
+# Optional
+# Default: 2
+#
+# maxMem = 3
 
 ################################################################
 # Web configuration backend


### PR DESCRIPTION
This PR adds retry request in case of network error.
You can enable retry in your global config file adding `[retry]`.
The default config set a maximum storage in memory by request of 2 Mo and a maximum attempts of (number servers in backend) -1.
Your can override this:

```
# Enable retry sending request if network error
#
# Optional
#
[retry]

# Number of attempts
#
# Optional
# Default: (number servers in backend) -1
#
attempts = 3

# Sets the maximum request body to be stored in memory in Mo
#
# Optional
# Default: 2
#
maxMem = 3
```

Fixes #210 