### PR TITLE
add skip_cleanup in deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,10 +56,12 @@ deploy:
       tags: true
   - provider: script
     script: script/deploy.sh
+    skip_cleanup: true
     on:
       repo: containous/traefik
       tags: true
   - provider: script
     script: script/deploy-docker.sh
+    skip_cleanup: true
     on:
       repo: containous/traefik


### PR DESCRIPTION
CI is failing (like in https://travis-ci.org/containous/traefik/jobs/197589236) due to clean up made by Travis.
This PR adds `skip_cleanup` in deploy.

Signed-off-by: Emile Vauge <emile@vauge.com>