### PR TITLE
Fix Docker API version for Windows

### DIFF
--- a/provider/docker.go
+++ b/provider/docker.go
@@ -31,8 +31,6 @@ import (
 )
 
 const (
-	// DockerAPIVersion is a constant holding the version of the Docker API traefik will use
-	DockerAPIVersion string = "1.21"
 	// SwarmAPIVersion is a constant holding the version of the Docker API traefik will use
 	SwarmAPIVersion string = "1.24"
 	// SwarmDefaultWatchTime is the duration of the interval when polling docker

--- a/provider/docker_unix.go
+++ b/provider/docker_unix.go
@@ -1,0 +1,8 @@
+// +build !windows
+
+package provider
+
+const (
+	// DockerAPIVersion is a constant holding the version of the Docker API traefik will use
+	DockerAPIVersion string = "1.21"
+)

--- a/provider/docker_windows.go
+++ b/provider/docker_windows.go
@@ -1,0 +1,6 @@
+package provider
+
+const (
+	// DockerAPIVersion is a constant holding the version of the Docker API traefik will use
+	DockerAPIVersion string = "1.24"
+)


### PR DESCRIPTION
This fixes #1094 and increases the DockerAPIVersion from 1.21 to the minimal supported version 1.24 for Windows containers. Increase the API version only for the Windows binary, so all other platforms aren't affected by this change.
