### PR TITLE
Forward certs and Authorization

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -163,7 +163,8 @@ type Redirect struct {
 
 // TLS configures TLS for an entry point
 type TLS struct {
-	Certificates Certificates
+	Certificates      Certificates
+	RequireClientCert bool
 }
 
 // Certificates defines traefik certificates type

--- a/configuration.go
+++ b/configuration.go
@@ -25,6 +25,8 @@ type GlobalConfiguration struct {
 	AccessLogsFile            string                  `description:"Access logs file"`
 	TraefikLogsFile           string                  `description:"Traefik logs file"`
 	LogLevel                  string                  `short:"l" description:"Log level"`
+	ClientCertFile            string                  `description:"Client cert to be used for backend clients."`
+	ClientCertKeyFile         string                  `description:"Client cert key to be used for backend clients."`
 	EntryPoints               EntryPoints             `description:"Entrypoints definition using format: --entryPoints='Name:http Address::8000 Redirect.EntryPoint:https' --entryPoints='Name:https Address::4442 TLS:tests/traefik.crt,tests/traefik.key'"`
 	Constraints               types.Constraints       `description:"Filter services by constraint, matching with service tags."`
 	ACME                      *acme.ACME              `description:"Enable ACME (Let's Encrypt): automatic SSL"`

--- a/mocks/Marathon.go
+++ b/mocks/Marathon.go
@@ -147,8 +147,8 @@ func (_m *Marathon) CreateApplication(application *marathon.Application) (*marat
 }
 
 // DeleteApplication provides a mock function with given fields: name
-func (_m *Marathon) DeleteApplication(name string) (*marathon.DeploymentID, error) {
-	ret := _m.Called(name)
+func (_m *Marathon) DeleteApplication(name string, force bool) (*marathon.DeploymentID, error) {
+	ret := _m.Called(name, force)
 
 	var r0 *marathon.DeploymentID
 	if rf, ok := ret.Get(0).(func(string) *marathon.DeploymentID); ok {
@@ -496,9 +496,55 @@ func (_m *Marathon) Groups() (*marathon.Groups, error) {
 	return r0, r1
 }
 
+// Groups provides a mock function with given fields:
+func (_m *Marathon) GroupsBy(opts *marathon.GetGroupOpts) (*marathon.Groups, error) {
+	ret := _m.Called(opts)
+
+	var r0 *marathon.Groups
+	if rf, ok := ret.Get(0).(func() *marathon.Groups); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*marathon.Groups)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Group provides a mock function with given fields: name
 func (_m *Marathon) Group(name string) (*marathon.Group, error) {
 	ret := _m.Called(name)
+
+	var r0 *marathon.Group
+	if rf, ok := ret.Get(0).(func(string) *marathon.Group); ok {
+		r0 = rf(name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*marathon.Group)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Group provides a mock function with given fields: name
+func (_m *Marathon) GroupBy(name string, opts *marathon.GetGroupOpts) (*marathon.Group, error) {
+	ret := _m.Called(name, opts)
 
 	var r0 *marathon.Group
 	if rf, ok := ret.Get(0).(func(string) *marathon.Group); ok {
@@ -534,8 +580,8 @@ func (_m *Marathon) CreateGroup(group *marathon.Group) error {
 }
 
 // DeleteGroup provides a mock function with given fields: name
-func (_m *Marathon) DeleteGroup(name string) (*marathon.DeploymentID, error) {
-	ret := _m.Called(name)
+func (_m *Marathon) DeleteGroup(name string, force bool) (*marathon.DeploymentID, error) {
+	ret := _m.Called(name, force)
 
 	var r0 *marathon.DeploymentID
 	if rf, ok := ret.Get(0).(func(string) *marathon.DeploymentID); ok {
@@ -557,8 +603,8 @@ func (_m *Marathon) DeleteGroup(name string) (*marathon.DeploymentID, error) {
 }
 
 // UpdateGroup provides a mock function with given fields: id, group
-func (_m *Marathon) UpdateGroup(id string, group *marathon.Group) (*marathon.DeploymentID, error) {
-	ret := _m.Called(id, group)
+func (_m *Marathon) UpdateGroup(id string, group *marathon.Group, force bool) (*marathon.DeploymentID, error) {
+	ret := _m.Called(id, group, force)
 
 	var r0 *marathon.DeploymentID
 	if rf, ok := ret.Get(0).(func(string, *marathon.Group) *marathon.DeploymentID); ok {
@@ -850,3 +896,32 @@ func (_m *Marathon) AbdicateLeader() (string, error) {
 
 	return r0, r1
 }
+
+// ApplicationBy provides a mock function with the given fields:
+func (_m *Marathon) ApplicationBy(name string, opts *marathon.GetAppOpts) (*marathon.Application, error) {
+    ret := _m.Called(name, opts)
+
+	var r0 *marathon.Application
+    if ret.Get(0) != nil {
+        r0 = ret.Get(0).(*marathon.Application)
+    }
+
+    r1 := ret.Error(1)
+
+	return r0, r1
+}
+/*
+// ApplicationByVersion provides a mock function with the given fields:
+func (_m *Marathon) ApplicationByVersion(name, version string) (*marathon.Application, error) {
+    ret := _m.Called(name, version)
+
+	var r0 *marathon.Application
+    if ret.Get(0) != nil {
+        r0 = ret.Get(0).(*marathon.Application)
+    }
+
+    r1 := ret.Error(1)
+
+	return r0, r1
+}
+*/

--- a/provider/marathon.go
+++ b/provider/marathon.go
@@ -120,7 +120,13 @@ func (provider *Marathon) loadMarathonConfig() *types.Configuration {
 		"getDomain":          provider.getDomain,
 		"getProtocol":        provider.getProtocol,
 		"getPassHostHeader":  provider.getPassHostHeader,
+<<<<<<< HEAD
 		"getPriority":        provider.getPriority,
+||||||| merged common ancestors
+=======
+		"getForwardCerts":    provider.getForwardCerts,
+		"getInsecureCert":    provider.getInsecureCert,
+>>>>>>> Added code to get the new options from Marathon labels.
 		"getEntryPoints":     provider.getEntryPoints,
 		"getFrontendRule":    provider.getFrontendRule,
 		"getFrontendBackend": provider.getFrontendBackend,
@@ -183,13 +189,13 @@ func taskFilter(task marathon.Task, applications *marathon.Applications, exposed
 	}
 
 	//filter indeterminable task port
-    // Defaulting the values to "" if there are no Labels defined.
-    portIndexLabel := ""
-    portValueLabel := ""
-    if application.Labels != nil {
-        portIndexLabel = (*application.Labels)["traefik.portIndex"]
-        portValueLabel = (*application.Labels)["traefik.port"]
-    }
+	// Defaulting the values to "" if there are no Labels defined.
+	portIndexLabel := ""
+	portValueLabel := ""
+	if application.Labels != nil {
+		portIndexLabel = (*application.Labels)["traefik.portIndex"]
+		portValueLabel = (*application.Labels)["traefik.port"]
+	}
 	if portIndexLabel != "" && portValueLabel != "" {
 		log.Debugf("Filtering marathon task %s specifying both traefik.portIndex and traefik.port labels", task.AppID)
 		return false
@@ -260,21 +266,21 @@ func getApplication(task marathon.Task, apps []marathon.Application) (marathon.A
 }
 
 func isApplicationEnabled(application marathon.Application, exposedByDefault bool) bool {
-    enabled := ""
-    if application.Labels != nil {
-        enabled = (*application.Labels)["traefik.enable"]
-    }
-    return exposedByDefault && enabled != "false" || enabled == "true"
+	enabled := ""
+	if application.Labels != nil {
+		enabled = (*application.Labels)["traefik.enable"]
+	}
+	return exposedByDefault && enabled != "false" || enabled == "true"
 }
 
 func (provider *Marathon) getLabel(application marathon.Application, label string) (string, error) {
-    if application.Labels != nil {
-        for key, value := range (*application.Labels) {
-            if key == label {
-                return value, nil
-            }
-        }
-    }
+	if application.Labels != nil {
+		for key, value := range *application.Labels {
+			if key == label {
+				return value, nil
+			}
+		}
+	}
 	return "", errors.New("Label not found:" + label)
 }
 
@@ -343,6 +349,20 @@ func (provider *Marathon) getPriority(application marathon.Application) string {
 		return priority
 	}
 	return "0"
+}
+
+func (provider *Marathon) getForwardCerts(application marathon.Application) string {
+	if forwardCerts, err := provider.getLabel(application, "traefik.frontend.forwardCerts"); err == nil {
+		return forwardCerts
+	}
+	return "false"
+}
+
+func (provider *Marathon) getInsecureCert(application marathon.Application) string {
+	if insecureCert, err := provider.getLabel(application, "traefik.frontend.insecureCert"); err == nil {
+		return insecureCert
+	}
+	return "false"
 }
 
 func (provider *Marathon) getEntryPoints(application marathon.Application) []string {

--- a/provider/marathon.go
+++ b/provider/marathon.go
@@ -183,8 +183,13 @@ func taskFilter(task marathon.Task, applications *marathon.Applications, exposed
 	}
 
 	//filter indeterminable task port
-	portIndexLabel := (*application.Labels)["traefik.portIndex"]
-	portValueLabel := (*application.Labels)["traefik.port"]
+    // Defaulting the values to "" if there are no Labels defined.
+    portIndexLabel := ""
+    portValueLabel := ""
+    if application.Labels != nil {
+        portIndexLabel = (*application.Labels)["traefik.portIndex"]
+        portValueLabel = (*application.Labels)["traefik.port"]
+    }
 	if portIndexLabel != "" && portValueLabel != "" {
 		log.Debugf("Filtering marathon task %s specifying both traefik.portIndex and traefik.port labels", task.AppID)
 		return false
@@ -255,15 +260,21 @@ func getApplication(task marathon.Task, apps []marathon.Application) (marathon.A
 }
 
 func isApplicationEnabled(application marathon.Application, exposedByDefault bool) bool {
-	return exposedByDefault && (*application.Labels)["traefik.enable"] != "false" || (*application.Labels)["traefik.enable"] == "true"
+    enabled := ""
+    if application.Labels != nil {
+        enabled = (*application.Labels)["traefik.enable"]
+    }
+    return exposedByDefault && enabled != "false" || enabled == "true"
 }
 
 func (provider *Marathon) getLabel(application marathon.Application, label string) (string, error) {
-	for key, value := range *application.Labels {
-		if key == label {
-			return value, nil
-		}
-	}
+    if application.Labels != nil {
+        for key, value := range (*application.Labels) {
+            if key == label {
+                return value, nil
+            }
+        }
+    }
 	return "", errors.New("Label not found:" + label)
 }
 

--- a/provider/marathon.go
+++ b/provider/marathon.go
@@ -123,6 +123,8 @@ func (provider *Marathon) loadMarathonConfig() *types.Configuration {
 		"getPriority":        provider.getPriority,
 		"getForwardCerts":    provider.getForwardCerts,
 		"getInsecureCert":    provider.getInsecureCert,
+        "getAuthType":        provider.getAuthType,
+        "getAuthConfig":      provider.getAuthConfig,
 		"getEntryPoints":     provider.getEntryPoints,
 		"getFrontendRule":    provider.getFrontendRule,
 		"getFrontendBackend": provider.getFrontendBackend,
@@ -359,6 +361,20 @@ func (provider *Marathon) getInsecureCert(application marathon.Application) stri
 		return insecureCert
 	}
 	return "false"
+}
+
+func (provider *Marathon) getAuthType(application marathon.Application) string {
+	if authType, err := provider.getLabel(application, "traefik.frontend.authType"); err == nil {
+		return authType
+	}
+	return ""
+}
+
+func (provider *Marathon) getAuthConfig(application marathon.Application) string {
+	if authConfig, err := provider.getLabel(application, "traefik.frontend.authConfig"); err == nil {
+		return authConfig
+	}
+	return ""
 }
 
 func (provider *Marathon) getEntryPoints(application marathon.Application) []string {

--- a/provider/marathon.go
+++ b/provider/marathon.go
@@ -120,13 +120,9 @@ func (provider *Marathon) loadMarathonConfig() *types.Configuration {
 		"getDomain":          provider.getDomain,
 		"getProtocol":        provider.getProtocol,
 		"getPassHostHeader":  provider.getPassHostHeader,
-<<<<<<< HEAD
 		"getPriority":        provider.getPriority,
-||||||| merged common ancestors
-=======
 		"getForwardCerts":    provider.getForwardCerts,
 		"getInsecureCert":    provider.getInsecureCert,
->>>>>>> Added code to get the new options from Marathon labels.
 		"getEntryPoints":     provider.getEntryPoints,
 		"getFrontendRule":    provider.getFrontendRule,
 		"getFrontendBackend": provider.getFrontendBackend,

--- a/provider/marathon_test.go
+++ b/provider/marathon_test.go
@@ -823,6 +823,64 @@ func TestMarathonGetPassHostHeader(t *testing.T) {
 	}
 }
 
+func TestMarathonGetForwardCerts(t *testing.T) {
+	provider := &Marathon{}
+
+	applications := []struct {
+		application marathon.Application
+		expected    string
+	}{
+		{
+			application: marathon.Application{},
+			expected:    "false",
+		},
+		{
+			application: marathon.Application{
+				Labels: &map[string]string{
+					"traefik.frontend.forwardCerts": "true",
+				},
+			},
+			expected: "true",
+		},
+	}
+
+	for _, a := range applications {
+		actual := provider.getForwardCerts(a.application)
+		if actual != a.expected {
+			t.Fatalf("expected %q, got %q", a.expected, actual)
+		}
+	}
+}
+
+func TestMarathonGetInsecureCert(t *testing.T) {
+	provider := &Marathon{}
+
+	applications := []struct {
+		application marathon.Application
+		expected    string
+	}{
+		{
+			application: marathon.Application{},
+			expected:    "false",
+		},
+		{
+			application: marathon.Application{
+				Labels: &map[string]string{
+					"traefik.frontend.insecureCert": "true",
+				},
+			},
+			expected: "true",
+		},
+	}
+
+	for _, a := range applications {
+		actual := provider.getInsecureCert(a.application)
+		if actual != a.expected {
+			t.Fatalf("expected %q, got %q", a.expected, actual)
+		}
+	}
+}
+
 func TestMarathonGetEntryPoints(t *testing.T) {
 	provider := &Marathon{}
 

--- a/server.go
+++ b/server.go
@@ -20,6 +20,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/codegangsta/negroni"
+	"github.com/containous/oxy/forward"
 	"github.com/containous/mux"
 	"github.com/containous/traefik/middlewares"
 	"github.com/containous/traefik/provider"
@@ -29,7 +30,6 @@ import (
 	"github.com/streamrail/concurrent-map"
 	"github.com/vulcand/oxy/cbreaker"
 	"github.com/vulcand/oxy/connlimit"
-	"github.com/vulcand/oxy/forward"
 	"github.com/vulcand/oxy/roundrobin"
 	"github.com/vulcand/oxy/utils"
 	"golang.org/x/net/http2"

--- a/server.go
+++ b/server.go
@@ -426,7 +426,7 @@ func (server *Server) loadConfig(configurations configs, globalConfiguration Glo
 				}
 				fwd, err = forward.New(forward.Logger(oxyLogger),
 					forward.PassHostHeader(frontend.PassHostHeader),
-					// forward.ForwardSslCerts(),
+					forward.ForwardSslCerts(),
 					forward.RoundTripper(rt),
                     forward.Authorization(frontend.AuthType, frontend.AuthConfig))
 			} else {

--- a/server.go
+++ b/server.go
@@ -282,7 +282,7 @@ func (server *Server) createTLSConfig(entryPointName string, tlsOption *TLS, rou
 
 	config := &tls.Config{}
 	if tlsOption.RequireClientCert {
-		config.ClientAuth = tls.RequireAndVerifyClientCert
+		config.ClientAuth = tls.VerifyClientCertIfGiven
 	}
 	config.Certificates = []tls.Certificate{}
 	for _, v := range tlsOption.Certificates {

--- a/server.go
+++ b/server.go
@@ -279,6 +279,9 @@ func (server *Server) createTLSConfig(entryPointName string, tlsOption *TLS, rou
 	}
 
 	config := &tls.Config{}
+	if tlsOption.RequireClientCert {
+		config.ClientAuth = tls.RequireAndVerifyClientCert
+	}
 	config.Certificates = []tls.Certificate{}
 	for _, v := range tlsOption.Certificates {
 		cert, err := tls.LoadX509KeyPair(v.CertFile, v.KeyFile)

--- a/server.go
+++ b/server.go
@@ -392,7 +392,12 @@ func (server *Server) loadConfig(configurations configs, globalConfiguration Glo
 			frontend := configuration.Frontends[frontendName]
 
 			log.Debugf("Creating frontend %s", frontendName)
-			fwd, _ := forward.New(forward.Logger(oxyLogger), forward.PassHostHeader(frontend.PassHostHeader))
+			var fwd *forward.Forwarder
+			if frontend.ForwardCerts {
+				fwd, _ = forward.New(forward.Logger(oxyLogger), forward.PassHostHeader(frontend.PassHostHeader), forward.ForwardSslCerts())
+			} else {
+				fwd, _ = forward.New(forward.Logger(oxyLogger), forward.PassHostHeader(frontend.PassHostHeader))
+			}
 			saveBackend := middlewares.NewSaveBackend(fwd)
 			if len(frontend.EntryPoints) == 0 {
 				log.Errorf("No entrypoint defined for frontend %s, defaultEntryPoints:%s", frontendName, globalConfiguration.DefaultEntryPoints)

--- a/templates/kv.tmpl
+++ b/templates/kv.tmpl
@@ -41,6 +41,10 @@
     backend = "{{Get "" . "/backend"}}"
     passHostHeader = {{Get "true" . "/passHostHeader"}}
     priority = {{Get "0" . "/priority"}}
+    forwardCerts = {{ Get "false" . "/forwardCerts"}}
+    insecureCert = {{ Get "false" . "/insecureCert"}}
+    authType = {{ Get "" . "/authType"}}
+    authConfig = {{ Get "" . "/authConfig"}}
     entryPoints = [{{range $entryPoints}}
       "{{.}}",
     {{end}}]

--- a/templates/kv.tmpl
+++ b/templates/kv.tmpl
@@ -30,7 +30,7 @@
 {{range $servers}}
 [backends."{{Last $backend}}".servers."{{Last .}}"]
     url = "{{Get "" . "/url"}}"
-    weight = {{Get ""  . "/weight"}}
+    weight = {{Get "0"  . "/weight"}}
 {{end}}
 {{end}}
 

--- a/templates/marathon.tmpl
+++ b/templates/marathon.tmpl
@@ -10,6 +10,8 @@
   backend = "backend{{getFrontendBackend .}}"
   passHostHeader = {{getPassHostHeader .}}
   priority = {{getPriority .}}
+  forwardCerts = {{getForwardCerts .}}
+  insecureCert = {{getInsecureCert .}}
   entryPoints = [{{range getEntryPoints .}}
     "{{.}}",
   {{end}}]

--- a/templates/marathon.tmpl
+++ b/templates/marathon.tmpl
@@ -12,6 +12,8 @@
   priority = {{getPriority .}}
   forwardCerts = {{getForwardCerts .}}
   insecureCert = {{getInsecureCert .}}
+  authType = '{{getAuthType .}}'
+  authConfig = '{{getAuthConfig .}}'
   entryPoints = [{{range getEntryPoints .}}
     "{{.}}",
   {{end}}]

--- a/types/types.go
+++ b/types/types.go
@@ -55,6 +55,8 @@ type Frontend struct {
 	Priority       int              `json:"priority"`
 	ForwardCerts   bool             `json:"forwardCerts,omitempty"`
 	InsecureCert   bool             `json:"insecureCert,omitempty"`
+    AuthType       string           `json:"authType,omitempty"`
+    AuthConfig     string           `json:"authConfig,omitempty"`
 }
 
 // LoadBalancerMethod holds the method of load balancing to use.

--- a/types/types.go
+++ b/types/types.go
@@ -54,6 +54,7 @@ type Frontend struct {
 	PassHostHeader bool             `json:"passHostHeader,omitempty"`
 	Priority       int              `json:"priority"`
 	ForwardCerts   bool             `json:"forwardCerts,omitempty"`
+	InsecureCert   bool             `json:"insecureCert,omitempty"`
 }
 
 // LoadBalancerMethod holds the method of load balancing to use.

--- a/types/types.go
+++ b/types/types.go
@@ -53,6 +53,7 @@ type Frontend struct {
 	Routes         map[string]Route `json:"routes,omitempty"`
 	PassHostHeader bool             `json:"passHostHeader,omitempty"`
 	Priority       int              `json:"priority"`
+	ForwardCerts   bool             `json:"forwardCerts,omitempty"`
 }
 
 // LoadBalancerMethod holds the method of load balancing to use.


### PR DESCRIPTION
This relates to the pull request of the same name for containous/oxy.

The goal of this was to be able to forward client SSL Cert information to back-end services through Traefik.  This is important as some of the services need to authorize users.

Also, this integrates authorization code into Traefik as we needed to be able to authorize users at the proxy level and deny them access before they hit any of the back-end services.