### PR TITLE
Create static folder on first generate

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -3,6 +3,7 @@ Copyright
 */
 
 //go:generate rm -vf autogen/gen.go
+//go:generate mkdir -p static
 //go:generate go-bindata -pkg autogen -o autogen/gen.go ./static/... ./templates/...
 
 //go:generate mkdir -p vendor/github.com/docker/docker/autogen/dockerversion


### PR DESCRIPTION
Ensure that static folder exists so `go generate` doesn't fail. 