### PR TITLE
Added note for how to avoid running vendor tests

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -112,6 +112,8 @@ More: https://labix.org/gocheck
 ```
 ok      _/home/vincent/src/github/vdemeester/traefik    0.004s
 ```
+- Note that `$ go test ./...` will run all tests (including the ones in the vendor directory for the dependencies that glide have fetched). If you only want to run the tests for traefik use `$ go test $(glide novendor)` instead.
+
 
 ### Documentation
 


### PR DESCRIPTION
Initially I got all these wired error messages telling me that various libraries was missing when I tried to run the test suite for Traefik (using the suggested command `go test ./...`). Finally, I realized that I actually was trying to run the tests for all dependency libraries.

I have added a note about how to only run the tests associated with Traefik to the contribution guide. That might keep others from doing the same mistake.
