### PR TITLE
Allow setting circuitbreaker expression via Kubernetes annotation

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -766,7 +766,7 @@ watch = true
 # filename = "docker.tmpl"
 
 # Expose containers by default in traefik
-# If set to false, containers that don't have `traefik.enable=true` will be ignored 
+# If set to false, containers that don't have `traefik.enable=true` will be ignored
 #
 # Optional
 # Default: true
@@ -1062,6 +1062,10 @@ Annotations can be used on containers to override default behaviour for the whol
 - `traefik.frontend.rule.type: PathPrefixStrip`: override the default frontend rule type (Default: `PathPrefix`).
 
 You can find here an example [ingress](https://raw.githubusercontent.com/containous/traefik/master/examples/k8s/cheese-ingress.yaml) and [replication controller](https://raw.githubusercontent.com/containous/traefik/master/examples/k8s/traefik.yaml).
+
+Additionally, an annotation can be used on Kubernetes services to set the [circuit breaker expression](https://docs.traefik.io/basics/#backends) for a backend.
+
+- `traefik.backend.circuitbreaker: <expression>`: set the circuit breaker expression for the backend (Default: nil).
 
 ## Consul backend
 

--- a/docs/user-guide/kubernetes.md
+++ b/docs/user-guide/kubernetes.md
@@ -1,6 +1,6 @@
 # Kubernetes Ingress Controller
 
-This guide explains how to use Træfɪk as an Ingress controller in a Kubernetes cluster. 
+This guide explains how to use Træfɪk as an Ingress controller in a Kubernetes cluster.
 If you are not familiar with Ingresses in Kubernetes you might want to read the [Kubernetes user guide](http://kubernetes.io/docs/user-guide/ingress/)
 
 The config files used in this guide can be found in the [examples directory](https://github.com/containous/traefik/tree/master/examples/k8s)
@@ -114,7 +114,7 @@ metadata:
   namespace: kube-system
 spec:
   selector:
-    k8s-app: traefik-ingress-lb 
+    k8s-app: traefik-ingress-lb
   ports:
   - port: 80
     targetPort: 8080
@@ -140,7 +140,7 @@ kubectl apply -f examples/k8s/ui.yaml
 ```
 
 Now lets setup an entry in our /etc/hosts file to route `traefik-ui.local`
-to our cluster. 
+to our cluster.
 
 > In production you would want to set up real dns entries.
 
@@ -300,6 +300,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: wensleydale
+  annotations:
+    traefik.backend.circuitbreaker: "NetworkErrorRatio() > 0.5"
 spec:
   ports:
   - name: http
@@ -408,6 +410,10 @@ spec:
 > Notice that we are configuring Træfɪk to strip the prefix from the url path
 > with the `traefik.frontend.rule.type` annotation so that we can use
 > the containers from the previous example without modification.
+
+> Notice that we also set a [circuit breaker expression](https://docs.traefik.io/basics/#backends) for one of the backends
+> by setting the `traefik.backend.circuitbreaker` annotation on the service.
+
 
 ```sh
 kubectl apply -f examples/k8s/cheeses-ingress.yaml

--- a/docs/user-guide/kubernetes.md
+++ b/docs/user-guide/kubernetes.md
@@ -311,6 +311,11 @@ spec:
     app: cheese
     task: wensleydale
 ```
+
+> Notice that we also set a [circuit breaker expression](https://docs.traefik.io/basics/#backends) for one of the backends
+> by setting the `traefik.backend.circuitbreaker` annotation on the service.
+
+
 [examples/k8s/cheese-services.yaml](https://github.com/containous/traefik/tree/master/examples/k8s/cheese-services.yaml)
 
 ```sh
@@ -410,10 +415,6 @@ spec:
 > Notice that we are configuring Træfɪk to strip the prefix from the url path
 > with the `traefik.frontend.rule.type` annotation so that we can use
 > the containers from the previous example without modification.
-
-> Notice that we also set a [circuit breaker expression](https://docs.traefik.io/basics/#backends) for one of the backends
-> by setting the `traefik.backend.circuitbreaker` annotation on the service.
-
 
 ```sh
 kubectl apply -f examples/k8s/cheeses-ingress.yaml

--- a/provider/kubernetes.go
+++ b/provider/kubernetes.go
@@ -167,6 +167,12 @@ func (provider *Kubernetes) loadIngresses(k8sClient k8s.Client) (*types.Configur
 					continue
 				}
 
+				if expression := service.Annotations["traefik.backend.circuitbreaker"]; expression != "" {
+					templateObjects.Backends[r.Host+pa.Path].CircuitBreaker = &types.CircuitBreaker{
+						Expression: expression,
+					}
+				}
+
 				protocol := "http"
 				for _, port := range service.Spec.Ports {
 					if equalPorts(port, pa.Backend.ServicePort) {

--- a/provider/kubernetes_test.go
+++ b/provider/kubernetes_test.go
@@ -1336,7 +1336,7 @@ func TestServiceAnnotations(t *testing.T) {
 				UID:       "1",
 				Namespace: "testing",
 				Annotations: map[string]string{
-					"traefik.backend.circuitbreaker": "NetworkErrorRatio() > 0.5",
+					"traefik.backend.circuitbreaker":      "NetworkErrorRatio() > 0.5",
 					"traefik.backend.loadbalancer.method": "drr",
 				},
 			},
@@ -1355,7 +1355,7 @@ func TestServiceAnnotations(t *testing.T) {
 				UID:       "2",
 				Namespace: "testing",
 				Annotations: map[string]string{
-					"traefik.backend.circuitbreaker": "",
+					"traefik.backend.circuitbreaker":      "",
 					"traefik.backend.loadbalancer.sticky": "true",
 				},
 			},

--- a/templates/kubernetes.tmpl
+++ b/templates/kubernetes.tmpl
@@ -1,4 +1,8 @@
 [backends]{{range $backendName, $backend := .Backends}}
+    {{if $backend.CircuitBreaker}}
+    [backends."{{$backendName}}".circuitbreaker]
+      expression = "{{$backend.CircuitBreaker.Expression}}"
+    {{end}}
     {{range $serverName, $server := $backend.Servers}}
     [backends."{{$backendName}}".servers."{{$serverName}}"]
     url = "{{$server.URL}}"


### PR DESCRIPTION
Annotation on a service - `traefik.backend.circuitbreaker` - allows one to set a circuit breaker expression.