### PR TITLE
deploy.sh: upload release source tarball

### DIFF
--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -27,6 +27,7 @@ sudo chmod +x /usr/bin/ghr
 
 # github release and tag
 echo "Github release..."
+tar cfz dist/traefik-${VERSION}.src.tar.gz --exclude-vcs --exclude dist .
 ghr -t $GITHUB_TOKEN -u containous -r traefik ${VERSION} dist/
 
 # update docs.traefik.io


### PR DESCRIPTION
Having a release tarball including all vendor source makes life of maintainers a lot easier to create downstream packages.
It also ensures that as long as the go release is available the software can be build reproducible.