### PR TITLE
Add support for docker healthcheck 👼

### DIFF
--- a/provider/docker_test.go
+++ b/provider/docker_test.go
@@ -569,12 +569,18 @@ func TestDockerGetLabel(t *testing.T) {
 	}{
 		{
 			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "foo",
+				},
 				Config: &container.Config{},
 			},
 			expected: "Label not found:",
 		},
 		{
 			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "foo",
+				},
 				Config: &container.Config{
 					Labels: map[string]string{
 						"foo": "bar",
@@ -608,6 +614,9 @@ func TestDockerGetLabels(t *testing.T) {
 	}{
 		{
 			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "foo",
+				},
 				Config: &container.Config{},
 			},
 			expectedLabels: map[string]string{},
@@ -615,6 +624,9 @@ func TestDockerGetLabels(t *testing.T) {
 		},
 		{
 			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "foo",
+				},
 				Config: &container.Config{
 					Labels: map[string]string{
 						"foo": "fooz",
@@ -628,6 +640,9 @@ func TestDockerGetLabels(t *testing.T) {
 		},
 		{
 			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "foo",
+				},
 				Config: &container.Config{
 					Labels: map[string]string{
 						"foo": "fooz",


### PR DESCRIPTION
This add the simplest support for `HEALTHCHECK` for the docker provider.

Fixes #666.

- React to health_status events
- Filter container that have a health status *and* that are not healthy

It works like the other provider that support healthchecks (marathon for example) — if healthcheck are not supported, then it work as usual and if a container supports it, it filters the container if it's not healthy.

- [x] <del>Update documentation</del> (*it's actually not documented on other providers, so…*)
- [x] <del>Add integration tests</del> (*too much extra work on that, I need to update libkermit and add support for a `testRequire` thingy with a check on docker >= 1.12* — will do in a follow up)

/cc @containous/traefik 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>