### PR TITLE
Fix period in frontend name in KV store

### DIFF
--- a/templates/kv.tmpl
+++ b/templates/kv.tmpl
@@ -27,7 +27,7 @@
 [frontends]{{range $frontends}}
     {{$frontend := Last .}}
     {{$entryPoints := SplitGet . "/entrypoints"}}
-    [frontends.{{$frontend}}]
+    [frontends."{{$frontend}}"]
     backend = "{{Get "" . "/backend"}}"
     passHostHeader = {{Get "false" . "/passHostHeader"}}
     entryPoints = [{{range $entryPoints}}
@@ -35,7 +35,7 @@
     {{end}}]
     {{$routes := List . "/routes/"}}
         {{range $routes}}
-        [frontends.{{$frontend}}.routes.{{Last .}}]
+        [frontends."{{$frontend}}".routes."{{Last .}}"]
         rule = "{{Get "" . "/rule"}}"
         {{end}}
 {{end}}


### PR DESCRIPTION
This PR fixes KV store template when frontend name contain periods.
Fixes #295 