### PR TITLE
Libkermit integration 😇

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 6f5b6e92b805fed0bb6a5bfe411b5ca501bc04accebeb739cec039e6499271e2
-updated: 2016-03-16T13:22:21.850972237+01:00
+hash: 7734b691c46b399a06cdcaa5d7feb77ea32e350cd4ff04dcbc73c06ef22468e6
+updated: 2016-03-27T19:57:17.213688266+02:00
 imports:
 - name: github.com/alecthomas/template
   version: b867cc6ab45cece8143cfcc6fc9c77cf3f2c23c0
@@ -79,7 +79,7 @@ imports:
   - utils
   - volume
 - name: github.com/docker/libcompose
-  version: d3089811c119a211469a9cc93caea684d937e5d3
+  version: e290a513ba909ca3afefd5cd611f3a3fe56f6a3a
   subpackages:
   - docker
   - logger
@@ -114,10 +114,10 @@ imports:
   - external/github.com/Sirupsen/logrus
   - external/github.com/docker/docker/pkg/idtools
   - external/github.com/docker/docker/pkg/ioutils
+  - external/github.com/docker/docker/pkg/longpath
   - external/github.com/docker/docker/pkg/pools
   - external/github.com/docker/docker/pkg/promise
   - external/github.com/docker/docker/pkg/system
-  - external/github.com/docker/docker/pkg/longpath
   - external/github.com/opencontainers/runc/libcontainer/user
   - external/golang.org/x/sys/unix
   - external/golang.org/x/net/context
@@ -217,6 +217,8 @@ imports:
   version: 54ed61c2b47e263ae2f01b86837b0c4bd1da28e8
 - name: github.com/unrolled/render
   version: 26b4e3aac686940fe29521545afad9966ddfc80c
+- name: github.com/vdemeester/libkermit
+  version: 01a5399bdbd3312916c9fa4848108fbc81fe88d8
 - name: github.com/vdemeester/shakers
   version: 8fe734f75f3a70b651cbfbf8a55a009da09e8dc5
 - name: github.com/vulcand/oxy

--- a/glide.yaml
+++ b/glide.yaml
@@ -124,7 +124,7 @@ import:
   - package: gopkg.in/alecthomas/kingpin.v2
     ref:     639879d6110b1b0409410c7b737ef0bb18325038
   - package: github.com/docker/libcompose
-    ref:     d3089811c119a211469a9cc93caea684d937e5d3
+    ref:     e290a513ba909ca3afefd5cd611f3a3fe56f6a3a
     subpackages:
       - docker
       - logger
@@ -165,3 +165,5 @@ import:
   - package: github.com/vulcand/vulcand/plugin/rewrite
   - package: github.com/stretchr/testify/mock
   - package: github.com/xenolf/lego
+  - package: github.com/vdemeester/libkermit
+    ref: 01a5399bdbd3312916c9fa4848108fbc81fe88d8

--- a/integration/consul_test.go
+++ b/integration/consul_test.go
@@ -9,6 +9,13 @@ import (
 	check "gopkg.in/check.v1"
 )
 
+// Consul test suites (using libcompose)
+type ConsulSuite struct{ BaseSuite }
+
+func (s *ConsulSuite) SetUpSuite(c *check.C) {
+	s.createComposeProject(c, "consul")
+}
+
 func (s *ConsulSuite) TestSimpleConfiguration(c *check.C) {
 	cmd := exec.Command(traefikBinary, "--configFile=fixtures/consul/simple.toml")
 	err := cmd.Start()

--- a/integration/etcd_test.go
+++ b/integration/etcd_test.go
@@ -9,6 +9,13 @@ import (
 	check "gopkg.in/check.v1"
 )
 
+// Etcd test suites (using libcompose)
+type EtcdSuite struct{ BaseSuite }
+
+func (s *EtcdSuite) SetUpSuite(c *check.C) {
+	s.createComposeProject(c, "etcd")
+}
+
 func (s *EtcdSuite) TestSimpleConfiguration(c *check.C) {
 	cmd := exec.Command(traefikBinary, "--configFile=fixtures/etcd/simple.toml")
 	err := cmd.Start()

--- a/integration/file_test.go
+++ b/integration/file_test.go
@@ -9,6 +9,15 @@ import (
 	check "gopkg.in/check.v1"
 )
 
+// File test suites
+type FileSuite struct{ BaseSuite }
+
+func (s *FileSuite) SetUpSuite(c *check.C) {
+	s.createComposeProject(c, "file")
+
+	s.composeProject.Start()
+}
+
 func (s *FileSuite) TestSimpleConfiguration(c *check.C) {
 	cmd := exec.Command(traefikBinary, "--configFile=fixtures/file/simple.toml")
 	err := cmd.Start()

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -35,36 +35,6 @@ func init() {
 
 var traefikBinary = "../dist/traefik"
 
-// File test suites
-type FileSuite struct{ BaseSuite }
-
-func (s *FileSuite) SetUpSuite(c *check.C) {
-	s.createComposeProject(c, "file")
-
-	s.composeProject.Up()
-}
-
-// Consul test suites (using libcompose)
-type ConsulSuite struct{ BaseSuite }
-
-func (s *ConsulSuite) SetUpSuite(c *check.C) {
-	s.createComposeProject(c, "consul")
-}
-
-// Etcd test suites (using libcompose)
-type EtcdSuite struct{ BaseSuite }
-
-func (s *EtcdSuite) SetUpSuite(c *check.C) {
-	s.createComposeProject(c, "etcd")
-}
-
-// Marathon test suites (using libcompose)
-type MarathonSuite struct{ BaseSuite }
-
-func (s *MarathonSuite) SetUpSuite(c *check.C) {
-	s.createComposeProject(c, "marathon")
-}
-
 type BaseSuite struct {
 	composeProject *project.Project
 	listenChan     chan project.Event

--- a/integration/marathon_test.go
+++ b/integration/marathon_test.go
@@ -9,6 +9,13 @@ import (
 	check "gopkg.in/check.v1"
 )
 
+// Marathon test suites (using libcompose)
+type MarathonSuite struct{ BaseSuite }
+
+func (s *MarathonSuite) SetUpSuite(c *check.C) {
+	s.createComposeProject(c, "marathon")
+}
+
 func (s *MarathonSuite) TestSimpleConfiguration(c *check.C) {
 	cmd := exec.Command(traefikBinary, "--configFile=fixtures/marathon/simple.toml")
 	err := cmd.Start()


### PR DESCRIPTION
This changes the integration tests to use [libkermit](https://github.com/vdemeester/libkermit). This is a start, `libkermit` will get more feature in over time and `traefik` will benefit from it first 😇.

- It simplifies writing integration tests.
- It uses `docker/engine` API, and this is the first step to migrate traefik to use `engine-api` as well — will come soon.

An open question (completely related to `libkermit`) is : should `compose.Project` embedded `docker.Project` and thus let it have all the `docker.Project` methods ? (this would mean, no need for the `project` attribute on `DockerSuite` and `ConsulCatalogSuite` for example).

🐸