### PR TITLE
Carry: Updating Toml to sure PathPrefix instead of Path

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -934,7 +934,7 @@ The Keys-Values structure should look (using `prefix = "/traefik"`):
 | `/traefik/frontends/frontend2/backend`             | `backend1`   |
 | `/traefik/frontends/frontend2/passHostHeader`      | `true`       |
 | `/traefik/frontends/frontend2/entrypoints`         | `http,https` |
-| `/traefik/frontends/frontend2/routes/test_2/rule`  | `Path:/test` |
+| `/traefik/frontends/frontend2/routes/test_2/rule`  | `PathPrefix:/test` |
 
 ## Atomic configuration changes
 


### PR DESCRIPTION
Carry PR #312, closes #312.

---

This works out of the box with zero changes.
As per: http://www.gorillatoolkit.org/pkg/mux

Once can use PathPrefix instead of Path, which provides much more predictable usage.
I.e. when i push /web here and / over there, I expect sub directories to work as well.

Tested with Latest & KV