### PR TITLE
Fix openssl travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,6 @@ sudo: required
 services:
 - docker
 
-before_install:
-- openssl aes-256-cbc -K $encrypted_27087ae1f4db_key -iv $encrypted_27087ae1f4db_iv -in .travis/traefik.id_rsa.enc -out ~/.ssh/traefik.id_rsa -d
-- eval "$(ssh-agent -s)"
-- chmod 600 ~/.ssh/traefik.id_rsa
-- ssh-add ~/.ssh/traefik.id_rsa
-
 install:
 - sudo service docker stop
 - sudo curl https://get.docker.com/builds/Linux/x86_64/docker-1.10.1 -o /usr/bin/docker

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Run it and forget it!
 
 ## Features
 
-- [It's fast](docs/index.md#benchmarks)
+- [It's fast](http://docs.traefik.io/benchmarks)
 - No dependency hell, single binary made with go
 - Rest API
 - Multiple backends supported: Docker, Mesos/Marathon, Consul, Etcd, and more to come

--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -2,24 +2,36 @@
 set -e
 
 if ([ "$TRAVIS_BRANCH" = "master" ] || [ ! -z "$TRAVIS_TAG" ]) && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-  echo "Deploying"
+  echo "Deploying..."
 else
   echo "Skipping deploy"
   exit 0
 fi
 
+# load ssl key
+echo "Loading key..."
+openssl aes-256-cbc -K $encrypted_27087ae1f4db_key -iv $encrypted_27087ae1f4db_iv -in .travis/traefik.id_rsa.enc -out ~/.ssh/traefik.id_rsa -d
+eval "$(ssh-agent -s)"
+chmod 600 ~/.ssh/traefik.id_rsa
+ssh-add ~/.ssh/traefik.id_rsa
+
+# download github release
+echo "Downloading ghr..."
 curl -LO https://github.com/tcnksm/ghr/releases/download/pre-release/linux_amd64.zip
 unzip -q linux_amd64.zip
 sudo mv ghr /usr/bin/ghr
 sudo chmod +x /usr/bin/ghr
 
 # github release and tag
+echo "Github release..."
 ghr -t $GITHUB_TOKEN -u containous -r traefik --prerelease ${VERSION} dist/
 
 # update docs.traefik.io
+echo "Generating and updating documentation..."
 mkdocs gh-deploy --clean
 
 # update traefik-library-image repo (official Docker image)
+echo "Updating traefik-library-imag repo..."
 git config --global user.email "emile@vauge.com"
 git config --global user.name "Emile Vauge"
 git clone git@github.com:containous/traefik-library-image.git
@@ -31,6 +43,7 @@ echo $VERSION | git tag -a $VERSION --file -
 git push -q --follow-tags -u origin master
 
 # create docker image emilevauge/traefik (compatibility)
+echo "Updating docker emilevauge/traefik image..."
 docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
 docker tag containous/traefik emilevauge/traefik:latest
 docker push emilevauge/traefik:latest

--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -8,7 +8,7 @@ else
   exit 0
 fi
 
-# load ssl key
+# load ssh key
 echo "Loading key..."
 openssl aes-256-cbc -K $encrypted_27087ae1f4db_key -iv $encrypted_27087ae1f4db_iv -in .travis/traefik.id_rsa.enc -out ~/.ssh/traefik.id_rsa -d
 eval "$(ssh-agent -s)"
@@ -17,7 +17,7 @@ ssh-add ~/.ssh/traefik.id_rsa
 
 # download github release
 echo "Downloading ghr..."
-curl -LO https://github.com/tcnksm/ghr/releases/download/pre-release/linux_amd64.zip
+curl -LOs https://github.com/tcnksm/ghr/releases/download/pre-release/linux_amd64.zip
 unzip -q linux_amd64.zip
 sudo mv ghr /usr/bin/ghr
 sudo chmod +x /usr/bin/ghr


### PR DESCRIPTION
This PR fixes the bug in CI: https://travis-ci.org/containous/traefik/builds/120948445
```
openssl aes-256-cbc -K $encrypted_27087ae1f4db_key -iv $encrypted_27087ae1f4db_iv -in .travis/traefik.id_rsa.enc -out ~/.ssh/traefik.id_rsa -d
iv undefined
```