### PR TITLE
Add a verbose mode to builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ TRAEFIK_ENVS := \
 	-e OS_ARCH_ARG \
 	-e OS_PLATFORM_ARG \
 	-e TESTFLAGS \
+	-e VERBOSE \
 	-e VERSION
 
 SRCS = $(shell git ls-files '*.go' | grep -v '^external/')

--- a/script/binary
+++ b/script/binary
@@ -8,6 +8,11 @@ fi
 
 rm -f dist/traefik
 
+FLAGS=""
+if [ -n "$VERBOSE" ]; then
+    FLAGS="${FLAGS} -v"
+fi
+
 if [ -z "$VERSION" ]; then
     VERSION=$(git rev-parse HEAD)
 fi
@@ -17,4 +22,4 @@ if [ -z "$DATE" ]; then
 fi
 
 # Build binaries
-CGO_ENABLED=0 GOGC=off go build -v -ldflags "-X main.Version=$VERSION -X main.BuildDate=$DATE" -a -installsuffix nocgo -o dist/traefik .
+CGO_ENABLED=0 GOGC=off go build $FLAGS -ldflags "-X main.Version=$VERSION -X main.BuildDate=$DATE" -a -installsuffix nocgo -o dist/traefik .

--- a/script/test-integration
+++ b/script/test-integration
@@ -4,7 +4,11 @@ set -e
 export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export DEST=.
 
-TESTFLAGS="$TESTFLAGS -test.timeout=30m -check.v"
+TESTFLAGS="${TESTFLAGS} -test.timeout=30m -check.v"
+
+if [ -n "$VERBOSE" ]; then
+    TESTFLAGS="${TESTFLAGS} -v"
+fi
 
 cd integration
 CGO_ENABLED=0 go test $TESTFLAGS

--- a/script/test-unit
+++ b/script/test-unit
@@ -26,6 +26,10 @@ find_dirs() {
 
 TESTFLAGS="-cover -coverprofile=cover.out ${TESTFLAGS}"
 
+if [ -n "$VERBOSE" ]; then
+    TESTFLAGS="${TESTFLAGS} -v"
+fi
+
 if [ -z "$TESTDIRS" ]; then
     TESTDIRS=$(find_dirs '*_test.go')
 fi


### PR DESCRIPTION
Using the VERBOSE environment variable, tests and binary compilation are ran in verbose mode (using -v), but by default there are more quiet :angel: 🐶.

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>