### PR TITLE
Fix docker version specifier

### DIFF
--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -14,12 +14,12 @@ ARG GLIDE_VERSION=v0.12.3
 
 # Download glide
 RUN mkdir -p /usr/local/bin \
-    && curl -SL https://github.com/Masterminds/glide/releases/download/${GLIDE_VERSION}/glide-${GLIDE_VERSION}-linux-amd64.tar.gz \
+    && curl -fL https://github.com/Masterminds/glide/releases/download/${GLIDE_VERSION}/glide-${GLIDE_VERSION}-linux-amd64.tar.gz \
     | tar -xzC /usr/local/bin --transform 's#^.+/##x'
 
 # Download docker
 RUN mkdir -p /usr/local/bin \
-    && curl -SL https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz \
+    && curl -fL https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz \
     | tar -xzC /usr/local/bin --transform 's#^.+/##x'
 
 WORKDIR /go/src/github.com/containous/traefik

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -6,7 +6,7 @@ RUN go get github.com/jteeuwen/go-bindata/... \
 && go get github.com/client9/misspell/cmd/misspell
 
 # Which docker version to test on
-ARG DOCKER_VERSION=v0.10.3
+ARG DOCKER_VERSION=1.10.3
 
 
 # Which glide version to test on


### PR DESCRIPTION
[This commit](https://github.com/containous/traefik/commit/c1182377dbc4ec8175dd94e416fb28c118a792e2#diff-4ed9134755756c63936ea8cedb5c3b8f) from PR #1067 introduced a wrong Docker version specifier: The major version is 1 and does not come with a leading `v` character. The PR corrects both.

~~To my surprise, the Docker build on Travis CI did not invalidate the cache when the [originating PR ran](https://travis-ci.org/containous/traefik/jobs/197589236). As far as I understand [the documentation](https://docs.docker.com/engine/reference/builder/#/impact-on-build-caching), this should have been the case.~~ The problem wasn't caught during the Travis CI run since we [set the `DOCKER_VERSION` environment variable in the Travis configuration file](https://github.com/containous/traefik/blob/d0e2349dfd2bf9b5c5e5bf37e50d3e9214d5191a/.travis.yml#L17-L18) and [pass it through as the build argument](https://github.com/containous/traefik/blob/d0e2349dfd2bf9b5c5e5bf37e50d3e9214d5191a/Makefile#L22), thereby never invalidating the corresponding Docker cache layer since ARGs are invalidated only when their content changes. Running any Docker-requiring Make target locally, however, surfaces the issue. I'm not exactly sure how to detect such problems in the future.

Additionally, it wasn't super easy to spot the problem due to the chosen curl parameters. Hence, I piggybacked the following changes:

- Added `-f` (`--fail`): It turns HTTP error response codes into non-zero exit codes, making curl fail early and properly. While the documentation mentions that there is supposed to be no output, we do see an error message. (I got a pretty clear _curl: (22) The requested URL returned error: 403 Forbidden_.)
- Dropped `-S` (`--show-error`): It is only meaningful when used together with `-s` (`--silent`). We do not want to go silent but see the progress bar though.