### PR TITLE
Add FreeBSD & OpenBSD to crossbinary

### DIFF
--- a/script/crossbinary
+++ b/script/crossbinary
@@ -22,7 +22,7 @@ fi
 rm -f dist/traefik_*
 
 # Build 386 amd64 binaries
-OS_PLATFORM_ARG=(linux darwin windows freebsd)
+OS_PLATFORM_ARG=(linux darwin windows freebsd openbsd)
 OS_ARCH_ARG=(386 amd64)
 for OS in ${OS_PLATFORM_ARG[@]}; do
   for ARCH in ${OS_ARCH_ARG[@]}; do

--- a/script/crossbinary
+++ b/script/crossbinary
@@ -22,7 +22,7 @@ fi
 rm -f dist/traefik_*
 
 # Build 386 amd64 binaries
-OS_PLATFORM_ARG=(linux darwin windows)
+OS_PLATFORM_ARG=(linux darwin windows freebsd)
 OS_ARCH_ARG=(386 amd64)
 for OS in ${OS_PLATFORM_ARG[@]}; do
   for ARCH in ${OS_ARCH_ARG[@]}; do


### PR DESCRIPTION
Closes #923 

Binaries are successfully built via the `script/crossbinary`.

While I've not got an OpenBSD server or VM to hand, I've tested the `go` + `glide` method on a FreeBSD server, a `go build` completes successfully however a `go test $(glide novendor)` has a build failure in `github.com/containous/traefik/integration` as follows

```
# go test github.com/containous/traefik/integration
# github.com/containous/traefik/vendor/github.com/docker/docker/pkg/mount
cc: warning: argument unused during compilation: '-gno-record-gcc-switches'
# github.com/containous/traefik/vendor/github.com/docker/docker/pkg/mount
cc: warning: argument unused during compilation: '-pthread'
cc: warning: argument unused during compilation: '-gno-record-gcc-switches'
# github.com/containous/traefik/vendor/github.com/docker/docker/runconfig/opts
vendor/github.com/docker/docker/runconfig/opts/parse.go:530: flags.Changed undefined (type *pflag.FlagSet has no field or method Changed)
FAIL	github.com/containous/traefik/integration [build failed]
```

but I'm not really familiar enough with Docker to know whether these would be expected on FreeBSD or if they are a current issue for Linux as well.

The other packages (those with tests) all pass.