### PR TITLE
Bump node to 6 for webui

### DIFF
--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:5.4
+FROM node:6.3.0
 
 ENV WEBUI_DIR /src/webui
 RUN mkdir -p $WEBUI_DIR


### PR DESCRIPTION
@ldez should we even use node 6 now ? (6.3 is available on the hub)

Signed-off-by: Vincent Demeester <vincent@sbr.pm>