### PR TITLE
Update broken link and add a comment to sample config file 

### DIFF
--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -90,7 +90,7 @@
 
 # Enable on demand certificate. This will request a certificate from Let's Encrypt during the first TLS handshake for a hostname that does not yet have a certificate.
 # WARNING, TLS handshakes will be slow when requesting a hostname certificate for the first time, this can leads to DoS attacks.
-# WARNING, Take note that Let's Encrypt have rate limiting: https://community.letsencrypt.org/t/quick-start-guide/1631
+# WARNING, Take note that Let's Encrypt have rate limiting: https://letsencrypt.org/docs/rate-limits
 #
 # Optional
 #
@@ -113,6 +113,9 @@
 
 # Domains list
 # You can provide SANs (alternative domains) to each main domain
+# All domains must have A/AAAA records pointing to Traefik
+# WARNING, Take note that Let's Encrypt have rate limiting: https://letsencrypt.org/docs/rate-limits
+# Each domain & SANs will lead to a certificate request.
 #
 # [[acme.domains]]
 #   main = "local1.com"


### PR DESCRIPTION
Just a small fix for a broken link in the sample config to Let's Encrypt's rate limits. This link was missed in commit 7d936ec which fixed the broken link in the docs.

Also added a few comments to clarify how rate limiting impacts the acme.domains settings.

Thanks for your consideration, Emile! I'm really enjoying working with Traefik and looking forward to putting it into production soon.