### PR TITLE
Fix travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,16 @@ env:
     - VERSION: $TRAVIS_TAG
     - CODENAME: camembert
 
-#addons:
-#  apt:
-#    packages:
-#    - docker-engine=$DOCKER_VERSION.*
+matrix:
+  fast_finish: true
+  include:
+  - env: DOCKER_VERSION=1.10.3
+  - env: DOCKER_VERSION=1.13.0
+  - env: DOCKER_VERSION=1.12.6
 
 before_install:
   - sudo -E apt-get -yq update
   - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install docker-engine=${DOCKER_VERSION}*
-
 install:
   - docker version
   - pip install --user -r requirements.txt
@@ -27,44 +28,39 @@ before_script:
   - make validate
   - make binary
 script:
-  - make test-unit
-  - make test-integration
+  - travis_retry make test-unit
+  - travis_retry make test-integration
 after_failure:
   - docker ps
-
-matrix:
-  fast_finish: true
-  include:
-  - env: DOCKER_VERSION=1.10.3
-  - env: DOCKER_VERSION=1.13.0
-  - env: DOCKER_VERSION=1.12.6
-    after_success:
-      - make crossbinary
-      - make image
-    before_deploy:
-      - mkdocs build --clean
-      - tar cfz dist/traefik-${VERSION}.src.tar.gz --exclude-vcs --exclude dist .
-    deploy:
-      - provider: pages
-        edge: true
-        github_token: ${GITHUB_TOKEN}
-        local_dir: site
-        on:
-          repo: containous/traefik
-          tags: true
-      - provider: releases
-        api_key: ${GITHUB_TOKEN}
-        file: dist/traefik_*
-        file_glob: true
-        on:
-          repo: containous/traefik
-          tags: true
-      - provider: scripts
-        script: script/deploy.sh
-        on:
-          repo: containous/traefik
-          tags: true
-      - provider: scripts
-        script: script/deploy-docker.sh
-        on:
-          repo: containous/traefik
+after_success:
+  - make crossbinary
+  - make image
+before_deploy:
+  - mkdocs build --clean
+  - tar cfz dist/traefik-${VERSION}.src.tar.gz --exclude-vcs --exclude dist .
+deploy:
+  - provider: pages
+    edge: true
+    github_token: ${GITHUB_TOKEN}
+    local_dir: site
+    skip_cleanup: true
+    on:
+      repo: containous/traefik
+      tags: true
+  - provider: releases
+    api_key: ${GITHUB_TOKEN}
+    file: dist/traefik*
+    skip_cleanup: true
+    file_glob: true
+    on:
+      repo: containous/traefik
+      tags: true
+  - provider: script
+    script: script/deploy.sh
+    on:
+      repo: containous/traefik
+      tags: true
+  - provider: script
+    script: script/deploy-docker.sh
+    on:
+      repo: containous/traefik

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ matrix:
   fast_finish: true
   include:
   - env: DOCKER_VERSION=1.10.3
-  - env: DOCKER_VERSION=1.13.0
   - env: DOCKER_VERSION=1.12.6
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Twitter](https://img.shields.io/twitter/follow/traefikproxy.svg?style=social)](https://twitter.com/intent/follow?screen_name=traefikproxy)
 
 
-Træfɪk is a modern HTTP reverse proxy and load balancer made to deploy microservices with ease.
+Træfɪk (pronounced like [traffic](https://speak-ipa.bearbin.net/speak.cgi?speak=%CB%88tr%C3%A6f%C9%AAk)) is a modern HTTP reverse proxy and load balancer made to deploy microservices with ease.
 It supports several backends ([Docker](https://www.docker.com/), [Swarm](https://docs.docker.com/swarm), [Kubernetes](http://kubernetes.io), [Marathon](https://mesosphere.github.io/marathon/), [Mesos](https://github.com/apache/mesos), [Consul](https://www.consul.io/), [Etcd](https://coreos.com/etcd/), [Zookeeper](https://zookeeper.apache.org), [BoltDB](https://github.com/boltdb/bolt), [Eureka](https://github.com/Netflix/eureka), Rest API, file...) to manage its configuration automatically and dynamically.
 
 ## Overview

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -1,13 +1,21 @@
 FROM golang:1.7
 
-RUN go get github.com/Masterminds/glide \
-&& go get github.com/jteeuwen/go-bindata/... \
+RUN go get github.com/jteeuwen/go-bindata/... \
 && go get github.com/golang/lint/golint \
 && go get github.com/kisielk/errcheck \
 && go get github.com/client9/misspell/cmd/misspell
 
 # Which docker version to test on
-ARG DOCKER_VERSION=1.10.1
+ARG DOCKER_VERSION=v0.10.3
+
+
+# Which glide version to test on
+ARG GLIDE_VERSION=v0.12.3
+
+# Download glide
+RUN mkdir -p /usr/local/bin \
+    && curl -SL https://github.com/Masterminds/glide/releases/download/${GLIDE_VERSION}/glide-${GLIDE_VERSION}-linux-amd64.tar.gz \
+    | tar -xzC /usr/local/bin --transform 's#^.+/##x'
 
 # Download docker
 RUN mkdir -p /usr/local/bin \

--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -3,12 +3,17 @@ FROM node:6.9.1
 ENV WEBUI_DIR /src/webui
 RUN mkdir -p $WEBUI_DIR
 
+RUN apt-get -yq update \
+&& apt-get -yq --no-install-suggests --no-install-recommends --force-yes install apt-transport-https \
+&& curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+&& echo "deb https://dl.yarnpkg.com/debian/ stable main" |  tee /etc/apt/sources.list.d/yarn.list \
+&& apt-get -yq update && apt-get -yq --no-install-suggests --no-install-recommends --force-yes install yarn
+
 COPY package.json $WEBUI_DIR/
 COPY yarn.lock $WEBUI_DIR/
 
 WORKDIR $WEBUI_DIR
 RUN npm set progress=false
-RUN npm install --quiet --global yarn@0.16.1
 RUN yarn install
 
 COPY . $WEBUI_DIR/


### PR DESCRIPTION
This PR fixes Travis script issues from #843:
- add `skip_cleanup` in pages & releases
- deploy `traefik*` in releases (in order to deploy `traefik` default linux binary)
- fix provider `script` instead of `scripts`
- fix how yarn is installed
- remove docker 1.13 from tests (really, really, really unstable)
- how do i pronounce this damn project ? 

There are still some strange issue on this new script. For example, this job is green but there is one integration test failing https://travis-ci.org/containous/traefik/jobs/194860155#L2078.

/cc @guilhem @vdemeester 

Signed-off-by: Emile Vauge <emile@vauge.com>