### PR TITLE
Add **/*.test to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ dist/
 vendor/
 !dist/traefik
 site/
+**/*.test


### PR DESCRIPTION
`*.test` files are generated by `go test`, do not include them into the build context. It will lighter a bit the build context. 🐭.

🐸
Signed-off-by: Vincent Demeester <vincent@sbr.pm>