### PR TITLE
Add HTTP compression

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -98,7 +98,7 @@ func (ep *EntryPoints) String() string {
 // Set's argument is a string to be parsed to set the flag.
 // It's a comma-separated list, so we split it.
 func (ep *EntryPoints) Set(value string) error {
-	regex := regexp.MustCompile("(?:Name:(?P<Name>\\S*))\\s*(?:Address:(?P<Address>\\S*))?\\s*(?:TLS:(?P<TLS>\\S*))?\\s*((?P<TLSACME>TLS))?\\s*(?:CA:(?P<CA>\\S*))?\\s*(?:Redirect.EntryPoint:(?P<RedirectEntryPoint>\\S*))?\\s*(?:Redirect.Regex:(?P<RedirectRegex>\\S*))?\\s*(?:Redirect.Replacement:(?P<RedirectReplacement>\\S*))?")
+	regex := regexp.MustCompile("(?:Name:(?P<Name>\\S*))\\s*(?:Address:(?P<Address>\\S*))?\\s*(?:TLS:(?P<TLS>\\S*))?\\s*((?P<TLSACME>TLS))?\\s*(?:CA:(?P<CA>\\S*))?\\s*(?:Redirect.EntryPoint:(?P<RedirectEntryPoint>\\S*))?\\s*(?:Redirect.Regex:(?P<RedirectRegex>\\S*))?\\s*(?:Redirect.Replacement:(?P<RedirectReplacement>\\S*))?\\s*(?:Compress:(?P<Compress>\\S*))?")
 	match := regex.FindAllStringSubmatch(value, -1)
 	if match == nil {
 		return errors.New("Bad EntryPoints format: " + value)
@@ -137,10 +137,16 @@ func (ep *EntryPoints) Set(value string) error {
 		}
 	}
 
+	compress := false
+	if len(result["Compress"]) > 0 {
+		compress = strings.EqualFold(result["Compress"], "enable") || strings.EqualFold(result["Compress"], "on")
+	}
+
 	(*ep)[result["Name"]] = &EntryPoint{
 		Address:  result["Address"],
 		TLS:      tls,
 		Redirect: redirect,
+		Compress: compress,
 	}
 
 	return nil
@@ -166,6 +172,7 @@ type EntryPoint struct {
 	TLS      *TLS
 	Redirect *Redirect
 	Auth     *types.Auth
+	Compress bool
 }
 
 // Redirect configures a redirection of an entry point to another, or to an URL

--- a/docs/toml.md
+++ b/docs/toml.md
@@ -198,6 +198,12 @@ Supported filters:
 #       CertFile = "integration/fixtures/https/snitest.org.cert"
 #       KeyFile = "integration/fixtures/https/snitest.org.key"
 
+# To enable compression support using gzip format:
+# [entryPoints]
+#   [entryPoints.http]
+#   address = ":80"
+#   compress = true
+
 [entryPoints]
   [entryPoints.http]
   address = ":80"

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b82175c1aafff6c4e98c8ac4baea3832895c9600beac445c10af4c004982ef05
-updated: 2016-09-20T16:03:26.379383173+02:00
+hash: c0ac205a859d78847e21d3cd63f427ffba985755c6ae84373e4a20364ba39b05
+updated: 2016-09-28T16:50:04.352639437+01:00
 imports:
 - name: github.com/abbot/go-http-auth
   version: cb4372376e1e00e9f6ab9ec142e029302c9e7140
@@ -16,7 +16,7 @@ imports:
 - name: github.com/codahale/hdrhistogram
   version: f8ad88b59a584afeee9d334eff879b104439117b
 - name: github.com/codegangsta/cli
-  version: d53eb991652b1d438abdd34ce4bfa3ef1539108e
+  version: 1efa31f08b9333f1bd4882d61f9d668a70cd902e
 - name: github.com/codegangsta/negroni
   version: 3f7ce7b928e14ff890b067e5bbbc80af73690a9c
 - name: github.com/containous/flaeg
@@ -26,7 +26,7 @@ imports:
 - name: github.com/containous/staert
   version: 044bdfee6c8f5e8fb71f70d5ba1cf4cb11a94e97
 - name: github.com/coreos/etcd
-  version: a70513621cf914e2de4dbf90d8a0328e807ffd12
+  version: 1c9e0a0e33051fed6c05c141e6fcbfe5c7f2a899
   subpackages:
   - client
   - pkg/pathutil
@@ -36,7 +36,7 @@ imports:
   subpackages:
   - spew
 - name: github.com/docker/distribution
-  version: b6e0cfbdaa1ddc3a17c95142c7bf6e42c5567370
+  version: 99cb7c0946d2f5a38015443e515dc916295064d7
   subpackages:
   - context
   - digest
@@ -155,13 +155,13 @@ imports:
 - name: github.com/gambol99/go-marathon
   version: a558128c87724cd7430060ef5aedf39f83937f55
 - name: github.com/go-check/check
-  version: 4f90aeace3a26ad7021961c297b22c42160c7b25
+  version: 11d3bc7aa68e238947792f30573146a3231fc0f1
 - name: github.com/gogo/protobuf
-  version: a11c89fbb0ad4acfa8abc4a4d5f7e27c477169b1
+  version: 89f1976ff373a3e549675d2f212c10f98b6c6316
   subpackages:
   - proto
 - name: github.com/golang/glog
-  version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
+  version: fca8c8854093a154ff1eb580aae10276ad6b1b5f
 - name: github.com/google/go-querystring
   version: 9235644dd9e52eeae6fa48efd539fdc351a0af53
   subpackages:
@@ -169,13 +169,13 @@ imports:
 - name: github.com/gorilla/context
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/hashicorp/consul
-  version: 67a03d57b5851011e5601ee6e7e3d05699548462
+  version: d5b7530ec593f1ec2a8f8a7c145bcadafa88b572
   subpackages:
   - api
 - name: github.com/hashicorp/go-cleanhttp
   version: ad28ea4487f05916463e2423a55166280e8254b5
 - name: github.com/hashicorp/serf
-  version: 555e0dcbb180ecbd03431adc28226bb3192558bc
+  version: b7a120a5fc494f6dd5e858f42fd0fd4022d6320f
   subpackages:
   - coordinate
 - name: github.com/jarcoal/httpmock
@@ -193,7 +193,7 @@ imports:
 - name: github.com/mattn/go-shellwords
   version: 525bedee691b5a8df547cb5cf9f86b7fb1883e24
 - name: github.com/mesos/mesos-go
-  version: 2b28dad0aa75289407717b98d82c7871543bb4db
+  version: 068d5470506e3780189fe607af40892814197c5e
   subpackages:
   - detector
   - detector/zoo
@@ -222,16 +222,18 @@ imports:
   version: ca63d7c062ee3c9f34db231e352b60012b4fd0c1
 - name: github.com/moul/http2curl
   version: b1479103caacaa39319f75e7f57fc545287fca0d
+- name: github.com/NYTimes/gziphandler
+  version: f6438dbf4a82c56684964b03956aa727b0d7816b
 - name: github.com/ogier/pflag
   version: 45c278ab3607870051a2ea9040bb85fcb8557481
 - name: github.com/opencontainers/runc
-  version: 38e0df9ec67c05e73b656c02c9222f24c1683d73
+  version: d9fec4c63b089ddfc267194ecb6cda58a13f072c
   subpackages:
   - libcontainer/user
 - name: github.com/parnurzeal/gorequest
   version: 29ced6f360a5ac3823a3675b4e29fbab336cc186
 - name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/ryanuber/go-glob
@@ -245,18 +247,18 @@ imports:
 - name: github.com/streamrail/concurrent-map
   version: 8bf1e9bacbf65b10c81d0f4314cf2b1ebef728b5
 - name: github.com/stretchr/objx
-  version: 1a9d0bb9f541897e62256577b352fdbc1fb4fd94
+  version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify
-  version: d77da356e56a7428ad25149ca77381849a6a5232
+  version: 976c720a22c8eb4eb6a0b4348ad85ad12491a506
   subpackages:
   - assert
   - mock
 - name: github.com/thoas/stats
   version: 152b5d051953fdb6e45f14b6826962aadc032324
 - name: github.com/tv42/zbase32
-  version: 501572607d0273fc75b3b261fa4904d63f6ffa0e
+  version: 03389da7e0bf9844767f82690f4d68fc097a1306
 - name: github.com/ugorji/go
-  version: 98ef79d6c615fa258e892ed0b11c6e013712693e
+  version: b94837a2404ab90efe9289e77a70694c355739cb
   subpackages:
   - codec
 - name: github.com/unrolled/render
@@ -280,9 +282,9 @@ imports:
 - name: github.com/vulcand/predicate
   version: 19b9dde14240d94c804ae5736ad0e1de10bf8fe6
 - name: github.com/vulcand/route
-  version: 61904570391bdf22252f8e376b49a57593d9124c
+  version: cb89d787ddbb1c5849a7ac9f79004c1fd12a4a32
 - name: github.com/vulcand/vulcand
-  version: 7b479b160401beccbc9521b922588fa2a64c4818
+  version: 643ca8acff8386e3b276f6feb8ba9b5893dbc4a2
   subpackages:
   - conntracker
   - plugin
@@ -293,31 +295,30 @@ imports:
   subpackages:
   - acme
 - name: golang.org/x/crypto
-  version: 81372b2fc2f10bef2a7f338da115c315a56b2726
+  version: d81fdb778bf2c40a91b24519d60cdc5767318829
   subpackages:
   - bcrypt
   - blowfish
   - ocsp
 - name: golang.org/x/net
-  version: 71a035914f99bb58fe82eac0f1289f10963d876c
+  version: b400c2eff1badec7022a8c8f5bea058b6315eed7
   subpackages:
   - context
   - proxy
   - publicsuffix
 - name: golang.org/x/sys
-  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
+  version: 62bee037599929a6e9146f29d10dd5208c43507d
   subpackages:
   - unix
   - windows
 - name: gopkg.in/fsnotify.v1
   version: a8a77c9133d2d6fd8334f3260d06f60e8d80a5fb
 - name: gopkg.in/mgo.v2
-  version: 3f83fa5005286a7fe593b055f0d7771a7dce4655
+  version: 22287bab4379e1fbf6002fb4eb769888f3fb224c
   subpackages:
   - bson
-  - internal/json
 - name: gopkg.in/square/go-jose.v1
-  version: 139276ceb5afbf13e636c44e9382f0ca75c12ba3
+  version: aa2e30fdd1fe9dd3394119af66451ae790d50e0d
   subpackages:
   - cipher
   - json
@@ -331,13 +332,13 @@ testImports:
 - name: github.com/flynn/go-shlex
   version: 3f9db97f856818214da2e1057f8ad84803971cff
 - name: github.com/gorilla/mux
-  version: 0a192a193177452756c362c20087ddafcf6829c4
+  version: 9fa818a44c2bf1396a17f9d5a3c0f6dd39d2ff8e
 - name: github.com/libkermit/docker-check
   version: cbe0ef03b3d23070eac4d00ba8828f2cc7f7e5a3
 - name: github.com/spf13/pflag
-  version: c7e63cf4530bcd3ba943729cee0efeff2ebea63f
+  version: 08b1a584251b5b62f458943640fc8ebd4d50aaa5
 - name: github.com/vbatts/tar-split
-  version: 6810cedb21b2c3d0b9bb8f9af12ff2dc7a2f14df
+  version: bd4c5d64c3e9297f410025a3b1bd0c58f659e721
   subpackages:
   - archive/tar
   - tar/asm

--- a/glide.yaml
+++ b/glide.yaml
@@ -98,3 +98,4 @@ import:
 - package: github.com/abbot/go-http-auth
 - package: github.com/miekg/dns
   version: 5d001d020961ae1c184f9f8152fdc73810481677
+- package: github.com/NYTimes/gziphandler

--- a/middlewares/compress.go
+++ b/middlewares/compress.go
@@ -1,0 +1,16 @@
+package middlewares
+
+import (
+	"github.com/NYTimes/gziphandler"
+	"net/http"
+)
+
+// Rewrite is a middleware that allows redirections
+type Compress struct {
+}
+
+//
+func (_ *Compress) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	newGzipHandler := gziphandler.GzipHandler(next)
+	newGzipHandler.ServeHTTP(rw, r)
+}

--- a/middlewares/compress.go
+++ b/middlewares/compress.go
@@ -5,12 +5,12 @@ import (
 	"net/http"
 )
 
-// Rewrite is a middleware that allows redirections
+// Compress is a middleware that allows redirections
 type Compress struct {
 }
 
-//
-func (_ *Compress) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+// ServerHTTP is a function used by negroni
+func (c *Compress) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	newGzipHandler := gziphandler.GzipHandler(next)
 	newGzipHandler.ServeHTTP(rw, r)
 }

--- a/server.go
+++ b/server.go
@@ -146,6 +146,9 @@ func (server *Server) startHTTPServers() {
 			}
 			serverMiddlewares = append(serverMiddlewares, authMiddleware)
 		}
+		if server.globalConfiguration.EntryPoints[newServerEntryPointName].Compress {
+			serverMiddlewares = append(serverMiddlewares, &middlewares.Compress{})
+		}
 		newsrv, err := server.prepareServer(newServerEntryPointName, newServerEntryPoint.httpRouter, server.globalConfiguration.EntryPoints[newServerEntryPointName], nil, serverMiddlewares...)
 		if err != nil {
 			log.Fatal("Error preparing server: ", err)
@@ -680,6 +683,7 @@ func (server *Server) loadEntryPointConfig(entryPointName string, entryPoint *En
 	log.Debugf("Creating entryPoint redirect %s -> %s : %s -> %s", entryPointName, entryPoint.Redirect.EntryPoint, regex, replacement)
 	negroni := negroni.New()
 	negroni.Use(rewrite)
+
 	return negroni, nil
 }
 

--- a/server.go
+++ b/server.go
@@ -683,7 +683,6 @@ func (server *Server) loadEntryPointConfig(entryPointName string, entryPoint *En
 	log.Debugf("Creating entryPoint redirect %s -> %s : %s -> %s", entryPointName, entryPoint.Redirect.EntryPoint, regex, replacement)
 	negroni := negroni.New()
 	negroni.Use(rewrite)
-
 	return negroni, nil
 }
 

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -219,6 +219,12 @@
 #       CertFile = "integration/fixtures/https/snitest.org.cert"
 #       KeyFile = "integration/fixtures/https/snitest.org.key"
 
+# To enable compression support using gzip format:
+# [entryPoints]
+#   [entryPoints.http]
+#   address = ":80"
+#   compress = true
+
 # Enable retry sending request if network error
 #
 # Optional


### PR DESCRIPTION
Create a new middlewares to add HTTP compression

Add an option for it "Compress" in entrypoint configuration.

This add a dependency to "github.com/NYTimes/gziphandler".

