### PR TITLE
Ensure that we don't add balancees with no health check runs if there is a health check defined on it

### DIFF
--- a/provider/marathon.go
+++ b/provider/marathon.go
@@ -264,6 +264,9 @@ func (provider *Marathon) taskFilter(task marathon.Task, applications *marathon.
 					return false
 				}
 			}
+		} else {
+			log.Debugf("Filtering marathon task %s with defined healthcheck as no healthcheck has run yet", task.AppID)
+			return false
 		}
 	}
 	return true

--- a/provider/marathon_test.go
+++ b/provider/marathon_test.go
@@ -629,7 +629,7 @@ func TestMarathonTaskFilter(t *testing.T) {
 					},
 				},
 			},
-			expected:         true,
+			expected:         false,
 			exposedByDefault: true,
 		},
 		{


### PR DESCRIPTION
Have been running into Traefik balancing against marathon balancees on container startup where the container is not yet ready to serve traffic. 

As of the current behavior, the marathon provider will allow balancing to: 

- Items which do not have health checks
- Items which have health checks where all results are passing
- Items which have health checks which have not been run yet 

This PR aims to ensure that items which have health checks have at least one passing health check result prior to allowing them to be balanced against, removing the last category.