### PR TITLE
[OPS-521] Keypr custom http errors

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -47,6 +47,8 @@ type GlobalConfiguration struct {
 	Kubernetes                *provider.Kubernetes    `description:"Enable Kubernetes backend"`
 	Mesos                     *provider.Mesos         `description:"Enable Mesos backend"`
 	CustomBackendHttpError    bool                    `description:"Use custom HTTP response on backend service 404"`
+	CustomBackendErrorMessage string                  `description:"Custom error message to send in HTTP response if backend service returns a 404."`
+	CustomBackendErrorCode    int                     `description:"Custom HTTP status code to return if a backend service returns 404."`
 }
 
 // DefaultEntryPoints holds default entry points

--- a/configuration.go
+++ b/configuration.go
@@ -46,6 +46,7 @@ type GlobalConfiguration struct {
 	Boltdb                    *provider.BoltDb        `description:"Enable Boltdb backend"`
 	Kubernetes                *provider.Kubernetes    `description:"Enable Kubernetes backend"`
 	Mesos                     *provider.Mesos         `description:"Enable Mesos backend"`
+	CustomBackendHttpError    bool                    `description:"Use custom HTTP response on backend service 404"`
 }
 
 // DefaultEntryPoints holds default entry points

--- a/configuration.go
+++ b/configuration.go
@@ -368,6 +368,9 @@ func NewTraefikConfiguration() *TraefikConfiguration {
 			DefaultEntryPoints:        []string{},
 			ProvidersThrottleDuration: time.Duration(2 * time.Second),
 			MaxIdleConnsPerHost:       200,
+			CustomBackendHttpError:    false,
+			CustomBackendErrorCode:    502,
+			CustomBackendErrorMessage: "Unable to GET Backend",
 		},
 		ConfigFile: "",
 	}

--- a/configuration.go
+++ b/configuration.go
@@ -46,7 +46,7 @@ type GlobalConfiguration struct {
 	Boltdb                    *provider.BoltDb        `description:"Enable Boltdb backend"`
 	Kubernetes                *provider.Kubernetes    `description:"Enable Kubernetes backend"`
 	Mesos                     *provider.Mesos         `description:"Enable Mesos backend"`
-	CustomBackendHttpError    bool                    `description:"Use custom HTTP response on backend service 404"`
+	CustomBackendHTTPError    bool                    `description:"Use custom HTTP response on backend service 404"`
 	CustomBackendErrorMessage string                  `description:"Custom error message to send in HTTP response if backend service returns a 404."`
 	CustomBackendErrorCode    int                     `description:"Custom HTTP status code to return if a backend service returns 404."`
 }
@@ -368,7 +368,7 @@ func NewTraefikConfiguration() *TraefikConfiguration {
 			DefaultEntryPoints:        []string{},
 			ProvidersThrottleDuration: time.Duration(2 * time.Second),
 			MaxIdleConnsPerHost:       200,
-			CustomBackendHttpError:    false,
+			CustomBackendHTTPError:    false,
 			CustomBackendErrorCode:    502,
 			CustomBackendErrorMessage: "Unable to GET Backend",
 		},

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -67,7 +67,7 @@
 # Optional
 # Default: false
 #
-# CustomBackendHttpError = false
+# CustomBackendHTTPError = false
 
 # Custom error message to use when a backend service is unavailable.
 #

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -69,6 +69,20 @@
 #
 # CustomBackendHttpError = false
 
+# Custom error message to use when a backend service is unavailable.
+#
+# Optional
+# Default: "Unable to GET Backend"
+#
+# CustomBackendErrorMessage: "Unable to GET Backend"
+
+# Custom HTTP response code to return if a backend service is unavailable
+#
+# Optional
+# Default: 502
+#
+# CustomBackendErrorCode: 502
+
 # Enable ACME (Let's Encrypt): automatic SSL
 #
 # Optional

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -62,6 +62,13 @@
 #
 # defaultEntryPoints = ["http", "https"]
 
+# Whether or not to use a custom HTTP response, instead of 404, if a backend service is unavailable.
+#
+# Optional
+# Default: false
+#
+# CustomBackendHttpError = false
+
 # Enable ACME (Let's Encrypt): automatic SSL
 #
 # Optional

--- a/web.go
+++ b/web.go
@@ -159,10 +159,9 @@ func (provider *WebProvider) getBackendHandler(response http.ResponseWriter, req
 		}
 	}
 	//http.NotFound(response, request)
-	if provider.server.globalConfiguration.CustomBackendHttpError {
+	if provider.server.globalConfiguration.CustomBackendHTTPError {
 		response.WriteHeader(provider.server.globalConfiguration.CustomBackendErrorCode)
 		fmt.Fprintf(response, provider.server.globalConfiguration.CustomBackendErrorMessage)
-		return
 	} else {
 		http.NotFound(response, request)
 	}

--- a/web.go
+++ b/web.go
@@ -16,7 +16,6 @@ import (
 	"github.com/elazarl/go-bindata-assetfs"
 	"github.com/thoas/stats"
 	"github.com/unrolled/render"
-	"github.com/stretchr/testify/http"
 )
 
 var metrics = stats.New()

--- a/web.go
+++ b/web.go
@@ -16,6 +16,7 @@ import (
 	"github.com/elazarl/go-bindata-assetfs"
 	"github.com/thoas/stats"
 	"github.com/unrolled/render"
+	"github.com/stretchr/testify/http"
 )
 
 var metrics = stats.New()
@@ -158,7 +159,14 @@ func (provider *WebProvider) getBackendHandler(response http.ResponseWriter, req
 			return
 		}
 	}
-	http.NotFound(response, request)
+	//http.NotFound(response, request)
+	if provider.server.globalConfiguration.CustomBackendHttpError {
+		response.WriteHeader(provider.server.globalConfiguration.CustomBackendErrorCode)
+		fmt.Fprintf(response, provider.server.globalConfiguration.CustomBackendErrorMessage)
+		return
+	} else {
+		http.NotFound(response, request)
+	}
 }
 
 func (provider *WebProvider) getServersHandler(response http.ResponseWriter, request *http.Request) {


### PR DESCRIPTION
This PR creates the option to send back custom error HTTP response codes and messages if a backend handler returns a 404.  

What is the best way to automate testing this feature?  I want to include unit tests before this PR may be approved.  

Thanks.