### PR TITLE
Migrate docker provider traefik to engine-api

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 2e15595ec349ec462fa2b0a52e26e3f3dcbd17fed66dad9a1e1c2e2c0385fe49
-updated: 2016-04-02T15:25:37.354420171+02:00
+hash: 79b6eb2a613b5e2ce5c57150eec41ac04def3f232a3613fd8b5a88b5e1041b38
+updated: 2016-04-02T15:42:37.505896092+02:00
 imports:
 - name: github.com/alecthomas/template
   version: b867cc6ab45cece8143cfcc6fc9c77cf3f2c23c0
@@ -89,10 +89,18 @@ imports:
   - types/container
   - types/filters
   - types/strslice
+  - client/transport
+  - client/transport/cancellable
+  - types/network
+  - types/registry
+  - types/time
+  - types/blkiodev
 - name: github.com/docker/go-connections
   version: f549a9393d05688dff0992ef3efd8bbe6c628aeb
   subpackages:
   - nat
+  - sockets
+  - tlsconfig
 - name: github.com/docker/go-units
   version: 5d2041e26a699eaca682e2ea41c8f891e1060444
 - name: github.com/docker/libcompose
@@ -113,26 +121,6 @@ imports:
   version: d5cac425555ca5cf00694df246e04f05e6a55150
 - name: github.com/flynn/go-shlex
   version: 3f9db97f856818214da2e1057f8ad84803971cff
-- name: github.com/fsouza/go-dockerclient
-  version: a49c8269a6899cae30da1f8a4b82e0ce945f9967
-  subpackages:
-  - external/github.com/docker/docker/opts
-  - external/github.com/docker/docker/pkg/archive
-  - external/github.com/docker/docker/pkg/fileutils
-  - external/github.com/docker/docker/pkg/homedir
-  - external/github.com/docker/docker/pkg/stdcopy
-  - external/github.com/hashicorp/go-cleanhttp
-  - external/github.com/Sirupsen/logrus
-  - external/github.com/docker/docker/pkg/idtools
-  - external/github.com/docker/docker/pkg/ioutils
-  - external/github.com/docker/docker/pkg/longpath
-  - external/github.com/docker/docker/pkg/pools
-  - external/github.com/docker/docker/pkg/promise
-  - external/github.com/docker/docker/pkg/system
-  - external/github.com/opencontainers/runc/libcontainer/user
-  - external/golang.org/x/sys/unix
-  - external/golang.org/x/net/context
-  - external/github.com/docker/go-units
 - name: github.com/gambol99/go-marathon
   version: ade11d1dc2884ee1f387078fc28509559b6235d1
 - name: github.com/go-check/check
@@ -182,6 +170,8 @@ imports:
   version: 565402cd71fbd9c12aa7e295324ea357e970a61e
 - name: github.com/mailgun/timetools
   version: fd192d755b00c968d312d23f521eb0cdc6f66bd0
+- name: github.com/Microsoft/go-winio
+  version: 9e2895e5f6c3f16473b91d37fae6e89990a4520c
 - name: github.com/miekg/dns
   version: 7e024ce8ce18b21b475ac6baf8fa3c42536bf2fa
 - name: github.com/mitchellh/mapstructure
@@ -223,6 +213,8 @@ imports:
   version: 54ed61c2b47e263ae2f01b86837b0c4bd1da28e8
 - name: github.com/unrolled/render
   version: 26b4e3aac686940fe29521545afad9966ddfc80c
+- name: github.com/vdemeester/docker-events
+  version: bd72e1848b08db4b5ed1a2e9277621b9f5e5d1f3
 - name: github.com/vdemeester/libkermit
   version: 7e4e689a6fa9281e0fb9b7b9c297e22d5342a5ec
 - name: github.com/vdemeester/shakers
@@ -257,6 +249,7 @@ imports:
   subpackages:
   - context
   - publicsuffix
+  - proxy
 - name: golang.org/x/sys
   version: eb2c74142fd19a79b3f237334c7384d5167b1b46
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -52,8 +52,6 @@ import:
     ref:     26b4e3aac686940fe29521545afad9966ddfc80c
   - package: github.com/flynn/go-shlex
     ref:     3f9db97f856818214da2e1057f8ad84803971cff
-  - package: github.com/fsouza/go-dockerclient
-    ref:     a49c8269a6899cae30da1f8a4b82e0ce945f9967
   - package: github.com/boltdb/bolt
     ref:     51f99c862475898df9773747d3accd05a7ca33c1
   - package: gopkg.in/mgo.v2
@@ -168,8 +166,11 @@ import:
     - types/container
     - types/filters
     - types/strslice
+  - package: github.com/vdemeester/docker-events
   - package: github.com/docker/go-connections
     subpackages:
     - nat
+    - sockets
+    - tlsconfig
   - package: github.com/docker/go-units
   - package: github.com/mailgun/multibuf

--- a/provider/docker_test.go
+++ b/provider/docker_test.go
@@ -6,7 +6,10 @@ import (
 	"testing"
 
 	"github.com/containous/traefik/types"
-	"github.com/fsouza/go-dockerclient"
+	docker "github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/container"
+	"github.com/docker/engine-api/types/network"
+	"github.com/docker/go-connections/nat"
 )
 
 func TestDockerGetFrontendName(t *testing.T) {
@@ -15,20 +18,24 @@ func TestDockerGetFrontendName(t *testing.T) {
 	}
 
 	containers := []struct {
-		container docker.Container
+		container docker.ContainerJSON
 		expected  string
 	}{
 		{
-			container: docker.Container{
-				Name:   "foo",
-				Config: &docker.Config{},
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "foo",
+				},
+				Config: &container.Config{},
 			},
 			expected: "Host-foo-docker-localhost",
 		},
 		{
-			container: docker.Container{
-				Name: "bar",
-				Config: &docker.Config{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "bar",
+				},
+				Config: &container.Config{
 					Labels: map[string]string{
 						"traefik.frontend.rule": "Headers:User-Agent,bat/0.1.0",
 					},
@@ -37,9 +44,11 @@ func TestDockerGetFrontendName(t *testing.T) {
 			expected: "Headers-User-Agent-bat-0-1-0",
 		},
 		{
-			container: docker.Container{
-				Name: "test",
-				Config: &docker.Config{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "test",
+				},
+				Config: &container.Config{
 					Labels: map[string]string{
 						"traefik.frontend.rule": "Host:foo.bar",
 					},
@@ -48,9 +57,11 @@ func TestDockerGetFrontendName(t *testing.T) {
 			expected: "Host-foo-bar",
 		},
 		{
-			container: docker.Container{
-				Name: "test",
-				Config: &docker.Config{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "test",
+				},
+				Config: &container.Config{
 					Labels: map[string]string{
 						"traefik.frontend.rule": "Path:/test",
 					},
@@ -59,9 +70,11 @@ func TestDockerGetFrontendName(t *testing.T) {
 			expected: "Path-test",
 		},
 		{
-			container: docker.Container{
-				Name: "test",
-				Config: &docker.Config{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "test",
+				},
+				Config: &container.Config{
 					Labels: map[string]string{
 						"traefik.frontend.rule": "PathPrefix:/test2",
 					},
@@ -85,27 +98,33 @@ func TestDockerGetFrontendRule(t *testing.T) {
 	}
 
 	containers := []struct {
-		container docker.Container
+		container docker.ContainerJSON
 		expected  string
 	}{
 		{
-			container: docker.Container{
-				Name:   "foo",
-				Config: &docker.Config{},
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "foo",
+				},
+				Config: &container.Config{},
 			},
 			expected: "Host:foo.docker.localhost",
 		},
 		{
-			container: docker.Container{
-				Name:   "bar",
-				Config: &docker.Config{},
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "bar",
+				},
+				Config: &container.Config{},
 			},
 			expected: "Host:bar.docker.localhost",
 		},
 		{
-			container: docker.Container{
-				Name: "test",
-				Config: &docker.Config{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "test",
+				},
+				Config: &container.Config{
 					Labels: map[string]string{
 						"traefik.frontend.rule": "Host:foo.bar",
 					},
@@ -114,9 +133,11 @@ func TestDockerGetFrontendRule(t *testing.T) {
 			expected: "Host:foo.bar",
 		},
 		{
-			container: docker.Container{
-				Name: "test",
-				Config: &docker.Config{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "test",
+				},
+				Config: &container.Config{
 					Labels: map[string]string{
 						"traefik.frontend.rule": "Path:/test",
 					},
@@ -138,27 +159,33 @@ func TestDockerGetBackend(t *testing.T) {
 	provider := &Docker{}
 
 	containers := []struct {
-		container docker.Container
+		container docker.ContainerJSON
 		expected  string
 	}{
 		{
-			container: docker.Container{
-				Name:   "foo",
-				Config: &docker.Config{},
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "foo",
+				},
+				Config: &container.Config{},
 			},
 			expected: "foo",
 		},
 		{
-			container: docker.Container{
-				Name:   "bar",
-				Config: &docker.Config{},
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "bar",
+				},
+				Config: &container.Config{},
 			},
 			expected: "bar",
 		},
 		{
-			container: docker.Container{
-				Name: "test",
-				Config: &docker.Config{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "test",
+				},
+				Config: &container.Config{
 					Labels: map[string]string{
 						"traefik.backend": "foobar",
 					},
@@ -180,24 +207,30 @@ func TestDockerGetPort(t *testing.T) {
 	provider := &Docker{}
 
 	containers := []struct {
-		container docker.Container
+		container docker.ContainerJSON
 		expected  string
 	}{
 		{
-			container: docker.Container{
-				Name:            "foo",
-				Config:          &docker.Config{},
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "foo",
+				},
+				Config:          &container.Config{},
 				NetworkSettings: &docker.NetworkSettings{},
 			},
 			expected: "",
 		},
 		{
-			container: docker.Container{
-				Name:   "bar",
-				Config: &docker.Config{},
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "bar",
+				},
+				Config: &container.Config{},
 				NetworkSettings: &docker.NetworkSettings{
-					Ports: map[docker.Port][]docker.PortBinding{
-						"80/tcp": {},
+					NetworkSettingsBase: docker.NetworkSettingsBase{
+						Ports: nat.PortMap{
+							"80/tcp": {},
+						},
 					},
 				},
 			},
@@ -205,9 +238,9 @@ func TestDockerGetPort(t *testing.T) {
 		},
 		// FIXME handle this better..
 		// {
-		// 	container: docker.Container{
+		// 	container: docker.ContainerJSON{
 		// 		Name:   "bar",
-		// 		Config: &docker.Config{},
+		// 		Config: &container.Config{},
 		// 		NetworkSettings: &docker.NetworkSettings{
 		// 			Ports: map[docker.Port][]docker.PortBinding{
 		// 				"80/tcp":  []docker.PortBinding{},
@@ -218,16 +251,20 @@ func TestDockerGetPort(t *testing.T) {
 		// 	expected: "80",
 		// },
 		{
-			container: docker.Container{
-				Name: "test",
-				Config: &docker.Config{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "test",
+				},
+				Config: &container.Config{
 					Labels: map[string]string{
 						"traefik.port": "8080",
 					},
 				},
 				NetworkSettings: &docker.NetworkSettings{
-					Ports: map[docker.Port][]docker.PortBinding{
-						"80/tcp": {},
+					NetworkSettingsBase: docker.NetworkSettingsBase{
+						Ports: nat.PortMap{
+							"80/tcp": {},
+						},
 					},
 				},
 			},
@@ -247,20 +284,24 @@ func TestDockerGetWeight(t *testing.T) {
 	provider := &Docker{}
 
 	containers := []struct {
-		container docker.Container
+		container docker.ContainerJSON
 		expected  string
 	}{
 		{
-			container: docker.Container{
-				Name:   "foo",
-				Config: &docker.Config{},
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "foo",
+				},
+				Config: &container.Config{},
 			},
 			expected: "1",
 		},
 		{
-			container: docker.Container{
-				Name: "test",
-				Config: &docker.Config{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "test",
+				},
+				Config: &container.Config{
 					Labels: map[string]string{
 						"traefik.weight": "10",
 					},
@@ -284,20 +325,24 @@ func TestDockerGetDomain(t *testing.T) {
 	}
 
 	containers := []struct {
-		container docker.Container
+		container docker.ContainerJSON
 		expected  string
 	}{
 		{
-			container: docker.Container{
-				Name:   "foo",
-				Config: &docker.Config{},
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "foo",
+				},
+				Config: &container.Config{},
 			},
 			expected: "docker.localhost",
 		},
 		{
-			container: docker.Container{
-				Name: "test",
-				Config: &docker.Config{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "test",
+				},
+				Config: &container.Config{
 					Labels: map[string]string{
 						"traefik.domain": "foo.bar",
 					},
@@ -319,20 +364,24 @@ func TestDockerGetProtocol(t *testing.T) {
 	provider := &Docker{}
 
 	containers := []struct {
-		container docker.Container
+		container docker.ContainerJSON
 		expected  string
 	}{
 		{
-			container: docker.Container{
-				Name:   "foo",
-				Config: &docker.Config{},
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "foo",
+				},
+				Config: &container.Config{},
 			},
 			expected: "http",
 		},
 		{
-			container: docker.Container{
-				Name: "test",
-				Config: &docker.Config{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "test",
+				},
+				Config: &container.Config{
 					Labels: map[string]string{
 						"traefik.protocol": "https",
 					},
@@ -354,20 +403,24 @@ func TestDockerGetPassHostHeader(t *testing.T) {
 	provider := &Docker{}
 
 	containers := []struct {
-		container docker.Container
+		container docker.ContainerJSON
 		expected  string
 	}{
 		{
-			container: docker.Container{
-				Name:   "foo",
-				Config: &docker.Config{},
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "foo",
+				},
+				Config: &container.Config{},
 			},
 			expected: "false",
 		},
 		{
-			container: docker.Container{
-				Name: "test",
-				Config: &docker.Config{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "test",
+				},
+				Config: &container.Config{
 					Labels: map[string]string{
 						"traefik.frontend.passHostHeader": "true",
 					},
@@ -387,18 +440,18 @@ func TestDockerGetPassHostHeader(t *testing.T) {
 
 func TestDockerGetLabel(t *testing.T) {
 	containers := []struct {
-		container docker.Container
+		container docker.ContainerJSON
 		expected  string
 	}{
 		{
-			container: docker.Container{
-				Config: &docker.Config{},
+			container: docker.ContainerJSON{
+				Config: &container.Config{},
 			},
 			expected: "Label not found:",
 		},
 		{
-			container: docker.Container{
-				Config: &docker.Config{
+			container: docker.ContainerJSON{
+				Config: &container.Config{
 					Labels: map[string]string{
 						"foo": "bar",
 					},
@@ -424,20 +477,20 @@ func TestDockerGetLabel(t *testing.T) {
 
 func TestDockerGetLabels(t *testing.T) {
 	containers := []struct {
-		container      docker.Container
+		container      docker.ContainerJSON
 		expectedLabels map[string]string
 		expectedError  string
 	}{
 		{
-			container: docker.Container{
-				Config: &docker.Config{},
+			container: docker.ContainerJSON{
+				Config: &container.Config{},
 			},
 			expectedLabels: map[string]string{},
 			expectedError:  "Label not found:",
 		},
 		{
-			container: docker.Container{
-				Config: &docker.Config{
+			container: docker.ContainerJSON{
+				Config: &container.Config{
 					Labels: map[string]string{
 						"foo": "fooz",
 					},
@@ -449,8 +502,8 @@ func TestDockerGetLabels(t *testing.T) {
 			expectedError: "Label not found: bar",
 		},
 		{
-			container: docker.Container{
-				Config: &docker.Config{
+			container: docker.ContainerJSON{
+				Config: &container.Config{
 					Labels: map[string]string{
 						"foo": "fooz",
 						"bar": "barz",
@@ -480,125 +533,168 @@ func TestDockerGetLabels(t *testing.T) {
 
 func TestDockerTraefikFilter(t *testing.T) {
 	containers := []struct {
-		container docker.Container
+		container docker.ContainerJSON
 		expected  bool
 	}{
 		{
-			container: docker.Container{
-				Config:          &docker.Config{},
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "container",
+				},
+				Config:          &container.Config{},
 				NetworkSettings: &docker.NetworkSettings{},
 			},
 			expected: false,
 		},
 		{
-			container: docker.Container{
-				Config: &docker.Config{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "container",
+				},
+				Config: &container.Config{
 					Labels: map[string]string{
 						"traefik.enable": "false",
 					},
 				},
 				NetworkSettings: &docker.NetworkSettings{
-					Ports: map[docker.Port][]docker.PortBinding{
-						"80/tcp": {},
+					NetworkSettingsBase: docker.NetworkSettingsBase{
+						Ports: nat.PortMap{
+							"80/tcp": {},
+						},
 					},
 				},
 			},
 			expected: false,
 		},
 		{
-			container: docker.Container{
-				Config: &docker.Config{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "container",
+				},
+				Config: &container.Config{
 					Labels: map[string]string{
 						"traefik.frontend.rule": "Host:foo.bar",
 					},
 				},
 				NetworkSettings: &docker.NetworkSettings{
-					Ports: map[docker.Port][]docker.PortBinding{
-						"80/tcp": {},
+					NetworkSettingsBase: docker.NetworkSettingsBase{
+						Ports: nat.PortMap{
+							"80/tcp": {},
+						},
 					},
 				},
 			},
 			expected: true,
 		},
 		{
-			container: docker.Container{
-				Config: &docker.Config{},
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "container",
+				},
+				Config: &container.Config{},
 				NetworkSettings: &docker.NetworkSettings{
-					Ports: map[docker.Port][]docker.PortBinding{
-						"80/tcp":  {},
-						"443/tcp": {},
+					NetworkSettingsBase: docker.NetworkSettingsBase{
+						Ports: nat.PortMap{
+							"80/tcp":  {},
+							"443/tcp": {},
+						},
 					},
 				},
 			},
 			expected: false,
 		},
 		{
-			container: docker.Container{
-				Config: &docker.Config{},
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "container",
+				},
+				Config: &container.Config{},
 				NetworkSettings: &docker.NetworkSettings{
-					Ports: map[docker.Port][]docker.PortBinding{
-						"80/tcp": {},
+					NetworkSettingsBase: docker.NetworkSettingsBase{
+						Ports: nat.PortMap{
+							"80/tcp": {},
+						},
 					},
 				},
 			},
 			expected: true,
 		},
 		{
-			container: docker.Container{
-				Config: &docker.Config{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "container",
+				},
+				Config: &container.Config{
 					Labels: map[string]string{
 						"traefik.port": "80",
 					},
 				},
 				NetworkSettings: &docker.NetworkSettings{
-					Ports: map[docker.Port][]docker.PortBinding{
-						"80/tcp":  {},
-						"443/tcp": {},
+					NetworkSettingsBase: docker.NetworkSettingsBase{
+						Ports: nat.PortMap{
+							"80/tcp":  {},
+							"443/tcp": {},
+						},
 					},
 				},
 			},
 			expected: true,
 		},
 		{
-			container: docker.Container{
-				Config: &docker.Config{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "container",
+				},
+				Config: &container.Config{
 					Labels: map[string]string{
 						"traefik.enable": "true",
 					},
 				},
 				NetworkSettings: &docker.NetworkSettings{
-					Ports: map[docker.Port][]docker.PortBinding{
-						"80/tcp": {},
+					NetworkSettingsBase: docker.NetworkSettingsBase{
+						Ports: nat.PortMap{
+							"80/tcp": {},
+						},
 					},
 				},
 			},
 			expected: true,
 		},
 		{
-			container: docker.Container{
-				Config: &docker.Config{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "container",
+				},
+				Config: &container.Config{
 					Labels: map[string]string{
 						"traefik.enable": "anything",
 					},
 				},
 				NetworkSettings: &docker.NetworkSettings{
-					Ports: map[docker.Port][]docker.PortBinding{
-						"80/tcp": {},
+					NetworkSettingsBase: docker.NetworkSettingsBase{
+						Ports: nat.PortMap{
+							"80/tcp": {},
+						},
 					},
 				},
 			},
 			expected: true,
 		},
 		{
-			container: docker.Container{
-				Config: &docker.Config{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "container",
+				},
+				Config: &container.Config{
 					Labels: map[string]string{
 						"traefik.frontend.rule": "Host:foo.bar",
 					},
 				},
 				NetworkSettings: &docker.NetworkSettings{
-					Ports: map[docker.Port][]docker.PortBinding{
-						"80/tcp": {},
+					NetworkSettingsBase: docker.NetworkSettingsBase{
+						Ports: nat.PortMap{
+							"80/tcp": {},
+						},
 					},
 				},
 			},
@@ -616,26 +712,30 @@ func TestDockerTraefikFilter(t *testing.T) {
 
 func TestDockerLoadDockerConfig(t *testing.T) {
 	cases := []struct {
-		containers        []docker.Container
+		containers        []docker.ContainerJSON
 		expectedFrontends map[string]*types.Frontend
 		expectedBackends  map[string]*types.Backend
 	}{
 		{
-			containers:        []docker.Container{},
+			containers:        []docker.ContainerJSON{},
 			expectedFrontends: map[string]*types.Frontend{},
 			expectedBackends:  map[string]*types.Backend{},
 		},
 		{
-			containers: []docker.Container{
+			containers: []docker.ContainerJSON{
 				{
-					Name:   "test",
-					Config: &docker.Config{},
+					ContainerJSONBase: &docker.ContainerJSONBase{
+						Name: "test",
+					},
+					Config: &container.Config{},
 					NetworkSettings: &docker.NetworkSettings{
-						Ports: map[docker.Port][]docker.PortBinding{
-							"80/tcp": {},
+						NetworkSettingsBase: docker.NetworkSettingsBase{
+							Ports: nat.PortMap{
+								"80/tcp": {},
+							},
 						},
-						Networks: map[string]docker.ContainerNetwork{
-							"bridgde": {
+						Networks: map[string]*network.EndpointSettings{
+							"bridge": {
 								IPAddress: "127.0.0.1",
 							},
 						},
@@ -667,38 +767,46 @@ func TestDockerLoadDockerConfig(t *testing.T) {
 			},
 		},
 		{
-			containers: []docker.Container{
+			containers: []docker.ContainerJSON{
 				{
-					Name: "test1",
-					Config: &docker.Config{
+					ContainerJSONBase: &docker.ContainerJSONBase{
+						Name: "test1",
+					},
+					Config: &container.Config{
 						Labels: map[string]string{
 							"traefik.backend":              "foobar",
 							"traefik.frontend.entryPoints": "http,https",
 						},
 					},
 					NetworkSettings: &docker.NetworkSettings{
-						Ports: map[docker.Port][]docker.PortBinding{
-							"80/tcp": {},
+						NetworkSettingsBase: docker.NetworkSettingsBase{
+							Ports: nat.PortMap{
+								"80/tcp": {},
+							},
 						},
-						Networks: map[string]docker.ContainerNetwork{
-							"bridgde": {
+						Networks: map[string]*network.EndpointSettings{
+							"bridge": {
 								IPAddress: "127.0.0.1",
 							},
 						},
 					},
 				},
 				{
-					Name: "test2",
-					Config: &docker.Config{
+					ContainerJSONBase: &docker.ContainerJSONBase{
+						Name: "test2",
+					},
+					Config: &container.Config{
 						Labels: map[string]string{
 							"traefik.backend": "foobar",
 						},
 					},
 					NetworkSettings: &docker.NetworkSettings{
-						Ports: map[docker.Port][]docker.PortBinding{
-							"80/tcp": {},
+						NetworkSettingsBase: docker.NetworkSettingsBase{
+							Ports: nat.PortMap{
+								"80/tcp": {},
+							},
 						},
-						Networks: map[string]docker.ContainerNetwork{
+						Networks: map[string]*network.EndpointSettings{
 							"bridge": {
 								IPAddress: "127.0.0.1",
 							},


### PR DESCRIPTION
The docker provider now uses `docker/engine-api` and `vdemeester/docker-events` instead of fsouza-dockerclient 🐳. 

Compared to *before*, this filters the events by container (the daemon will only send `container` events), thus should receive a little less events.

- [x] Do some more tests and benchmarks on this 🐙 (with `-race`).

Fixes #284

/cc @emilevauge for how to run the benchmarks :angel: 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>