### PR TITLE
Import order as goimports does

### DIFF
--- a/acme/account.go
+++ b/acme/account.go
@@ -7,11 +7,12 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"github.com/containous/traefik/log"
-	"github.com/xenolf/lego/acme"
 	"reflect"
 	"sync"
 	"time"
+
+	"github.com/containous/traefik/log"
+	"github.com/xenolf/lego/acme"
 )
 
 // Account is used to store lets encrypt registration info

--- a/acme/acme.go
+++ b/acme/acme.go
@@ -5,6 +5,12 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	fmtlog "log"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/BurntSushi/ty/fun"
 	"github.com/cenk/backoff"
 	"github.com/containous/staert"
@@ -14,11 +20,6 @@ import (
 	"github.com/containous/traefik/types"
 	"github.com/xenolf/lego/acme"
 	"github.com/xenolf/lego/providers/dns"
-	"io/ioutil"
-	fmtlog "log"
-	"os"
-	"strings"
-	"time"
 )
 
 var (

--- a/acme/acme_test.go
+++ b/acme/acme_test.go
@@ -2,12 +2,13 @@ package acme
 
 import (
 	"encoding/base64"
-	"github.com/xenolf/lego/acme"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"sync"
 	"testing"
+
+	"github.com/xenolf/lego/acme"
 )
 
 func TestDomainsSet(t *testing.T) {

--- a/acme/challengeProvider.go
+++ b/acme/challengeProvider.go
@@ -2,15 +2,15 @@ package acme
 
 import (
 	"crypto/tls"
+	"fmt"
 	"strings"
 	"sync"
+	"time"
 
-	"fmt"
 	"github.com/cenk/backoff"
 	"github.com/containous/traefik/cluster"
 	"github.com/containous/traefik/log"
 	"github.com/xenolf/lego/acme"
-	"time"
 )
 
 var _ acme.ChallengeProviderTimeout = (*challengeProvider)(nil)

--- a/acme/localStore.go
+++ b/acme/localStore.go
@@ -3,10 +3,11 @@ package acme
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/containous/traefik/cluster"
-	"github.com/containous/traefik/log"
 	"io/ioutil"
 	"sync"
+
+	"github.com/containous/traefik/cluster"
+	"github.com/containous/traefik/log"
 )
 
 var _ cluster.Store = (*LocalStore)(nil)

--- a/cluster/datastore.go
+++ b/cluster/datastore.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
+	"time"
+
 	"github.com/cenk/backoff"
 	"github.com/containous/staert"
 	"github.com/containous/traefik/job"
 	"github.com/containous/traefik/log"
 	"github.com/docker/libkv/store"
 	"github.com/satori/go.uuid"
-	"sync"
-	"time"
 )
 
 // Metadata stores Object plus metadata

--- a/cluster/leadership.go
+++ b/cluster/leadership.go
@@ -2,12 +2,13 @@ package cluster
 
 import (
 	"context"
+	"time"
+
 	"github.com/cenk/backoff"
 	"github.com/containous/traefik/log"
 	"github.com/containous/traefik/safe"
 	"github.com/containous/traefik/types"
 	"github.com/docker/leadership"
-	"time"
 )
 
 // Leadership allows leadership election using a KV store

--- a/cmd/bug.go
+++ b/cmd/bug.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/containous/flaeg"
-	"github.com/mvdan/xurls"
 	"net/url"
 	"os/exec"
 	"regexp"
 	"runtime"
 	"text/template"
+
+	"github.com/containous/flaeg"
+	"github.com/mvdan/xurls"
 )
 
 var (

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,12 +2,13 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/containous/flaeg"
-	"github.com/containous/traefik/version"
 	"io"
 	"os"
 	"runtime"
 	"text/template"
+
+	"github.com/containous/flaeg"
+	"github.com/containous/traefik/version"
 )
 
 var versionTemplate = `Version:      {{.Version}}

--- a/job/job.go
+++ b/job/job.go
@@ -1,8 +1,9 @@
 package job
 
 import (
-	"github.com/cenk/backoff"
 	"time"
+
+	"github.com/cenk/backoff"
 )
 
 var (

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -1,9 +1,10 @@
 package job
 
 import (
-	"github.com/cenk/backoff"
 	"testing"
 	"time"
+
+	"github.com/cenk/backoff"
 )
 
 func TestJobBackOff(t *testing.T) {

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,8 +1,9 @@
 package log
 
 import (
-	"github.com/Sirupsen/logrus"
 	"io"
+
+	"github.com/Sirupsen/logrus"
 )
 
 var (

--- a/middlewares/authenticator.go
+++ b/middlewares/authenticator.go
@@ -2,12 +2,13 @@ package middlewares
 
 import (
 	"fmt"
+	"net/http"
+	"strings"
+
 	"github.com/abbot/go-http-auth"
 	"github.com/codegangsta/negroni"
 	"github.com/containous/traefik/log"
 	"github.com/containous/traefik/types"
-	"net/http"
-	"strings"
 )
 
 // Authenticator is a middleware that provides HTTP basic and digest authentication

--- a/middlewares/authenticator_test.go
+++ b/middlewares/authenticator_test.go
@@ -2,13 +2,14 @@ package middlewares
 
 import (
 	"fmt"
-	"github.com/codegangsta/negroni"
-	"github.com/containous/traefik/types"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/codegangsta/negroni"
+	"github.com/containous/traefik/types"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBasicAuthFail(t *testing.T) {

--- a/middlewares/compress.go
+++ b/middlewares/compress.go
@@ -1,8 +1,9 @@
 package middlewares
 
 import (
-	"github.com/NYTimes/gziphandler"
 	"net/http"
+
+	"github.com/NYTimes/gziphandler"
 )
 
 // Compress is a middleware that allows redirections

--- a/middlewares/handlerSwitcher.go
+++ b/middlewares/handlerSwitcher.go
@@ -1,9 +1,10 @@
 package middlewares
 
 import (
+	"net/http"
+
 	"github.com/containous/mux"
 	"github.com/containous/traefik/safe"
-	"net/http"
 )
 
 // HandlerSwitcher allows hot switching of http.ServeMux

--- a/middlewares/logger_test.go
+++ b/middlewares/logger_test.go
@@ -2,8 +2,6 @@ package middlewares
 
 import (
 	"fmt"
-	shellwords "github.com/mattn/go-shellwords"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -11,6 +9,9 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	shellwords "github.com/mattn/go-shellwords"
+	"github.com/stretchr/testify/assert"
 )
 
 type logtestResponseWriter struct{}

--- a/middlewares/retry.go
+++ b/middlewares/retry.go
@@ -3,10 +3,11 @@ package middlewares
 import (
 	"bufio"
 	"bytes"
-	"github.com/containous/traefik/log"
-	"github.com/vulcand/oxy/utils"
 	"net"
 	"net/http"
+
+	"github.com/containous/traefik/log"
+	"github.com/vulcand/oxy/utils"
 )
 
 var (

--- a/middlewares/rewrite.go
+++ b/middlewares/rewrite.go
@@ -1,9 +1,10 @@
 package middlewares
 
 import (
+	"net/http"
+
 	"github.com/containous/traefik/log"
 	"github.com/vulcand/vulcand/plugin/rewrite"
-	"net/http"
 )
 
 // Rewrite is a middleware that allows redirections

--- a/provider/boltdb.go
+++ b/provider/boltdb.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+
 	"github.com/containous/traefik/safe"
 	"github.com/containous/traefik/types"
 	"github.com/docker/libkv/store"

--- a/provider/consul.go
+++ b/provider/consul.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+
 	"github.com/containous/traefik/safe"
 	"github.com/containous/traefik/types"
 	"github.com/docker/libkv/store"

--- a/provider/docker_test.go
+++ b/provider/docker_test.go
@@ -9,9 +9,8 @@ import (
 	docker "github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
 	"github.com/docker/engine-api/types/network"
+	"github.com/docker/engine-api/types/swarm"
 	"github.com/docker/go-connections/nat"
-
-	swarm "github.com/docker/engine-api/types/swarm"
 )
 
 func TestDockerGetFrontendName(t *testing.T) {

--- a/provider/etcd.go
+++ b/provider/etcd.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+
 	"github.com/containous/traefik/safe"
 	"github.com/containous/traefik/types"
 	"github.com/docker/libkv/store"

--- a/provider/eureka.go
+++ b/provider/eureka.go
@@ -1,17 +1,18 @@
 package provider
 
 import (
+	"io/ioutil"
+	"strconv"
+	"strings"
+	"text/template"
+	"time"
+
 	"github.com/ArthurHlt/go-eureka-client/eureka"
 	log "github.com/Sirupsen/logrus"
 	"github.com/cenk/backoff"
 	"github.com/containous/traefik/job"
 	"github.com/containous/traefik/safe"
 	"github.com/containous/traefik/types"
-	"io/ioutil"
-	"strconv"
-	"strings"
-	"text/template"
-	"time"
 )
 
 // Eureka holds configuration of the Eureka provider.

--- a/provider/eureka_test.go
+++ b/provider/eureka_test.go
@@ -1,8 +1,9 @@
 package provider
 
 import (
-	"github.com/ArthurHlt/go-eureka-client/eureka"
 	"testing"
+
+	"github.com/ArthurHlt/go-eureka-client/eureka"
 )
 
 func TestEurekaGetPort(t *testing.T) {

--- a/provider/kubernetes.go
+++ b/provider/kubernetes.go
@@ -7,16 +7,14 @@ import (
 	"text/template"
 	"time"
 
-	"k8s.io/client-go/1.5/pkg/api/v1"
-	"k8s.io/client-go/1.5/pkg/util/intstr"
-
+	"github.com/cenk/backoff"
+	"github.com/containous/traefik/job"
 	"github.com/containous/traefik/log"
 	"github.com/containous/traefik/provider/k8s"
 	"github.com/containous/traefik/safe"
 	"github.com/containous/traefik/types"
-
-	"github.com/cenk/backoff"
-	"github.com/containous/traefik/job"
+	"k8s.io/client-go/1.5/pkg/api/v1"
+	"k8s.io/client-go/1.5/pkg/util/intstr"
 )
 
 var _ Provider = (*Kubernetes)(nil)

--- a/provider/kubernetes_test.go
+++ b/provider/kubernetes_test.go
@@ -5,12 +5,11 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/containous/traefik/provider/k8s"
+	"github.com/containous/traefik/types"
 	"k8s.io/client-go/1.5/pkg/api/v1"
 	"k8s.io/client-go/1.5/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/1.5/pkg/util/intstr"
-
-	"github.com/containous/traefik/provider/k8s"
-	"github.com/containous/traefik/types"
 )
 
 func TestLoadIngresses(t *testing.T) {

--- a/provider/kv.go
+++ b/provider/kv.go
@@ -2,12 +2,12 @@
 package provider
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"text/template"
 	"time"
 
-	"errors"
 	"github.com/BurntSushi/ty/fun"
 	"github.com/cenk/backoff"
 	"github.com/containous/traefik/job"

--- a/provider/kv_test.go
+++ b/provider/kv_test.go
@@ -2,14 +2,14 @@ package provider
 
 import (
 	"errors"
-	"github.com/containous/traefik/types"
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/containous/traefik/types"
 	"github.com/docker/libkv/store"
-	"reflect"
-	"sort"
 )
 
 func TestKvList(t *testing.T) {

--- a/provider/marathon.go
+++ b/provider/marathon.go
@@ -2,14 +2,13 @@ package provider
 
 import (
 	"errors"
+	"math"
 	"net"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"text/template"
-
-	"math"
-	"net/http"
 	"time"
 
 	"github.com/BurntSushi/ty/fun"

--- a/provider/marathon_test.go
+++ b/provider/marathon_test.go
@@ -1,10 +1,9 @@
 package provider
 
 import (
+	"errors"
 	"reflect"
 	"testing"
-
-	"errors"
 
 	"github.com/containous/traefik/mocks"
 	"github.com/containous/traefik/types"

--- a/provider/mesos.go
+++ b/provider/mesos.go
@@ -2,11 +2,10 @@ package provider
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 	"text/template"
-
-	"fmt"
 	"time"
 
 	"github.com/BurntSushi/ty/fun"
@@ -16,7 +15,8 @@ import (
 	"github.com/containous/traefik/safe"
 	"github.com/containous/traefik/types"
 	"github.com/mesos/mesos-go/detector"
-	_ "github.com/mesos/mesos-go/detector/zoo" // Registers the ZK detector
+	// Register mesos zoo the detector
+	_ "github.com/mesos/mesos-go/detector/zoo"
 	"github.com/mesosphere/mesos-dns/detect"
 	"github.com/mesosphere/mesos-dns/logging"
 	"github.com/mesosphere/mesos-dns/records"

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -2,15 +2,14 @@ package provider
 
 import (
 	"bytes"
-	"io/ioutil"
-	"strings"
-	"text/template"
-	"unicode"
-
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"io/ioutil"
 	"os"
+	"strings"
+	"text/template"
+	"unicode"
 
 	"github.com/BurntSushi/toml"
 	"github.com/containous/traefik/autogen"

--- a/provider/zk.go
+++ b/provider/zk.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+
 	"github.com/containous/traefik/safe"
 	"github.com/containous/traefik/types"
 	"github.com/docker/libkv/store"

--- a/safe/routine.go
+++ b/safe/routine.go
@@ -2,9 +2,10 @@ package safe
 
 import (
 	"context"
-	"github.com/containous/traefik/log"
 	"runtime/debug"
 	"sync"
+
+	"github.com/containous/traefik/log"
 )
 
 type routine struct {

--- a/types/types.go
+++ b/types/types.go
@@ -4,9 +4,10 @@ import (
 	"encoding"
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/docker/libkv/store"
 	"github.com/ryanuber/go-glob"
-	"strings"
 )
 
 // Backend holds backend configuration.

--- a/version/version.go
+++ b/version/version.go
@@ -1,10 +1,11 @@
 package version
 
 import (
+	"net/url"
+
 	"github.com/containous/traefik/log"
 	"github.com/google/go-github/github"
 	goversion "github.com/hashicorp/go-version"
-	"net/url"
 )
 
 var (


### PR DESCRIPTION
This re-order imports on all files according to `goimports`, i.e. built-in first, then the other ones, in order.

It's a little bit OCD, but also if we decide to use this as *code style*, it's like `gofmt`, something else where conflicts should happen less.

/cc @containous/traefik 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>