### PR TITLE
Added an option to skip URL cleaning.

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -148,10 +148,11 @@ func (ep *EntryPoints) Type() string {
 
 // EntryPoint holds an entry point configuration of the reverse proxy (ip, port, TLS...)
 type EntryPoint struct {
-	Network  string
-	Address  string
-	TLS      *TLS
-	Redirect *Redirect
+	Network   string
+	Address   string
+	TLS       *TLS
+	Redirect  *Redirect
+    SkipClean bool
 }
 
 // Redirect configures a redirection of an entry point to another, or to an URL

--- a/configuration.go
+++ b/configuration.go
@@ -152,7 +152,7 @@ type EntryPoint struct {
 	Address   string
 	TLS       *TLS
 	Redirect  *Redirect
-    SkipClean bool
+	SkipClean bool
 }
 
 // Redirect configures a redirection of an entry point to another, or to an URL

--- a/server.go
+++ b/server.go
@@ -358,9 +358,9 @@ func (server *Server) buildEntryPoints(globalConfiguration GlobalConfiguration) 
 	serverEntryPoints := make(map[string]*serverEntryPoint)
 	for entryPointName, entryPoint := range globalConfiguration.EntryPoints {
 		router := server.buildDefaultHTTPRouter()
-        if entryPoint.SkipClean {
-            router.SkipClean
-        }
+		if entryPoint.SkipClean {
+			router.SkipClean
+		}
 		serverEntryPoints[entryPointName] = &serverEntryPoint{
 			httpRouter: middlewares.NewHandlerSwitcher(router),
 		}

--- a/server.go
+++ b/server.go
@@ -356,8 +356,11 @@ func (server *Server) prepareServer(entryPointName string, router *middlewares.H
 
 func (server *Server) buildEntryPoints(globalConfiguration GlobalConfiguration) map[string]*serverEntryPoint {
 	serverEntryPoints := make(map[string]*serverEntryPoint)
-	for entryPointName := range globalConfiguration.EntryPoints {
+	for entryPointName, entryPoint := range globalConfiguration.EntryPoints {
 		router := server.buildDefaultHTTPRouter()
+        if entryPoint.SkipClean {
+            router.SkipClean
+        }
 		serverEntryPoints[entryPointName] = &serverEntryPoint{
 			httpRouter: middlewares.NewHandlerSwitcher(router),
 		}


### PR DESCRIPTION
See https://github.com/gorilla/mux/issues/94

This was done as we have Marathon behind Traefik and it adds additional "/" characters to the URLs.  Without this option, you, at a minimum, lose the ability to restart apps.
