### PR TITLE
Carry: http protocol should not use TLS

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -10,12 +10,13 @@ import (
 	"strings"
 	"time"
 
+	"net/http"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/containous/traefik/middlewares"
 	"github.com/containous/traefik/provider"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"net/http"
 )
 
 var traefikCmd = &cobra.Command{
@@ -171,7 +172,7 @@ func init() {
 	traefikCmd.PersistentFlags().StringVar(&arguments.Boltdb.Prefix, "boltdb.prefix", "/traefik", "Prefix used for KV store")
 
 	traefikCmd.PersistentFlags().BoolVar(&arguments.kubernetes, "kubernetes", false, "Enable Kubernetes backend")
-	traefikCmd.PersistentFlags().StringVar(&arguments.Kubernetes.Endpoint, "kubernetes.endpoint", "127.0.0.1:8080", "Kubernetes server endpoint")
+	traefikCmd.PersistentFlags().StringVar(&arguments.Kubernetes.Endpoint, "kubernetes.endpoint", "http://127.0.0.1:8080", "Kubernetes server endpoint")
 	traefikCmd.PersistentFlags().StringSliceVar(&arguments.Kubernetes.Namespaces, "kubernetes.namespaces", []string{}, "Kubernetes namespaces")
 
 	_ = viper.BindPFlag("configFile", traefikCmd.PersistentFlags().Lookup("configFile"))

--- a/provider/k8s/client.go
+++ b/provider/k8s/client.go
@@ -5,11 +5,12 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"github.com/containous/traefik/safe"
-	"github.com/parnurzeal/gorequest"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/containous/traefik/safe"
+	"github.com/parnurzeal/gorequest"
 )
 
 const (
@@ -201,6 +202,11 @@ func (c *clientImpl) do(request *gorequest.SuperAgent) ([]byte, error) {
 func (c *clientImpl) request(url string) *gorequest.SuperAgent {
 	// Make request to Kubernetes API
 	request := gorequest.New().Get(url)
+
+	if strings.HasPrefix(url, "http://") {
+		return request
+	}
+
 	if len(c.token) > 0 {
 		request.Header["Authorization"] = "Bearer " + c.token
 		pool := x509.NewCertPool()


### PR DESCRIPTION
Carry #382, closes #382.

---

I need this in order to run kubectl proxy and then
make traefik use http://localhost to get to my cluster
when developing