### PR TITLE
feat(consul-catalog-provider): + setting unique backend name + backendd redirecting to internal container ip

### DIFF
--- a/provider/consul_catalog_test.go
+++ b/provider/consul_catalog_test.go
@@ -63,6 +63,7 @@ func TestConsulCatalogBuildConfig(t *testing.T) {
 						{
 							Service: &api.AgentService{
 								Service: "test",
+								Address: "127.0.0.1",
 								Port:    80,
 							},
 							Node: &api.Node{
@@ -86,7 +87,7 @@ func TestConsulCatalogBuildConfig(t *testing.T) {
 			expectedBackends: map[string]*types.Backend{
 				"backend-test": {
 					Servers: map[string]types.Server{
-						"server-localhost-80": {
+						"test--127-0-0-1--80": {
 							URL: "http://127.0.0.1:80",
 						},
 					},

--- a/templates/consul_catalog.tmpl
+++ b/templates/consul_catalog.tmpl
@@ -1,6 +1,6 @@
 [backends]{{range .Nodes}}
-    [backends.backend-{{getBackend .}}.servers.server-{{.Node.Node | replace "." "-"}}-{{.Service.Port}}]
-    url = "http://{{.Node.Address}}:{{.Service.Port}}"
+    [backends.backend-{{getBackend .}}.servers.{{.Service.Service | replace "." "-"}}--{{.Service.Address | replace "." "-"}}--{{.Service.Port}}]
+    url = "http://{{.Service.Address}}:{{.Service.Port}}"
 {{end}}
 
 [frontends]{{range .Services}}


### PR DESCRIPTION
see https://github.com/containous/traefik/issues/275

**Caution**: Breaking (see issue)