### PR TITLE
fix for nil clientTLS causing issue

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -11,6 +11,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"github.com/BurntSushi/toml"
+	log "github.com/Sirupsen/logrus"
 	"github.com/containous/traefik/autogen"
 	"github.com/containous/traefik/safe"
 	"github.com/containous/traefik/types"
@@ -109,6 +110,10 @@ type ClientTLS struct {
 // CreateTLSConfig creates a TLS config from ClientTLS structures
 func (clientTLS *ClientTLS) CreateTLSConfig() (*tls.Config, error) {
 	var err error
+	if clientTLS == nil {
+		log.Warnf("clientTLS is nil")
+		return nil, nil
+	}
 	caPool := x509.NewCertPool()
 	if clientTLS.CA != "" {
 		var ca []byte


### PR DESCRIPTION
In testing locally, I found that I was receiving a NPE due to this being nil. I was using the marathon provider at the time, and I believe it happened as a result of that provider asking for client TLS handling even though it hadn't been configured.