### PR TITLE
Fix error during asset compilation.

### DIFF
--- a/webui/package.json
+++ b/webui/package.json
@@ -21,7 +21,8 @@
     "angular-ui-bootstrap": "^2.0.0",
     "angular-ui-router": "^0.3.1",
     "bootstrap": "^3.3.6",
-    "moment": "^2.14.1"
+    "moment": "^2.14.1",
+    "nvd3": "^1.8.4"
   },
   "devDependencies": {
     "angular-mocks": "^1.4.2",


### PR DESCRIPTION
An error occurs during asset compilation caused by a version mismatch with angular-nvd3 and nvd3:

```
ERROR in ./src/app/sections/sections.js
Module not found: Error: Can't resolve 'nvd3' in '.../webui/src/app/sections'
 @ ./src/app/sections/sections.js 4:0-15

ERROR in ./~/angular-nvd3/dist/angular-nvd3.js
Module not found: Error: Can't resolve 'nvd3' in '.../webui/node_modules/angular-nvd3/dist'
 @ ./~/angular-nvd3/dist/angular-nvd3.js 13:13-28
```

This commit specifies an explicit version for nvd3 in package.json.