### PR TITLE
Disable gorilla/mux URL cleaning to prevent sending redirect

### DIFF
--- a/server.go
+++ b/server.go
@@ -668,6 +668,7 @@ func (server *Server) buildDefaultHTTPRouter() *mux.Router {
 	router := mux.NewRouter()
 	router.NotFoundHandler = http.HandlerFunc(notFoundHandler)
 	router.StrictSlash(true)
+	router.SkipClean(true)
 	return router
 }
 


### PR DESCRIPTION
This fixes #167 and #651. By default, gorilla/mux cleans URL paths
such that adjacent slashes are collapsed into one single slash. This
behavior is pretty common in application stacks and it is fine, but
for Traefik, this can lead to incorrect URL paths forwarded to backend
servers.

See https://github.com/gorilla/mux/issues/94 for background.

Credits goes to @sybrandy as the author of the original fix in #521