### PR TITLE
Name servers after thier pods

### DIFF
--- a/provider/kubernetes.go
+++ b/provider/kubernetes.go
@@ -268,7 +268,11 @@ func (provider *Kubernetes) loadIngresses(k8sClient k8s.Client) (*types.Configur
 							for _, subset := range endpoints.Subsets {
 								for _, address := range subset.Addresses {
 									url := protocol + "://" + address.IP + ":" + strconv.Itoa(endpointPortNumber(port, subset.Ports))
-									templateObjects.Backends[r.Host+pa.Path].Servers[url] = types.Server{
+									name := url
+									if address.TargetRef != nil && address.TargetRef.Name != "" {
+										name = address.TargetRef.Name
+									}
+									templateObjects.Backends[r.Host+pa.Path].Servers[name] = types.Server{
 										URL:    url,
 										Weight: 1,
 									}


### PR DESCRIPTION
The TargetRef contains information from the object referenced
by the pod, unless the service has been set up with bare
endpoints - i.e. not pointing at pods this information
will be present.

It just makes the information that we show in the web-ui
a little more constent with that shown in kubectl
and the kuberntes dashboard.
