### PR TITLE
Add a forward authentication option

### DIFF
--- a/auth/forward.go
+++ b/auth/forward.go
@@ -1,0 +1,77 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/containous/traefik/log"
+	"github.com/containous/traefik/types"
+	"github.com/stretchr/stew/objects"
+)
+
+// Forward the authentication to a external server
+func Forward(forward *types.Forward, w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+
+	client := http.Client{}
+
+	forwardReq, err := http.NewRequest("GET", forward.Address, nil)
+	if err != nil {
+		log.Debugf("Error calling {}. Cause {}", forward.Address, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	forwardReq.Header.Add("Accept", "application/json")
+	forwardQuery := forwardReq.URL.Query()
+	rQuery := r.URL.Query()
+	for _, reqParam := range forward.RequestParameters {
+		paramValue := rQuery.Get(reqParam.Name)
+		forwardQuery.Add(reqParam.As, paramValue)
+	}
+	forwardReq.URL.RawQuery = forwardQuery.Encode()
+	forwardResponse, forwardErr := client.Do(forwardReq)
+	if forwardErr != nil {
+		log.Debugf("Error calling {}. Cause: {}", forward.Address, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	defer forwardResponse.Body.Close()
+	body, readError := ioutil.ReadAll(forwardResponse.Body)
+	if readError != nil {
+		log.Debugf("Error reading body {}. Cause: {}", forward.Address, readError)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if forwardResponse.StatusCode != 200 {
+		log.Debugf("Remote error {}. StatusCode: {}", forward.Address, forwardResponse.StatusCode)
+		w.WriteHeader(forwardResponse.StatusCode)
+		w.Write(body)
+	}
+
+	data := make(map[string]interface{})
+	if err := json.Unmarshal(body, &data); err != nil {
+		log.Debugf("Auth failed...")
+		return
+	}
+
+	objects := objects.Map(data)
+	for _, replay := range forward.ResponseReplayFields {
+		object := objects.Get(replay.Path)
+		value := fmt.Sprintf("%v", object)
+		switch replay.In {
+		case "parameter":
+			rQuery.Add(replay.As, value)
+
+		case "header", "":
+			r.Header.Add(replay.As, value)
+		}
+
+	}
+
+	r.URL.RawQuery = rQuery.Encode()
+	r.RequestURI = r.URL.RequestURI()
+	next(w, r)
+}

--- a/auth/forward_test.go
+++ b/auth/forward_test.go
@@ -1,0 +1,70 @@
+package auth
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/containous/traefik/types"
+)
+
+func TestForwarder(t *testing.T) {
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		if r.URL.Query().Get("emailField") == "" {
+			t.Errorf("Missing forward request parameters. Informed just: %v", r.URL.Query())
+		}
+
+		fmt.Println("Chamou o servidor")
+		fmt.Fprintln(w, "{ \"user\" : { \"id\" : 100, \"name\": \"John Lennon\" }}")
+
+	}))
+	defer ts.Close()
+
+	nextCalled := false
+	next := func(w http.ResponseWriter, r *http.Request) {
+
+		if r.Header.Get("X-User-Id") != "100" {
+			t.Errorf("Missing replay header X-User-Id. Headers: %v", r.Header)
+		}
+
+		if r.URL.Query().Get("name") != "John Lennon" {
+			t.Errorf("Missing replay parameter name. Parameters: %v", r.URL.Query())
+		}
+
+		nextCalled = true
+	}
+
+	req := httptest.NewRequest("GET", "http://example.com/foo?email=john@beatles.com", nil)
+	w := httptest.NewRecorder()
+
+	forward := types.Forward{}
+	forward.Address = ts.URL
+	forward.RequestParameters = map[string]*types.ForwardRequestParameter{
+		"email": {
+			Name: "email",
+			As:   "emailField",
+		},
+	}
+	forward.ResponseReplayFields = map[string]*types.ResponseReplayField{
+		"user": {
+			Path: "user.id",
+			As:   "X-User-Id",
+			In:   "header",
+		},
+		"name": {
+			Path: "user.name",
+			As:   "name",
+			In:   "parameter",
+		},
+	}
+
+	Forward(&forward, w, req, next)
+
+	if !nextCalled {
+		t.Error("Next not called")
+	}
+
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: aae2fd761966717bcc30d8c03590cc28df8af49b36cc1d87689512cdfb44475e
-updated: 2016-11-16T21:37:51.673291661+01:00
+hash: 249e33e53346f70c4f9ae533fd20c0816dd7e2a0760beca6ecfbae47743e2b8d
+updated: 2016-11-23T21:21:42.480410524-02:00
 imports:
 - name: github.com/abbot/go-http-auth
   version: cb4372376e1e00e9f6ab9ec142e029302c9e7140
@@ -10,7 +10,7 @@ imports:
 - name: github.com/ArthurHlt/gominlog
   version: 068c01ce147ad68fca25ef3fa29ae5395ae273ab
 - name: github.com/boltdb/bolt
-  version: f4c032d907f61f08dba2d719c58f108a1abb8e81
+  version: 5cc10bbbc5c141029940133bb33c9e969512a698
 - name: github.com/BurntSushi/toml
   version: 99064174e013895bbd9b025c31100bd1d9b590ca
 - name: github.com/BurntSushi/ty
@@ -24,7 +24,7 @@ imports:
 - name: github.com/codegangsta/cli
   version: 1efa31f08b9333f1bd4882d61f9d668a70cd902e
 - name: github.com/codegangsta/negroni
-  version: 3f7ce7b928e14ff890b067e5bbbc80af73690a9c
+  version: dc6b9d037e8dab60cbfc09c61d6932537829be8b
 - name: github.com/containous/flaeg
   version: a731c034dda967333efce5f8d276aeff11f8ff87
 - name: github.com/containous/mux
@@ -38,13 +38,13 @@ imports:
   - pkg/pathutil
   - pkg/types
 - name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
 - name: github.com/daviddengcn/go-colortext
   version: 3b18c8575a432453d41fdafb340099fff5bba2f7
 - name: github.com/docker/distribution
-  version: 99cb7c0946d2f5a38015443e515dc916295064d7
+  version: 87917f30529e6a7fca8eaff2932424915fb11225
   subpackages:
   - context
   - digest
@@ -124,15 +124,15 @@ imports:
   - types/time
   - types/versions
 - name: github.com/docker/go-connections
-  version: 988efe982fdecb46f01d53465878ff1f2ff411ce
+  version: 990a1a1a70b0da4c4cb70e117971a4f0babfbf1a
   subpackages:
   - nat
   - sockets
   - tlsconfig
 - name: github.com/docker/go-units
-  version: f2145db703495b2e525c59662db69a7344b00bb8
+  version: f2d77a61e3c169b43402a0a1e84f06daf29b8190
 - name: github.com/docker/leadership
-  version: 0a913e2d71a12fd14a028452435cb71ac8d82cb6
+  version: bfc7753dd48af19513b29deec23c364bf0f274eb
 - name: github.com/docker/libcompose
   version: d1876c1d68527a49c0aac22a0b161acc7296b740
   subpackages:
@@ -151,7 +151,7 @@ imports:
   - version
   - yaml
 - name: github.com/docker/libkv
-  version: 3fce6a0f26e07da3eac45796a8e255547a47a750
+  version: 35d3e2084c650109e7bcc7282655b1bc8ba924ff
   subpackages:
   - store
   - store/boltdb
@@ -161,13 +161,13 @@ imports:
 - name: github.com/donovanhide/eventsource
   version: fd1de70867126402be23c306e1ce32828455d85b
 - name: github.com/elazarl/go-bindata-assetfs
-  version: 9a6736ed45b44bf3835afeebb3034b57ed329f3e
+  version: 57eb5e1fc594ad4b0b1dbea7b286d299e0cb43c2
 - name: github.com/gambol99/go-marathon
   version: a558128c87724cd7430060ef5aedf39f83937f55
 - name: github.com/go-check/check
-  version: 4f90aeace3a26ad7021961c297b22c42160c7b25
+  version: 11d3bc7aa68e238947792f30573146a3231fc0f1
 - name: github.com/gogo/protobuf
-  version: 99cb9b23110011cc45571c901ecae6f6f5e65cd3
+  version: e33835a643a970c11ac74f6333f5f6866387a101
   subpackages:
   - proto
 - name: github.com/golang/glog
@@ -177,17 +177,18 @@ imports:
   subpackages:
   - query
 - name: github.com/gorilla/context
-  version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
+  version: aed02d124ae4a0e94fea4541c8effd05bf0c8296
 - name: github.com/hashicorp/consul
-  version: d8e2fb7dd594163e25a89bc52c1a4613f5c5bfb8
+  version: fce7d75609a04eeb9d4bf41c8dc592aac18fc97d
   subpackages:
   - api
 - name: github.com/hashicorp/go-cleanhttp
-  version: ad28ea4487f05916463e2423a55166280e8254b5
+  version: 875fb671b3ddc66f8e2f0acc33829c8cb989a38d
 - name: github.com/hashicorp/serf
-  version: b03bf85930b2349eb04b97c8fac437495296e3e7
+  version: 6c4672d66fc6312ddde18399262943e21175d831
   subpackages:
   - coordinate
+  - serf
 - name: github.com/jarcoal/httpmock
   version: 145b10d659265440f062c31ea15326166bae56ee
 - name: github.com/libkermit/compose
@@ -229,7 +230,7 @@ imports:
 - name: github.com/miekg/dns
   version: 5d001d020961ae1c184f9f8152fdc73810481677
 - name: github.com/mitchellh/mapstructure
-  version: ca63d7c062ee3c9f34db231e352b60012b4fd0c1
+  version: d2dd0262208475919e1a362f675cfc0e7c10e905
 - name: github.com/moul/http2curl
   version: b1479103caacaa39319f75e7f57fc545287fca0d
 - name: github.com/NYTimes/gziphandler
@@ -237,11 +238,11 @@ imports:
 - name: github.com/ogier/pflag
   version: 45c278ab3607870051a2ea9040bb85fcb8557481
 - name: github.com/opencontainers/runc
-  version: 02f8fa7863dd3f82909a73e2061897828460d52f
+  version: 1a81e9ab1f138c091fe5c86d0883f87716088527
   subpackages:
   - libcontainer/user
 - name: github.com/parnurzeal/gorequest
-  version: e30af16d4e485943aab0b0885ad6bdbb8c0d3dc7
+  version: 045012d33ef41ea146c1b675df9296d0dc1a212d
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
@@ -249,24 +250,33 @@ imports:
 - name: github.com/ryanuber/go-glob
   version: 572520ed46dbddaed19ea3d9541bdd0494163693
 - name: github.com/samuel/go-zookeeper
-  version: 87e1bca4477a3cc767ca71be023ced183d74e538
+  version: e64db453f3512cade908163702045e0f31137843
   subpackages:
   - zk
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/Sirupsen/logrus
-  version: 3ec0642a7fb6488f65b06f9040adc67e3990296a
+  version: a283a10442df8dc09befd873fab202bf8a253d6a
 - name: github.com/streamrail/concurrent-map
-  version: 8bf1e9bacbf65b10c81d0f4314cf2b1ebef728b5
+  version: 65a174a3a4188c0b7099acbc6cfa0c53628d3287
 - name: github.com/stretchr/objx
   version: cbeaeb16a013161a98496fad62933b1d21786672
+- name: github.com/stretchr/signature
+  version: 168b2a1e1b562bf381d47471e31f5979a2a51cd5
+- name: github.com/stretchr/stew
+  version: 80ef0842b48b329a6120607c817a85aff5a2ec71
+  subpackages:
+  - objects
+  - strings
 - name: github.com/stretchr/testify
-  version: 976c720a22c8eb4eb6a0b4348ad85ad12491a506
+  version: d77da356e56a7428ad25149ca77381849a6a5232
   subpackages:
   - assert
   - mock
+- name: github.com/stretchr/tracer
+  version: 66d3696bba973e1697f7d68413b3f19c6d6e2a7c
 - name: github.com/thoas/stats
-  version: 152b5d051953fdb6e45f14b6826962aadc032324
+  version: 79b768ff1780f4e5b0ed132e192bfeefe9f85a9c
 - name: github.com/tv42/zbase32
   version: 03389da7e0bf9844767f82690f4d68fc097a1306
 - name: github.com/ugorji/go
@@ -274,7 +284,7 @@ imports:
   subpackages:
   - codec
 - name: github.com/unrolled/render
-  version: 526faf80cd4b305bb8134abea8d20d5ced74faa6
+  version: 198ad4d8b8a4612176b804ca10555b222a086b40
 - name: github.com/vdemeester/docker-events
   version: be74d4929ec1ad118df54349fda4b0cba60f849b
 - name: github.com/vdemeester/shakers
@@ -296,7 +306,7 @@ imports:
 - name: github.com/vulcand/route
   version: cb89d787ddbb1c5849a7ac9f79004c1fd12a4a32
 - name: github.com/vulcand/vulcand
-  version: bed092e10989250b48bdb6aa3b0557b207f05c80
+  version: 28a4e5c0892167589737b95ceecbcef00295be50
   subpackages:
   - conntracker
   - plugin
@@ -324,13 +334,13 @@ imports:
   - unix
   - windows
 - name: gopkg.in/fsnotify.v1
-  version: 944cff21b3baf3ced9a880365682152ba577d348
+  version: a8a77c9133d2d6fd8334f3260d06f60e8d80a5fb
 - name: gopkg.in/mgo.v2
-  version: 22287bab4379e1fbf6002fb4eb769888f3fb224c
+  version: 29cc868a5ca65f401ff318143f9408d02f4799cc
   subpackages:
   - bson
 - name: gopkg.in/square/go-jose.v1
-  version: aa2e30fdd1fe9dd3394119af66451ae790d50e0d
+  version: e3f973b66b91445ec816dd7411ad1b6495a5a2fc
   subpackages:
   - cipher
   - json
@@ -350,7 +360,7 @@ testImports:
 - name: github.com/spf13/pflag
   version: 5644820622454e71517561946e3d94b9f9db6842
 - name: github.com/vbatts/tar-split
-  version: bd4c5d64c3e9297f410025a3b1bd0c58f659e721
+  version: 6810cedb21b2c3d0b9bb8f9af12ff2dc7a2f14df
   subpackages:
   - archive/tar
   - tar/asm

--- a/glide.yaml
+++ b/glide.yaml
@@ -99,6 +99,7 @@ import:
 - package: github.com/docker/leadership
 - package: github.com/satori/go.uuid
   version: ^1.1.0
+- package: github.com/stretchr/stew/objects
 - package: github.com/ArthurHlt/go-eureka-client
   subpackages:
   - eureka

--- a/middlewares/authenticator.go
+++ b/middlewares/authenticator.go
@@ -2,8 +2,10 @@ package middlewares
 
 import (
 	"fmt"
-	"github.com/abbot/go-http-auth"
+	goauth "github.com/abbot/go-http-auth"
+
 	"github.com/codegangsta/negroni"
+	"github.com/containous/traefik/auth"
 	"github.com/containous/traefik/log"
 	"github.com/containous/traefik/types"
 	"net/http"
@@ -28,7 +30,7 @@ func NewAuthenticator(authConfig *types.Auth) (*Authenticator, error) {
 		if err != nil {
 			return nil, err
 		}
-		basicAuth := auth.NewBasicAuthenticator("traefik", authenticator.secretBasic)
+		basicAuth := goauth.NewBasicAuthenticator("traefik", authenticator.secretBasic)
 		authenticator.handler = negroni.HandlerFunc(func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 			if username := basicAuth.CheckAuth(r); username == "" {
 				log.Debugf("Auth failed...")
@@ -42,13 +44,17 @@ func NewAuthenticator(authConfig *types.Auth) (*Authenticator, error) {
 		if err != nil {
 			return nil, err
 		}
-		digestAuth := auth.NewDigestAuthenticator("traefik", authenticator.secretDigest)
+		digestAuth := goauth.NewDigestAuthenticator("traefik", authenticator.secretDigest)
 		authenticator.handler = negroni.HandlerFunc(func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 			if username, _ := digestAuth.CheckAuth(r); username == "" {
 				digestAuth.RequireAuth(w, r)
 			} else {
 				next.ServeHTTP(w, r)
 			}
+		})
+	} else if authConfig.Forward != nil {
+		authenticator.handler = negroni.HandlerFunc(func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+			auth.Forward(authConfig.Forward, w, r, next)
 		})
 	}
 	return &authenticator, nil

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -211,6 +211,33 @@
 #   [entryPoints.http.auth.basic]
 #   users = ["test:traefik:a2688e031edb4be6a3797f3882655c05 ", "test2:traefik:518845800f9e2bfb1f1f740ec24f074e"]
 #
+# To enable forward auth on an entrypoint
+# This configuration will take the request parameters email and token, send it as theEmail and theToken 
+# to the authentication address http://authserver.com/auth. If the response code is 200
+# the body user object will have it's field id replayed in the header as X-User-Id and the field
+# name as a parameter userName.
+# [entryPoints]
+#   [entryPoints.http]
+#   address = ":80"
+#   [entryPoints.http.auth.forward]
+#   address = "http://authserver.com/auth"
+#    [entryPoints.http.auth.Forward.requestParameters.email]
+#    name = "email"
+#    as = "theEmail"
+#    [entryPoints.http.auth.Forward.requestParameters.token]
+#    name = "token"
+#    as = "theToken"
+#    [entryPoints.http.auth.Forward.responseReplayFields.userId]
+#    path = "user.id"
+#    as = "X-User-Id"
+#    in = "header"
+#    [entryPoints.http.auth.Forward.responseReplayFields.userName]
+#    path = "user.name"
+#    as = ""
+#    in = "parameter"
+#
+#
+#
 # To specify an https entrypoint with a minimum TLS version, and specifying an array of cipher suites (from crypto/tls):
 # [entryPoints]
 #   [entryPoints.https]

--- a/types/types.go
+++ b/types/types.go
@@ -207,8 +207,9 @@ type Cluster struct {
 
 // Auth holds authentication configuration (BASIC, DIGEST, users)
 type Auth struct {
-	Basic  *Basic
-	Digest *Digest
+	Basic   *Basic
+	Digest  *Digest
+	Forward *Forward
 }
 
 // Users authentication users
@@ -222,6 +223,28 @@ type Basic struct {
 // Digest HTTP authentication
 type Digest struct {
 	Users
+}
+
+// Forward authentication
+type Forward struct {
+	Address              string
+	RequestParameters    map[string]*ForwardRequestParameter
+	ResponseReplayFields map[string]*ResponseReplayField
+}
+
+// ForwardRequestParameter describe the parameter extracted from the request
+// and used with remote authentication address
+type ForwardRequestParameter struct {
+	Name string
+	As   string
+}
+
+// ResponseReplayField describe witch fields from the forwarded authentication
+// must be replayed in the actual request
+type ResponseReplayField struct {
+	Path string
+	As   string
+	In   string
 }
 
 // CanonicalDomain returns a lower case domain with trim space


### PR DESCRIPTION
Now it is possible to delegate the authentication to a third party agent, like a OAuth endpoint. This authentication option extracts parameters from the original request, forward then to a authentication endpoint, if it succeed part of the response body might be added to the request. 
