### PR TITLE
Kubernetes provider: traefik.frontend.rule.type logging

### DIFF
--- a/provider/kubernetes.go
+++ b/provider/kubernetes.go
@@ -2,11 +2,6 @@ package provider
 
 import (
 	"fmt"
-	log "github.com/Sirupsen/logrus"
-	"github.com/containous/traefik/provider/k8s"
-	"github.com/containous/traefik/safe"
-	"github.com/containous/traefik/types"
-	"github.com/emilevauge/backoff"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -14,6 +9,12 @@ import (
 	"strings"
 	"text/template"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/containous/traefik/provider/k8s"
+	"github.com/containous/traefik/safe"
+	"github.com/containous/traefik/types"
+	"github.com/emilevauge/backoff"
 )
 
 const (
@@ -224,8 +225,10 @@ func (provider *Kubernetes) loadIngresses(k8sClient k8s.Client) (*types.Configur
 						ruleType = "Path"
 					case "pathprefix":
 						ruleType = "PathPrefix"
+					case "":
+						ruleType = "PathPrefix"
 					default:
-						log.Warnf("Unknown RuleType `%s`, falling back to `PathPrefix", ruleType)
+						log.Warnf("Unknown RuleType %s for %s/%s, falling back to PathPrefix", ruleType, i.ObjectMeta.Namespace, i.ObjectMeta.Name)
 						ruleType = "PathPrefix"
 					}
 


### PR DESCRIPTION
Don't log a warning if traefik.frontend.rule.type is empty, log namespace and ingress if invalide.

Removes the spamming of ```time="2016-08-18T18:37:14+02:00" level=warning msg="Unknown RuleType ``, falling back to \`PathPrefix"``` for every rule.

Example: <https://gist.githubusercontent.com/yvespp/3e7aac2990d1124a0bd631326eaa2ff7/raw/a10c28cd0639434ab9b30dec84a7583525d6dc64/traefik.log4>