### PR TITLE
Update libkermit again for compose enhancements

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 7ae4c083b2f2754acc858a7e2cd453343966dc62eef01fbd51adf8c718959a0c
-updated: 2016-04-02T12:38:43.346296635+02:00
+hash: 2e15595ec349ec462fa2b0a52e26e3f3dcbd17fed66dad9a1e1c2e2c0385fe49
+updated: 2016-04-02T15:25:37.354420171+02:00
 imports:
 - name: github.com/alecthomas/template
   version: b867cc6ab45cece8143cfcc6fc9c77cf3f2c23c0
@@ -224,7 +224,7 @@ imports:
 - name: github.com/unrolled/render
   version: 26b4e3aac686940fe29521545afad9966ddfc80c
 - name: github.com/vdemeester/libkermit
-  version: 9012902ed333111cf804fd5a28114d8a64002951
+  version: 7e4e689a6fa9281e0fb9b7b9c297e22d5342a5ec
 - name: github.com/vdemeester/shakers
   version: 24d7f1d6a71aa5d9cbe7390e4afb66b7eef9e1b3
 - name: github.com/vulcand/oxy

--- a/glide.yaml
+++ b/glide.yaml
@@ -154,7 +154,7 @@ import:
   - package: github.com/stretchr/testify/mock
   - package: github.com/xenolf/lego
   - package: github.com/vdemeester/libkermit
-    ref: 9012902ed333111cf804fd5a28114d8a64002951
+    ref: 7e4e689a6fa9281e0fb9b7b9c297e22d5342a5ec
   - package: github.com/docker/libcompose
     version: e290a513ba909ca3afefd5cd611f3a3fe56f6a3a
   - package: github.com/docker/distribution

--- a/integration/consul_catalog_test.go
+++ b/integration/consul_catalog_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-check/check"
 	"github.com/hashicorp/consul/api"
 
-	docker "github.com/vdemeester/libkermit/docker/check"
 	checker "github.com/vdemeester/shakers"
 )
 
@@ -18,16 +17,14 @@ type ConsulCatalogSuite struct {
 	BaseSuite
 	consulIP     string
 	consulClient *api.Client
-	project      *docker.Project
 }
 
 func (s *ConsulCatalogSuite) SetUpSuite(c *check.C) {
-	s.project = docker.NewProjectFromEnv(c)
 
 	s.createComposeProject(c, "consul_catalog")
 	s.composeProject.Start(c)
 
-	consul := s.project.Inspect(c, "integration-test-consul_catalog_consul_1")
+	consul := s.composeProject.Container(c, "consul")
 
 	s.consulIP = consul.NetworkSettings.IPAddress
 	config := api.DefaultConfig()
@@ -94,7 +91,7 @@ func (s *ConsulCatalogSuite) TestSingleService(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	defer cmd.Process.Kill()
 
-	nginx := s.project.Inspect(c, "integration-test-consul_catalog_nginx_1")
+	nginx := s.composeProject.Container(c, "nginx")
 
 	err = s.registerService("test", nginx.NetworkSettings.IPAddress, 80)
 	c.Assert(err, checker.IsNil, check.Commentf("Error registering service"))


### PR DESCRIPTION
Using `.Container(…)`, it's way easier to get the container from a project's service 🐙.

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>