### PR TITLE
Added the possibility to handle multiple frontends in Docker backend provider

### DIFF
--- a/provider/docker.go
+++ b/provider/docker.go
@@ -2,12 +2,12 @@ package provider
 
 import (
 	"errors"
+	"github.com/vdemeester/docker-events"
 	"net/http"
 	"strconv"
 	"strings"
 	"text/template"
 	"time"
-  "github.com/vdemeester/docker-events"
 
 	"github.com/BurntSushi/ty/fun"
 	log "github.com/Sirupsen/logrus"

--- a/provider/docker.go
+++ b/provider/docker.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"errors"
-	"github.com/vdemeester/docker-events"
 	"net/http"
 	"strconv"
 	"strings"
@@ -19,6 +18,7 @@ import (
 	eventtypes "github.com/docker/engine-api/types/events"
 	"github.com/docker/engine-api/types/filters"
 	"github.com/docker/go-connections/sockets"
+	"github.com/vdemeester/docker-events"
 	"golang.org/x/net/context"
 )
 

--- a/provider/docker.go
+++ b/provider/docker.go
@@ -7,8 +7,7 @@ import (
 	"strings"
 	"text/template"
 	"time"
-
-	"golang.org/x/net/context"
+  "github.com/vdemeester/docker-events"
 
 	"github.com/BurntSushi/ty/fun"
 	log "github.com/Sirupsen/logrus"
@@ -20,7 +19,7 @@ import (
 	eventtypes "github.com/docker/engine-api/types/events"
 	"github.com/docker/engine-api/types/filters"
 	"github.com/docker/go-connections/sockets"
-	"github.com/vdemeester/docker-events"
+	"golang.org/x/net/context"
 )
 
 // DockerAPIVersion is a constant holding the version of the Docker API traefik will use
@@ -168,15 +167,25 @@ func (provider *Docker) loadDockerConfig(containersInspected []dockertypes.Conta
 		return provider.containerFilter(container, provider.ExposedByDefault)
 	}, containersInspected).([]dockertypes.ContainerJSON)
 
-	frontends := map[string][]dockertypes.ContainerJSON{}
+	type Frontend struct {
+		Rule       string
+		Containers []dockertypes.ContainerJSON
+	}
+
+	frontends := map[string]Frontend{}
 	for _, container := range filteredContainers {
-		frontendName := provider.getFrontendName(container)
-		frontends[frontendName] = append(frontends[frontendName], container)
+		for frontendName, frontendRule := range provider.getFrontendName(container) {
+			frontend := frontends[frontendName]
+			frontends[frontendName] = Frontend{
+				Rule:       frontendRule,
+				Containers: append(frontend.Containers, container),
+			}
+		}
 	}
 
 	templateObjects := struct {
 		Containers []dockertypes.ContainerJSON
-		Frontends  map[string][]dockertypes.ContainerJSON
+		Frontends  map[string]Frontend
 		Domain     string
 	}{
 		filteredContainers,
@@ -218,18 +227,22 @@ func (provider *Docker) containerFilter(container dockertypes.ContainerJSON, exp
 	return true
 }
 
-func (provider *Docker) getFrontendName(container dockertypes.ContainerJSON) string {
+func (provider *Docker) getFrontendName(container dockertypes.ContainerJSON) map[string]string {
 	// Replace '.' with '-' in quoted keys because of this issue https://github.com/BurntSushi/toml/issues/78
-	return normalize(provider.getFrontendRule(container))
+	frontendNames := make(map[string]string)
+	for _, rule := range provider.getFrontendRule(container) {
+		frontendNames[normalize(rule)] = rule
+	}
+	return frontendNames
 }
 
 // GetFrontendRule returns the frontend rule for the specified container, using
 // it's label. It returns a default one (Host) if the label is not present.
-func (provider *Docker) getFrontendRule(container dockertypes.ContainerJSON) string {
+func (provider *Docker) getFrontendRule(container dockertypes.ContainerJSON) []string {
 	if label, err := getLabel(container, "traefik.frontend.rule"); err == nil {
-		return label
+		return strings.Split(label, "&&")
 	}
-	return "Host:" + provider.getSubDomain(container.Name) + "." + provider.Domain
+	return []string{"Host:" + provider.getSubDomain(container.Name) + "." + provider.Domain}
 }
 
 func (provider *Docker) getBackend(container dockertypes.ContainerJSON) string {

--- a/templates/docker.tmpl
+++ b/templates/docker.tmpl
@@ -4,14 +4,14 @@
     weight = {{getWeight .}}
 {{end}}
 
-[frontends]{{range $frontend, $containers := .Frontends}}
-  [frontends."frontend-{{$frontend}}"]{{$container := index $containers 0}}
+[frontends]{{range $frontendName, $frontend := .Frontends}}
+  [frontends."frontend-{{$frontendName}}"]{{$container := index $frontend.Containers 0}}
   backend = "backend-{{getBackend $container}}"
   passHostHeader = {{getPassHostHeader $container}}
   priority = {{getPriority $container}}
   entryPoints = [{{range getEntryPoints $container}}
     "{{.}}",
   {{end}}]
-    [frontends."frontend-{{$frontend}}".routes."route-frontend-{{$frontend}}"]
-    rule = "{{getFrontendRule $container}}"
+    [frontends."frontend-{{$frontendName}}".routes."route-frontend-{{$frontendName}}"]
+    rule = "{{$frontend.Rule}}"
 {{end}}


### PR DESCRIPTION
Hi,

We encountered a little issue when working with *traefik*, in a special use case we had, when using the Docker backend provider. The scenario is better explained by the means of an example, so below is a `docker-compose.yml` we created to test this scenario:

```
version: '2'
services:
  traefik:
    image: traefik:v1.0.0
    command: --docker --docker.domain=docker.localhost --logLevel=DEBUG
    ports:
      - "80:80"
    volumes:
      - /dev/null:/traefik.toml
      - /var/run/docker.sock:/var/run/docker.sock
  whoami1:
    image: emilevauge/whoami
    labels:
      - "traefik.backend=whoami"
      - "traefik.frontend.rule=Host:whoami.docker.localhost"
  whoami2:
    image: emilevauge/whoami
    labels:
      - "traefik.backend=whoami"
      - "traefik.frontend.rule=Host:whoami.docker.localhost"
```

As you can see we have two `whoami` containers which are part of the same backend. We wanted these containers to have a frontend rule that matches the host `whoami.docker.localhost`, but we also wanted these containers to have another frontend rule that matches the host `proxy.docker.localhost` and all paths prefixed by `/whoami` (which must be stripped from the URL). So, using the *file* backend, this were resulting in a `traefik.toml` file like the one below:

```
# traefik.toml
logLevel = "DEBUG"
defaultEntryPoints = ["http"]
[entryPoints]
  [entryPoints.http]
  address = ":80"

[file]

# rules
[backends]
  [backends.backend1]
    [backends.backend1.servers.server1]
    url = "http://172.18.0.2:80"
    [backends.backend1.servers.server2]
    url = "http://172.18.0.3:80"

[frontends]
  [frontends.frontend1]
  backend = "backend1"
    [frontends.frontend1.routes.test_1]
    rule = "Host:whoami.docker.localhost"
  [frontends.frontend2]
  backend = "backend1"
    [frontends.frontend2.routes.test_1]
    rule = "Host:proxy.docker.localhost;PathPrefixStrip:/whoami"
```

This worked fine, so we could have the following answers:

```
$ curl -H "Host:whoami.docker.localhost" localhost
Hostname: 43945723dd85
IP: 127.0.0.1
IP: ::1
IP: 172.18.0.2
IP: fe80::42:acff:fe12:2
GET / HTTP/1.1
Host: whoami.docker.localhost
User-Agent: curl/7.35.0
Accept: */*
Accept-Encoding: gzip
X-Forwarded-For: 172.18.0.1
X-Forwarded-Host: whoami.docker.localhost
X-Forwarded-Proto: http
X-Forwarded-Server: 2c5a48d8ccdb


$ curl -H "Host:proxy.docker.localhost" localhost/whoami/version
Hostname: 0e6df3415a89
IP: 127.0.0.1
IP: ::1
IP: 172.18.0.3
IP: fe80::42:acff:fe12:3
GET /version HTTP/1.1
Host: proxy.docker.localhost
User-Agent: curl/7.35.0
Accept: */*
Accept-Encoding: gzip
X-Forwarded-For: 172.18.0.1
X-Forwarded-Host: proxy.docker.localhost
X-Forwarded-Proto: http
X-Forwarded-Server: 2c5a48d8ccdb
```
(Notice the path stripped in the second request).

So we deeped into the documentation and traefik's code in order to see if we could translate this configuration inside the Docker backend provider, but all of our tries didn't work because in any case we got two separated frontends created. We tried configurations like the one below:

```
version: '2'
services:
  traefik:
    image: traefik:v1.0.0
    command: --docker --docker.domain=docker.localhost --logLevel=DEBUG
    ports:
      - "80:80"
    volumes:
      - /dev/null:/traefik.toml
      - /var/run/docker.sock:/var/run/docker.sock
  whoami1:
    image: emilevauge/whoami
    labels:
      - "traefik.backend=whoami"
      - "traefik.frontend.rule=Host:whoami.docker.localhost,proxy.docker.localhost;PathPrefixStrip:/resources,/"
  whoami2:
    image: emilevauge/whoami
    labels:
      - "traefik.backend=whoami"
      - "traefik.frontend.rule=Host:whoami.docker.localhost,proxy.docker.localhost;PathPrefixStrip:/resources,/"
```

None worked. Finally, we decided to modify traefik's docker provider source code and `docker.tmpl` file to meet our needs. This PR allows us to create separated frontends which matches the same backend, with different rules. This can be tested using the following `docker-compose.yml` file:

```
version: '2'
services:
  traefik:
    image: devopsbq/traefik:v1.0.0
    command: --docker --docker.domain=docker.localhost --logLevel=DEBUG
    ports:
      - "80:80"
    volumes:
      - /dev/null:/traefik.toml
      - /var/run/docker.sock:/var/run/docker.sock
  whoami1:
    image: emilevauge/whoami
    labels:
      - "traefik.backend=whoami"
      - "traefik.frontend.rule=Host:whoami.docker.localhost&&Host:proxy.docker.localhost;PathPrefixStrip:/resources"
  whoami2:
    image: emilevauge/whoami
    labels:
      - "traefik.backend=whoami"
      - "traefik.frontend.rule=Host:whoami.docker.localhost&&Host:proxy.docker.localhost;PathPrefixStrip:/resources"
```

We used the `&&` separator in order to specify more than one frontend, because it worked for us, but we could change it to something else. Everything now worked fine:

```
$ curl -H "Host:whoami.docker.localhost" localhost
Hostname: 43945723dd85
IP: 127.0.0.1
IP: ::1
IP: 172.18.0.2
IP: fe80::42:acff:fe12:2
GET / HTTP/1.1
Host: whoami.docker.localhost
User-Agent: curl/7.35.0
Accept: */*
Accept-Encoding: gzip
X-Forwarded-For: 172.18.0.1
X-Forwarded-Host: whoami.docker.localhost
X-Forwarded-Proto: http
X-Forwarded-Server: 2c5a48d8ccdb


$ curl -H "Host:proxy.docker.localhost" localhost/whoami/version
Hostname: 0e6df3415a89
IP: 127.0.0.1
IP: ::1
IP: 172.18.0.3
IP: fe80::42:acff:fe12:3
GET /version HTTP/1.1
Host: proxy.docker.localhost
User-Agent: curl/7.35.0
Accept: */*
Accept-Encoding: gzip
X-Forwarded-For: 172.18.0.1
X-Forwarded-Host: proxy.docker.localhost
X-Forwarded-Proto: http
X-Forwarded-Server: 2c5a48d8ccdb
```
