### PR TITLE
check permissions on acme.json during startup

### DIFF
--- a/acme/localStore.go
+++ b/acme/localStore.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"sync"
 
 	"github.com/containous/traefik/cluster"
@@ -38,7 +39,21 @@ func (s *LocalStore) Load() (cluster.Object, error) {
 	s.storageLock.Lock()
 	defer s.storageLock.Unlock()
 	account := &Account{}
-	file, err := ioutil.ReadFile(s.file)
+
+	f, err := os.Open(s.file)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if fi.Mode().Perm()&0077 != 0 {
+		return nil, fmt.Errorf("permissions %o for %s are too open, please use 600", fi.Mode().Perm(), s.file)
+	}
+
+	file, err := ioutil.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}

--- a/server.go
+++ b/server.go
@@ -499,7 +499,7 @@ func (server *Server) prepareServer(entryPointName string, router *middlewares.H
 	negroni.UseHandler(router)
 	tlsConfig, err := server.createTLSConfig(entryPointName, entryPoint.TLS, router)
 	if err != nil {
-		log.Errorf("Error creating TLS config %s", err)
+		log.Errorf("Error creating TLS config: %s", err)
 		return nil, err
 	}
 
@@ -517,7 +517,7 @@ func (server *Server) prepareServer(entryPointName string, router *middlewares.H
 		TLSConfig: tlsConfig,
 	}, tlsConfig)
 	if err != nil {
-		log.Errorf("Error hijacking server %s", err)
+		log.Errorf("Error hijacking server: %s", err)
 		return nil, err
 	}
 	return gracefulServer, nil


### PR DESCRIPTION
Follow-up from #639. At the moment people that were affected by this security issue would still be vulnerable even after upgrading. This patch makes sure permissions are also checked for already existing files.

This might also happen with docker-compose, where it isn't uncommon to just touch a file so that it bind-mounts as a file instead of a directory, and some users might forget to put the permissions afterwards.

In case of perm issue it'd fail on startup like this :
```
ERRO[2017-01-01T14:45:55+01:00] Error creating TLS config: permissions 644 for acme.json are too open, please use 600
FATA[2017-01-01T14:45:55+01:00] Error preparing server: permissions 644 for acme.json are too open, please use 600
```