### PR TITLE
Refactor hot reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ traefik.toml
 *.test
 vendor/
 static/
+glide.lock

--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ It supports several backends ([Docker :whale:](https://www.docker.com/), [Mesos/
 
 ## Features
 
+- It's fast
 - No dependency hell, single binary made with go
 - Simple json Rest API
 - Simple TOML file configuration
 - Multiple backends supported: Docker, Mesos/Marathon, Consul, Etcd, and more to come
 - Watchers for backends, can listen change in backends to apply a new configuration automatically
 - Hot-reloading of configuration. No need to restart the process
-- Graceful shutdown http connections during hot-reloads
+- Graceful shutdown http connections
 - Circuit breakers on backends
 - Round Robin, rebalancer load-balancers
 - Rest Metrics

--- a/middlewares/handlerSwitcher.go
+++ b/middlewares/handlerSwitcher.go
@@ -1,0 +1,40 @@
+package middlewares
+
+import (
+	"github.com/gorilla/mux"
+	"net/http"
+	"sync"
+)
+
+// HandlerSwitcher allows hot switching of http.ServeMux
+type HandlerSwitcher struct {
+	handler     *mux.Router
+	handlerLock *sync.Mutex
+}
+
+// NewHandlerSwitcher builds a new instance of HandlerSwitcher
+func NewHandlerSwitcher(newHandler *mux.Router) (hs *HandlerSwitcher) {
+	return &HandlerSwitcher{
+		handler:     newHandler,
+		handlerLock: &sync.Mutex{},
+	}
+}
+
+func (hs *HandlerSwitcher) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	hs.handlerLock.Lock()
+	handlerBackup := hs.handler
+	hs.handlerLock.Unlock()
+	handlerBackup.ServeHTTP(rw, r)
+}
+
+// GetHandler returns the current http.ServeMux
+func (hs *HandlerSwitcher) GetHandler() (newHandler *mux.Router) {
+	return hs.handler
+}
+
+// UpdateHandler safely updates the current http.ServeMux with a new one
+func (hs *HandlerSwitcher) UpdateHandler(newHandler *mux.Router) {
+	hs.handlerLock.Lock()
+	hs.handler = newHandler
+	defer hs.handlerLock.Unlock()
+}


### PR DESCRIPTION
This PR refactor the way Traefik manages hot-reloads.
As it appears there are issues sometimes with [manners](https://github.com/braintree/manners/issues/13), we now simply hot-switch the `http.ServeMux` of the server. This is way more simpler and safer.
Manners is still used for graceful shutdown of Traefik.
Fixes #236
//cc @gbjk 

![](https://i.imgflip.com/109j1i.jpg)