### PR TITLE
remove leading slash in traefik/alias example, fixes #407

### DIFF
--- a/docs/user-guide/kv-config.md
+++ b/docs/user-guide/kv-config.md
@@ -267,7 +267,7 @@ Given the key structure below, Træfɪk will use the `http://172.17.0.2:80` as i
 
 | Key                                                                     | Value                       |
 |-------------------------------------------------------------------------|-----------------------------|
-| `/traefik/alias`                                                        | `/traefik_configurations/1` |
+| `/traefik/alias`                                                        | `traefik_configurations/1` |
 | `/traefik_configurations/1/backends/backend1/servers/server1/url`       | `http://172.17.0.2:80`      |
 | `/traefik_configurations/1/backends/backend1/servers/server1/weight`    | `10`                        |
 
@@ -275,7 +275,7 @@ When an atomic configuration change is required, you may write a new configurati
 
 | Key                                                                     | Value                       |
 |-------------------------------------------------------------------------|-----------------------------|
-| `/traefik/alias`                                                        | `/traefik_configurations/1` |
+| `/traefik/alias`                                                        | `traefik_configurations/1` |
 | `/traefik_configurations/1/backends/backend1/servers/server1/url`       | `http://172.17.0.2:80`      |
 | `/traefik_configurations/1/backends/backend1/servers/server1/weight`    | `10`                        |
 | `/traefik_configurations/2/backends/backend1/servers/server1/url`       | `http://172.17.0.2:80`      |
@@ -287,7 +287,7 @@ Once the `/traefik/alias` key is updated, the new `/traefik_configurations/2` co
 
 | Key                                                                     | Value                       |
 |-------------------------------------------------------------------------|-----------------------------|
-| `/traefik/alias`                                                        | `/traefik_configurations/2` |
+| `/traefik/alias`                                                        | `traefik_configurations/2` |
 | `/traefik_configurations/1/backends/backend1/servers/server1/url`       | `http://172.17.0.2:80`      |
 | `/traefik_configurations/1/backends/backend1/servers/server1/weight`    | `10`                        |
 | `/traefik_configurations/2/backends/backend1/servers/server1/url`       | `http://172.17.0.3:80`      |


### PR DESCRIPTION
When storing the alias with a leading slash the behavior described in #407 occurs. The correct way is to store the value without leading slash, resulting in correct behavior. This PR fixes the documentation so other users don't run into the same problem when they try out the example or create their own following the documentation.
