### PR TITLE
Fix networkMap construction in ListServices

### DIFF
--- a/provider/docker.go
+++ b/provider/docker.go
@@ -615,7 +615,8 @@ func listServices(ctx context.Context, dockerClient client.APIClient) ([]dockerD
 		return []dockerData{}, err
 	}
 	for _, network := range networkList {
-		networkMap[network.ID] = &network
+		networkToAdd := network
+		networkMap[network.ID] = &networkToAdd
 	}
 
 	var dockerDataList []dockerData


### PR DESCRIPTION
This PR fixes #719 

The problem is due to a moving pointer reference. The networkMap lists network IDs all with the same network information.
