### PR TITLE
Build backend config using the K8S endpoint resource.

### DIFF
--- a/provider/k8s/endpoints.go
+++ b/provider/k8s/endpoints.go
@@ -1,0 +1,84 @@
+package k8s
+
+// Endpoints is a collection of endpoints that implement the actual service.  Example:
+//   Name: "mysvc",
+//   Subsets: [
+//     {
+//       Addresses: [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],
+//       Ports: [{"name": "a", "port": 8675}, {"name": "b", "port": 309}]
+//     },
+//     {
+//       Addresses: [{"ip": "10.10.3.3"}],
+//       Ports: [{"name": "a", "port": 93}, {"name": "b", "port": 76}]
+//     },
+//  ]
+type Endpoints struct {
+	TypeMeta   `json:",inline"`
+	ObjectMeta `json:"metadata,omitempty"`
+
+	// The set of all endpoints is the union of all subsets.
+	Subsets []EndpointSubset
+}
+
+// EndpointSubset is a group of addresses with a common set of ports.  The
+// expanded set of endpoints is the Cartesian product of Addresses x Ports.
+// For example, given:
+//   {
+//     Addresses: [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],
+//     Ports:     [{"name": "a", "port": 8675}, {"name": "b", "port": 309}]
+//   }
+// The resulting set of endpoints can be viewed as:
+//     a: [ 10.10.1.1:8675, 10.10.2.2:8675 ],
+//     b: [ 10.10.1.1:309, 10.10.2.2:309 ]
+type EndpointSubset struct {
+	Addresses         []EndpointAddress
+	NotReadyAddresses []EndpointAddress
+	Ports             []EndpointPort
+}
+
+// EndpointAddress is a tuple that describes single IP address.
+type EndpointAddress struct {
+	// The IP of this endpoint.
+	// IPv6 is also accepted but not fully supported on all platforms. Also, certain
+	// kubernetes components, like kube-proxy, are not IPv6 ready.
+	// TODO: This should allow hostname or IP, see #4447.
+	IP string
+	// Optional: Hostname of this endpoint
+	// Meant to be used by DNS servers etc.
+	Hostname string `json:"hostname,omitempty"`
+	// Optional: The kubernetes object related to the entry point.
+	TargetRef *ObjectReference
+}
+
+// EndpointPort is a tuple that describes a single port.
+type EndpointPort struct {
+	// The name of this port (corresponds to ServicePort.Name).  Optional
+	// if only one port is defined.  Must be a DNS_LABEL.
+	Name string
+
+	// The port number.
+	Port int32
+
+	// The IP protocol for this port.
+	Protocol Protocol
+}
+
+// ObjectReference contains enough information to let you inspect or modify the referred object.
+type ObjectReference struct {
+	Kind            string `json:"kind,omitempty"`
+	Namespace       string `json:"namespace,omitempty"`
+	Name            string `json:"name,omitempty"`
+	UID             UID    `json:"uid,omitempty"`
+	APIVersion      string `json:"apiVersion,omitempty"`
+	ResourceVersion string `json:"resourceVersion,omitempty"`
+
+	// Optional. If referring to a piece of an object instead of an entire object, this string
+	// should contain information to identify the sub-object. For example, if the object
+	// reference is to a container within a pod, this would take on a value like:
+	// "spec.containers{name}" (where "name" refers to the name of the container that triggered
+	// the event) or if no container name is specified "spec.containers[2]" (container with
+	// index 2 in this pod). This syntax is chosen only to have some well-defined way of
+	// referencing a part of an object.
+	// TODO: this design is not final and this field is subject to change in the future.
+	FieldPath string `json:"fieldPath,omitempty"`
+}

--- a/provider/kubernetes_test.go
+++ b/provider/kubernetes_test.go
@@ -24,7 +24,7 @@ func TestLoadIngresses(t *testing.T) {
 									Path: "/bar",
 									Backend: k8s.IngressBackend{
 										ServiceName: "service1",
-										ServicePort: k8s.FromString("http"),
+										ServicePort: k8s.FromInt(80),
 									},
 								},
 							},
@@ -39,7 +39,7 @@ func TestLoadIngresses(t *testing.T) {
 								{
 									Backend: k8s.IngressBackend{
 										ServiceName: "service3",
-										ServicePort: k8s.FromInt(443),
+										ServicePort: k8s.FromString("https"),
 									},
 								},
 								{
@@ -66,7 +66,6 @@ func TestLoadIngresses(t *testing.T) {
 				ClusterIP: "10.0.0.1",
 				Ports: []k8s.ServicePort{
 					{
-						Name: "http",
 						Port: 80,
 					},
 				},
@@ -98,6 +97,10 @@ func TestLoadIngresses(t *testing.T) {
 				Ports: []k8s.ServicePort{
 					{
 						Name: "http",
+						Port: 80,
+					},
+					{
+						Name: "https",
 						Port: 443,
 					},
 				},
@@ -133,6 +136,49 @@ func TestLoadIngresses(t *testing.T) {
 					Ports: []k8s.EndpointPort{
 						{
 							Port: 8080,
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: k8s.ObjectMeta{
+				Name:      "service3",
+				UID:       "3",
+				Namespace: "testing",
+			},
+			Subsets: []k8s.EndpointSubset{
+				{
+					Addresses: []k8s.EndpointAddress{
+						{
+							IP: "10.15.0.1",
+						},
+					},
+					Ports: []k8s.EndpointPort{
+						{
+							Name: "http",
+							Port: 8080,
+						},
+						{
+							Name: "https",
+							Port: 8443,
+						},
+					},
+				},
+				{
+					Addresses: []k8s.EndpointAddress{
+						{
+							IP: "10.15.0.2",
+						},
+					},
+					Ports: []k8s.EndpointPort{
+						{
+							Name: "http",
+							Port: 9080,
+						},
+						{
+							Name: "https",
+							Port: 9443,
 						},
 					},
 				},
@@ -174,8 +220,12 @@ func TestLoadIngresses(t *testing.T) {
 						URL:    "http://10.0.0.2:802",
 						Weight: 1,
 					},
-					"3": {
-						URL:    "https://10.0.0.3:443",
+					"https://10.15.0.1:8443": {
+						URL:    "https://10.15.0.1:8443",
+						Weight: 1,
+					},
+					"https://10.15.0.2:9443": {
+						URL:    "https://10.15.0.2:9443",
 						Weight: 1,
 					},
 				},

--- a/provider/kubernetes_test.go
+++ b/provider/kubernetes_test.go
@@ -1212,14 +1212,13 @@ func (c clientMock) GetIngresses(predicate func(k8s.Ingress) bool) ([]k8s.Ingres
 func (c clientMock) WatchIngresses(predicate func(k8s.Ingress) bool, stopCh <-chan bool) (chan interface{}, chan error, error) {
 	return c.watchChan, make(chan error), nil
 }
-func (c clientMock) GetServices(predicate func(k8s.Service) bool) ([]k8s.Service, error) {
-	var services []k8s.Service
+func (c clientMock) GetService(name, namespace string) (k8s.Service, error) {
 	for _, service := range c.services {
-		if predicate(service) {
-			services = append(services, service)
+		if service.Namespace == namespace && service.Name == name {
+			return service, nil
 		}
 	}
-	return services, nil
+	return k8s.Service{}, nil
 }
 
 func (c clientMock) GetEndpoints(name, namespace string) (k8s.Endpoints, error) {


### PR DESCRIPTION
* Potentialy saves a network hop
* Ability to configure LB algothim (given some work to expose an
anotation etc...)
* K8s config Watch is triggered far less often