### PR TITLE
Support libkv.WatchTree chan errors:

### DIFF
--- a/provider/kv_test.go
+++ b/provider/kv_test.go
@@ -264,6 +264,7 @@ func TestKvWatchTree(t *testing.T) {
 		<-configChan
 		close(c1) // WatchTree chans can close due to error
 	case <-time.After(1 * time.Second):
+		t.Fatalf("Failed to create a new WatchTree chan")
 	}
 
 	select {
@@ -271,6 +272,7 @@ func TestKvWatchTree(t *testing.T) {
 		c2 <- []*store.KVPair{}
 		<-configChan
 	case <-time.After(1 * time.Second):
+		t.Fatalf("Failed to create a new WatchTree chan")
 	}
 
 	select {


### PR DESCRIPTION
  - libkv.WatchTree returns a channel whose messages represent changes
    to the watched tree. In situations where libkv cannot read from the
    underlying store, libkv will close the provided channel.
  - This PR handles this edge case and fixes #238.