### PR TITLE
Allow setting load balancer method and sticky using service annotations

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -766,7 +766,7 @@ watch = true
 # filename = "docker.tmpl"
 
 # Expose containers by default in traefik
-# If set to false, containers that don't have `traefik.enable=true` will be ignored 
+# If set to false, containers that don't have `traefik.enable=true` will be ignored
 #
 # Optional
 # Default: true
@@ -1060,6 +1060,11 @@ Træfɪk can be configured to use Kubernetes Ingress as a backend configuration:
 Annotations can be used on containers to override default behaviour for the whole Ingress resource:
 
 - `traefik.frontend.rule.type: PathPrefixStrip`: override the default frontend rule type (Default: `PathPrefix`).
+
+Annotations can be used on the Kubernetes service to override default behaviour:
+
+- `traefik.backend.loadbalancer.method=drr`: override the default `wrr` load balancer algorithm
+- `traefik.backend.loadbalancer.sticky=true`: enable backend sticky sessions
 
 You can find here an example [ingress](https://raw.githubusercontent.com/containous/traefik/master/examples/k8s/cheese-ingress.yaml) and [replication controller](https://raw.githubusercontent.com/containous/traefik/master/examples/k8s/traefik.yaml).
 

--- a/templates/kubernetes.tmpl
+++ b/templates/kubernetes.tmpl
@@ -1,4 +1,9 @@
 [backends]{{range $backendName, $backend := .Backends}}
+    [backends."{{$backendName}}".loadbalancer]
+      method = "{{$backend.LoadBalancer.Method}}"
+      {{if $backend.LoadBalancer.Sticky}}
+          sticky = true
+      {{end}}
     {{range $serverName, $server := $backend.Servers}}
     [backends."{{$backendName}}".servers."{{$serverName}}"]
     url = "{{$server.URL}}"


### PR DESCRIPTION
My take on #940 - slightly modified.

As we are setting backend behavior, I think the annotations should be on the backend - the Kubernetes service.

Includes unit tests for sticky and drr. having issues getting integration tests running locally, but I'll figure that out and patch as needed.