### PR TITLE
Update glide files to use most recent version of containous/oxy

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -22,7 +22,7 @@ imports:
 - name: github.com/codegangsta/negroni
   version: c7477ad8e330bef55bf1ebe300cf8aa67c492d1b
 - name: github.com/containous/oxy
-  version: 0b5b371bce661385d35439204298fa6fb5db5463
+  version: 021f82bd8260ba15f5862a9fe62018437720dff5
   subpackages:
   - cbreaker
   - forward

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,7 +7,7 @@ import:
   - package: github.com/mailgun/log
     ref:     44874009257d4d47ba9806f1b7f72a32a015e4d8
   - package: github.com/containous/oxy
-    ref:     0b5b371bce661385d35439204298fa6fb5db5463
+    ref:     021f82bd8260ba15f5862a9fe62018437720dff5
     subpackages:
       - cbreaker
       - forward


### PR DESCRIPTION
Update glide files to use most recent version of containous/oxy

Related to https://github.com/containous/oxy/pull/1