### PR TITLE
If Marathon doesn't have healthcheck, assume it's ok

### DIFF
--- a/provider/marathon.go
+++ b/provider/marathon.go
@@ -234,9 +234,6 @@ func taskFilter(task marathon.Task, applications *marathon.Applications, exposed
 					return false
 				}
 			}
-		} else {
-			log.Debugf("Filtering marathon task %s with bad healthcheck", task.AppID)
-			return false
 		}
 	}
 	return true

--- a/provider/marathon_test.go
+++ b/provider/marathon_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"errors"
+
 	"github.com/containous/traefik/mocks"
 	"github.com/containous/traefik/types"
 	"github.com/gambol99/go-marathon"
@@ -324,7 +325,7 @@ func TestMarathonTaskFilter(t *testing.T) {
 					},
 				},
 			},
-			expected:         false,
+			expected:         true,
 			exposedByDefault: true,
 		},
 		{


### PR DESCRIPTION
Healthcheck are not mandatory, so if a result is not present, assume it
is ok to continue. Fixes the case when a new leader is elected and
don't have any healthcheck result's, returning 404 to all requests.
https://github.com/containous/traefik/issues/653