### PR TITLE
Go back to standard golang image

### DIFF
--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -1,8 +1,6 @@
-FROM golang:1.6.1-alpine
+FROM golang:1.6.2
 
-RUN apk update && apk add git bash gcc musl-dev \
-&& go get github.com/Masterminds/glide \
-&& go get github.com/mitchellh/gox \
+RUN go get github.com/Masterminds/glide \
 && go get github.com/jteeuwen/go-bindata/... \
 && go get github.com/golang/lint/golint \
 && go get github.com/kisielk/errcheck

--- a/script/crossbinary
+++ b/script/crossbinary
@@ -9,13 +9,13 @@ fi
 if [ -z "$1" ]; then
     # Remove windows platform because of
     # https://github.com/mailgun/log/issues/10
-    OS_PLATFORM_ARG=(-os="darwin linux")
+    OS_PLATFORM_ARG=(linux)
 else
     OS_PLATFORM_ARG=($1)
 fi
 
 if [ -z "$2" ]; then
-    OS_ARCH_ARG=(-arch="386 amd64 arm")
+    OS_ARCH_ARG=(386 amd64 arm)
 else
     OS_ARCH_ARG=($2)
 fi
@@ -32,5 +32,9 @@ fi
 rm -f dist/traefik_*
 
 # Build binaries
-GOGC=off gox -ldflags "-X main.Version=$VERSION -X main.BuildDate=$DATE" "${OS_PLATFORM_ARG[@]}" "${OS_ARCH_ARG[@]}" \
-    -output="dist/traefik_{{.OS}}-{{.Arch}}"
+for OS in ${OS_PLATFORM_ARG[@]}; do
+  for ARCH in ${OS_ARCH_ARG[@]}; do
+    echo "Building binary for $OS/$ARCH..."
+    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 go build -ldflags "-s -w -X main.Version=$VERSION -X main.BuildDate=$DATE" -o "dist/traefik_$OS-$ARCH" .
+  done
+done


### PR DESCRIPTION
- [x] Use of `golang` image instead of `golang-alpine` 
- [x] Bump to go v1.6.2
- [x] Removed gox (issue with cross compilation)

Signed-off-by: Emile Vauge <emile@vauge.com>