### PR TITLE
Update docker dependencies to fix issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ services:
 - docker
 install:
 - sudo service docker stop
-- sudo curl https://get.docker.com/builds/Linux/x86_64/docker-1.10.1 -o /usr/bin/docker
+- sudo curl https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 -o /usr/bin/docker
 - sudo chmod +x /usr/bin/docker
 - sudo service docker start
 - pip install --user mkdocs

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,18 @@ env:
     - secure: btt4r13t09gQlHb6gYrvGC2yGCMMHfnp1Mz1RQedc4Mpf/FfT8aE6xmK2a2i9CCvskjrP0t/BFaS4yxIURjnFRn+ugQIEa0pLspB9UJArW/vgOSpIWM9/OQ/fg8z5XuMxN6Md4DL1/iLypMNSageA1x0TRdt89+D1N1dALpg5XRCXLFbC84TLi0gjlFuib9ibPKzEhLT+anCRJ6iZMzeupDSoaCVbAtJMoDvXw4+4AcRZ1+k4MybBLyCib5boaEOt4pTT88mz4Kk0YaMwPVJyg9Qv36VqyUcPS09Yd95LuyVQ4+tZt8Y1ccbIzULsK+sLM3hLCzxlmlpN3dQBlZJiiRtQde0mgGAKyC0P0A1XjuDTywcsa5edB+fTk1Dsewz9xZ9V0NmMz8t+UNZnaSsAPga9i86jULbXUUwMVSzVRc+Xgx02liB/8qI1xYC9FM6ilStt7rn7mF0k3KbiWhcptgeXjO6Lah9FjEKd5w4MXsdUSTi/86rQaLo+kj+XdaTrXCTulKHyRyQEUj+8V1w0oVz7pcGjePHd7y5oU9ByifVQy6sytuFBfRZvugM5bKHo+i0pcWvixrZS42DrzwxZJsspANOvqSe5ifVbvOkfUppQdCBIwptxV5N1b49XPKU3W/w34QJ8xGmKp3TFA7WwVCztriFHjPgiRpB3EG99Bg=
     - REPO: $TRAVIS_REPO_SLUG
     - VERSION: v1.0.0-beta.$TRAVIS_BUILD_NUMBER
+  matrix:
+    - DOCKER_VERSION=1.9.1
+    - DOCKER_VERSION=1.10.1
 sudo: required
 services:
 - docker
 install:
 - sudo service docker stop
-- sudo curl https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 -o /usr/bin/docker
+- sudo curl https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION} -o /usr/bin/docker
 - sudo chmod +x /usr/bin/docker
 - sudo service docker start
+- docker version
 - pip install --user mkdocs
 - pip install --user pymdown-extensions
 before_script:

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ validate: build  ## validate gofmt, golint and go vet
 	$(DOCKER_RUN_TRAEFIK) ./script/make.sh  validate-gofmt validate-govet validate-golint 
 
 build: dist
-	docker build -t "$(TRAEFIK_DEV_IMAGE)" -f build.Dockerfile .
+	docker build --build-arg=DOCKER_VERSION=${DOCKER_VERSION} -t "$(TRAEFIK_DEV_IMAGE)" -f build.Dockerfile .
 
 build-webui:
 	docker build -t traefik-webui -f webui/Dockerfile webui

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -6,10 +6,7 @@ RUN go get github.com/Masterminds/glide \
 && go get github.com/kisielk/errcheck
 
 # Which docker version to test on
-ENV DOCKER_VERSION 1.9.1
-
-# enable GO15VENDOREXPERIMENT
-ENV GO15VENDOREXPERIMENT 1
+ARG DOCKER_VERSION=1.10.1
 
 # Download docker
 RUN set -ex; \

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -6,7 +6,7 @@ RUN go get github.com/Masterminds/glide \
 && go get github.com/kisielk/errcheck
 
 # Which docker version to test on
-ENV DOCKER_VERSION 1.10.1
+ENV DOCKER_VERSION 1.9.1
 
 # enable GO15VENDOREXPERIMENT
 ENV GO15VENDOREXPERIMENT 1

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: a9f41b9fe89ac3028da27ac9cbe31db9a79ae89082f42507d4d0c58290517ee2
-updated: 2016-04-27T17:14:45.61228359Z
+hash: da7239dce8bda69f6e10b2f2bfae57dd4fd95b817055dca1379a72af42939b97
+updated: 2016-05-12T11:48:22.158455011+02:00
 imports:
 - name: github.com/alecthomas/template
   version: b867cc6ab45cece8143cfcc6fc9c77cf3f2c23c0
@@ -42,11 +42,12 @@ imports:
   subpackages:
   - spew
 - name: github.com/docker/distribution
-  version: ff6f38ccb69afa96214c7ee955359465d1fc767a
+  version: 467fc068d88aa6610691b7f1a677271a3fac4aac
   subpackages:
   - reference
+  - digest
 - name: github.com/docker/docker
-  version: f39987afe8d611407887b3094c03d6ba6a766a67
+  version: 9837ec4da53f15f9120d53a6e1517491ba8b0261
   subpackages:
   - autogen
   - api
@@ -85,7 +86,7 @@ imports:
   - utils
   - volume
 - name: github.com/docker/engine-api
-  version: 8924d6900370b4c7e7984be5adc61f50a80d7537
+  version: fd7f99d354831e7e809386087e7ec3129fdb1520
   subpackages:
   - client
   - types
@@ -96,11 +97,13 @@ imports:
   - client/transport
   - client/transport/cancellable
   - types/network
+  - types/reference
   - types/registry
   - types/time
+  - types/versions
   - types/blkiodev
 - name: github.com/docker/go-connections
-  version: f549a9393d05688dff0992ef3efd8bbe6c628aeb
+  version: 5b7154ba2efe13ff86ae8830a9e7cb120b080d6e
   subpackages:
   - nat
   - sockets
@@ -108,7 +111,7 @@ imports:
 - name: github.com/docker/go-units
   version: 5d2041e26a699eaca682e2ea41c8f891e1060444
 - name: github.com/docker/libcompose
-  version: e290a513ba909ca3afefd5cd611f3a3fe56f6a3a
+  version: 8ee7bcc364f7b8194581a3c6bd9fa019467c7873
 - name: github.com/docker/libkv
   version: 7283ef27ed32fe267388510a91709b307bb9942c
   subpackages:
@@ -121,12 +124,6 @@ imports:
   version: 9cbd2a1374f46905c68a4eb3694a130610adc62a
 - name: github.com/donovanhide/eventsource
   version: d8a3071799b98cacd30b6da92f536050ccfe6da4
-- name: github.com/eapache/go-resiliency
-  version: b86b1ec0dd4209a588dc1285cdd471e73525c0b3
-  subpackages:
-  - breaker
-- name: github.com/eapache/queue
-  version: ded5959c0d4e360646dc9e9908cff48666781367
 - name: github.com/elazarl/go-bindata-assetfs
   version: d5cac425555ca5cf00694df246e04f05e6a55150
 - name: github.com/flynn/go-shlex
@@ -137,8 +134,6 @@ imports:
   version: 11d3bc7aa68e238947792f30573146a3231fc0f1
 - name: github.com/golang/glog
   version: fca8c8854093a154ff1eb580aae10276ad6b1b5f
-- name: github.com/golang/snappy
-  version: ec642410cd033af63620b66a91ccbd3c69c2c59a
 - name: github.com/google/go-querystring
   version: 9235644dd9e52eeae6fa48efd539fdc351a0af53
   subpackages:
@@ -150,13 +145,13 @@ imports:
 - name: github.com/gorilla/mux
   version: f15e0c49460fd49eebe2bcc8486b05d1bef68d3a
 - name: github.com/gorilla/websocket
-  version: e2e3d8414d0fbae04004f151979f4e27c6747fe7
+  version: 1f512fc3f05332ba7117626cdfb4e07474e58e60
 - name: github.com/hashicorp/consul
   version: de080672fee9e6104572eeea89eccdca135bb918
   subpackages:
   - api
 - name: github.com/hashicorp/hcl
-  version: 2604f3bda7e8960c1be1063709e7d7f0765048d0
+  version: 9a905a34e6280ce905da1a32344b25e81011197a
   subpackages:
   - hcl/ast
   - hcl/parser
@@ -168,12 +163,14 @@ imports:
   - json/token
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
-- name: github.com/klauspost/crc32
-  version: 19b0b332c9e4516a6370a0456e6182c3b5036720
 - name: github.com/kr/pretty
   version: add1dbc86daf0f983cd4a48ceb39deb95c729b67
 - name: github.com/kr/text
-  version: bb797dc4fb8320488f47bf11de07a733d7233e1f
+  version: 7cafcd837844e784b526369c9bce262804aebc60
+- name: github.com/libkermit/docker
+  version: 9f5a90f8eb3c49bf56e81621f98b3cd86fe4139f
+- name: github.com/libkermit/docker-check
+  version: bb75a86b169c6c5d22c0ee98278124036f272d7b
 - name: github.com/magiconair/properties
   version: c265cfa48dda6474e208715ca93e987829f572f8
 - name: github.com/mailgun/log
@@ -187,19 +184,19 @@ imports:
 - name: github.com/mattn/go-shellwords
   version: 525bedee691b5a8df547cb5cf9f86b7fb1883e24
 - name: github.com/Microsoft/go-winio
-  version: 862b6557927a5c5c81e411c12aa6de7e566cbb7a
+  version: 3b8b3c98b207f95fe0cd6c7c311a9ac497ba7c0f
 - name: github.com/miekg/dns
-  version: dd83d5cbcfd986f334b2747feeb907e281318fdf
+  version: 48ab6605c66ac797e07f615101c3e9e10e932b66
 - name: github.com/mitchellh/mapstructure
   version: d2dd0262208475919e1a362f675cfc0e7c10e905
 - name: github.com/moul/http2curl
   version: 1812aee76a1ce98d604a44200c6a23c689b17a89
 - name: github.com/opencontainers/runc
-  version: 4ab132458fc3e9dbeea624153e0331952dc4c8d5
+  version: 2441732d6fcc0fb0a542671a4372e0c7bc99c19e
   subpackages:
   - libcontainer/user
 - name: github.com/parnurzeal/gorequest
-  version: 91b42fce877cc6af96c45818665a4c615cc5f4ee
+  version: a39a2f8d0463091df7344dbf586a9986e9f7184f
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
@@ -208,28 +205,26 @@ imports:
   version: fa6674abf3f4580b946a01bf7a1ce4ba8766205b
   subpackages:
   - zk
-- name: github.com/Shopify/sarama
-  version: 92a286e4dde1688175cff3d2ec9b49a02838b447
 - name: github.com/Sirupsen/logrus
   version: 418b41d23a1bf978c06faea5313ba194650ac088
 - name: github.com/spf13/cast
   version: ee7b3e0353166ab1f3a605294ac8cd2b77953778
 - name: github.com/spf13/cobra
-  version: 4c05eb1145f16d0e6bb4a3e1b6d769f4713cb41f
+  version: 0f866a6211e33cde2091d9290c08f6afd6c9ebbc
   subpackages:
   - cobra
 - name: github.com/spf13/jwalterweatherman
   version: 33c24e77fb80341fe7130ee7c594256ff08ccc46
 - name: github.com/spf13/pflag
-  version: 1f296710f879815ad9e6d39d947c828c3e4b4c3d
+  version: cb88ea77998c3f024757528e3305022ab50b43be
 - name: github.com/spf13/viper
   version: a212099cbe6fbe8d07476bfda8d2d39b6ff8f325
 - name: github.com/streamrail/concurrent-map
-  version: 788b276dc7eabf20890ea3fa280956664d58b329
+  version: 1ce4642e5a162df67825d273a86b87e6cc8a076b
 - name: github.com/stretchr/objx
   version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify
-  version: bcd9e3389dd03b0b668d11f4d462a6af6c2dfd60
+  version: 6cb3b85ef5a0efef77caef88363ec4d4b5c0976d
   subpackages:
   - mock
   - assert
@@ -242,9 +237,7 @@ imports:
 - name: github.com/unrolled/render
   version: 26b4e3aac686940fe29521545afad9966ddfc80c
 - name: github.com/vdemeester/docker-events
-  version: 6ea3f28df37f29a47498bc8b32b36ad8491dbd37
-- name: github.com/vdemeester/libkermit
-  version: 7e4e689a6fa9281e0fb9b7b9c297e22d5342a5ec
+  version: ce5347b72aafad4e3bebd966f15e4183839d5172
 - name: github.com/vdemeester/shakers
   version: 24d7f1d6a71aa5d9cbe7390e4afb66b7eef9e1b3
 - name: github.com/vulcand/oxy
@@ -265,11 +258,11 @@ imports:
 - name: github.com/wendal/errors
   version: f66c77a7882b399795a8987ebf87ef64a427417e
 - name: github.com/xenolf/lego
-  version: 23e88185c255e95a106835d80e76e5a3a66d7c54
+  version: 948483535f53c34d144419869ecbed86251a30f6
   subpackages:
   - acme
 - name: golang.org/x/crypto
-  version: d68c3ecb62c850b645dc072a8d78006286bf81ca
+  version: b76c864ef1dca1d8f271f917c290cddcce3d9e0d
   subpackages:
   - ocsp
 - name: golang.org/x/net
@@ -291,7 +284,7 @@ imports:
   subpackages:
   - bson
 - name: gopkg.in/square/go-jose.v1
-  version: 40d457b439244b546f023d056628e5184136899b
+  version: e3f973b66b91445ec816dd7411ad1b6495a5a2fc
   subpackages:
   - cipher
   - json

--- a/glide.yaml
+++ b/glide.yaml
@@ -59,7 +59,7 @@ import:
   subpackages:
   - bson
 - package: github.com/docker/docker
-  version: f39987afe8d611407887b3094c03d6ba6a766a67
+  version: 9837ec4da53f15f9120d53a6e1517491ba8b0261
   subpackages:
   - autogen
   - api
@@ -104,7 +104,7 @@ import:
 - package: gopkg.in/yaml.v2
   version: 7ad95dd0798a40da1ccdff6dff35fd177b5edf
 - package: github.com/opencontainers/runc
-  version: 4ab132458fc3e9dbeea624153e0331952dc4c8d5
+  version: 2441732d6fcc0fb0a542671a4372e0c7bc99c19e
   subpackages:
   - libcontainer/user
 - package: github.com/gorilla/mux
@@ -157,16 +157,18 @@ import:
   subpackages:
   - mock
 - package: github.com/xenolf/lego
-- package: github.com/vdemeester/libkermit
-  version: 7e4e689a6fa9281e0fb9b7b9c297e22d5342a5ec
+- package: github.com/libkermit/docker-check
+  version: bb75a86b169c6c5d22c0ee98278124036f272d7b
+- package: github.com/libkermit/docker
+  version: 9f5a90f8eb3c49bf56e81621f98b3cd86fe4139f
 - package: github.com/docker/libcompose
-  version: e290a513ba909ca3afefd5cd611f3a3fe56f6a3a
+  version: 8ee7bcc364f7b8194581a3c6bd9fa019467c7873
 - package: github.com/docker/distribution
-  version: ff6f38ccb69afa96214c7ee955359465d1fc767a
+  version: 467fc068d88aa6610691b7f1a677271a3fac4aac
   subpackages:
   - reference
 - package: github.com/docker/engine-api
-  version: 8924d6900370b4c7e7984be5adc61f50a80d7537
+  version: fd7f99d354831e7e809386087e7ec3129fdb1520
   subpackages:
   - client
   - types

--- a/integration/docker_test.go
+++ b/integration/docker_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/docker/docker/pkg/namesgenerator"
 	"github.com/go-check/check"
 
-	d "github.com/vdemeester/libkermit/docker"
-	docker "github.com/vdemeester/libkermit/docker/check"
+	d "github.com/libkermit/docker"
+	docker "github.com/libkermit/docker-check"
 	checker "github.com/vdemeester/shakers"
 )
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/containous/traefik/integration/utils"
 	"github.com/go-check/check"
 
-	compose "github.com/vdemeester/libkermit/compose/check"
+	"github.com/libkermit/docker-check/compose"
 	checker "github.com/vdemeester/shakers"
 )
 

--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if ([ "$TRAVIS_BRANCH" = "master" ] || [ ! -z "$TRAVIS_TAG" ]) && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+if ([ "$TRAVIS_BRANCH" = "master" ] || [ ! -z "$TRAVIS_TAG" ]) && [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$DOCKER_VERSION" = "1.10.1" ]; then
   echo "Deploying..."
 else
   echo "Skipping deploy"

--- a/script/test-integration
+++ b/script/test-integration
@@ -11,4 +11,6 @@ if [ -n "$VERBOSE" ]; then
 fi
 
 cd integration
+echo "Testing against…"
+docker version
 CGO_ENABLED=0 go test $TESTFLAGS


### PR DESCRIPTION
Update `engine-api`, `libcompose` and related dependencies (including `libkermit`), to fix issues with docker v1.9.1 and lower 🐮.

Should fix #360

/cc @emilevauge @gdippolito 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>