### PR TITLE
Allow for wildcards in k8s ingress host, fixes #792

### DIFF
--- a/provider/kubernetes.go
+++ b/provider/kubernetes.go
@@ -125,9 +125,15 @@ func (provider *Kubernetes) loadIngresses(k8sClient k8s.Client) (*types.Configur
 					}
 				}
 				if len(r.Host) > 0 {
+					rule := "Host:" + r.Host
+
+					if strings.Contains(r.Host, "*") {
+						rule = "HostRegexp:" + strings.Replace(r.Host, "*", "{subdomain:[A-Za-z0-9-_]+}", 1)
+					}
+
 					if _, exists := templateObjects.Frontends[r.Host+pa.Path].Routes[r.Host]; !exists {
 						templateObjects.Frontends[r.Host+pa.Path].Routes[r.Host] = types.Route{
-							Rule: "Host:" + r.Host,
+							Rule: rule,
 						}
 					}
 				}


### PR DESCRIPTION
Example ingress:

```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  namespace: deis
  name: deis
spec:
  rules:
  - host: "*.example.com"
    http:
      paths:
      - path: /
        backend:
          serviceName: deis-router
          servicePort: 80
```