### PR TITLE
Fix push to old docker repo emilevauge/traefik

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1113,9 +1113,9 @@ Transfer/sec:      0.99MB
 
 ```sh
 $ docker run -d -l traefik.backend=test1 -l traefik.frontend.rule=Host -l traefik.frontend.value=test.traefik.localhost emilevauge/whoami
-$ docker run -d -l traefik.backend=test1 -l traefik.frontend.rule=Host -l traefik.frontend.value=test.traefik.docker.localhost emilevauge/whoami
+$ docker run -d -l traefik.backend=test1 -l traefik.frontend.rule=Host -l traefik.frontend.value=test.traefik.localhost emilevauge/whoami
 $ docker run -d -p 8080:8080 -p 80:80 -v $PWD/traefik.toml:/traefik.toml -v /var/run/docker.sock:/var/run/docker.sock containous/traefik
-$ wrk -t12 -c400 -d60s -H "Host: test.traefik.docker.localhost" --latency http://127.0.0.1:80
+$ wrk -t12 -c400 -d60s -H "Host: test.traefik.localhost" --latency http://127.0.0.1:80
 Running 1m test @ http://127.0.0.1:80
   12 threads and 400 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev

--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -31,6 +31,7 @@ git push --follow-tags -u origin master
 
 # create docker image emilevauge/traefik (compatibility)
 docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+docker tag containous/traefik emilevauge/traefik:latest
 docker push emilevauge/traefik:latest
 docker tag emilevauge/traefik:latest emilevauge/traefik:${VERSION}
 docker push emilevauge/traefik:${VERSION}


### PR DESCRIPTION
This PR maintains the old docker repo `emilevauge/traefik` up to date.