### PR TITLE
Add travis cache support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,11 @@ env:
 #    packages:
 #    - docker-engine=$DOCKER_VERSION.*
 
+cache:
+  directories:
+  - $HOME/.glide
+  - $HOME/.npm
+
 before_install:
   - sudo -E apt-get -yq update
   - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install docker-engine=${DOCKER_VERSION}*

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ TRAEFIK_ENVS := \
 SRCS = $(shell git ls-files '*.go' | grep -v '^external/')
 
 BIND_DIR := "dist"
-TRAEFIK_MOUNT := -v "$(CURDIR)/$(BIND_DIR):/go/src/github.com/containous/traefik/$(BIND_DIR)"
+TRAEFIK_MOUNT := -v "$(CURDIR)/$(BIND_DIR):/go/src/github.com/containous/traefik/$(BIND_DIR)" -v "$(HOME)/.glide:/root/.glide" -v "$(HOME)/.npm:/root/.npm"
 
 GIT_BRANCH := $(subst heads/,,$(shell git rev-parse --abbrev-ref HEAD 2>/dev/null))
 TRAEFIK_DEV_IMAGE := traefik-dev$(if $(GIT_BRANCH),:$(GIT_BRANCH))


### PR DESCRIPTION
This PR adds [Travis cache](https://docs.travis-ci.com/user/caching/) support for glide & npm dependencies.
I hope this will speed up Travis a bit :pray: 

Signed-off-by: Emile Vauge <emile@vauge.com>