### PR TITLE
Make systemd unit installable

### DIFF
--- a/contrib/systemd/traefik.service
+++ b/contrib/systemd/traefik.service
@@ -4,3 +4,6 @@ Description=Traefik
 [Service]
 ExecStart=/usr/bin/traefik --configFile=/etc/traefik.toml
 Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Having a install section makes it possible to enable/disable traefik
using the standard systemd commands

`systemctl enable traefik`
`systemctl disable traefk`