### PR TITLE
[Bugfix] "storageFile" instead of "storage"

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -258,7 +258,7 @@ email = "test@traefik.io"
 #
 # Required
 #
-storage = "acme.json" # or "traefik/acme/account" if using KV store
+storageFile = "acme.json" # or "traefik/acme/account" if using KV store
 
 # Entrypoint to proxy acme challenge to.
 # WARNING, must point to an entrypoint on port 443


### PR DESCRIPTION
Hi,
it took me 2 hours to notice, that it should say "storageFile" instead of just "storage".