### PR TITLE
Fix k8s example UI port.

### DIFF
--- a/examples/k8s/ui.yaml
+++ b/examples/k8s/ui.yaml
@@ -10,7 +10,7 @@ spec:
   ports:
   - name: web
     port: 80
-    targetPort: 8080
+    targetPort: 8081
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress


### PR DESCRIPTION
Port was out of sync from 495cba591f6f558d5e43804a82b3ba5778913eb3.