### PR TITLE
feat(prometheus): Adding a Prometheus exporter on /metrics.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,10 @@
-hash: 5a6dbc30a69abd002736bd5113e0f783c448faee20a0791c724ec2c3c1cfb8bb
-updated: 2016-06-03T18:11:43.839017153+02:00
+hash: 4c9ef4cfd56fad88b0d8e777f3bb5b01a7baa6989d57b49a327cdfc2641d1153
+updated: 2016-06-11T18:27:39.653103846+02:00
 imports:
+- name: github.com/beorn7/perks
+  version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
+  subpackages:
+  - quantile
 - name: github.com/boltdb/bolt
   version: dfb21201d9270c1082d5fb0f07f500311ff72f18
 - name: github.com/BurntSushi/toml
@@ -96,6 +100,10 @@ imports:
   version: ade11d1dc2884ee1f387078fc28509559b6235d1
 - name: github.com/go-check/check
   version: 4f90aeace3a26ad7021961c297b22c42160c7b25
+- name: github.com/golang/protobuf
+  version: 9e6977f30c91c78396e719e164e57f9287fff42c
+  subpackages:
+  - proto
 - name: github.com/google/go-querystring
   version: 9235644dd9e52eeae6fa48efd539fdc351a0af53
   subpackages:
@@ -127,6 +135,10 @@ imports:
   version: fd192d755b00c968d312d23f521eb0cdc6f66bd0
 - name: github.com/mattn/go-shellwords
   version: 525bedee691b5a8df547cb5cf9f86b7fb1883e24
+- name: github.com/matttproud/golang_protobuf_extensions
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
+  subpackages:
+  - pbutil
 - name: github.com/Microsoft/go-winio
   version: 4f1a71750d95a5a8a46c40a67ffbed8129c2f138
 - name: github.com/miekg/dns
@@ -145,6 +157,22 @@ imports:
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
+- name: github.com/prometheus/client_golang
+  version: 488edd04dc224ba64c401747cd0a4b5f05dfb234
+  subpackages:
+  - prometheus
+- name: github.com/prometheus/client_model
+  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
+  subpackages:
+  - go
+- name: github.com/prometheus/common
+  version: a3a8fe85f2579bcfec713dbfacbdd0797a792f3a
+  subpackages:
+  - expfmt
+  - internal/bitbucket.org/ww/goautoneg
+  - model
+- name: github.com/prometheus/procfs
+  version: abf152e5f3e97f2fafac028d2cc06c1feb87ffa5
 - name: github.com/ryanuber/go-glob
   version: 572520ed46dbddaed19ea3d9541bdd0494163693
 - name: github.com/samuel/go-zookeeper

--- a/glide.yaml
+++ b/glide.yaml
@@ -77,3 +77,4 @@ import:
 - package: github.com/mattn/go-shellwords
 - package: github.com/vdemeester/shakers
 - package: github.com/ryanuber/go-glob
+- package: github.com/prometheus/client_golang

--- a/metrics/health.go
+++ b/metrics/health.go
@@ -1,0 +1,17 @@
+package metrics
+
+import (
+	"github.com/thoas/stats"
+	"github.com/unrolled/render"
+	"net/http"
+)
+
+// Metrics holds Traefik aggregated stats
+var Metrics = stats.New()
+
+// GetHealthHandler expose Metrics data on /health
+func GetHealthHandler(templatesRenderer *render.Render) func(http.ResponseWriter, *http.Request) {
+	return func(response http.ResponseWriter, request *http.Request) {
+		templatesRenderer.JSON(response, http.StatusOK, Metrics.Data())
+	}
+}

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -1,0 +1,183 @@
+package metrics
+
+import (
+	"net/http"
+	"os"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	namespace = "traefik"
+)
+
+// TODO: #156 - More detailed metrics
+type entrypointMetrics struct {
+}
+
+// TODO: #156 - More detailed metrics
+type providerMetrics struct {
+}
+
+// TODO: #156 - More detailed metrics
+type frontendMetrics struct {
+}
+
+// TODO: #156 - More detailed metrics
+type backendMetrics struct {
+}
+
+type globalMetrics struct {
+	UpTime                    prometheus.Gauge
+	RequestResponseTimeTotal  prometheus.Gauge
+	RequestResponseTimeAvg    prometheus.Gauge
+	RequestStatusCountCurrent map[string]prometheus.Gauge
+	RequestStatusCountTotal   map[string]prometheus.Gauge
+
+	Entrypoints entrypointMetrics
+	Providers   providerMetrics
+	Frontends   frontendMetrics
+	Backends    backendMetrics
+}
+
+// Exporter holds exporter configuration and metric collectors
+type Exporter struct {
+	mutex   sync.RWMutex
+	metrics globalMetrics
+}
+
+//func newCounter(metricName string, docString string, constLabels prometheus.Labels) prometheus.Counter {
+//	return prometheus.NewCounter(
+//		prometheus.CounterOpts{
+//			Namespace:   namespace,
+//			Name:        metricName,
+//			Help:        docString,
+//			ConstLabels: constLabels,
+//		},
+//	)
+//}
+
+func newGauge(metricName string, docString string, constLabels prometheus.Labels) prometheus.Gauge {
+	return prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace:   namespace,
+			Name:        metricName,
+			Help:        docString,
+			ConstLabels: constLabels,
+		},
+	)
+}
+
+//func newHistogram(metricName string, docString string, buckets []float64, constLabels prometheus.Labels) prometheus.Gauge {
+//	return prometheus.NewHistogram(
+//		prometheus.HistogramOpts{
+//			Namespace:   namespace,
+//			Name:        metricName,
+//			Help:        docString,
+//			ConstLabels: constLabels,
+//			Buckets:     buckets,
+//		},
+//	)
+//}
+
+// Please use summary carefully. It can slow-down you code !
+// The merge algorithm seems to be slow at write and fast at scrape time.
+// https://github.com/prometheus/client_golang/blob/master/prometheus/summary.go#L142
+// Do not create too many objectives and think about the margin of error (value of the map). Both move performances down.
+//func newSummary(metricName string, docString string, Objectives map[float64]float64, constLabels prometheus.Labels) prometheus.Gauge {
+//	return prometheus.NewSummary(
+//		prometheus.SummaryOpts{
+//			Namespace:   namespace,
+//			Name:        metricName,
+//			Help:        docString,
+//			ConstLabels: constLabels,
+//			Objectives:  map[float64]float64,
+//		},
+//	)
+//}
+
+// Describe describes all the metrics ever exported by the Traefik exporter. It
+// implements prometheus.Collector.
+func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
+	ch <- e.metrics.UpTime.Desc()
+	ch <- e.metrics.RequestResponseTimeTotal.Desc()
+	ch <- e.metrics.RequestResponseTimeAvg.Desc()
+
+	for _, metric := range e.metrics.RequestStatusCountCurrent {
+		ch <- metric.Desc()
+	}
+	for _, metric := range e.metrics.RequestStatusCountTotal {
+		ch <- metric.Desc()
+	}
+}
+
+// Collect delivers the Traefik stats to Prometheus
+// as Prometheus metrics. It implements prometheus.Collector.
+func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
+	e.mutex.Lock() // To protect metrics from concurrent collects.
+	defer e.mutex.Unlock()
+
+	e.refresh()
+
+	ch <- e.metrics.UpTime
+	ch <- e.metrics.RequestResponseTimeTotal
+	ch <- e.metrics.RequestResponseTimeAvg
+
+	for _, metric := range e.metrics.RequestStatusCountCurrent {
+		ch <- metric
+	}
+	for _, metric := range e.metrics.RequestStatusCountTotal {
+		ch <- metric
+	}
+}
+
+func (e *Exporter) refresh() {
+	var data = Metrics.Data()
+
+	e.metrics.UpTime.Set(data.UpTimeSec)
+	e.metrics.RequestResponseTimeTotal.Set(data.TotalResponseTimeSec)
+	e.metrics.RequestResponseTimeAvg.Set(data.AverageResponseTimeSec)
+
+	// Current request count, labeled by statusCode
+	// Must be reset for missing status code metrics in data
+	for _, metric := range e.metrics.RequestStatusCountCurrent {
+		metric.Set(0)
+	}
+	for statusCode, nbr := range data.StatusCodeCount {
+		if _, ok := e.metrics.RequestStatusCountCurrent[statusCode]; ok == false {
+			e.metrics.RequestStatusCountCurrent[statusCode] = newGauge("request_count_current", "Number of request handled by Traefik", prometheus.Labels{"statusCode": statusCode})
+		}
+		e.metrics.RequestStatusCountCurrent[statusCode].Set(float64(nbr))
+	}
+
+	// Total request count, labeled by statusCode
+	for statusCode, nbr := range data.TotalStatusCodeCount {
+		if _, ok := e.metrics.RequestStatusCountTotal[statusCode]; ok == false {
+			e.metrics.RequestStatusCountTotal[statusCode] = newGauge("request_count_total", "Number of request handled by Traefik", prometheus.Labels{"statusCode": statusCode})
+		}
+		e.metrics.RequestStatusCountTotal[statusCode].Set(float64(nbr))
+	}
+}
+
+var exporter *Exporter
+
+func init() {
+	exporter = &Exporter{
+		metrics: globalMetrics{
+			UpTime: newGauge("uptime", "Current Traefik uptime", nil),
+			RequestResponseTimeTotal:  newGauge("request_response_time_total", "Total response time of Traefik requests", nil),
+			RequestResponseTimeAvg:    newGauge("request_response_time_avg", "Average response time of Traefik requests", nil),
+			RequestStatusCountCurrent: map[string]prometheus.Gauge{},
+			RequestStatusCountTotal:   map[string]prometheus.Gauge{},
+		},
+	}
+}
+
+// GetPrometheusHandler expose Metrics data in the Prometheus format on /metrics
+func GetPrometheusHandler() http.Handler {
+	prometheus.MustRegister(exporter)
+	prometheus.Unregister(prometheus.NewGoCollector())
+	prometheus.Unregister(prometheus.NewProcessCollector(os.Getpid(), ""))
+	return prometheus.UninstrumentedHandler()
+}

--- a/server.go
+++ b/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containous/oxy/roundrobin"
 	"github.com/containous/oxy/stream"
 	"github.com/containous/oxy/utils"
+	"github.com/containous/traefik/metrics"
 	"github.com/containous/traefik/middlewares"
 	"github.com/containous/traefik/provider"
 	"github.com/containous/traefik/safe"
@@ -118,7 +119,7 @@ func (server *Server) Close() {
 func (server *Server) startHTTPServers() {
 	server.serverEntryPoints = server.buildEntryPoints(server.globalConfiguration)
 	for newServerEntryPointName, newServerEntryPoint := range server.serverEntryPoints {
-		newsrv, err := server.prepareServer(newServerEntryPointName, newServerEntryPoint.httpRouter, server.globalConfiguration.EntryPoints[newServerEntryPointName], nil, server.loggerMiddleware, metrics)
+		newsrv, err := server.prepareServer(newServerEntryPointName, newServerEntryPoint.httpRouter, server.globalConfiguration.EntryPoints[newServerEntryPointName], nil, server.loggerMiddleware, metrics.Metrics)
 		if err != nil {
 			log.Fatal("Error preparing server: ", err)
 		}


### PR DESCRIPTION
Partially related to #156 

This is a first implementation of Prometheus in Traefik, on the web port, route ```/metrics```.

This exporter is currently pulling the data exposed by http://github.com/thoas/stats. These are an aggregation of metrics since LB startup. However, the Prometheus design actually recommends to push a brut, time-based metric (aka. at each single request), then aggregate at the query time using the Prometheus query language (from UI, Grafana...).

I think, in a futur step, http://github.com/thoas/stats should be replaced by a custom middleware to:
- Provide more detailed metrics #156 
- Push data into the Prometheus collector.

New deps: ```github.com/prometheus/client_golang``` and nested