### PR TITLE
Allow specification of dialertimeout

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -325,6 +325,7 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 	defaultMarathon.Endpoint = "http://127.0.0.1:8080"
 	defaultMarathon.ExposedByDefault = true
 	defaultMarathon.Constraints = []types.Constraint{}
+	defaultMarathon.DialerTimeout = 60
 
 	// default Consul
 	var defaultConsul provider.Consul

--- a/docs/toml.md
+++ b/docs/toml.md
@@ -836,6 +836,15 @@ domain = "marathon.localhost"
 # Optional
 #
 # dcosToken = "xxxxxx"
+
+# Override DialerTimeout
+# Amount of time in seconds to allow the Marathon provider to wait to open a TCP
+# connection to a Marathon master
+#
+# Optional
+# Default: 60
+# dialerTimeout = 5
+
 ```
 
 Labels can be used on containers to override default behaviour:

--- a/provider/marathon.go
+++ b/provider/marathon.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"errors"
+	"net"
 	"net/url"
 	"sort"
 	"strconv"
@@ -26,13 +27,14 @@ var _ Provider = (*Marathon)(nil)
 // Marathon holds configuration of the Marathon provider.
 type Marathon struct {
 	BaseProvider
-	Endpoint                string     `description:"Marathon server endpoint. You can also specify multiple endpoint for Marathon"`
-	Domain                  string     `description:"Default domain used"`
-	ExposedByDefault        bool       `description:"Expose Marathon apps by default"`
-	GroupsAsSubDomains      bool       `description:"Convert Marathon groups to subdomains"`
-	DCOSToken               string     `description:"DCOSToken for DCOS environment, This will override the Authorization header"`
-	MarathonLBCompatibility bool       `description:"Add compatibility with marathon-lb labels"`
-	TLS                     *ClientTLS `description:"Enable Docker TLS support"`
+	Endpoint                string        `description:"Marathon server endpoint. You can also specify multiple endpoint for Marathon"`
+	Domain                  string        `description:"Default domain used"`
+	ExposedByDefault        bool          `description:"Expose Marathon apps by default"`
+	GroupsAsSubDomains      bool          `description:"Convert Marathon groups to subdomains"`
+	DCOSToken               string        `description:"DCOSToken for DCOS environment, This will override the Authorization header"`
+	MarathonLBCompatibility bool          `description:"Add compatibility with marathon-lb labels"`
+	TLS                     *ClientTLS    `description:"Enable Docker TLS support"`
+	DialerTimeout           time.Duration `description:"Set a non-default connection timeout for Marathon"`
 	Basic                   *MarathonBasic
 	marathonClient          marathon.Marathon
 }
@@ -70,6 +72,9 @@ func (provider *Marathon) Provide(configurationChan chan<- types.ConfigMessage, 
 		config.HTTPClient = &http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: TLSConfig,
+				DialContext: (&net.Dialer{
+					Timeout: time.Second * provider.DialerTimeout,
+				}).DialContext,
 			},
 		}
 		client, err := marathon.NewClient(config)

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -487,6 +487,14 @@
 #
 # groupsAsSubDomains = true
 
+# Override DialerTimeout
+# Amount of time in seconds to allow the Marathon provider to wait to open a TCP
+# connection to a Marathon master
+#
+# Optional
+# Default: 60
+# dialerTimeout = 5
+
 # Enable Marathon basic authentication
 #
 # Optional


### PR DESCRIPTION
The default value for a connection timeout for the http.Transport is zero; in cases where marathon is behind a proxy or similar device that does not explicitly refuse TCP connections, this means that the current Traefik behavior will be to wait for a connection indefinitely. It would be preferable to set some default that is not indefinite, and allow configuration of same if a different timeout is desired.
