### PR TITLE
Implemented k8s entry point support

### DIFF
--- a/templates/kubernetes.tmpl
+++ b/templates/kubernetes.tmpl
@@ -10,6 +10,9 @@
   [frontends."{{$frontendName}}"]
   backend = "{{$frontend.Backend}}"
   priority = {{$frontend.Priority}}
+  entryPoints = [{{range $frontend.EntryPoints}}
+      "{{.}}",
+    {{end}}]
   passHostHeader = {{$frontend.PassHostHeader}}
     {{range $routeName, $route := $frontend.Routes}}
     [frontends."{{$frontendName}}".routes."{{$routeName}}"]


### PR DESCRIPTION
Hi,

I had the urgent need to run services on multiple ports and hacked the k8s provider to support it in some way. Entry points are defined by appending their name to the and of ingress' host rules. E.g.:

 rules:
  - host: webdav.demo.de-https2

If this suffix is omitted default entry points will be used.
I'm actually not sure if this is a candidate for inclusion because it's pretty hacky but maybe someone is interested in such functionality. Anyway I would be happy if you review the code since it's my first lines of Go code.