### PR TITLE
Use sdnotify for systemd

### DIFF
--- a/contrib/systemd/traefik.service
+++ b/contrib/systemd/traefik.service
@@ -2,6 +2,7 @@
 Description=Traefik
 
 [Service]
+Type=notify
 ExecStart=/usr/bin/traefik --configFile=/etc/traefik.toml
 Restart=on-failure
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 39ff28cc1d13d5915a870b14491ece1849c4eaf5a56cecd50a7676ecee6c6143
-updated: 2016-10-06T14:06:39.455848971+02:00
+hash: 61a63d2dd37e5a9bf32c83fa520f54458c3fe6b520f89b9615d8b26f5d3f317f
+updated: 2016-10-24T15:09:49.3944218+02:00
 imports:
 - name: github.com/abbot/go-http-auth
   version: cb4372376e1e00e9f6ab9ec142e029302c9e7140
@@ -31,6 +31,10 @@ imports:
   - client
   - pkg/pathutil
   - pkg/types
+- name: github.com/coreos/go-systemd
+  version: 43e4800a6165b4e02bb2a36673c54b230d6f7b26
+  subpackages:
+  - daemon
 - name: github.com/davecgh/go-spew
   version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
@@ -340,7 +344,7 @@ testImports:
 - name: github.com/libkermit/docker-check
   version: cbe0ef03b3d23070eac4d00ba8828f2cc7f7e5a3
 - name: github.com/spf13/pflag
-  version: 08b1a584251b5b62f458943640fc8ebd4d50aaa5
+  version: 5644820622454e71517561946e3d94b9f9db6842
 - name: github.com/vbatts/tar-split
   version: bd4c5d64c3e9297f410025a3b1bd0c58f659e721
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -102,3 +102,7 @@ import:
 - package: github.com/docker/leadership
 - package: github.com/satori/go.uuid
   version: ^1.1.0
+- package: github.com/coreos/go-systemd
+  version: v12
+  subpackages:
+  - daemon

--- a/server.go
+++ b/server.go
@@ -91,7 +91,7 @@ func NewServer(globalConfiguration GlobalConfiguration) *Server {
 	return server
 }
 
-// Start starts the server and blocks until server is shutted down.
+// Start starts the server.
 func (server *Server) Start() {
 	server.startHTTPServers()
 	server.startLeadership()
@@ -104,6 +104,10 @@ func (server *Server) Start() {
 	server.configureProviders()
 	server.startProviders()
 	go server.listenSignals()
+}
+
+// Wait blocks until server is shutted down.
+func (server *Server) Wait() {
 	<-server.stopChan
 }
 

--- a/traefik.go
+++ b/traefik.go
@@ -268,17 +268,13 @@ func run(traefikConfiguration *TraefikConfiguration) {
 	}
 	log.Debugf("Global configuration loaded %s", string(jsonConf))
 	server := NewServer(globalConfiguration)
+	server.Start()
 	defer server.Close()
-	stopped := make(chan bool, 1)
-	go func() {
-		server.Start()
-		stopped <- true
-	}()
 	sent, err := daemon.SdNotify("READY=1")
 	if !sent && err != nil {
 		log.Error("Fail to notify", err)
 	}
-	<-stopped
+	server.Wait()
 	log.Info("Shutting down")
 }
 

--- a/traefik.go
+++ b/traefik.go
@@ -24,6 +24,8 @@ import (
 	"github.com/containous/traefik/version"
 	"github.com/docker/libkv/store"
 	"github.com/satori/go.uuid"
+
+	"github.com/coreos/go-systemd/daemon"
 )
 
 var versionTemplate = `Version:      {{.Version}}
@@ -266,8 +268,17 @@ func run(traefikConfiguration *TraefikConfiguration) {
 	}
 	log.Debugf("Global configuration loaded %s", string(jsonConf))
 	server := NewServer(globalConfiguration)
-	server.Start()
 	defer server.Close()
+	stopped := make(chan bool, 1)
+	go func() {
+		server.Start()
+		stopped <- true
+	}()
+	sent, err := daemon.SdNotify("READY=1")
+	if !sent && err != nil {
+		log.Error("Fail to notify", err)
+	}
+	<-stopped
 	log.Info("Shutting down")
 }
 


### PR DESCRIPTION
This is useful if a configuration is long to load.
Systemd will continue dependency chain only when server have finish to start.

https://www.freedesktop.org/software/systemd/man/systemd.service.html#Type=