### PR TITLE
toml zookeeper doc fix

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -1241,7 +1241,7 @@ watch = true
 #
 # Optional
 #
-prefix = "/traefik"
+prefix = "traefik"
 
 # Override default configuration template. For advanced users :)
 #


### PR DESCRIPTION
Having that slash there causes traefik to be able to get keys from ZK