### PR TITLE
Fix acme renew panic

### DIFF
--- a/acme/acme.go
+++ b/acme/acme.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	log "github.com/Sirupsen/logrus"
+	"github.com/containous/traefik/safe"
 	"github.com/xenolf/lego/acme"
 	"io/ioutil"
 	fmtlog "log"
@@ -242,7 +243,9 @@ func (a *ACME) CreateConfig(tlsConfig *tls.Config, CheckOnDemandDomain func(doma
 		return err
 	}
 
-	go a.retrieveCertificates(client, account)
+	safe.Go(func() {
+		a.retrieveCertificates(client, account)
+	})
 
 	tlsConfig.GetCertificate = func(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 		if challengeCert, ok := wrapperChallengeProvider.getCertificate(clientHello.ServerName); ok {
@@ -261,7 +264,7 @@ func (a *ACME) CreateConfig(tlsConfig *tls.Config, CheckOnDemandDomain func(doma
 	}
 
 	ticker := time.NewTicker(24 * time.Hour)
-	go func() {
+	safe.Go(func() {
 		for {
 			select {
 			case <-ticker.C:
@@ -272,7 +275,7 @@ func (a *ACME) CreateConfig(tlsConfig *tls.Config, CheckOnDemandDomain func(doma
 			}
 		}
 
-	}()
+	})
 	return nil
 }
 

--- a/provider/consul_catalog.go
+++ b/provider/consul_catalog.go
@@ -8,6 +8,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/cenkalti/backoff"
+	"github.com/containous/traefik/safe"
 	"github.com/containous/traefik/types"
 	"github.com/hashicorp/consul/api"
 )
@@ -35,7 +36,7 @@ func (provider *ConsulCatalog) watchServices(stopCh <-chan struct{}) <-chan map[
 
 	catalog := provider.client.Catalog()
 
-	go func() {
+	safe.Go(func() {
 		defer close(watchCh)
 
 		opts := &api.QueryOptions{WaitTime: DefaultWatchWaitTime}
@@ -64,7 +65,7 @@ func (provider *ConsulCatalog) watchServices(stopCh <-chan struct{}) <-chan map[
 				watchCh <- data
 			}
 		}
-	}()
+	})
 
 	return watchCh
 }
@@ -182,7 +183,7 @@ func (provider *ConsulCatalog) Provide(configurationChan chan<- types.ConfigMess
 	}
 	provider.client = client
 
-	go func() {
+	safe.Go(func() {
 		notify := func(err error, time time.Duration) {
 			log.Errorf("Consul connection error %+v, retrying in %s", err, time)
 		}
@@ -193,7 +194,7 @@ func (provider *ConsulCatalog) Provide(configurationChan chan<- types.ConfigMess
 		if err != nil {
 			log.Fatalf("Cannot connect to consul server %+v", err)
 		}
-	}()
+	})
 
 	return err
 }

--- a/provider/docker.go
+++ b/provider/docker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/BurntSushi/ty/fun"
 	log "github.com/Sirupsen/logrus"
 	"github.com/cenkalti/backoff"
+	"github.com/containous/traefik/safe"
 	"github.com/containous/traefik/types"
 	"github.com/fsouza/go-dockerclient"
 )
@@ -33,7 +34,7 @@ type DockerTLS struct {
 // Provide allows the provider to provide configurations to traefik
 // using the given configuration channel.
 func (provider *Docker) Provide(configurationChan chan<- types.ConfigMessage) error {
-	go func() {
+	safe.Go(func() {
 		operation := func() error {
 			var dockerClient *docker.Client
 			var err error
@@ -93,7 +94,7 @@ func (provider *Docker) Provide(configurationChan chan<- types.ConfigMessage) er
 		if err != nil {
 			log.Fatalf("Cannot connect to docker server %+v", err)
 		}
-	}()
+	})
 
 	return nil
 }

--- a/provider/file.go
+++ b/provider/file.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	log "github.com/Sirupsen/logrus"
+	"github.com/containous/traefik/safe"
 	"github.com/containous/traefik/types"
 	"gopkg.in/fsnotify.v1"
 )
@@ -34,7 +35,7 @@ func (provider *File) Provide(configurationChan chan<- types.ConfigMessage) erro
 
 	if provider.Watch {
 		// Process events
-		go func() {
+		safe.Go(func() {
 			defer watcher.Close()
 			for {
 				select {
@@ -53,7 +54,7 @@ func (provider *File) Provide(configurationChan chan<- types.ConfigMessage) erro
 					log.Error("Watcher event error", error)
 				}
 			}
-		}()
+		})
 		err = watcher.Add(filepath.Dir(file.Name()))
 		if err != nil {
 			log.Error("Error adding file watcher", err)

--- a/provider/kv.go
+++ b/provider/kv.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/BurntSushi/ty/fun"
 	log "github.com/Sirupsen/logrus"
+	"github.com/containous/traefik/safe"
 	"github.com/containous/traefik/types"
 	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
@@ -101,7 +102,9 @@ func (provider *Kv) provide(configurationChan chan<- types.ConfigMessage) error 
 	}
 	provider.kvclient = kv
 	if provider.Watch {
-		go provider.watchKv(configurationChan, provider.Prefix)
+		safe.Go(func() {
+			provider.watchKv(configurationChan, provider.Prefix)
+		})
 	}
 	configuration := provider.loadConfig()
 	configurationChan <- types.ConfigMessage{

--- a/provider/kv_test.go
+++ b/provider/kv_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containous/traefik/safe"
 	"github.com/docker/libkv/store"
 	"reflect"
 	"sort"
@@ -256,7 +257,9 @@ func TestKvWatchTree(t *testing.T) {
 	}
 
 	configChan := make(chan types.ConfigMessage)
-	go provider.watchKv(configChan, "prefix")
+	safe.Go(func() {
+		provider.watchKv(configChan, "prefix")
+	})
 
 	select {
 	case c1 := <-returnedChans:

--- a/provider/marathon.go
+++ b/provider/marathon.go
@@ -10,6 +10,7 @@ import (
 	"crypto/tls"
 	"github.com/BurntSushi/ty/fun"
 	log "github.com/Sirupsen/logrus"
+	"github.com/containous/traefik/safe"
 	"github.com/containous/traefik/types"
 	"github.com/gambol99/go-marathon"
 	"net/http"
@@ -63,7 +64,7 @@ func (provider *Marathon) Provide(configurationChan chan<- types.ConfigMessage) 
 		if err := client.AddEventsListener(update, marathon.EVENTS_APPLICATIONS); err != nil {
 			log.Errorf("Failed to register for events, %s", err)
 		} else {
-			go func() {
+			safe.Go(func() {
 				for {
 					event := <-update
 					log.Debug("Marathon event receveived", event)
@@ -75,7 +76,7 @@ func (provider *Marathon) Provide(configurationChan chan<- types.ConfigMessage) 
 						}
 					}
 				}
-			}()
+			})
 		}
 	}
 

--- a/safe/safe.go
+++ b/safe/safe.go
@@ -1,0 +1,28 @@
+package safe
+
+import (
+	"log"
+	"runtime/debug"
+)
+
+// Go starts a recoverable goroutine
+func Go(goroutine func()) {
+	GoWithRecover(goroutine, defaultRecoverGoroutine)
+}
+
+// GoWithRecover starts a recoverable goroutine using given customRecover() function
+func GoWithRecover(goroutine func(), customRecover func(err interface{})) {
+	go func() {
+		defer func() {
+			if err := recover(); err != nil {
+				customRecover(err)
+			}
+		}()
+		goroutine()
+	}()
+}
+
+func defaultRecoverGoroutine(err interface{}) {
+	log.Println(err)
+	debug.PrintStack()
+}

--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -32,7 +32,7 @@ docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
 docker tag containous/traefik emilevauge/traefik:latest
 docker push emilevauge/traefik:latest
 docker tag emilevauge/traefik:latest emilevauge/traefik:${VERSION}
-docker push -q emilevauge/traefik:${VERSION}
+docker push emilevauge/traefik:${VERSION}
 
 cd ..
 rm -Rf traefik-library-image/


### PR DESCRIPTION
This PR fixes an issue with Let's Encrypt certificate renew process.
It also adds a recovering mechanism for some goroutines:

```
func GoSafe(goroutine func()) {
	go func() {
		defer recoverGoroutine()
		goroutine()
	}()
}

func recoverGoroutine() {
	if err := recover(); err != nil {
		log.Println(err)
		debug.PrintStack()
	}
}
```

```
safe.GoSafe(func() {
	// my safe go routine
})
```

Fixes #269 

Signed-off-by: Emile Vauge <emile@vauge.com>