### PR TITLE
Add a forward authentication option v2

### DIFF
--- a/auth/forward.go
+++ b/auth/forward.go
@@ -1,0 +1,77 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/containous/traefik/log"
+	"github.com/containous/traefik/types"
+	"github.com/stretchr/stew/objects"
+)
+
+// Forward the authentication to a external server
+func Forward(forward *types.Forward, w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+
+	client := http.Client{}
+
+	forwardReq, err := http.NewRequest("GET", forward.Address, nil)
+	if err != nil {
+		log.Debugf("Error calling {}. Cause {}", forward.Address, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	forwardReq.Header.Add("Accept", "application/json")
+	forwardQuery := forwardReq.URL.Query()
+	rQuery := r.URL.Query()
+	for _, reqParam := range forward.RequestParameters {
+		paramValue := rQuery.Get(reqParam.Name)
+		forwardQuery.Add(reqParam.As, paramValue)
+	}
+	forwardReq.URL.RawQuery = forwardQuery.Encode()
+	forwardResponse, forwardErr := client.Do(forwardReq)
+	if forwardErr != nil {
+		log.Debugf("Error calling {}. Cause: {}", forward.Address, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	defer forwardResponse.Body.Close()
+	body, readError := ioutil.ReadAll(forwardResponse.Body)
+	if readError != nil {
+		log.Debugf("Error reading body {}. Cause: {}", forward.Address, readError)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if forwardResponse.StatusCode != 200 {
+		log.Debugf("Remote error {}. StatusCode: {}", forward.Address, forwardResponse.StatusCode)
+		w.WriteHeader(forwardResponse.StatusCode)
+		w.Write(body)
+	}
+
+	data := make(map[string]interface{})
+	if err := json.Unmarshal(body, &data); err != nil {
+		log.Debugf("Auth failed...")
+		return
+	}
+
+	objects := objects.Map(data)
+	for _, replay := range forward.ResponseReplayFields {
+		object := objects.Get(replay.Path)
+		value := fmt.Sprintf("%v", object)
+		switch replay.In {
+		case "parameter":
+			rQuery.Add(replay.As, value)
+
+		case "header", "":
+			r.Header.Add(replay.As, value)
+		}
+
+	}
+
+	r.URL.RawQuery = rQuery.Encode()
+	r.RequestURI = r.URL.RequestURI()
+	next(w, r)
+}

--- a/auth/forward.go
+++ b/auth/forward.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 
@@ -18,21 +17,32 @@ func Forward(forward *types.Forward, w http.ResponseWriter, r *http.Request, nex
 
 	forwardReq, err := http.NewRequest("GET", forward.Address, nil)
 	if err != nil {
-		log.Debugf("Error calling {}. Cause {}", forward.Address, err)
+		log.Debugf("Error calling %s. Cause %s", forward.Address, err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+
+	if forward.ForwardAllHeaders {
+		forwardReq.Header = r.Header
+	}
+
 	forwardReq.Header.Add("Accept", "application/json")
 	forwardQuery := forwardReq.URL.Query()
 	rQuery := r.URL.Query()
 	for _, reqParam := range forward.RequestParameters {
-		paramValue := rQuery.Get(reqParam.Name)
-		forwardQuery.Add(reqParam.As, paramValue)
+		switch reqParam.In {
+		case "parameter", "":
+			paramValue := rQuery.Get(reqParam.Name)
+			forwardQuery.Add(reqParam.As, paramValue)
+		case "header":
+			headerValues := r.Header.Get(reqParam.Name)
+			forwardReq.Header.Add(reqParam.As, headerValues)
+		}
 	}
 	forwardReq.URL.RawQuery = forwardQuery.Encode()
 	forwardResponse, forwardErr := client.Do(forwardReq)
 	if forwardErr != nil {
-		log.Debugf("Error calling {}. Cause: {}", forward.Address, err)
+		log.Debugf("Error calling %s. Cause: %s", forward.Address, err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -40,27 +50,40 @@ func Forward(forward *types.Forward, w http.ResponseWriter, r *http.Request, nex
 	defer forwardResponse.Body.Close()
 	body, readError := ioutil.ReadAll(forwardResponse.Body)
 	if readError != nil {
-		log.Debugf("Error reading body {}. Cause: {}", forward.Address, readError)
+		log.Debugf("Error reading body %s. Cause: %s", forward.Address, readError)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
 	if forwardResponse.StatusCode != 200 {
-		log.Debugf("Remote error {}. StatusCode: {}", forward.Address, forwardResponse.StatusCode)
+		log.Debugf("Remote error %s. StatusCode: %s", forward.Address, forwardResponse.StatusCode)
 		w.WriteHeader(forwardResponse.StatusCode)
 		w.Write(body)
+		return
 	}
 
 	data := make(map[string]interface{})
 	if err := json.Unmarshal(body, &data); err != nil {
-		log.Debugf("Auth failed...")
+		log.Debugf("Error Auth failed %s", err)
 		return
 	}
 
 	objects := objects.Map(data)
 	for _, replay := range forward.ResponseReplayFields {
 		object := objects.Get(replay.Path)
-		value := fmt.Sprintf("%v", object)
+		var value string
+		switch v := object.(type) {
+		case string:
+			value = v
+		default:
+			byteValue, err := json.Marshal(object)
+			if err != nil {
+				log.Debugf("Error failed to Marshal object: %v. Cause: %s", object, err)
+				return
+			}
+			value = string(byteValue)
+		}
+
 		switch replay.In {
 		case "parameter":
 			rQuery.Add(replay.As, value)

--- a/auth/forward_test.go
+++ b/auth/forward_test.go
@@ -1,0 +1,70 @@
+package auth
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/containous/traefik/types"
+)
+
+func TestForwarder(t *testing.T) {
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		if r.URL.Query().Get("emailField") == "" {
+			t.Errorf("Missing forward request parameters. Informed just: %v", r.URL.Query())
+		}
+
+		fmt.Println("Chamou o servidor")
+		fmt.Fprintln(w, "{ \"user\" : { \"id\" : 100, \"name\": \"John Lennon\" }}")
+
+	}))
+	defer ts.Close()
+
+	nextCalled := false
+	next := func(w http.ResponseWriter, r *http.Request) {
+
+		if r.Header.Get("X-User-Id") != "100" {
+			t.Errorf("Missing replay header X-User-Id. Headers: %v", r.Header)
+		}
+
+		if r.URL.Query().Get("name") != "John Lennon" {
+			t.Errorf("Missing replay parameter name. Parameters: %v", r.URL.Query())
+		}
+
+		nextCalled = true
+	}
+
+	req := httptest.NewRequest("GET", "http://example.com/foo?email=john@beatles.com", nil)
+	w := httptest.NewRecorder()
+
+	forward := types.Forward{}
+	forward.Address = ts.URL
+	forward.RequestParameters = map[string]*types.ForwardRequestParameter{
+		"email": {
+			Name: "email",
+			As:   "emailField",
+		},
+	}
+	forward.ResponseReplayFields = map[string]*types.ResponseReplayField{
+		"user": {
+			Path: "user.id",
+			As:   "X-User-Id",
+			In:   "header",
+		},
+		"name": {
+			Path: "user.name",
+			As:   "name",
+			In:   "parameter",
+		},
+	}
+
+	Forward(&forward, w, req, next)
+
+	if !nextCalled {
+		t.Error("Next not called")
+	}
+
+}

--- a/auth/forward_test.go
+++ b/auth/forward_test.go
@@ -31,11 +31,20 @@ func TestForwarder(t *testing.T) {
 		}
 		cookie, err := r.Cookie("test")
 		if err != nil {
-			t.Error("Missing forward request cookie test")
+			t.Errorf("Error getting forward request cookie test. Error: %s", err)
 		}
 
 		if cookie.Value != "data" {
 			t.Errorf("The forward cookie is invalid: %v", cookie)
+		}
+
+		cookie, err = r.Cookie("authTokenCookie")
+		if err != nil {
+			t.Errorf("Error getting forward transformation request cookie test. Error: %s", err)
+		}
+
+		if cookie.Value != "abc123" {
+			t.Errorf("The forward transformed cookie is invalid: %v", cookie)
 		}
 
 		fmt.Println("Chamou o servidor")
@@ -77,7 +86,14 @@ func TestForwarder(t *testing.T) {
 		Name:   "test",
 		Value:  "data",
 		Path:   "/test",
-		Domain: "example.com",
+		Domain: "www.example.com",
+	}
+	req.AddCookie(cookie)
+
+	cookie = &http.Cookie{
+		Name:   "auth_token",
+		Value:  "abc123",
+		Domain: ".example.com",
 	}
 	req.AddCookie(cookie)
 	w := httptest.NewRecorder()
@@ -116,6 +132,13 @@ func TestForwarder(t *testing.T) {
 			Path: "user.accounts",
 			As:   "X-User-Accounts",
 			In:   "header",
+		},
+	}
+
+	forward.RequestCookies = map[string]*types.ForwardRequestCookie{
+		"auth_token": {
+			Name: "auth_token",
+			As:   "authTokenCookie",
 		},
 	}
 

--- a/docs/toml.md
+++ b/docs/toml.md
@@ -229,6 +229,29 @@ Supported filters:
 [entryPoints]
   [entryPoints.http]
   address = ":80"
+
+# [entryPoints.http]
+#  address = ":80"
+#  [entryPoints.http.auth.forward]
+#    address = "http://authserver.com/auth"
+#    forwardAllHeaders = true
+#    [entryPoints.http.auth.forward.requestParameters.email]
+#      name = "email"
+#      as = "theEmail"
+#      in = "parameter"
+#    [entryPoints.http.auth.forward.requestParameters.token]
+#      name = "token"
+#      as = "theToken"
+#      in = "header"
+#    [entryPoints.http.auth.forward.responseReplayFields.userId]
+#      path = "user.id"
+#      as = "X-User-Id"
+#      in = "header"
+#    [entryPoints.http.auth.forward.responseReplayFields.userName]
+#      path = "user.name"
+#      as = "" # No name transformation
+#      in = "parameter"
+#
 ```
 
 ## Retry configuration

--- a/docs/toml.md
+++ b/docs/toml.md
@@ -239,6 +239,10 @@ Supported filters:
 #      name = "email"
 #      as = "theEmail"
 #      in = "parameter"
+#    [entryPoints.http.auth.forward.requestParameters.email]
+#      name = "email"
+#      as = "theEmail"
+#      in = "parameter"
 #    [entryPoints.http.auth.forward.requestParameters.token]
 #      name = "token"
 #      as = "theToken"

--- a/docs/toml.md
+++ b/docs/toml.md
@@ -230,32 +230,35 @@ Supported filters:
   [entryPoints.http]
   address = ":80"
 
-# [entryPoints.http]
-#  address = ":80"
-#  [entryPoints.http.auth.forward]
-#    address = "http://authserver.com/auth"
-#    forwardAllHeaders = true
-#    [entryPoints.http.auth.forward.requestParameters.email]
-#      name = "email"
-#      as = "theEmail"
-#      in = "parameter"
-#    [entryPoints.http.auth.forward.requestParameters.email]
-#      name = "email"
-#      as = "theEmail"
-#      in = "parameter"
-#    [entryPoints.http.auth.forward.requestParameters.token]
-#      name = "token"
-#      as = "theToken"
-#      in = "header"
-#    [entryPoints.http.auth.forward.responseReplayFields.userId]
-#      path = "user.id"
-#      as = "X-User-Id"
-#      in = "header"
-#    [entryPoints.http.auth.forward.responseReplayFields.userName]
-#      path = "user.name"
-#      as = "" # No name transformation
-#      in = "parameter"
-#
+defaultEntryPoints = ["http"]
+[entryPoints]
+  [entryPoints.http]
+  address = ":80"
+  [entryPoints.http.auth.forward]
+    address = "http://authserver.com/auth"
+    forwardAllHeaders = true
+    [entryPoints.http.auth.forward.requestParameters.email]
+      name = "email"
+      as = "theEmail"
+      in = "parameter"
+    [entryPoints.http.auth.forward.requestParameters.token]
+      name = "token"
+      as = "theToken"
+      in = "header"
+    [entryPoints.http.auth.forward.requestHeaders.userId]
+      name = "userId"
+      as = "user_id"
+    [entryPoints.http.auth.forward.requestCookies.account]
+      name = "account"
+      as = "userAccount"
+    [entryPoints.http.auth.forward.responseReplayFields.userId]
+      path = "user.id"
+      as = "X-User-Id"
+      in = "header"
+    [entryPoints.http.auth.forward.responseReplayFields.userName]
+      path = "user.name"
+      as = "" # No name transformation
+      in = "parameter"
 ```
 
 ## Retry configuration

--- a/docs/user-guide/examples.md
+++ b/docs/user-guide/examples.md
@@ -146,7 +146,7 @@ In addition to this, traefik provides basic functionality to modify the original
 This allows you to map a request parameter or header (in this case token) from e.g. `traefik.com/secret?token=foobar` to `authserver.com/auth?theToken=foobar`.
 Use the keywords name and as in the `entryPoints.http.auth.forward.requestParameters` setting key as shown in the example.
 As well you can set `entryPoints.http.auth.forward.forwardAllHeaders = true` to forward all request headers to the authentication server as they ware received by traefik.
-
+You can also forward specific cookies by setting `entryPoints.http.auth.forward.requestCookies` there you can also change the cookie name.
 Moreover, you can also replay certain information from the back end authentication response back to the original request received by traefik.
 For this to work, your authentication back end must send a JSON response.
 ```
@@ -157,19 +157,25 @@ defaultEntryPoints = ["http"]
   [entryPoints.http.auth.forward]
     address = "http://authserver.com/auth"
     forwardAllHeaders = true
-    [entryPoints.http.auth.Forward.requestParameters.email]
+    [entryPoints.http.auth.forward.requestParameters.email]
       name = "email"
       as = "theEmail"
       in = "parameter"
-    [entryPoints.http.auth.Forward.requestParameters.token]
+    [entryPoints.http.auth.forward.requestParameters.token]
       name = "token"
       as = "theToken"
       in = "header"
-    [entryPoints.http.auth.Forward.responseReplayFields.userId]
+    [entryPoints.http.auth.forward.requestHeaders.userId]
+      name = "userId"
+      as = "user_id"
+    [entryPoints.http.auth.forward.requestCookies.account]
+      name = "account"
+      as = "userAccount"
+    [entryPoints.http.auth.forward.responseReplayFields.userId]
       path = "user.id"
       as = "X-User-Id"
       in = "header"
-    [entryPoints.http.auth.Forward.responseReplayFields.userName]
+    [entryPoints.http.auth.forward.responseReplayFields.userName]
       path = "user.name"
       as = "" # No name transformation
       in = "parameter"

--- a/docs/user-guide/examples.md
+++ b/docs/user-guide/examples.md
@@ -140,7 +140,7 @@ It works by forwarding any incoming request from traefik proxy to a specified en
 This endpoint address is called "authentication back end".
 The response of the authentication back end is then evaluated.
 The authentication back end has to send a response with an HTTP status code 200 to allow access.
-Any other status code will result in traefik returning the authentiucation back end response to the original request (so if your back end sends a response with a 503 header and any body, traefik will also send a 503 response including the body).
+Any other status code will result in traefik returning the authentication back end response to the original request (so if your back end sends a response with a 503 header and any body, traefik will also send a 503 response including the body).
 
 In addition to this, traefik provides basic functionality to modify the original request's query parameters before they are sent to the authentication back end.
 This allows you to map a request parameter or header (in this case token) from e.g. `traefik.com/secret?token=foobar` to `authserver.com/auth?theToken=foobar`.

--- a/docs/user-guide/examples.md
+++ b/docs/user-guide/examples.md
@@ -131,3 +131,46 @@ defaultEntryPoints = ["http"]
     [entryPoints.http.auth.basic]
     users = ["test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/", "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"]
 ```
+
+
+## Enable authentication forwarding
+
+Authentication forwarding is a mechanism to allow for arbitrary authentication back ends to be used.
+It works by forwarding any incoming request from traefik proxy to a specified endpoint (the setting key `entryPoints.http.auth.forward.address`).
+This endpoint address is called "authentication back end".
+The response of the authentication back end is then evaluated.
+The authentication back end has to send a response with an HTTP status code 200 to allow access.
+Any other status code will result in traefik returning the authentiucation back end response to the original request (so if your back end sends a response with a 503 header and any body, traefik will also send a 503 response including the body).
+
+In addition to this, traefik provides basic functionality to modify the original request's query parameters before they are sent to the authentication back end.
+This allows you to map a request parameter or header (in this case token) from e.g. `traefik.com/secret?token=foobar` to `authserver.com/auth?theToken=foobar`.
+Use the keywords name and as in the `entryPoints.http.auth.forward.requestParameters` setting key as shown in the example.
+As well you can set `entryPoints.http.auth.forward.forwardAllHeaders = true` to forward all request headers to the authentication server as they ware received by traefik.
+
+Moreover, you can also replay certain information from the back end authentication response back to the original request received by traefik.
+For this to work, your authentication back end must send a JSON response.
+```
+defaultEntryPoints = ["http"]
+[entryPoints]
+  [entryPoints.http]
+  address = ":80"
+  [entryPoints.http.auth.forward]
+    address = "http://authserver.com/auth"
+    forwardAllHeaders = true
+    [entryPoints.http.auth.Forward.requestParameters.email]
+      name = "email"
+      as = "theEmail"
+      in = "parameter"
+    [entryPoints.http.auth.Forward.requestParameters.token]
+      name = "token"
+      as = "theToken"
+      in = "header"
+    [entryPoints.http.auth.Forward.responseReplayFields.userId]
+      path = "user.id"
+      as = "X-User-Id"
+      in = "header"
+    [entryPoints.http.auth.Forward.responseReplayFields.userName]
+      path = "user.name"
+      as = "" # No name transformation
+      in = "parameter"
+```

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 0d092f94db69882e79d229c34b9483899e1208eaa7dd0acdd5184635cb0cdaaa
-updated: 2017-01-12T12:31:31.35220213+01:00
+hash: 641c5b51e30a4ec0dac16fd0b0209860964594d139ff7a9d12bc97301490b8b0
+updated: 2017-01-17T10:30:21.194298544+02:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -402,11 +402,20 @@ imports:
   version: 65a174a3a4188c0b7099acbc6cfa0c53628d3287
 - name: github.com/stretchr/objx
   version: cbeaeb16a013161a98496fad62933b1d21786672
+- name: github.com/stretchr/signature
+  version: 168b2a1e1b562bf381d47471e31f5979a2a51cd5
+- name: github.com/stretchr/stew
+  version: 80ef0842b48b329a6120607c817a85aff5a2ec71
+  subpackages:
+  - objects
+  - strings
 - name: github.com/stretchr/testify
   version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
   - mock
+- name: github.com/stretchr/tracer
+  version: 66d3696bba973e1697f7d68413b3f19c6d6e2a7c
 - name: github.com/thoas/stats
   version: 79b768ff1780f4e5b0ed132e192bfeefe9f85a9c
 - name: github.com/timewasted/linode

--- a/glide.yaml
+++ b/glide.yaml
@@ -102,6 +102,7 @@ import:
   version: ^0.5.1
 - package: github.com/gogo/protobuf
   version: 0.3
+- package: github.com/stretchr/stew/objects
 - package: github.com/ArthurHlt/go-eureka-client
   subpackages:
   - eureka

--- a/glide.yaml
+++ b/glide.yaml
@@ -101,8 +101,7 @@ import:
 - package: github.com/gambol99/go-marathon
   version: ^0.5.1
 - package: github.com/gogo/protobuf
-  version: 0.3
-- package: github.com/stretchr/stew/objects
+  version: "0.3"
 - package: github.com/ArthurHlt/go-eureka-client
   subpackages:
   - eureka
@@ -119,3 +118,6 @@ import:
   version: v0.3.0
   subpackages:
   - metrics
+- package: github.com/stretchr/stew
+  subpackages:
+  - objects

--- a/middlewares/authenticator.go
+++ b/middlewares/authenticator.go
@@ -5,8 +5,10 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/abbot/go-http-auth"
+	goauth "github.com/abbot/go-http-auth"
+
 	"github.com/codegangsta/negroni"
+	"github.com/containous/traefik/auth"
 	"github.com/containous/traefik/log"
 	"github.com/containous/traefik/types"
 )
@@ -29,7 +31,7 @@ func NewAuthenticator(authConfig *types.Auth) (*Authenticator, error) {
 		if err != nil {
 			return nil, err
 		}
-		basicAuth := auth.NewBasicAuthenticator("traefik", authenticator.secretBasic)
+		basicAuth := goauth.NewBasicAuthenticator("traefik", authenticator.secretBasic)
 		authenticator.handler = negroni.HandlerFunc(func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 			if username := basicAuth.CheckAuth(r); username == "" {
 				log.Debugf("Basic auth failed...")
@@ -47,7 +49,7 @@ func NewAuthenticator(authConfig *types.Auth) (*Authenticator, error) {
 		if err != nil {
 			return nil, err
 		}
-		digestAuth := auth.NewDigestAuthenticator("traefik", authenticator.secretDigest)
+		digestAuth := goauth.NewDigestAuthenticator("traefik", authenticator.secretDigest)
 		authenticator.handler = negroni.HandlerFunc(func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 			if username, _ := digestAuth.CheckAuth(r); username == "" {
 				log.Debugf("Digest auth failed...")
@@ -59,6 +61,10 @@ func NewAuthenticator(authConfig *types.Auth) (*Authenticator, error) {
 				}
 				next.ServeHTTP(w, r)
 			}
+		})
+	} else if authConfig.Forward != nil {
+		authenticator.handler = negroni.HandlerFunc(func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+			auth.Forward(authConfig.Forward, w, r, next)
 		})
 	}
 	return &authenticator, nil

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -284,7 +284,7 @@
 #    in = "header"
 #    [entryPoints.http.auth.Forward.responseReplayFields.userName]
 #    path = "user.name"
-#    as = ""
+#    as = "user_name"
 #    in = "parameter"
 #
 #

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -262,6 +262,33 @@
 #   [entryPoints.http.auth.basic]
 #   users = ["test:traefik:a2688e031edb4be6a3797f3882655c05 ", "test2:traefik:518845800f9e2bfb1f1f740ec24f074e"]
 #
+# To enable forward auth on an entrypoint
+# This configuration will take the request parameters email and token, send it as theEmail and theToken 
+# to the authentication address http://authserver.com/auth. If the response code is 200
+# the body user object will have it's field id replayed in the header as X-User-Id and the field
+# name as a parameter userName.
+# [entryPoints]
+#   [entryPoints.http]
+#   address = ":80"
+#   [entryPoints.http.auth.forward]
+#   address = "http://authserver.com/auth"
+#    [entryPoints.http.auth.Forward.requestParameters.email]
+#    name = "email"
+#    as = "theEmail"
+#    [entryPoints.http.auth.Forward.requestParameters.token]
+#    name = "token"
+#    as = "theToken"
+#    [entryPoints.http.auth.Forward.responseReplayFields.userId]
+#    path = "user.id"
+#    as = "X-User-Id"
+#    in = "header"
+#    [entryPoints.http.auth.Forward.responseReplayFields.userName]
+#    path = "user.name"
+#    as = ""
+#    in = "parameter"
+#
+#
+#
 # To specify an https entrypoint with a minimum TLS version, and specifying an array of cipher suites (from crypto/tls):
 # [entryPoints]
 #   [entryPoints.https]

--- a/types/types.go
+++ b/types/types.go
@@ -245,6 +245,7 @@ type Digest struct {
 // Forward authentication
 type Forward struct {
 	Address              string
+	ForwardAllHeaders    bool
 	RequestParameters    map[string]*ForwardRequestParameter
 	ResponseReplayFields map[string]*ResponseReplayField
 }
@@ -254,6 +255,7 @@ type Forward struct {
 type ForwardRequestParameter struct {
 	Name string
 	As   string
+	In   string
 }
 
 // ResponseReplayField describe witch fields from the forwarded authentication

--- a/types/types.go
+++ b/types/types.go
@@ -246,6 +246,8 @@ type Digest struct {
 type Forward struct {
 	Address              string
 	ForwardAllHeaders    bool
+	RequestHeaders       map[string]*ForwardRequestHeader
+	RequestCookies       map[string]*ForwardRequestCookie
 	RequestParameters    map[string]*ForwardRequestParameter
 	ResponseReplayFields map[string]*ResponseReplayField
 }
@@ -264,6 +266,20 @@ type ResponseReplayField struct {
 	Path string
 	As   string
 	In   string
+}
+
+// ForwardRequestCookie describes the cookies extracted from the request
+// and sent to remote authentication server
+type ForwardRequestCookie struct {
+	Name string
+	As   string
+}
+
+// ForwardRequestHeader describes the headers extracted from the request
+// and sent to remote authentication server
+type ForwardRequestHeader struct {
+	Name string
+	As   string
 }
 
 // CanonicalDomain returns a lower case domain with trim space

--- a/types/types.go
+++ b/types/types.go
@@ -225,6 +225,7 @@ type Cluster struct {
 type Auth struct {
 	Basic       *Basic
 	Digest      *Digest
+	Forward     *Forward
 	HeaderField string
 }
 
@@ -239,6 +240,28 @@ type Basic struct {
 // Digest HTTP authentication
 type Digest struct {
 	Users `mapstructure:","`
+}
+
+// Forward authentication
+type Forward struct {
+	Address              string
+	RequestParameters    map[string]*ForwardRequestParameter
+	ResponseReplayFields map[string]*ResponseReplayField
+}
+
+// ForwardRequestParameter describe the parameter extracted from the request
+// and used with remote authentication address
+type ForwardRequestParameter struct {
+	Name string
+	As   string
+}
+
+// ResponseReplayField describe witch fields from the forwarded authentication
+// must be replayed in the actual request
+type ResponseReplayField struct {
+	Path string
+	As   string
+	In   string
 }
 
 // CanonicalDomain returns a lower case domain with trim space


### PR DESCRIPTION
It seems that there is no progress in #764 so I have re-based the work that was done there and added something that I have been waiting for #764 to be merged.
Please take a look 
Now it is possible to delegate the authentication to a third party agent, like a OAuth endpoint. This authentication option extracts parameters from the original request, forward then to a authentication endpoint, if it succeed part of the response body can be added as json serialized headers.