### PR TITLE
Make duration logging consistent

### DIFF
--- a/integration/access_log_test.go
+++ b/integration/access_log_test.go
@@ -75,7 +75,7 @@ func (s *AccessLogSuite) TestAccessLog(c *check.C) {
 			c.Assert(tokens[9], checker.Equals, fmt.Sprintf("%d", i+1))
 			c.Assert(strings.HasPrefix(tokens[10], "frontend"), checker.True)
 			c.Assert(strings.HasPrefix(tokens[11], "http://127.0.0.1:808"), checker.True)
-			c.Assert(regexp.MustCompile("^\\d+\\.\\d+.*s$").MatchString(tokens[12]), checker.True)
+			c.Assert(regexp.MustCompile("^\\d+ms$").MatchString(tokens[12]), checker.True)
 		}
 	}
 	c.Assert(count, checker.Equals, 3)

--- a/middlewares/logger.go
+++ b/middlewares/logger.go
@@ -3,8 +3,6 @@ package middlewares
 import (
 	"bufio"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
-	"github.com/streamrail/concurrent-map"
 	"io"
 	"net"
 	"net/http"
@@ -13,6 +11,9 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/streamrail/concurrent-map"
 )
 
 const (
@@ -138,8 +139,9 @@ func (fblh frontendBackendLoggingHandler) ServeHTTP(rw http.ResponseWriter, req 
 	size := infoRw.GetSize()
 
 	elapsed := time.Now().UTC().Sub(startTime.UTC())
-	fmt.Fprintf(fblh.writer, `%s - %s [%s] "%s %s %s" %d %d "%s" "%s" %s "%s" "%s" %s%s`,
-		host, username, ts, method, uri, proto, status, size, referer, agent, fblh.reqid, frontend, backend, elapsed, "\n")
+	elapsedMillis := elapsed.Nanoseconds() / 1000000
+	fmt.Fprintf(fblh.writer, `%s - %s [%s] "%s %s %s" %d %d "%s" "%s" %s "%s" "%s" %dms%s`,
+		host, username, ts, method, uri, proto, status, size, referer, agent, fblh.reqid, frontend, backend, elapsedMillis, "\n")
 
 }
 


### PR DESCRIPTION
GH #559 points out that the logging of the elapsed time is inconsistent
depending on the scale of the measured time; this is due to Duration’s
String handling.

With this PR, I propose that traefik logs millis, and not fractions of
millis.