### PR TITLE
Add Rule AddPrefix

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -85,6 +85,7 @@ Frontends can be defined using the following rules:
 - `PathStrip`: Same as `Path` but strip the given prefix from the request URL's Path.
 - `PathPrefix`: PathPrefix adds a matcher for the URL path prefixes. This matches if the given template is a prefix of the full URL path.
 - `PathPrefixStrip`: Same as `PathPrefix` but strip the given prefix from the request URL's Path.
+- `AddPrefix` : Add prefix from the request URL's Path.
 
 You can use multiple rules by separating them by `;`
 

--- a/middlewares/addPrefix.go
+++ b/middlewares/addPrefix.go
@@ -1,0 +1,22 @@
+package middlewares
+
+import (
+	"net/http"
+)
+
+// AddPrefix is a middleware used to add prefix to an URL request
+type AddPrefix struct {
+	Handler http.Handler
+	Prefix  string
+}
+
+func (s *AddPrefix) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	r.URL.Path = s.Prefix + r.URL.Path
+	r.RequestURI = r.URL.RequestURI()
+	s.Handler.ServeHTTP(w, r)
+}
+
+// SetHandler sets handler
+func (s *AddPrefix) SetHandler(Handler http.Handler) {
+	s.Handler = Handler
+}

--- a/rules.go
+++ b/rules.go
@@ -74,6 +74,13 @@ func (r *Rules) pathStrip(paths ...string) *mux.Route {
 	return r.route.route
 }
 
+func (r *Rules) addPrefix(paths ...string) *mux.Route {
+	for _, path := range paths {
+		r.route.addPrefix = path
+	}
+	return r.route.route
+}
+
 func (r *Rules) pathPrefixStrip(paths ...string) *mux.Route {
 	sort.Sort(bySize(paths))
 	r.route.stripPrefixes = paths
@@ -107,6 +114,7 @@ func (r *Rules) parseRules(expression string, onRule func(functionName string, f
 		"Method":          r.methods,
 		"Headers":         r.headers,
 		"HeadersRegexp":   r.headersRegexp,
+		"AddPrefix":       r.addPrefix,
 	}
 
 	if len(expression) == 0 {

--- a/server.go
+++ b/server.go
@@ -64,6 +64,7 @@ type serverEntryPoint struct {
 type serverRoute struct {
 	route         *mux.Route
 	stripPrefixes []string
+	addPrefix     string
 }
 
 // NewServer returns an initialized Server.
@@ -718,15 +719,23 @@ func (server *Server) loadConfig(configurations configs, globalConfiguration Glo
 }
 
 func (server *Server) wireFrontendBackend(serverRoute *serverRoute, handler http.Handler) {
+	// add prefix
+	if len(serverRoute.addPrefix) > 0 {
+		handler = &middlewares.AddPrefix{
+			Prefix:  serverRoute.addPrefix,
+			Handler: handler,
+		}
+	}
+
 	// strip prefix
 	if len(serverRoute.stripPrefixes) > 0 {
-		serverRoute.route.Handler(&middlewares.StripPrefix{
+		handler = &middlewares.StripPrefix{
 			Prefixes: serverRoute.stripPrefixes,
 			Handler:  handler,
-		})
-	} else {
-		serverRoute.route.Handler(handler)
+		}
 	}
+
+	serverRoute.route.Handler(handler)
 }
 
 func (server *Server) loadEntryPointConfig(entryPointName string, entryPoint *EntryPoint) (http.Handler, error) {


### PR DESCRIPTION
Add the ability to add a prefix in the url when the backend is called.

example : 
```
[backends]

[backends.backend-test.servers.server-1]
url = "http:/backend-server"
weight = 1

[frontends]
[frontends.frontend-test]
    backend = "backend-test"
    entryPoints = ["http"]
[frontends.frontend-test.routes.route-host-test]
    rule = "PathPrefix:/test;PathPrefixStrip:/test;AddPrefix:/prefix"
```

when call http://traefik/test/url => forward http://backend-server/prefix/url