### PR TITLE
instruct to flatten dependencies with glide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -48,14 +48,14 @@ This can be verified via `$ go env`
 
 The idea behind `glide` is the following :
 
-- when checkout(ing) a project, run `$ glide install` from the cloned directory to install
+- when checkout(ing) a project, run `$ glide install -v` from the cloned directory to install
   (`go get …`) the dependencies in your `GOPATH`.
 - if you need another dependency, import and use it in
   the source, and run `$ glide get github.com/Masterminds/cookoo` to save it in
   `vendor` and add it to your `glide.yaml`.
 
 ```bash
-$ glide install
+$ glide install --strip-vendor
 # generate (Only required to integrate other components such as web dashboard)
 $ go generate
 # Standard go build


### PR DESCRIPTION
With the current instructions I was getting the following failure :

```
➜  traefik git:(master) ✗ ./traefik
./traefik flag redefined: log_dir
panic: ./traefik flag redefined: log_dir

goroutine 1 [running]:
panic(0x14ca9e0, 0xc420153230)
	/usr/local/Cellar/go/1.7.4_1/libexec/src/runtime/panic.go:500 +0x1a1
flag.(*FlagSet).Var(0xc420016660, 0x239de60, 0xc4201531e0, 0x17cde52, 0x7, 0x1806cac, 0x2f)
	/usr/local/Cellar/go/1.7.4_1/libexec/src/flag/flag.go:791 +0x43e
flag.(*FlagSet).StringVar(0xc420016660, 0xc4201531e0, 0x17cde52, 0x7, 0x0, 0x0, 0x1806cac, 0x2f)
	/usr/local/Cellar/go/1.7.4_1/libexec/src/flag/flag.go:694 +0x8b
flag.(*FlagSet).String(0xc420016660, 0x17cde52, 0x7, 0x0, 0x0, 0x1806cac, 0x2f, 0xc4201531d0)
	/usr/local/Cellar/go/1.7.4_1/libexec/src/flag/flag.go:707 +0x90
flag.String(0x17cde52, 0x7, 0x0, 0x0, 0x1806cac, 0x2f, 0xc4204db8c0)
	/usr/local/Cellar/go/1.7.4_1/libexec/src/flag/flag.go:714 +0x69
github.com/containous/traefik/vendor/github.com/golang/glog.init()
	/Users/bamarni/go/src/github.com/containous/traefik/vendor/github.com/golang/glog/glog_file.go:41 +0x148
github.com/containous/traefik/vendor/github.com/mesos/mesos-go/detector.init()
	/Users/bamarni/go/src/github.com/containous/traefik/vendor/github.com/mesos/mesos-go/detector/standalone.go:245 +0x71
github.com/containous/traefik/provider.init()
	/Users/bamarni/go/src/github.com/containous/traefik/provider/zk.go:36 +0x109
main.init()
	/Users/bamarni/go/src/github.com/containous/traefik/web.go:312 +0x76
```

It seems to be a known issues with nested vendor dependencies :

* https://github.com/kubernetes/kubernetes/issues/25572
* https://github.com/Masterminds/glide/issues/303