### PR TITLE
Kubernetes: cleanup channel handling

### DIFF
--- a/provider/kubernetes.go
+++ b/provider/kubernetes.go
@@ -52,7 +52,7 @@ func (provider *Kubernetes) Provide(configurationChan chan<- types.ConfigMessage
 	pool.Go(func(stop chan bool) {
 		operation := func() error {
 			for {
-				stopWatch := make(chan bool, 5)
+				stopWatch := make(chan struct{}, 1)
 				defer close(stopWatch)
 				log.Debugf("Using label selector: '%s'", provider.LabelSelector)
 				eventsChan, err := k8sClient.WatchAll(provider.LabelSelector, stopWatch)
@@ -69,7 +69,6 @@ func (provider *Kubernetes) Provide(configurationChan chan<- types.ConfigMessage
 				for {
 					select {
 					case <-stop:
-						stopWatch <- true
 						return nil
 					case event := <-eventsChan:
 						log.Debugf("Received event from kubernetes %+v", event)

--- a/provider/kubernetes_test.go
+++ b/provider/kubernetes_test.go
@@ -1277,10 +1277,6 @@ func (c clientMock) GetIngresses(namespaces k8s.Namespaces) []*v1beta1.Ingress {
 	return result
 }
 
-func (c clientMock) WatchIngresses(labelSelector string, stopCh <-chan struct{}) chan interface{} {
-	return c.watchChan
-}
-
 func (c clientMock) GetService(namespace, name string) (*v1.Service, bool, error) {
 	for _, service := range c.services {
 		if service.Namespace == namespace && service.Name == name {
@@ -1299,6 +1295,6 @@ func (c clientMock) GetEndpoints(namespace, name string) (*v1.Endpoints, bool, e
 	return &v1.Endpoints{}, true, nil
 }
 
-func (c clientMock) WatchAll(labelString string, stopCh <-chan bool) (chan interface{}, error) {
+func (c clientMock) WatchAll(labelString string, stopCh <-chan struct{}) (<-chan interface{}, error) {
 	return c.watchChan, nil
 }


### PR DESCRIPTION
This pull includes #929 and cleans up the channel handling of the Kubernetes Provider:
- Only use one channel for all Kubernetes watches
- Re-use stop channel from the provider
- Skip all events that have already been handled by the provider