### PR TITLE
feat(constraints): Supports constraints for docker backend

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -203,6 +203,7 @@ Træfɪk filters services according to service attributes/tags set in your confi
 
 Supported backends:
 
+- Docker
 - Consul Catalog
 
 Supported filters:
@@ -574,6 +575,14 @@ watch = true
 #  cert = "/etc/ssl/docker.crt"
 #  key = "/etc/ssl/docker.key"
 #  insecureskipverify = true
+
+# Constraint on Docker tags
+#
+# Optional
+#
+# constraints = ["tag==api", "tag==he*ld"]
+# Matching with containers having the label "traefik.tags" set to "api,helloworld"
+# ex: $ docker run -d -P --label traefik.tags=api,helloworld emilevauge/whoami
 ```
 
 Labels can be used on containers to override default behaviour:

--- a/provider/docker.go
+++ b/provider/docker.go
@@ -220,8 +220,7 @@ func (provider *Docker) ContainerFilter(container dockertypes.ContainerJSON) boo
 	}
 
 	constraintTags := strings.Split(container.Config.Labels["traefik.tags"], ",")
-	ok, failingConstraint := provider.MatchConstraints(constraintTags)
-	if ok == false {
+	if ok, failingConstraint := provider.MatchConstraints(constraintTags); !ok {
 		if failingConstraint != nil {
 			log.Debugf("Container %v pruned by '%v' constraint", container.Name, failingConstraint.String())
 		}

--- a/provider/docker_test.go
+++ b/provider/docker_test.go
@@ -621,6 +621,7 @@ func TestDockerGetLabels(t *testing.T) {
 }
 
 func TestDockerTraefikFilter(t *testing.T) {
+	provider := Docker{}
 	containers := []struct {
 		container docker.ContainerJSON
 		expected  bool
@@ -792,7 +793,7 @@ func TestDockerTraefikFilter(t *testing.T) {
 	}
 
 	for _, e := range containers {
-		actual := containerFilter(e.container)
+		actual := provider.ContainerFilter(e.container)
 		if actual != e.expected {
 			t.Fatalf("expected %v for %+v, got %+v", e.expected, e, actual)
 		}


### PR DESCRIPTION
Related to #311 #342 

```
[docker]
endpoint = "unix:///var/run/docker.sock"
constraints = ["tag==api", "tag==he*ld"]
```

```
$ docker run -d -P --label traefik.tags=api,helloworld emilevauge/whoami
```
