### PR TITLE
Added getIPAddress helper for docker template

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -539,7 +539,8 @@ Labels can be used on containers to override default behaviour:
 - `traefik.frontend.rule=Host:test.traefik.io`: override the default frontend rule (Default: `Host:{containerName}.{domain}`).
 - `traefik.frontend.passHostHeader=true`: forward client `Host` header to the backend.
 - `traefik.frontend.entryPoints=http,https`: assign this frontend to entry points `http` and `https`. Overrides `defaultEntryPoints`.
-* `traefik.domain=traefik.localhost`: override the default domain
+- `traefik.domain=traefik.localhost`: override the default domain
+- `traefik.docker.network`: Set the docker network to use for connections to this container
 
 
 ## Marathon backend
@@ -644,7 +645,7 @@ Træfɪk can be configured to use Kubernetes Ingress as a backend configuration:
 # and KUBERNETES_SERVICE_PORT_HTTPS as endpoint
 # Secure token will be found in /var/run/secrets/kubernetes.io/serviceaccount/token
 # and SSL CA cert in /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-# 
+#
 # Optional
 #
 # endpoint = "http://localhost:8080"
@@ -973,4 +974,3 @@ Once the `/traefik/alias` key is updated, the new `/traefik_configurations/2` co
 | `/traefik_configurations/2/backends/backend1/servers/server2/weight`    | `5`                        |
 
 Note that Træfɪk *will not watch for key changes in the `/traefik_configurations` prefix*. It will only watch for changes in the `/traefik` prefix. Further, if the `/traefik/alias` key is set, all other sibling keys with the `/traefik` prefix are ignored.
-

--- a/provider/docker_test.go
+++ b/provider/docker_test.go
@@ -203,6 +203,82 @@ func TestDockerGetBackend(t *testing.T) {
 	}
 }
 
+func TestDockerGetIPAddress(t *testing.T) { // TODO
+	provider := &Docker{}
+
+	containers := []struct {
+		container docker.ContainerJSON
+		expected  string
+	}{
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "bar",
+				},
+				Config: &container.Config{},
+				NetworkSettings: &docker.NetworkSettings{
+					Networks: map[string]*network.EndpointSettings{
+						"testnet": {
+							IPAddress: "10.11.12.13",
+						},
+					},
+				},
+			},
+			expected: "10.11.12.13",
+		},
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "bar",
+				},
+				Config: &container.Config{
+					Labels: map[string]string{
+						"traefik.docker.network": "testnet",
+					},
+				},
+				NetworkSettings: &docker.NetworkSettings{
+					Networks: map[string]*network.EndpointSettings{
+						"nottestnet": {
+							IPAddress: "10.11.12.13",
+						},
+					},
+				},
+			},
+			expected: "10.11.12.13",
+		},
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "bar",
+				},
+				Config: &container.Config{
+					Labels: map[string]string{
+						"traefik.docker.network": "testnet2",
+					},
+				},
+				NetworkSettings: &docker.NetworkSettings{
+					Networks: map[string]*network.EndpointSettings{
+						"testnet1": {
+							IPAddress: "10.11.12.13",
+						},
+						"testnet2": {
+							IPAddress: "10.11.12.14",
+						},
+					},
+				},
+			},
+			expected: "10.11.12.14",
+		},
+	}
+
+	for _, e := range containers {
+		actual := provider.getIPAddress(e.container)
+		if actual != e.expected {
+			t.Fatalf("expected %q, got %q", e.expected, actual)
+		}
+	}
+}
+
 func TestDockerGetPort(t *testing.T) {
 	provider := &Docker{}
 

--- a/templates/docker.tmpl
+++ b/templates/docker.tmpl
@@ -1,6 +1,6 @@
 [backends]{{range .Containers}}
     [backends.backend-{{getBackend .}}.servers.server-{{.Name | replace "/" "" | replace "." "-"}}]
-    url = "{{getProtocol .}}://{{range $i := .NetworkSettings.Networks}}{{if $i}}{{.IPAddress}}{{end}}{{end}}:{{getPort .}}"
+    url = "{{getProtocol .}}://{{getIPAddress .}}:{{getPort .}}"
     weight = {{getWeight .}}
 {{end}}
 


### PR DESCRIPTION
The docker template currently results in the IP address for a container being seen as every IP the container has (on every network it is a part of) being concatenated together.

For example a container that is a part of two networks and has the IPs `172.10.1.1` and `172.10.2.1` on those networks will have it's IP in the template filled in as `172.10.1.1172.10.2.1`.

This patch ensures that the user can select the network whose IP will be used with the `traefik.docket.network` label. If there is no label and more than one network, the first network will be used.