### PR TITLE
add k8s annotation for loadbalencer

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -757,7 +757,7 @@ watch = true
 # filename = "docker.tmpl"
 
 # Expose containers by default in traefik
-# If set to false, containers that don't have `traefik.enable=true` will be ignored 
+# If set to false, containers that don't have `traefik.enable=true` will be ignored
 #
 # Optional
 # Default: true
@@ -1051,6 +1051,11 @@ Træfɪk can be configured to use Kubernetes Ingress as a backend configuration:
 Annotations can be used on containers to override default behaviour for the whole Ingress resource:
 
 - `traefik.frontend.rule.type: PathPrefixStrip`: override the default frontend rule type (Default: `PathPrefix`).
+
+Annotations can be used on ingress to override default behaviour:
+
+- `traefik.backend.loadbalancer.method=drr`: override the default `wrr` load balancer algorithm
+- `traefik.backend.loadbalancer.sticky=true`: enable backend sticky sessions
 
 You can find here an example [ingress](https://raw.githubusercontent.com/containous/traefik/master/examples/k8s/cheese-ingress.yaml) and [replication controller](https://raw.githubusercontent.com/containous/traefik/master/examples/k8s/traefik.yaml).
 

--- a/provider/kubernetes_test.go
+++ b/provider/kubernetes_test.go
@@ -217,7 +217,10 @@ func TestLoadIngresses(t *testing.T) {
 					},
 				},
 				CircuitBreaker: nil,
-				LoadBalancer:   nil,
+				LoadBalancer: &types.LoadBalancer{
+					Sticky: false,
+					Method: "wrr",
+				},
 			},
 			"bar": {
 				Servers: map[string]types.Server{
@@ -235,7 +238,10 @@ func TestLoadIngresses(t *testing.T) {
 					},
 				},
 				CircuitBreaker: nil,
-				LoadBalancer:   nil,
+				LoadBalancer: &types.LoadBalancer{
+					Sticky: false,
+					Method: "wrr",
+				},
 			},
 		},
 		Frontends: map[string]*types.Frontend{
@@ -565,7 +571,10 @@ func TestGetPassHostHeader(t *testing.T) {
 					},
 				},
 				CircuitBreaker: nil,
-				LoadBalancer:   nil,
+				LoadBalancer: &types.LoadBalancer{
+					Sticky: false,
+					Method: "wrr",
+				},
 			},
 		},
 		Frontends: map[string]*types.Frontend{
@@ -674,7 +683,10 @@ func TestOnlyReferencesServicesFromOwnNamespace(t *testing.T) {
 					},
 				},
 				CircuitBreaker: nil,
-				LoadBalancer:   nil,
+				LoadBalancer: &types.LoadBalancer{
+					Sticky: false,
+					Method: "wrr",
+				},
 			},
 		},
 		Frontends: map[string]*types.Frontend{
@@ -860,7 +872,10 @@ func TestLoadNamespacedIngresses(t *testing.T) {
 					},
 				},
 				CircuitBreaker: nil,
-				LoadBalancer:   nil,
+				LoadBalancer: &types.LoadBalancer{
+					Sticky: false,
+					Method: "wrr",
+				},
 			},
 			"bar": {
 				Servers: map[string]types.Server{
@@ -874,7 +889,10 @@ func TestLoadNamespacedIngresses(t *testing.T) {
 					},
 				},
 				CircuitBreaker: nil,
-				LoadBalancer:   nil,
+				LoadBalancer: &types.LoadBalancer{
+					Sticky: false,
+					Method: "wrr",
+				},
 			},
 		},
 		Frontends: map[string]*types.Frontend{
@@ -1098,7 +1116,10 @@ func TestLoadMultipleNamespacedIngresses(t *testing.T) {
 					},
 				},
 				CircuitBreaker: nil,
-				LoadBalancer:   nil,
+				LoadBalancer: &types.LoadBalancer{
+					Sticky: false,
+					Method: "wrr",
+				},
 			},
 			"bar": {
 				Servers: map[string]types.Server{
@@ -1112,7 +1133,10 @@ func TestLoadMultipleNamespacedIngresses(t *testing.T) {
 					},
 				},
 				CircuitBreaker: nil,
-				LoadBalancer:   nil,
+				LoadBalancer: &types.LoadBalancer{
+					Sticky: false,
+					Method: "wrr",
+				},
 			},
 			"awesome/quix": {
 				Servers: map[string]types.Server{
@@ -1122,7 +1146,10 @@ func TestLoadMultipleNamespacedIngresses(t *testing.T) {
 					},
 				},
 				CircuitBreaker: nil,
-				LoadBalancer:   nil,
+				LoadBalancer: &types.LoadBalancer{
+					Sticky: false,
+					Method: "wrr",
+				},
 			},
 		},
 		Frontends: map[string]*types.Frontend{
@@ -1236,7 +1263,10 @@ func TestHostlessIngress(t *testing.T) {
 					},
 				},
 				CircuitBreaker: nil,
-				LoadBalancer:   nil,
+				LoadBalancer: &types.LoadBalancer{
+					Sticky: false,
+					Method: "wrr",
+				},
 			},
 		},
 		Frontends: map[string]*types.Frontend{

--- a/templates/kubernetes.tmpl
+++ b/templates/kubernetes.tmpl
@@ -1,4 +1,9 @@
 [backends]{{range $backendName, $backend := .Backends}}
+    [backends."{{$backendName}}".loadbalancer]
+      method = "{{$backend.LoadBalancer.Method}}"
+      {{if $backend.LoadBalancer.Sticky}}
+          sticky = true
+      {{end}}
     {{range $serverName, $server := $backend.Servers}}
     [backends."{{$backendName}}".servers."{{$serverName}}"]
     url = "{{$server.URL}}"


### PR DESCRIPTION
Add kubernetes ingress annotations for loadbalencer : 
- traefik.backend.loadbalancer.sticky : for sticky session (true or false)
- traefik.backend.loadbalancer.method : for loadbalencer method (wrr or drr)

Update #674 and #911 