### PR TITLE
Add basic auth support for web backend

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -411,6 +411,18 @@ address = ":8080"
 #
 # Optional
 # ReadOnly = false
+#
+# To enable basic auth on the webui
+# with 2 user/pass: test:test and test2:test2
+# Passwords can be encoded in MD5, SHA1 and BCrypt: you can use htpasswd to generate those ones
+#   [web.auth.basic] 
+#     users = ["test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/", "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"]
+# To enable digest auth on the webui
+# with 2 user/realm/pass: test:traefik:test and test2:traefik:test2
+# You can use htdigest to generate those ones
+#   [web.auth.basic] 
+#     users = ["test:traefik:a2688e031edb4be6a3797f3882655c05 ", "test2:traefik:518845800f9e2bfb1f1f740ec24f074e"]
+
 ```
 
 - `/`: provides a simple HTML frontend of Træfik

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -221,6 +221,17 @@
 # Optional
 # ReadOnly = false
 
+# To enable basic auth on the webui
+# with 2 user/pass: test:test and test2:test2
+# Passwords can be encoded in MD5, SHA1 and BCrypt: you can use htpasswd to generate those ones
+#   [web.auth.basic] 
+#     users = ["test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/", "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"]
+# To enable digest auth on the webui
+# with 2 user/realm/pass: test:traefik:test and test2:traefik:test2
+# You can use htdigest to generate those ones
+#   [web.auth.basic] 
+#     users = ["test:traefik:a2688e031edb4be6a3797f3882655c05 ", "test2:traefik:518845800f9e2bfb1f1f740ec24f074e"]
+
 
 ################################################################
 # File configuration backend


### PR DESCRIPTION
Hey there,

this PR enables traefik to protect the web backend per basic auth. All you need to do, is at these lines to your traefik.toml

`[web.auth.basic]
    users = ["traefik:$apr1$8EvWcwpO$RaRFXvDJk6LGQ5tM04RRd0"]`

so it looks like:

> [web]
address = ":8000"
  [web.auth.basic]
    users = ["traefik:$apr1$8EvWcwpO$RaRFXvDJk6LGQ5tM04RRd0"]

Feedback welcome! :)