### PR TITLE
Add sticky session support to Traefik.

### DIFF
--- a/provider/marathon.go
+++ b/provider/marathon.go
@@ -116,6 +116,7 @@ func (provider *Marathon) loadMarathonConfig() *types.Configuration {
 		"getEntryPoints":     provider.getEntryPoints,
 		"getFrontendRule":    provider.getFrontendRule,
 		"getFrontendBackend": provider.getFrontendBackend,
+		"getSticky":          provider.getSticky,
 		"replace":            replace,
 	}
 
@@ -310,6 +311,13 @@ func (provider *Marathon) getProtocol(task marathon.Task, applications []maratho
 		return label
 	}
 	return "http"
+}
+
+func (provider *Marathon) getSticky(application marathon.Application) string {
+	if sticky, err := provider.getLabel(application, "traefik.backend.sticky"); err == nil {
+		return sticky
+	}
+	return "false"
 }
 
 func (provider *Marathon) getPassHostHeader(application marathon.Application) string {

--- a/provider/marathon_test.go
+++ b/provider/marathon_test.go
@@ -101,7 +101,7 @@ func TestMarathonLoadConfig(t *testing.T) {
 						},
 					},
 					CircuitBreaker: nil,
-					LoadBalancer:   nil,
+					LoadBalancer:   &types.LoadBalancer{Sticky: false},
 				},
 			},
 		},

--- a/templates/marathon.tmpl
+++ b/templates/marathon.tmpl
@@ -4,7 +4,10 @@
     url = "{{getProtocol . $apps}}://{{.Host}}:{{getPort . $apps}}"
     weight = {{getWeight . $apps}}
 {{end}}
-
+{{range .Applications}}
+[backends.backend{{getFrontendBackend .}}.loadbalancer]
+sticky = {{getSticky .}}
+{{end}}
 [frontends]{{range .Applications}}
   [frontends.frontend{{.ID | replace "/" "-"}}]
   backend = "backend{{getFrontendBackend .}}"

--- a/types/types.go
+++ b/types/types.go
@@ -22,6 +22,7 @@ type MaxConn struct {
 // LoadBalancer holds load balancing configuration.
 type LoadBalancer struct {
 	Method string `json:"method,omitempty"`
+	Sticky bool   `json:"sticky,omitempty"`
 }
 
 // CircuitBreaker holds circuit breaker configuration.


### PR DESCRIPTION
Bonjour @emilevauge,

This change adds sticky session support, by using the new
oxy/rr/StickySession feature.

It depends on containous/oxy#4.

To use it, set traefik.backend.sticky to true.

This is currently only implemented in the wrr load balancer, and against
the Marathon backend, but lifting it should be very doable.

In the wrr load balancer, a cookie called _TRAEFIK_SERVERNAME will be
set with the backend to use.  If the cookie is altered to an invalid
backend server, or the server is removed from the load balancer, the
next server will be used instead.

Otherwise, the cookie will be checked in Oxy's rr on access and if valid
the connection will be wired through to it.