### PR TITLE
Add basic compatibility with marathon-lb

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -783,6 +783,13 @@ domain = "marathon.localhost"
 #
 # groupsAsSubDomains = true
 
+# Enable compatibility with marathon-lb labels
+#
+# Optional
+# Default: false
+#
+# marathonLBCompatibility = true
+
 # Enable Marathon basic authentication
 #
 # Optional


### PR DESCRIPTION
Add compatibility with labels: `HAPROXY_GROUP` and `HAPROXY_0_VHOST`.
* `HAPROXY_GROUP` become a new tag
* `HAPROXY_0_VHOST` become a rule `Host:`

https://github.com/mesosphere/marathon-lb