### PR TITLE
Prioritize kubernetes routes by path length

### DIFF
--- a/provider/kubernetes.go
+++ b/provider/kubernetes.go
@@ -209,6 +209,7 @@ func (provider *Kubernetes) loadIngresses(k8sClient k8s.Client) (*types.Configur
 						Backend:        r.Host + pa.Path,
 						PassHostHeader: PassHostHeader,
 						Routes:         make(map[string]types.Route),
+						Priority:       len(pa.Path),
 					}
 				}
 				if len(r.Host) > 0 {

--- a/provider/kubernetes_test.go
+++ b/provider/kubernetes_test.go
@@ -237,6 +237,7 @@ func TestLoadIngresses(t *testing.T) {
 			"foo/bar": {
 				Backend:        "foo/bar",
 				PassHostHeader: true,
+				Priority:       len("/bar"),
 				Routes: map[string]types.Route{
 					"/bar": {
 						Rule: "PathPrefix:/bar",
@@ -425,7 +426,8 @@ func TestRuleType(t *testing.T) {
 
 	expected := map[string]*types.Frontend{
 		"foo1/bar1": {
-			Backend: "foo1/bar1",
+			Backend:  "foo1/bar1",
+			Priority: len("/bar1"),
 			Routes: map[string]types.Route{
 				"/bar1": {
 					Rule: "PathPrefixStrip:/bar1",
@@ -436,7 +438,8 @@ func TestRuleType(t *testing.T) {
 			},
 		},
 		"foo1/bar2": {
-			Backend: "foo1/bar2",
+			Backend:  "foo1/bar2",
+			Priority: len("/bar2"),
 			Routes: map[string]types.Route{
 				"/bar2": {
 					Rule: "Path:/bar2",
@@ -447,7 +450,8 @@ func TestRuleType(t *testing.T) {
 			},
 		},
 		"foo2/bar1": {
-			Backend: "foo2/bar1",
+			Backend:  "foo2/bar1",
+			Priority: len("/bar1"),
 			Routes: map[string]types.Route{
 				"/bar1": {
 					Rule: "PathPrefix:/bar1",
@@ -458,7 +462,8 @@ func TestRuleType(t *testing.T) {
 			},
 		},
 		"foo2/bar2": {
-			Backend: "foo2/bar2",
+			Backend:  "foo2/bar2",
+			Priority: len("/bar2"),
 			Routes: map[string]types.Route{
 				"/bar2": {
 					Rule: "PathStrip:/bar2",
@@ -469,7 +474,8 @@ func TestRuleType(t *testing.T) {
 			},
 		},
 		"foo1/bar3": {
-			Backend: "foo1/bar3",
+			Backend:  "foo1/bar3",
+			Priority: len("/bar3"),
 			Routes: map[string]types.Route{
 				"/bar3": {
 					Rule: "PathPrefix:/bar3",
@@ -559,7 +565,8 @@ func TestGetPassHostHeader(t *testing.T) {
 		},
 		Frontends: map[string]*types.Frontend{
 			"foo/bar": {
-				Backend: "foo/bar",
+				Backend:  "foo/bar",
+				Priority: len("/bar"),
 				Routes: map[string]types.Route{
 					"/bar": {
 						Rule: "PathPrefix:/bar",
@@ -869,6 +876,7 @@ func TestLoadNamespacedIngresses(t *testing.T) {
 			"foo/bar": {
 				Backend:        "foo/bar",
 				PassHostHeader: true,
+				Priority:       len("/bar"),
 				Routes: map[string]types.Route{
 					"/bar": {
 						Rule: "PathPrefix:/bar",
@@ -1116,6 +1124,7 @@ func TestLoadMultipleNamespacedIngresses(t *testing.T) {
 			"foo/bar": {
 				Backend:        "foo/bar",
 				PassHostHeader: true,
+				Priority:       len("/bar"),
 				Routes: map[string]types.Route{
 					"/bar": {
 						Rule: "PathPrefix:/bar",
@@ -1137,6 +1146,7 @@ func TestLoadMultipleNamespacedIngresses(t *testing.T) {
 			"awesome/quix": {
 				Backend:        "awesome/quix",
 				PassHostHeader: true,
+				Priority:       len("/quix"),
 				Routes: map[string]types.Route{
 					"/quix": {
 						Rule: "PathPrefix:/quix",
@@ -1226,7 +1236,8 @@ func TestHostlessIngress(t *testing.T) {
 		},
 		Frontends: map[string]*types.Frontend{
 			"/bar": {
-				Backend: "/bar",
+				Backend:  "/bar",
+				Priority: len("/bar"),
 				Routes: map[string]types.Route{
 					"/bar": {
 						Rule: "PathPrefix:/bar",

--- a/templates/kubernetes.tmpl
+++ b/templates/kubernetes.tmpl
@@ -9,6 +9,7 @@
 [frontends]{{range $frontendName, $frontend := .Frontends}}
   [frontends."{{$frontendName}}"]
   backend = "{{$frontend.Backend}}"
+  priority = {{$frontend.Priority}}
   passHostHeader = {{$frontend.PassHostHeader}}
     {{range $routeName, $route := $frontend.Routes}}
     [frontends."{{$frontendName}}".routes."{{$routeName}}"]


### PR DESCRIPTION
The Kubernetes provider wasn't setting priorities which was causing
shorter paths to get chosen before longer ones. This now matches the
[documentation](https://github.com/containous/traefik/blob/master/docs/basics.md#priorities)
