### PR TITLE
Update server.go

### DIFF
--- a/server.go
+++ b/server.go
@@ -108,6 +108,7 @@ func (server *Server) Close() {
 	server.routinesPool.Stop()
 	close(server.configurationChan)
 	close(server.configurationValidatedChan)
+	signal.Stop(server.signals)
 	close(server.signals)
 	close(server.stopChan)
 	server.loggerMiddleware.Close()


### PR DESCRIPTION
Fixed a bug that caused a panic when sending multiple signals: signals are no longer sent on the server.signals channel after it has closed.