### PR TITLE
Makefile: Strip 'heads/' from git rev-parse --abbrev-ref HEAD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ SRCS = $(shell git ls-files '*.go' | grep -v '^external/')
 BIND_DIR := "dist"
 TRAEFIK_MOUNT := -v "$(CURDIR)/$(BIND_DIR):/go/src/github.com/containous/traefik/$(BIND_DIR)"
 
-GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
+GIT_BRANCH := $(subst heads/,,$(shell git rev-parse --abbrev-ref HEAD 2>/dev/null))
 TRAEFIK_DEV_IMAGE := traefik-dev$(if $(GIT_BRANCH),:$(GIT_BRANCH))
 REPONAME := $(shell echo $(REPO) | tr '[:upper:]' '[:lower:]')
 TRAEFIK_IMAGE := $(if $(REPONAME),$(REPONAME),"containous/traefik")


### PR DESCRIPTION
  git rev-parse --abbrev-ref HEAD can return results in a couple different ways:
  1) tag v1.1.0-rc3 exists and branch==v1.1.0-rc3
     result: heads/v1.1.0-rc3
  2) tag v1.1.0-rc3 doesn't exist and branch==v1.1.0-rc3
     result: v1.1.0-rc3

  Strip it off GIT_BRANCH regardless as it will break the build.  e.g.

  $ make binary
  docker build  -t "traefik-dev:heads/v1.1.0-rc3" -f build.Dockerfile .
  invalid value "traefik-dev:heads/v1.1.0-rc3" for flag -t: Error parsing reference: "traefik-dev:heads/v1.1.0-rc3" is not a valid repository/tag
  See 'docker build --help'.
  Makefile:51: recipe for target 'build' failed
  make: *** [build] Error 125