### PR TITLE
feat: Add defaultFuncMap to template

### DIFF
--- a/provider/docker.go
+++ b/provider/docker.go
@@ -258,7 +258,6 @@ func (provider *Docker) loadDockerConfig(containersInspected []dockerData) *type
 		"getMaxConnAmount":            provider.getMaxConnAmount,
 		"getMaxConnExtractorFunc":     provider.getMaxConnExtractorFunc,
 		"getSticky":                   provider.getSticky,
-		"replace":                     replace,
 	}
 
 	// filter containers

--- a/provider/eureka.go
+++ b/provider/eureka.go
@@ -84,8 +84,6 @@ func (provider *Eureka) Provide(configurationChan chan<- types.ConfigMessage, po
 // Build the configuration from Eureka server
 func (provider *Eureka) buildConfiguration() (*types.Configuration, error) {
 	var EurekaFuncMap = template.FuncMap{
-		"replace":       replace,
-		"tolower":       strings.ToLower,
 		"getPort":       provider.getPort,
 		"getProtocol":   provider.getProtocol,
 		"getWeight":     provider.getWeight,

--- a/provider/marathon.go
+++ b/provider/marathon.go
@@ -139,7 +139,6 @@ func (provider *Marathon) loadMarathonConfig() *types.Configuration {
 		"getEntryPoints":              provider.getEntryPoints,
 		"getFrontendRule":             provider.getFrontendRule,
 		"getFrontendBackend":          provider.getFrontendBackend,
-		"replace":                     replace,
 		"hasCircuitBreakerLabels":     provider.hasCircuitBreakerLabels,
 		"hasLoadBalancerLabels":       provider.hasLoadBalancerLabels,
 		"hasMaxConnLabels":            provider.hasMaxConnLabels,

--- a/provider/mesos.go
+++ b/provider/mesos.go
@@ -135,7 +135,6 @@ func (provider *Mesos) loadMesosConfig() *types.Configuration {
 		"getFrontendBackend": provider.getFrontendBackend,
 		"getID":              provider.getID,
 		"getFrontEndName":    provider.getFrontEndName,
-		"replace":            replace,
 	}
 
 	t := records.NewRecordGenerator(time.Duration(provider.StateTimeoutSecond) * time.Second)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -58,7 +58,19 @@ func (p *BaseProvider) getConfiguration(defaultTemplateFile string, funcMap temp
 		err error
 	)
 	configuration := new(types.Configuration)
-	tmpl := template.New(p.Filename).Funcs(funcMap)
+	var defaultFuncMap = template.FuncMap{
+		"replace":   replace,
+		"tolower":   strings.ToLower,
+		"normalize": normalize,
+		"split":     split,
+		"contains":  contains,
+	}
+
+	for funcID, funcElement := range funcMap {
+		defaultFuncMap[funcID] = funcElement
+	}
+
+	tmpl := template.New(p.Filename).Funcs(defaultFuncMap)
 	if len(p.Filename) > 0 {
 		buf, err = ioutil.ReadFile(p.Filename)
 		if err != nil {
@@ -91,6 +103,14 @@ func (p *BaseProvider) getConfiguration(defaultTemplateFile string, funcMap temp
 
 func replace(s1 string, s2 string, s3 string) string {
 	return strings.Replace(s3, s1, s2, -1)
+}
+
+func contains(substr, s string) bool {
+	return strings.Contains(s, substr)
+}
+
+func split(sep, s string) []string {
+	return strings.Split(s, sep)
 }
 
 func normalize(name string) string {


### PR DESCRIPTION
Add some defaults functions in the configuration template rendering.
- normalize (replace every non letter/number char with "-")
- tolower
- replace
- split
- contains