### PR TITLE
Update engine-api to fix versions issues

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -86,7 +86,7 @@ imports:
   - utils
   - volume
 - name: github.com/docker/engine-api
-  version: fd7f99d354831e7e809386087e7ec3129fdb1520
+  version: 3d3d0b6c9d2651aac27f416a6da0224c1875b3eb
   subpackages:
   - client
   - types
@@ -168,7 +168,7 @@ imports:
 - name: github.com/kr/text
   version: 7cafcd837844e784b526369c9bce262804aebc60
 - name: github.com/libkermit/docker
-  version: 9f5a90f8eb3c49bf56e81621f98b3cd86fe4139f
+  version: 3b5eb2973efff7af33cfb65141deaf4ed25c6d02
 - name: github.com/libkermit/docker-check
   version: bb75a86b169c6c5d22c0ee98278124036f272d7b
 - name: github.com/magiconair/properties

--- a/glide.yaml
+++ b/glide.yaml
@@ -160,7 +160,7 @@ import:
 - package: github.com/libkermit/docker-check
   version: bb75a86b169c6c5d22c0ee98278124036f272d7b
 - package: github.com/libkermit/docker
-  version: 9f5a90f8eb3c49bf56e81621f98b3cd86fe4139f
+  version: 3b5eb2973efff7af33cfb65141deaf4ed25c6d02
 - package: github.com/docker/libcompose
   version: 8ee7bcc364f7b8194581a3c6bd9fa019467c7873
 - package: github.com/docker/distribution
@@ -168,7 +168,7 @@ import:
   subpackages:
   - reference
 - package: github.com/docker/engine-api
-  version: fd7f99d354831e7e809386087e7ec3129fdb1520
+  version: 3d3d0b6c9d2651aac27f416a6da0224c1875b3eb
   subpackages:
   - client
   - types


### PR DESCRIPTION
Updating an engine-api that has fixed some versioning issues (filters json marshalling) 🐮.

For reference, the fix is https://github.com/docker/engine-api/pull/227/commits/38b38ec9db02d5f4916fa232da6b9dd840c9718c, depending on the client version, we marshall the `filters` different way. I though it was on all filters (that existed in 1.9.1) but turns out it was only on `ContainerList` (So I think, swarm would have the same problem with some heterogeneous agents version).

Should hopefully fix #360 this time. Still thinking of a way to test this without having a *flaky test* (with events it's hard :sweat:).

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>