### PR TITLE
Replace whitespace in tags in consul_catalog

### DIFF
--- a/provider/consul_catalog.go
+++ b/provider/consul_catalog.go
@@ -133,9 +133,11 @@ func (provider *ConsulCatalog) getBackendAddress(node *api.ServiceEntry) string 
 
 func (provider *ConsulCatalog) getBackendName(node *api.ServiceEntry, index int) string {
 	serviceName := node.Service.Service + "--" + node.Service.Address + "--" + strconv.Itoa(node.Service.Port)
-	if len(node.Service.Tags) > 0 {
-		serviceName += "--" + strings.Join(node.Service.Tags, "--")
+
+	for _, tag := range node.Service.Tags {
+		serviceName += "--" + normalize(tag)
 	}
+
 	serviceName = strings.Replace(serviceName, ".", "-", -1)
 	serviceName = strings.Replace(serviceName, "=", "-", -1)
 

--- a/provider/consul_catalog_test.go
+++ b/provider/consul_catalog_test.go
@@ -154,6 +154,17 @@ func TestConsulCatalogGetBackendName(t *testing.T) {
 			},
 			expected: "api--10-0-0-1--80--traefik-weight-42--traefik-enable-true--1",
 		},
+		{
+			node: &api.ServiceEntry{
+				Service: &api.AgentService{
+					Service: "api",
+					Address: "10.0.0.1",
+					Port:    80,
+					Tags:    []string{"a funny looking tag"},
+				},
+			},
+			expected: "api--10-0-0-1--80--a-funny-looking-tag--2",
+		},
 	}
 
 	for i, e := range services {


### PR DESCRIPTION
Another fun thing consul lets you do is use spaces in your tags. This
means when including tags in backend name it's possible to generate
invalid names.