### PR TITLE
#504 Initial support for Docker 1.12 Swarm Mode

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -4,13 +4,14 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"github.com/containous/traefik/acme"
-	"github.com/containous/traefik/provider"
-	"github.com/containous/traefik/types"
 	"os"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/containous/traefik/acme"
+	"github.com/containous/traefik/provider"
+	"github.com/containous/traefik/types"
 )
 
 // TraefikConfiguration holds GlobalConfiguration and other stuff
@@ -269,6 +270,7 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 	defaultDocker.Watch = true
 	defaultDocker.ExposedByDefault = true
 	defaultDocker.Endpoint = "unix:///var/run/docker.sock"
+	defaultDocker.SwarmMode = false
 
 	// default File
 	var defaultFile provider.File

--- a/docs/toml.md
+++ b/docs/toml.md
@@ -664,11 +664,19 @@ watch = true
 exposedbydefault = true
 
 # Use the IP address from the binded port instead of the inner network one. For specific use-case :)
+
 #
 # Optional
 # Default: false
 #
 usebindportip = true
+# Use Swarm Mode services as data provider
+#
+# Optional
+# Default: false
+#
+swarmmode = false
+
 
 # Enable docker TLS connection
 #

--- a/provider/docker_test.go
+++ b/provider/docker_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/docker/engine-api/types/container"
 	"github.com/docker/engine-api/types/network"
 	"github.com/docker/go-connections/nat"
+
+	swarm "github.com/docker/engine-api/types/swarm"
 )
 
 func TestDockerGetFrontendName(t *testing.T) {
@@ -85,7 +87,8 @@ func TestDockerGetFrontendName(t *testing.T) {
 	}
 
 	for _, e := range containers {
-		actual := provider.getFrontendName(e.container)
+		dockerData := parseContainer(e.container)
+		actual := provider.getFrontendName(dockerData)
 		if actual != e.expected {
 			t.Fatalf("expected %q, got %q", e.expected, actual)
 		}
@@ -148,7 +151,8 @@ func TestDockerGetFrontendRule(t *testing.T) {
 	}
 
 	for _, e := range containers {
-		actual := provider.getFrontendRule(e.container)
+		dockerData := parseContainer(e.container)
+		actual := provider.getFrontendRule(dockerData)
 		if actual != e.expected {
 			t.Fatalf("expected %q, got %q", e.expected, actual)
 		}
@@ -196,7 +200,8 @@ func TestDockerGetBackend(t *testing.T) {
 	}
 
 	for _, e := range containers {
-		actual := provider.getBackend(e.container)
+		dockerData := parseContainer(e.container)
+		actual := provider.getBackend(dockerData)
 		if actual != e.expected {
 			t.Fatalf("expected %q, got %q", e.expected, actual)
 		}
@@ -296,7 +301,8 @@ func TestDockerGetIPAddress(t *testing.T) { // TODO
 	}
 
 	for _, e := range containers {
-		actual := provider.getIPAddress(e.container)
+		dockerData := parseContainer(e.container)
+		actual := provider.getIPAddress(dockerData)
 		if actual != e.expected {
 			t.Fatalf("expected %q, got %q", e.expected, actual)
 		}
@@ -387,7 +393,8 @@ func TestDockerGetPort(t *testing.T) {
 	}
 
 	for _, e := range containers {
-		actual := provider.getPort(e.container)
+		dockerData := parseContainer(e.container)
+		actual := provider.getPort(dockerData)
 		if actual != e.expected {
 			t.Fatalf("expected %q, got %q", e.expected, actual)
 		}
@@ -426,7 +433,8 @@ func TestDockerGetWeight(t *testing.T) {
 	}
 
 	for _, e := range containers {
-		actual := provider.getWeight(e.container)
+		dockerData := parseContainer(e.container)
+		actual := provider.getWeight(dockerData)
 		if actual != e.expected {
 			t.Fatalf("expected %q, got %q", e.expected, actual)
 		}
@@ -467,7 +475,8 @@ func TestDockerGetDomain(t *testing.T) {
 	}
 
 	for _, e := range containers {
-		actual := provider.getDomain(e.container)
+		dockerData := parseContainer(e.container)
+		actual := provider.getDomain(dockerData)
 		if actual != e.expected {
 			t.Fatalf("expected %q, got %q", e.expected, actual)
 		}
@@ -506,7 +515,8 @@ func TestDockerGetProtocol(t *testing.T) {
 	}
 
 	for _, e := range containers {
-		actual := provider.getProtocol(e.container)
+		dockerData := parseContainer(e.container)
+		actual := provider.getProtocol(dockerData)
 		if actual != e.expected {
 			t.Fatalf("expected %q, got %q", e.expected, actual)
 		}
@@ -544,7 +554,8 @@ func TestDockerGetPassHostHeader(t *testing.T) {
 	}
 
 	for _, e := range containers {
-		actual := provider.getPassHostHeader(e.container)
+		dockerData := parseContainer(e.container)
+		actual := provider.getPassHostHeader(dockerData)
 		if actual != e.expected {
 			t.Fatalf("expected %q, got %q", e.expected, actual)
 		}
@@ -575,7 +586,8 @@ func TestDockerGetLabel(t *testing.T) {
 	}
 
 	for _, e := range containers {
-		label, err := getLabel(e.container, "foo")
+		dockerData := parseContainer(e.container)
+		label, err := getLabel(dockerData, "foo")
 		if e.expected != "" {
 			if err == nil || !strings.Contains(err.Error(), e.expected) {
 				t.Fatalf("expected an error with %q, got %v", e.expected, err)
@@ -632,7 +644,8 @@ func TestDockerGetLabels(t *testing.T) {
 	}
 
 	for _, e := range containers {
-		labels, err := getLabels(e.container, []string{"foo", "bar"})
+		dockerData := parseContainer(e.container)
+		labels, err := getLabels(dockerData, []string{"foo", "bar"})
 		if !reflect.DeepEqual(labels, e.expectedLabels) {
 			t.Fatalf("expect %v, got %v", e.expectedLabels, labels)
 		}
@@ -866,7 +879,8 @@ func TestDockerTraefikFilter(t *testing.T) {
 
 	for _, e := range containers {
 		provider.ExposedByDefault = e.exposedByDefault
-		actual := provider.containerFilter(e.container)
+		dockerData := parseContainer(e.container)
+		actual := provider.containerFilter(dockerData)
 		if actual != e.expected {
 			t.Fatalf("expected %v for %+v, got %+v", e.expected, e, actual)
 		}
@@ -1088,7 +1102,1046 @@ func TestDockerLoadDockerConfig(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		actualConfig := provider.loadDockerConfig(c.containers)
+		var dockerDataList []dockerData
+		for _, container := range c.containers {
+			dockerData := parseContainer(container)
+			dockerDataList = append(dockerDataList, dockerData)
+		}
+
+		actualConfig := provider.loadDockerConfig(dockerDataList)
+		// Compare backends
+		if !reflect.DeepEqual(actualConfig.Backends, c.expectedBackends) {
+			t.Fatalf("expected %#v, got %#v", c.expectedBackends, actualConfig.Backends)
+		}
+		if !reflect.DeepEqual(actualConfig.Frontends, c.expectedFrontends) {
+			t.Fatalf("expected %#v, got %#v", c.expectedFrontends, actualConfig.Frontends)
+		}
+	}
+}
+
+func TestSwarmGetFrontendName(t *testing.T) {
+	provider := &Docker{
+		Domain:    "docker.localhost",
+		SwarmMode: true,
+	}
+
+	services := []struct {
+		service  swarm.Service
+		expected string
+		networks map[string]*docker.NetworkResource
+	}{
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "foo",
+					},
+				},
+			},
+			expected: "Host-foo-docker-localhost",
+			networks: map[string]*docker.NetworkResource{},
+		},
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "bar",
+						Labels: map[string]string{
+							"traefik.frontend.rule": "Headers:User-Agent,bat/0.1.0",
+						},
+					},
+				},
+			},
+			expected: "Headers-User-Agent-bat-0-1-0",
+			networks: map[string]*docker.NetworkResource{},
+		},
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "test",
+						Labels: map[string]string{
+							"traefik.frontend.rule": "Host:foo.bar",
+						},
+					},
+				},
+			},
+			expected: "Host-foo-bar",
+			networks: map[string]*docker.NetworkResource{},
+		},
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "test",
+						Labels: map[string]string{
+							"traefik.frontend.rule": "Path:/test",
+						},
+					},
+				},
+			},
+			expected: "Path-test",
+			networks: map[string]*docker.NetworkResource{},
+		},
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "test",
+						Labels: map[string]string{
+							"traefik.frontend.rule": "PathPrefix:/test2",
+						},
+					},
+				},
+			},
+			expected: "PathPrefix-test2",
+			networks: map[string]*docker.NetworkResource{},
+		},
+	}
+
+	for _, e := range services {
+		dockerData := parseService(e.service, e.networks)
+		actual := provider.getFrontendName(dockerData)
+		if actual != e.expected {
+			t.Fatalf("expected %q, got %q", e.expected, actual)
+		}
+	}
+}
+
+func TestSwarmGetFrontendRule(t *testing.T) {
+	provider := &Docker{
+		Domain:    "docker.localhost",
+		SwarmMode: true,
+	}
+
+	services := []struct {
+		service  swarm.Service
+		expected string
+		networks map[string]*docker.NetworkResource
+	}{
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "foo",
+					},
+				},
+			},
+			expected: "Host:foo.docker.localhost",
+			networks: map[string]*docker.NetworkResource{},
+		},
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "bar",
+					},
+				},
+			},
+			expected: "Host:bar.docker.localhost",
+			networks: map[string]*docker.NetworkResource{},
+		},
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "test",
+						Labels: map[string]string{
+							"traefik.frontend.rule": "Host:foo.bar",
+						},
+					},
+				},
+			},
+			expected: "Host:foo.bar",
+			networks: map[string]*docker.NetworkResource{},
+		},
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "test",
+						Labels: map[string]string{
+							"traefik.frontend.rule": "Path:/test",
+						},
+					},
+				},
+			},
+			expected: "Path:/test",
+			networks: map[string]*docker.NetworkResource{},
+		},
+	}
+
+	for _, e := range services {
+		dockerData := parseService(e.service, e.networks)
+		actual := provider.getFrontendRule(dockerData)
+		if actual != e.expected {
+			t.Fatalf("expected %q, got %q", e.expected, actual)
+		}
+	}
+}
+
+func TestSwarmGetBackend(t *testing.T) {
+	provider := &Docker{
+		SwarmMode: true,
+	}
+
+	services := []struct {
+		service  swarm.Service
+		expected string
+		networks map[string]*docker.NetworkResource
+	}{
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "foo",
+					},
+				},
+			},
+			expected: "foo",
+			networks: map[string]*docker.NetworkResource{},
+		},
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "bar",
+					},
+				},
+			},
+			expected: "bar",
+			networks: map[string]*docker.NetworkResource{},
+		},
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "test",
+						Labels: map[string]string{
+							"traefik.backend": "foobar",
+						},
+					},
+				},
+			},
+			expected: "foobar",
+			networks: map[string]*docker.NetworkResource{},
+		},
+	}
+
+	for _, e := range services {
+		dockerData := parseService(e.service, e.networks)
+		actual := provider.getBackend(dockerData)
+		if actual != e.expected {
+			t.Fatalf("expected %q, got %q", e.expected, actual)
+		}
+	}
+}
+
+func TestSwarmGetIPAddress(t *testing.T) {
+	provider := &Docker{
+		SwarmMode: true,
+	}
+
+	services := []struct {
+		service  swarm.Service
+		expected string
+		networks map[string]*docker.NetworkResource
+	}{
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "bar",
+					},
+					EndpointSpec: &swarm.EndpointSpec{
+						Mode: swarm.ResolutionModeDNSRR,
+					},
+				},
+			},
+			expected: "",
+			networks: map[string]*docker.NetworkResource{},
+		},
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "bar",
+					},
+					EndpointSpec: &swarm.EndpointSpec{
+						Mode: swarm.ResolutionModeVIP,
+					},
+				},
+				Endpoint: swarm.Endpoint{
+					VirtualIPs: []swarm.EndpointVirtualIP{
+						{
+							NetworkID: "1",
+							Addr:      "10.11.12.13/24",
+						},
+					},
+				},
+			},
+			expected: "10.11.12.13",
+			networks: map[string]*docker.NetworkResource{
+				"1": {
+					Name: "foo",
+				},
+			},
+		},
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "bar",
+						Labels: map[string]string{
+							"traefik.docker.network": "barnet",
+						},
+					},
+					EndpointSpec: &swarm.EndpointSpec{
+						Mode: swarm.ResolutionModeVIP,
+					},
+				},
+				Endpoint: swarm.Endpoint{
+					VirtualIPs: []swarm.EndpointVirtualIP{
+						{
+							NetworkID: "1",
+							Addr:      "10.11.12.13/24",
+						},
+						{
+							NetworkID: "2",
+							Addr:      "10.11.12.99/24",
+						},
+					},
+				},
+			},
+			expected: "10.11.12.99",
+			networks: map[string]*docker.NetworkResource{
+				"1": {
+					Name: "foonet",
+				},
+				"2": {
+					Name: "barnet",
+				},
+			},
+		},
+	}
+
+	for _, e := range services {
+		dockerData := parseService(e.service, e.networks)
+		actual := provider.getIPAddress(dockerData)
+		if actual != e.expected {
+			t.Fatalf("expected %q, got %q", e.expected, actual)
+		}
+	}
+}
+
+func TestSwarmGetPort(t *testing.T) {
+	provider := &Docker{
+		SwarmMode: true,
+	}
+
+	services := []struct {
+		service  swarm.Service
+		expected string
+		networks map[string]*docker.NetworkResource
+	}{
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "bar",
+						Labels: map[string]string{
+							"traefik.port": "8080",
+						},
+					},
+					EndpointSpec: &swarm.EndpointSpec{
+						Mode: swarm.ResolutionModeDNSRR,
+					},
+				},
+			},
+			expected: "8080",
+			networks: map[string]*docker.NetworkResource{},
+		},
+	}
+
+	for _, e := range services {
+		dockerData := parseService(e.service, e.networks)
+		actual := provider.getPort(dockerData)
+		if actual != e.expected {
+			t.Fatalf("expected %q, got %q", e.expected, actual)
+		}
+	}
+}
+
+func TestSwarmGetWeight(t *testing.T) {
+	provider := &Docker{
+		SwarmMode: true,
+	}
+
+	services := []struct {
+		service  swarm.Service
+		expected string
+		networks map[string]*docker.NetworkResource
+	}{
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "bar",
+					},
+					EndpointSpec: &swarm.EndpointSpec{
+						Mode: swarm.ResolutionModeDNSRR,
+					},
+				},
+			},
+			expected: "1",
+			networks: map[string]*docker.NetworkResource{},
+		},
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "bar",
+						Labels: map[string]string{
+							"traefik.weight": "10",
+						},
+					},
+					EndpointSpec: &swarm.EndpointSpec{
+						Mode: swarm.ResolutionModeDNSRR,
+					},
+				},
+			},
+			expected: "10",
+			networks: map[string]*docker.NetworkResource{},
+		},
+	}
+
+	for _, e := range services {
+		dockerData := parseService(e.service, e.networks)
+		actual := provider.getWeight(dockerData)
+		if actual != e.expected {
+			t.Fatalf("expected %q, got %q", e.expected, actual)
+		}
+	}
+}
+
+func TestSwarmGetDomain(t *testing.T) {
+	provider := &Docker{
+		Domain:    "docker.localhost",
+		SwarmMode: true,
+	}
+
+	services := []struct {
+		service  swarm.Service
+		expected string
+		networks map[string]*docker.NetworkResource
+	}{
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "foo",
+					},
+					EndpointSpec: &swarm.EndpointSpec{
+						Mode: swarm.ResolutionModeDNSRR,
+					},
+				},
+			},
+			expected: "docker.localhost",
+			networks: map[string]*docker.NetworkResource{},
+		},
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "bar",
+						Labels: map[string]string{
+							"traefik.domain": "foo.bar",
+						},
+					},
+					EndpointSpec: &swarm.EndpointSpec{
+						Mode: swarm.ResolutionModeDNSRR,
+					},
+				},
+			},
+			expected: "foo.bar",
+			networks: map[string]*docker.NetworkResource{},
+		},
+	}
+
+	for _, e := range services {
+		dockerData := parseService(e.service, e.networks)
+		actual := provider.getDomain(dockerData)
+		if actual != e.expected {
+			t.Fatalf("expected %q, got %q", e.expected, actual)
+		}
+	}
+}
+
+func TestSwarmGetProtocol(t *testing.T) {
+	provider := &Docker{
+		SwarmMode: true,
+	}
+
+	services := []struct {
+		service  swarm.Service
+		expected string
+		networks map[string]*docker.NetworkResource
+	}{
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "bar",
+					},
+					EndpointSpec: &swarm.EndpointSpec{
+						Mode: swarm.ResolutionModeDNSRR,
+					},
+				},
+			},
+			expected: "http",
+			networks: map[string]*docker.NetworkResource{},
+		},
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "bar",
+						Labels: map[string]string{
+							"traefik.protocol": "https",
+						},
+					},
+					EndpointSpec: &swarm.EndpointSpec{
+						Mode: swarm.ResolutionModeDNSRR,
+					},
+				},
+			},
+			expected: "https",
+			networks: map[string]*docker.NetworkResource{},
+		},
+	}
+
+	for _, e := range services {
+		dockerData := parseService(e.service, e.networks)
+		actual := provider.getProtocol(dockerData)
+		if actual != e.expected {
+			t.Fatalf("expected %q, got %q", e.expected, actual)
+		}
+	}
+}
+
+func TestSwarmGetPassHostHeader(t *testing.T) {
+	provider := &Docker{
+		SwarmMode: true,
+	}
+
+	services := []struct {
+		service  swarm.Service
+		expected string
+		networks map[string]*docker.NetworkResource
+	}{
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "bar",
+					},
+					EndpointSpec: &swarm.EndpointSpec{
+						Mode: swarm.ResolutionModeDNSRR,
+					},
+				},
+			},
+			expected: "true",
+			networks: map[string]*docker.NetworkResource{},
+		},
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "bar",
+						Labels: map[string]string{
+							"traefik.frontend.passHostHeader": "false",
+						},
+					},
+					EndpointSpec: &swarm.EndpointSpec{
+						Mode: swarm.ResolutionModeDNSRR,
+					},
+				},
+			},
+			expected: "false",
+			networks: map[string]*docker.NetworkResource{},
+		},
+	}
+
+	for _, e := range services {
+		dockerData := parseService(e.service, e.networks)
+		actual := provider.getPassHostHeader(dockerData)
+		if actual != e.expected {
+			t.Fatalf("expected %q, got %q", e.expected, actual)
+		}
+	}
+}
+
+func TestSwarmGetLabel(t *testing.T) {
+
+	services := []struct {
+		service  swarm.Service
+		expected string
+		networks map[string]*docker.NetworkResource
+	}{
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "bar",
+					},
+					EndpointSpec: &swarm.EndpointSpec{
+						Mode: swarm.ResolutionModeDNSRR,
+					},
+				},
+			},
+			expected: "Label not found:",
+			networks: map[string]*docker.NetworkResource{},
+		},
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "test",
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+					},
+					EndpointSpec: &swarm.EndpointSpec{
+						Mode: swarm.ResolutionModeDNSRR,
+					},
+				},
+			},
+			expected: "",
+			networks: map[string]*docker.NetworkResource{},
+		},
+	}
+
+	for _, e := range services {
+		dockerData := parseService(e.service, e.networks)
+		label, err := getLabel(dockerData, "foo")
+		if e.expected != "" {
+			if err == nil || !strings.Contains(err.Error(), e.expected) {
+				t.Fatalf("expected an error with %q, got %v", e.expected, err)
+			}
+		} else {
+			if label != "bar" {
+				t.Fatalf("expected label 'bar', got %s", label)
+			}
+		}
+	}
+}
+
+func TestSwarmGetLabels(t *testing.T) {
+	services := []struct {
+		service        swarm.Service
+		expectedLabels map[string]string
+		expectedError  string
+		networks       map[string]*docker.NetworkResource
+	}{
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "test",
+					},
+				},
+			},
+			expectedLabels: map[string]string{},
+			expectedError:  "Label not found:",
+			networks:       map[string]*docker.NetworkResource{},
+		},
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "test",
+						Labels: map[string]string{
+							"foo": "fooz",
+						},
+					},
+				},
+			},
+			expectedLabels: map[string]string{
+				"foo": "fooz",
+			},
+			expectedError: "Label not found: bar",
+			networks:      map[string]*docker.NetworkResource{},
+		},
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "test",
+						Labels: map[string]string{
+							"foo": "fooz",
+							"bar": "barz",
+						},
+					},
+				},
+			},
+			expectedLabels: map[string]string{
+				"foo": "fooz",
+				"bar": "barz",
+			},
+			expectedError: "",
+			networks:      map[string]*docker.NetworkResource{},
+		},
+	}
+
+	for _, e := range services {
+		dockerData := parseService(e.service, e.networks)
+		labels, err := getLabels(dockerData, []string{"foo", "bar"})
+		if !reflect.DeepEqual(labels, e.expectedLabels) {
+			t.Fatalf("expect %v, got %v", e.expectedLabels, labels)
+		}
+		if e.expectedError != "" {
+			if err == nil || !strings.Contains(err.Error(), e.expectedError) {
+				t.Fatalf("expected an error with %q, got %v", e.expectedError, err)
+			}
+		}
+	}
+}
+
+func TestSwarmTraefikFilter(t *testing.T) {
+	provider := &Docker{
+		SwarmMode: true,
+	}
+	services := []struct {
+		service          swarm.Service
+		exposedByDefault bool
+		expected         bool
+		networks         map[string]*docker.NetworkResource
+	}{
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "container",
+					},
+				},
+			},
+			exposedByDefault: true,
+			expected:         false,
+			networks:         map[string]*docker.NetworkResource{},
+		},
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "container",
+						Labels: map[string]string{
+							"traefik.enable": "false",
+							"traefik.port":   "80",
+						},
+					},
+				},
+			},
+			exposedByDefault: true,
+			expected:         false,
+			networks:         map[string]*docker.NetworkResource{},
+		},
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "container",
+						Labels: map[string]string{
+							"traefik.frontend.rule": "Host:foo.bar",
+							"traefik.port":          "80",
+						},
+					},
+				},
+			},
+			exposedByDefault: true,
+			expected:         true,
+			networks:         map[string]*docker.NetworkResource{},
+		},
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "container",
+						Labels: map[string]string{
+							"traefik.port": "80",
+						},
+					},
+				},
+			},
+			exposedByDefault: true,
+			expected:         true,
+			networks:         map[string]*docker.NetworkResource{},
+		},
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "container",
+						Labels: map[string]string{
+							"traefik.enable": "true",
+							"traefik.port":   "80",
+						},
+					},
+				},
+			},
+			exposedByDefault: true,
+			expected:         true,
+			networks:         map[string]*docker.NetworkResource{},
+		},
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "container",
+						Labels: map[string]string{
+							"traefik.enable": "anything",
+							"traefik.port":   "80",
+						},
+					},
+				},
+			},
+			exposedByDefault: true,
+			expected:         true,
+			networks:         map[string]*docker.NetworkResource{},
+		},
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "container",
+						Labels: map[string]string{
+							"traefik.frontend.rule": "Host:foo.bar",
+							"traefik.port":          "80",
+						},
+					},
+				},
+			},
+			exposedByDefault: true,
+			expected:         true,
+			networks:         map[string]*docker.NetworkResource{},
+		},
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "container",
+						Labels: map[string]string{
+							"traefik.port": "80",
+						},
+					},
+				},
+			},
+			exposedByDefault: false,
+			expected:         false,
+			networks:         map[string]*docker.NetworkResource{},
+		},
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "container",
+						Labels: map[string]string{
+							"traefik.enable": "true",
+							"traefik.port":   "80",
+						},
+					},
+				},
+			},
+			exposedByDefault: false,
+			expected:         true,
+			networks:         map[string]*docker.NetworkResource{},
+		},
+	}
+
+	for _, e := range services {
+		dockerData := parseService(e.service, e.networks)
+		provider.ExposedByDefault = e.exposedByDefault
+		actual := provider.containerFilter(dockerData)
+		if actual != e.expected {
+			t.Fatalf("expected %v for %+v, got %+v", e.expected, e, actual)
+		}
+	}
+}
+
+func TestSwarmLoadDockerConfig(t *testing.T) {
+	cases := []struct {
+		services          []swarm.Service
+		expectedFrontends map[string]*types.Frontend
+		expectedBackends  map[string]*types.Backend
+		networks          map[string]*docker.NetworkResource
+	}{
+		{
+			services:          []swarm.Service{},
+			expectedFrontends: map[string]*types.Frontend{},
+			expectedBackends:  map[string]*types.Backend{},
+			networks:          map[string]*docker.NetworkResource{},
+		},
+		{
+			services: []swarm.Service{
+				{
+					Spec: swarm.ServiceSpec{
+						Annotations: swarm.Annotations{
+							Name: "test",
+							Labels: map[string]string{
+								"traefik.port": "80",
+							},
+						},
+						EndpointSpec: &swarm.EndpointSpec{
+							Mode: swarm.ResolutionModeVIP,
+						},
+					},
+					Endpoint: swarm.Endpoint{
+						VirtualIPs: []swarm.EndpointVirtualIP{
+							{
+								Addr:      "127.0.0.1/24",
+								NetworkID: "1",
+							},
+						},
+					},
+				},
+			},
+			expectedFrontends: map[string]*types.Frontend{
+				"frontend-Host-test-docker-localhost": {
+					Backend:        "backend-test",
+					PassHostHeader: true,
+					EntryPoints:    []string{},
+					Routes: map[string]types.Route{
+						"route-frontend-Host-test-docker-localhost": {
+							Rule: "Host:test.docker.localhost",
+						},
+					},
+				},
+			},
+			expectedBackends: map[string]*types.Backend{
+				"backend-test": {
+					Servers: map[string]types.Server{
+						"server-test": {
+							URL:    "http://127.0.0.1:80",
+							Weight: 1,
+						},
+					},
+					CircuitBreaker: nil,
+					LoadBalancer:   nil,
+				},
+			},
+			networks: map[string]*docker.NetworkResource{
+				"1": {
+					Name: "foo",
+				},
+			},
+		},
+		{
+			services: []swarm.Service{
+				{
+					Spec: swarm.ServiceSpec{
+						Annotations: swarm.Annotations{
+							Name: "test1",
+							Labels: map[string]string{
+								"traefik.port":                 "80",
+								"traefik.backend":              "foobar",
+								"traefik.frontend.entryPoints": "http,https",
+							},
+						},
+						EndpointSpec: &swarm.EndpointSpec{
+							Mode: swarm.ResolutionModeVIP,
+						},
+					},
+					Endpoint: swarm.Endpoint{
+						VirtualIPs: []swarm.EndpointVirtualIP{
+							{
+								Addr:      "127.0.0.1/24",
+								NetworkID: "1",
+							},
+						},
+					},
+				},
+				{
+					Spec: swarm.ServiceSpec{
+						Annotations: swarm.Annotations{
+							Name: "test2",
+							Labels: map[string]string{
+								"traefik.port":    "80",
+								"traefik.backend": "foobar",
+							},
+						},
+						EndpointSpec: &swarm.EndpointSpec{
+							Mode: swarm.ResolutionModeVIP,
+						},
+					},
+					Endpoint: swarm.Endpoint{
+						VirtualIPs: []swarm.EndpointVirtualIP{
+							{
+								Addr:      "127.0.0.1/24",
+								NetworkID: "1",
+							},
+						},
+					},
+				},
+			},
+			expectedFrontends: map[string]*types.Frontend{
+				"frontend-Host-test1-docker-localhost": {
+					Backend:        "backend-foobar",
+					PassHostHeader: true,
+					EntryPoints:    []string{"http", "https"},
+					Routes: map[string]types.Route{
+						"route-frontend-Host-test1-docker-localhost": {
+							Rule: "Host:test1.docker.localhost",
+						},
+					},
+				},
+				"frontend-Host-test2-docker-localhost": {
+					Backend:        "backend-foobar",
+					PassHostHeader: true,
+					EntryPoints:    []string{},
+					Routes: map[string]types.Route{
+						"route-frontend-Host-test2-docker-localhost": {
+							Rule: "Host:test2.docker.localhost",
+						},
+					},
+				},
+			},
+			expectedBackends: map[string]*types.Backend{
+				"backend-foobar": {
+					Servers: map[string]types.Server{
+						"server-test1": {
+							URL:    "http://127.0.0.1:80",
+							Weight: 1,
+						},
+						"server-test2": {
+							URL:    "http://127.0.0.1:80",
+							Weight: 1,
+						},
+					},
+					CircuitBreaker: nil,
+					LoadBalancer:   nil,
+				},
+			},
+			networks: map[string]*docker.NetworkResource{
+				"1": {
+					Name: "foo",
+				},
+			},
+		},
+	}
+
+	provider := &Docker{
+		Domain:           "docker.localhost",
+		ExposedByDefault: true,
+		SwarmMode:        true,
+	}
+
+	for _, c := range cases {
+		var dockerDataList []dockerData
+		for _, service := range c.services {
+			dockerData := parseService(service, c.networks)
+			dockerDataList = append(dockerDataList, dockerData)
+		}
+
+		actualConfig := provider.loadDockerConfig(dockerDataList)
 		// Compare backends
 		if !reflect.DeepEqual(actualConfig.Backends, c.expectedBackends) {
 			t.Fatalf("expected %#v, got %#v", c.expectedBackends, actualConfig.Backends)

--- a/server.go
+++ b/server.go
@@ -8,7 +8,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"errors"
-	"golang.org/x/net/context"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -19,6 +18,8 @@ import (
 	"sort"
 	"syscall"
 	"time"
+
+	"golang.org/x/net/context"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/codegangsta/negroni"

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -311,6 +311,66 @@
 #  insecureskipverify = true
 
 
+
+################################################################
+# Docker Swarmmode configuration backend
+################################################################
+
+# Enable Docker configuration backend
+#
+# Optional
+#
+# [docker]
+
+# Docker server endpoint. Can be a tcp or a unix socket endpoint.
+#
+# Required
+#
+# endpoint = "tcp://127.0.0.1:2375"
+
+# Default domain used.
+# Can be overridden by setting the "traefik.domain" label on a services.
+#
+# Required
+#
+# domain = "docker.localhost"
+
+# Enable watch docker changes
+#
+# Optional
+#
+# watch = true
+
+# Use Docker Swarm Mode as data provider
+#
+# Optional
+#
+# swarmmode = true
+
+# Override default configuration template. For advanced users :)
+#
+# Optional
+#
+# filename = "docker.tmpl"
+
+# Expose services by default in traefik
+#
+# Optional
+# Default: true
+#
+# exposedbydefault = true
+
+# Enable docker TLS connection
+#
+# Optional
+#
+#  [swarm.tls]
+#  ca = "/etc/ssl/ca.crt"
+#  cert = "/etc/ssl/docker.crt"
+#  key = "/etc/ssl/docker.key"
+#  insecureskipverify = true
+
+
 ################################################################
 # Mesos/Marathon configuration backend
 ################################################################


### PR DESCRIPTION
This new provide just work with one network and `traefik.port` label.

I include a provide swarm it`s quite similar with docker provider but this swarm provide watch for services data.