### PR TITLE
Fix marathon provider

### DIFF
--- a/provider/marathon.go
+++ b/provider/marathon.go
@@ -496,11 +496,6 @@ func (provider *Marathon) getCircuitBreakerExpression(application marathon.Appli
 
 func processPorts(application marathon.Application, task marathon.Task) []int {
 
-	// First using application ports
-	if len(application.Ports) > 0 {
-		return application.Ports
-	}
-
 	// Using default port configuration
 	if task.Ports != nil && len(task.Ports) > 0 {
 		return task.Ports

--- a/provider/marathon_test.go
+++ b/provider/marathon_test.go
@@ -1077,6 +1077,19 @@ func TestMarathonGetPort(t *testing.T) {
 				Ports: []int{80, 443},
 			},
 			expected: "443",
+		}, {
+			applications: []marathon.Application{
+				{
+					ID:     "application-with-port",
+					Ports:  []int{9999},
+					Labels: &map[string]string{},
+				},
+			},
+			task: marathon.Task{
+				AppID: "application-with-port",
+				Ports: []int{7777},
+			},
+			expected: "7777",
 		},
 	}
 


### PR DESCRIPTION
The IP-Per-Task PR introduced a bug using the marathon application
port mapping. This port should be used only in the proxy server, the
downstream connection should always be made with the task port.

This commit fix the regression and adds an unit test to prevent new
problems in this setup.

Fixes #1072