### PR TITLE
Bump to beta, using semver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 env:
   REPO: $TRAVIS_REPO_SLUG
-  VERSION: v1.0.alpha.$TRAVIS_COMMIT
+  VERSION: v1.0.0-beta.$TRAVIS_BUILD_NUMBER
 
 sudo: required
 


### PR DESCRIPTION
This PR bump to beta version, and now uses [semver](semver.org) : `v1.0.0-beta.$TRAVIS_BUILD_NUMBER`