### PR TITLE
traefik.port label override missing port

### DIFF
--- a/provider/docker.go
+++ b/provider/docker.go
@@ -198,6 +198,8 @@ func (provider *Docker) loadDockerConfig(containersInspected []dockertypes.Conta
 func containerFilter(container dockertypes.ContainerJSON) bool {
 	_, err := strconv.Atoi(container.Config.Labels["traefik.port"])
 	if err != nil {
+		log.Debugf("Container lacks traefik.port label. Checking ports %s", container.Name)
+		
 		if len(container.NetworkSettings.Ports) == 0 {
 			log.Debugf("Filtering container without port %s", container.Name)
 			return false

--- a/provider/docker.go
+++ b/provider/docker.go
@@ -196,14 +196,16 @@ func (provider *Docker) loadDockerConfig(containersInspected []dockertypes.Conta
 }
 
 func containerFilter(container dockertypes.ContainerJSON) bool {
-	if len(container.NetworkSettings.Ports) == 0 {
-		log.Debugf("Filtering container without port %s", container.Name)
-		return false
-	}
 	_, err := strconv.Atoi(container.Config.Labels["traefik.port"])
-	if len(container.NetworkSettings.Ports) > 1 && err != nil {
-		log.Debugf("Filtering container with more than 1 port and no traefik.port label %s", container.Name)
-		return false
+	if err != nil {
+		if len(container.NetworkSettings.Ports) == 0 {
+			log.Debugf("Filtering container without port %s", container.Name)
+			return false
+		}
+		if len(container.NetworkSettings.Ports) > 1 {
+			log.Debugf("Filtering container with more than 1 port and no traefik.port label %s", container.Name)
+			return false
+		}
 	}
 
 	if container.Config.Labels["traefik.enable"] == "false" {


### PR DESCRIPTION
When using docker network plugins (like calico) there is no possibility to "--publish" ports thus traefik never discovers the container.

The behaviour has been changed to use traefik.port regardless if docker "--expose"d or "--publish"ed a port.

If both ports and traefik.port is missing, the container will be filtered out.

Signed-off-by: Mathias Kaufmann <me@stei.gr>