### PR TITLE
Skip file permission check on Windows

### DIFF
--- a/acme/localStore.go
+++ b/acme/localStore.go
@@ -40,19 +40,15 @@ func (s *LocalStore) Load() (cluster.Object, error) {
 	defer s.storageLock.Unlock()
 	account := &Account{}
 
+	err := checkPermissions(s.file)
+	if err != nil {
+		return nil, err
+	}
 	f, err := os.Open(s.file)
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
-	fi, err := f.Stat()
-	if err != nil {
-		return nil, err
-	}
-	if fi.Mode().Perm()&0077 != 0 {
-		return nil, fmt.Errorf("permissions %o for %s are too open, please use 600", fi.Mode().Perm(), s.file)
-	}
-
 	file, err := ioutil.ReadAll(f)
 	if err != nil {
 		return nil, err

--- a/acme/localStore_unix.go
+++ b/acme/localStore_unix.go
@@ -1,0 +1,25 @@
+// +build !windows
+
+package acme
+
+import (
+	"fmt"
+	"os"
+)
+
+// Check file permissions
+func checkPermissions(name string) error {
+	f, err := os.Open(name)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	fi, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	if fi.Mode().Perm()&0077 != 0 {
+		return fmt.Errorf("permissions %o for %s are too open, please use 600", fi.Mode().Perm(), name)
+	}
+	return nil
+}

--- a/acme/localStore_windows.go
+++ b/acme/localStore_windows.go
@@ -1,0 +1,6 @@
+package acme
+
+// Do not check file permissions on Windows right now
+func checkPermissions(name string) error {
+	return nil
+}


### PR DESCRIPTION
As commented in https://github.com/containous/traefik/issues/1094#issuecomment-276795730 Traefik won't start in a Windows container as the file permission check introduced with #1009 does only work on Linux checking for 0x600.
I don't want to dig too deep into File ACL checks, so I skipped the check for Windows, open for other PR's to improve that.
