### PR TITLE
add sh before script in deploy...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,13 +55,13 @@ deploy:
       repo: containous/traefik
       tags: true
   - provider: script
-    script: script/deploy.sh
+    script: sh script/deploy.sh
     skip_cleanup: true
     on:
       repo: containous/traefik
       tags: true
   - provider: script
-    script: script/deploy-docker.sh
+    script: sh script/deploy-docker.sh
     skip_cleanup: true
     on:
       repo: containous/traefik


### PR DESCRIPTION
In order to avoid https://travis-ci.org/containous/traefik/jobs/197641627:
```
Deploying application
Script failed with status 127
```
This PR adds sh before script in deploy.
Solution taken from https://github.com/travis-ci/travis-ci/issues/5538

Signed-off-by: Emile Vauge <emile@vauge.com>