### PR TITLE
Fix marathon groups subdomain

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -636,7 +636,16 @@ domain = "marathon.localhost"
 # Optional
 # Default: false
 #
-# ExposedByDefault = true
+# exposedByDefault = true
+
+# Convert Marathon groups to subdomains
+# Default behavior: /foo/bar/myapp => foo-bar-myapp.{defaultDomain}
+# with groupsAsSubDomains enabled: /foo/bar/myapp => myapp.bar.foo.{defaultDomain}
+#
+# Optional
+# Default: false
+#
+# groupsAsSubDomains = true
 
 # Enable Marathon basic authentication
 #

--- a/examples/whoami-group.json
+++ b/examples/whoami-group.json
@@ -1,0 +1,40 @@
+{
+    "id": "/foo",
+    "groups": [
+        {
+            "id": "/foo/bar",
+            "apps": [
+                {
+                    "id": "whoami",
+                    "cpus": 0.1,
+                    "mem": 64.0,
+                    "instances": 3,
+                    "container": {
+                        "type": "DOCKER",
+                        "docker": {
+                            "image": "emilevauge/whoami",
+                            "network": "BRIDGE",
+                            "portMappings": [
+                                {
+                                    "containerPort": 80,
+                                    "hostPort": 0,
+                                    "protocol": "tcp"
+                                }
+                            ]
+                        }
+                    },
+                    "healthChecks": [
+                        {
+                            "protocol": "HTTP",
+                            "portIndex": 0,
+                            "path": "/",
+                            "gracePeriodSeconds": 5,
+                            "intervalSeconds": 20,
+                            "maxConsecutiveFailures": 3
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/provider/docker.go
+++ b/provider/docker.go
@@ -236,7 +236,7 @@ func (provider *Docker) getFrontendRule(container dockertypes.ContainerJSON) str
 	if label, err := getLabel(container, "traefik.frontend.rule"); err == nil {
 		return label
 	}
-	return "Host:" + getEscapedName(container.Name) + "." + provider.Domain
+	return "Host:" + provider.getEscapedName(container.Name) + "." + provider.Domain
 }
 
 func (provider *Docker) getBackend(container dockertypes.ContainerJSON) string {
@@ -348,4 +348,9 @@ func listContainers(dockerClient client.APIClient) ([]dockertypes.ContainerJSON,
 		containersInspected = append(containersInspected, containerInspected)
 	}
 	return containersInspected, nil
+}
+
+// Escape beginning slash "/", convert all others to dash "-"
+func (provider *Docker) getEscapedName(name string) string {
+	return strings.Replace(strings.TrimPrefix(name, "/"), "/", "-", -1)
 }

--- a/provider/docker.go
+++ b/provider/docker.go
@@ -236,7 +236,7 @@ func (provider *Docker) getFrontendRule(container dockertypes.ContainerJSON) str
 	if label, err := getLabel(container, "traefik.frontend.rule"); err == nil {
 		return label
 	}
-	return "Host:" + provider.getEscapedName(container.Name) + "." + provider.Domain
+	return "Host:" + provider.getSubDomain(container.Name) + "." + provider.Domain
 }
 
 func (provider *Docker) getBackend(container dockertypes.ContainerJSON) string {
@@ -351,6 +351,6 @@ func listContainers(dockerClient client.APIClient) ([]dockertypes.ContainerJSON,
 }
 
 // Escape beginning slash "/", convert all others to dash "-"
-func (provider *Docker) getEscapedName(name string) string {
+func (provider *Docker) getSubDomain(name string) string {
 	return strings.Replace(strings.TrimPrefix(name, "/"), "/", "-", -1)
 }

--- a/provider/marathon.go
+++ b/provider/marathon.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"errors"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"text/template"
@@ -341,7 +342,7 @@ func (provider *Marathon) getFrontendRule(application marathon.Application) stri
 	if label, err := provider.getLabel(application, "traefik.frontend.rule"); err == nil {
 		return label
 	}
-	return "Host:" + getEscapedName(application.ID) + "." + provider.Domain
+	return "Host:" + provider.getEscapedName(application.ID) + "." + provider.Domain
 }
 
 func (provider *Marathon) getBackend(task marathon.Task, applications []marathon.Application) string {
@@ -358,4 +359,11 @@ func (provider *Marathon) getFrontendBackend(application marathon.Application) s
 		return label
 	}
 	return replace("/", "-", application.ID)
+}
+
+func (provider *Marathon) getEscapedName(name string) string {
+	splitedName := strings.Split(strings.TrimPrefix(name, "/"), "/")
+	sort.Sort(sort.Reverse(sort.StringSlice(splitedName)))
+	reverseName := strings.Join(splitedName, ".")
+	return reverseName
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -85,11 +85,6 @@ func replace(s1 string, s2 string, s3 string) string {
 	return strings.Replace(s3, s1, s2, -1)
 }
 
-// Escape beginning slash "/", convert all others to dash "-"
-func getEscapedName(name string) string {
-	return strings.Replace(strings.TrimPrefix(name, "/"), "/", "-", -1)
-}
-
 func normalize(name string) string {
 	fargs := func(c rune) bool {
 		return !unicode.IsLetter(c) && !unicode.IsNumber(c)

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -306,7 +306,16 @@
 # Optional
 # Default: false
 #
-# ExposedByDefault = true
+# exposedByDefault = true
+
+# Convert Marathon groups to subdomains
+# Default behavior: /foo/bar/myapp => foo-bar-myapp.{defaultDomain}
+# with groupsAsSubDomains enabled: /foo/bar/myapp => myapp.bar.foo.{defaultDomain}
+#
+# Optional
+# Default: false
+#
+# groupsAsSubDomains = true
 
 # Enable Marathon basic authentication
 #


### PR DESCRIPTION
Fix marathon [groups](https://mesosphere.github.io/marathon/docs/application-groups.html) subdomain management.

Added new optional `groupsAsSubDomains`:

```
# Convert Marathon groups to subdomains
# Default behavior: /foo/bar/myapp => foo-bar-myapp.{defaultDomain}
# with groupsAsSubDomains enabled: /foo/bar/myapp => myapp.bar.foo.{defaultDomain}
#
# Optional
# Default: false
#
# groupsAsSubDomains = true
```

If enabled, instead of:
`/foo/bar/myapp` => `foo-bar-myapp.{defaultDomain}`
we now have:
`/foo/bar/myapp` => `myapp.bar.foo.{defaultDomain}`

Fixes #169

Signed-off-by: Emile Vauge <emile@vauge.com>