### PR TITLE
Fixed binary script so traefik version command doesn't just print default values

### DIFF
--- a/script/binary
+++ b/script/binary
@@ -26,4 +26,4 @@ if [ -z "$DATE" ]; then
 fi
 
 # Build binaries
-CGO_ENABLED=0 GOGC=off go build $FLAGS -ldflags "-s -w -X version.Version=$VERSION -X version.Codename=$CODENAME -X version.BuildDate=$DATE" -a -installsuffix nocgo -o dist/traefik .
+CGO_ENABLED=0 GOGC=off go build $FLAGS -ldflags "-s -w -X github.com/containous/traefik/version.Version=$VERSION -X github.com/containous/traefik/version.Codename=$CODENAME -X github.com/containous/traefik/version.BuildDate=$DATE" -a -installsuffix nocgo -o dist/traefik .


### PR DESCRIPTION
Fixes #569
