### PR TITLE
Move some stuff in the right packages

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -59,11 +59,11 @@ $ glide install --strip-vendor
 # generate (Only required to integrate other components such as web dashboard)
 $ go generate
 # Standard go build
-$ go build
-# Using gox to build multiple platform
-$ gox "linux darwin" "386 amd64 arm" \
-    -output="dist/traefik_{{.OS}}-{{.Arch}}"
+$ go build -o dist/traefik ./cmd/
+# To build cross-platform
+$ GOARCH=arm GOOS=linux CGO_ENABLED=0 go build -o "dist/traefik_$OS-$ARCH" ./cmd
 # run other commands like tests
+$ go test ./provider
 ```
 
 ### Tests

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -26,10 +26,10 @@ WORKDIR /go/src/github.com/containous/traefik
 
 COPY glide.yaml glide.yaml
 COPY glide.lock glide.lock
-RUN glide install -v
+RUN glide install --strip-vendor
 
 COPY integration/glide.yaml integration/glide.yaml
 COPY integration/glide.lock integration/glide.lock
-RUN cd integration && glide install
+RUN cd integration && glide install --strip-vendor
 
 COPY . /go/src/github.com/containous/traefik

--- a/cmd/bug.go
+++ b/cmd/bug.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"bytes"

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"fmt"

--- a/script/binary
+++ b/script/binary
@@ -26,4 +26,4 @@ if [ -z "$DATE" ]; then
 fi
 
 # Build binaries
-CGO_ENABLED=0 GOGC=off go build $FLAGS -ldflags "-s -w -X github.com/containous/traefik/version.Version=$VERSION -X github.com/containous/traefik/version.Codename=$CODENAME -X github.com/containous/traefik/version.BuildDate=$DATE" -a -installsuffix nocgo -o dist/traefik .
+CGO_ENABLED=0 GOGC=off go build $FLAGS -ldflags "-s -w -X github.com/containous/traefik/version.Version=$VERSION -X github.com/containous/traefik/version.Codename=$CODENAME -X github.com/containous/traefik/version.BuildDate=$DATE" -a -installsuffix nocgo -o dist/traefik ./cmd

--- a/script/crossbinary
+++ b/script/crossbinary
@@ -27,7 +27,7 @@ OS_ARCH_ARG=(386 amd64)
 for OS in ${OS_PLATFORM_ARG[@]}; do
   for ARCH in ${OS_ARCH_ARG[@]}; do
     echo "Building binary for $OS/$ARCH..."
-    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/containous/traefik/version.Version=$VERSION -X github.com/containous/traefik/version.Codename=$CODENAME -X github.com/containous/traefik/version.BuildDate=$DATE" -o "dist/traefik_$OS-$ARCH" .
+    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/containous/traefik/version.Version=$VERSION -X github.com/containous/traefik/version.Codename=$CODENAME -X github.com/containous/traefik/version.BuildDate=$DATE" -o "dist/traefik_$OS-$ARCH" ./cmd
   done
 done
 
@@ -38,6 +38,6 @@ OS_ARCH_ARG=(arm arm64)
 for OS in ${OS_PLATFORM_ARG[@]}; do
   for ARCH in ${OS_ARCH_ARG[@]}; do
     echo "Building binary for $OS/$ARCH..."
-    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/containous/traefik/version.Version=$VERSION -X github.com/containous/traefik/version.Codename=$CODENAME -X github.com/containous/traefik/version.BuildDate=$DATE" -o "dist/traefik_$OS-$ARCH" .
+    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/containous/traefik/version.Version=$VERSION -X github.com/containous/traefik/version.Codename=$CODENAME -X github.com/containous/traefik/version.BuildDate=$DATE" -o "dist/traefik_$OS-$ARCH" ./cmd
   done
 done

--- a/server/adapters.go
+++ b/server/adapters.go
@@ -1,7 +1,4 @@
-/*
-Copyright
-*/
-package main
+package server
 
 import (
 	"net/http"

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -1,4 +1,4 @@
-package main
+package server
 
 import (
 	"crypto/tls"

--- a/server/rules.go
+++ b/server/rules.go
@@ -1,16 +1,17 @@
-package main
+package server
 
 import (
 	"errors"
 	"fmt"
-	"github.com/BurntSushi/ty/fun"
-	"github.com/containous/mux"
-	"github.com/containous/traefik/types"
 	"net"
 	"net/http"
 	"reflect"
 	"sort"
 	"strings"
+
+	"github.com/BurntSushi/ty/fun"
+	"github.com/containous/mux"
+	"github.com/containous/traefik/types"
 )
 
 // Rules holds rule parsing and configuration

--- a/server/rules_test.go
+++ b/server/rules_test.go
@@ -1,11 +1,12 @@
-package main
+package server
 
 import (
-	"github.com/containous/mux"
 	"net/http"
 	"net/url"
 	"reflect"
 	"testing"
+
+	"github.com/containous/mux"
 )
 
 func TestParseOneRule(t *testing.T) {

--- a/server/server.go
+++ b/server/server.go
@@ -1,7 +1,5 @@
-/*
-Copyright
-*/
-package main
+// Package server holds the engine of traefik
+package server
 
 import (
 	"context"

--- a/server/web.go
+++ b/server/web.go
@@ -1,4 +1,4 @@
-package main
+package server
 
 import (
 	"encoding/json"


### PR DESCRIPTION
- This will help split stuff in smaller, better tested packages
- This moves some stuff like the traefik command to package `cmd`

Note that this is a start (and stays small) but the `server` package should be split up then, etc.

/cc @containous/traefik 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>