### PR TITLE
feat(consul-provider): If service ip is nil then use node ip

### DIFF
--- a/provider/consul_catalog.go
+++ b/provider/consul_catalog.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -123,6 +124,26 @@ func (provider *ConsulCatalog) getFrontendRule(service serviceUpdate) string {
 	return "Host:" + service.ServiceName + "." + provider.Domain
 }
 
+func (provider *ConsulCatalog) getBackendAddress(node *api.ServiceEntry) string {
+	if node.Service.Address != "" {
+		return node.Service.Address
+	}
+	return node.Node.Address
+}
+
+func (provider *ConsulCatalog) getBackendName(node *api.ServiceEntry, index int) string {
+	serviceName := node.Service.Service + "--" + node.Service.Address + "--" + strconv.Itoa(node.Service.Port)
+	if len(node.Service.Tags) > 0 {
+		serviceName += "--" + strings.Join(node.Service.Tags, "--")
+	}
+	serviceName = strings.Replace(serviceName, ".", "-", -1)
+	serviceName = strings.Replace(serviceName, "=", "-", -1)
+
+	// unique int at the end
+	serviceName += "--" + strconv.Itoa(index)
+	return serviceName
+}
+
 func (provider *ConsulCatalog) getAttribute(name string, tags []string, defaultValue string) string {
 	for _, tag := range tags {
 		if strings.Index(strings.ToLower(tag), DefaultConsulCatalogTagPrefix+".") == 0 {
@@ -136,11 +157,12 @@ func (provider *ConsulCatalog) getAttribute(name string, tags []string, defaultV
 
 func (provider *ConsulCatalog) buildConfig(catalog []catalogUpdate) *types.Configuration {
 	var FuncMap = template.FuncMap{
-		"getBackend":      provider.getBackend,
-		"getFrontendRule": provider.getFrontendRule,
-		"getAttribute":    provider.getAttribute,
-		"getEntryPoints":  provider.getEntryPoints,
-		"replace":         replace,
+		"getBackend":        provider.getBackend,
+		"getFrontendRule":   provider.getFrontendRule,
+		"getBackendName":    provider.getBackendName,
+		"getBackendAddress": provider.getBackendAddress,
+		"getAttribute":      provider.getAttribute,
+		"getEntryPoints":    provider.getEntryPoints,
 	}
 
 	allNodes := []*api.ServiceEntry{}

--- a/templates/consul_catalog.tmpl
+++ b/templates/consul_catalog.tmpl
@@ -1,9 +1,9 @@
 [backends]
-{{range .Nodes}}
-  {{if ne (getAttribute "enable" .Service.Tags "true") "false"}}
-    [backends.backend-{{getBackend .}}.servers.{{.Service.Service | replace "." "-"}}--{{.Service.Address | replace "." "-"}}--{{.Service.Port}}]
-      url = "{{getAttribute "protocol" .Service.Tags "http"}}://{{.Service.Address}}:{{.Service.Port}}"
-      {{$weight := getAttribute "backend.weight" .Service.Tags ""}}
+{{range $index, $node := .Nodes}}
+  {{if ne (getAttribute "enable" $node.Service.Tags "true") "false"}}
+    [backends.backend-{{getBackend $node}}.servers.{{getBackendName $node $index}}]
+      url = "{{getAttribute "protocol" $node.Service.Tags "http"}}://{{getBackendAddress $node}}:{{$node.Service.Port}}"
+      {{$weight := getAttribute "backend.weight" $node.Service.Tags ""}}
       {{with $weight}}
         weight = {{$weight}}
       {{end}}
@@ -25,7 +25,8 @@
   {{end}}
 {{end}}
 
-[frontends]{{range .Services}}
+[frontends]
+{{range .Services}}
   [frontends.frontend-{{.ServiceName}}]
   backend = "backend-{{.ServiceName}}"
   passHostHeader = {{getAttribute "frontend.passHostHeader" .Attributes "false"}}


### PR DESCRIPTION
#294 

Summary: In consul, Service.Address is optional. If equal to nil, then use the Node.Address