### PR TITLE
Kubernetes: HostRegexp support

### DIFF
--- a/provider/kubernetes.go
+++ b/provider/kubernetes.go
@@ -128,8 +128,15 @@ func (provider *Kubernetes) loadIngresses(k8sClient k8s.Client) (*types.Configur
 				}
 				if len(r.Host) > 0 {
 					if _, exists := templateObjects.Frontends[r.Host+pa.Path].Routes[r.Host]; !exists {
-						templateObjects.Frontends[r.Host+pa.Path].Routes[r.Host] = types.Route{
-							Rule: "Host:" + r.Host,
+						hostRegexpPrefix, ok := i.Annotations["traefik.frontend.rule.hostRegexpPrefix"]
+						if ok {
+							templateObjects.Frontends[r.Host+pa.Path].Routes[r.Host] = types.Route{
+								Rule: "HostRegexp:" + hostRegexpPrefix + r.Host,
+							}
+						} else {
+							templateObjects.Frontends[r.Host+pa.Path].Routes[r.Host] = types.Route{
+								Rule: "Host:" + r.Host,
+							}
 						}
 					}
 				}

--- a/provider/kubernetes_test.go
+++ b/provider/kubernetes_test.go
@@ -373,6 +373,32 @@ func TestRuleType(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Annotations: map[string]string{"traefik.frontend.rule.hostRegexpPrefix": "{subdomain:[a-z]+}."}, //subdomain hostRegexp prefix
+			},
+			Spec: v1beta1.IngressSpec{
+				Rules: []v1beta1.IngressRule{
+					{
+						Host: "foo3",
+						IngressRuleValue: v1beta1.IngressRuleValue{
+							HTTP: &v1beta1.HTTPIngressRuleValue{
+								Paths: []v1beta1.HTTPIngressPath{
+									{
+										Backend: v1beta1.IngressBackend{
+											ServiceName: "service3",
+											ServicePort: intstr.FromInt(801),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
 		{
 			ObjectMeta: v1.ObjectMeta{
 				Annotations: map[string]string{"traefik.frontend.rule.type": "PathXXStrip"}, //wrong rule
@@ -487,6 +513,15 @@ func TestRuleType(t *testing.T) {
 				},
 				"foo1": {
 					Rule: "Host:foo1",
+				},
+			},
+		},
+		"foo3": {
+			Backend:  "foo3",
+			Priority: 0,
+			Routes: map[string]types.Route{
+				"foo3": {
+					Rule: "HostRegexp:{subdomain:[a-z]+}.foo3",
 				},
 			},
 		},


### PR DESCRIPTION
We would like to use Kubernetes Ingress resources with Traefik's HostRegexp route rule so we can route subdomains to the same service. I couldn't find a way to annotate separate Ingress routes, so I had to  add the annotation on the Ingress level, but one ingress can have multiple hosts thus I used only prefix.

```yaml
meta:
  annotations:
    traefik.frontend.rule.hostRegexpPrefix: "{subdomain:[a-z]+}."
```

Which creates a route rule like this: `HostRegexp:{subdomain:[a-z]+}.traefik.example.com`.

I'm open to finding a better annotation key for this config.