### PR TITLE
Carry #818 —  Add systemd watchdog feature

### DIFF
--- a/contrib/systemd/traefik.service
+++ b/contrib/systemd/traefik.service
@@ -4,7 +4,8 @@ Description=Traefik
 [Service]
 Type=notify
 ExecStart=/usr/bin/traefik --configFile=/etc/traefik.toml
-Restart=on-failure
+Restart=always
+WatchdogSec=1s
 
 [Install]
 WantedBy=multi-user.target

--- a/glide.lock
+++ b/glide.lock
@@ -1,18 +1,21 @@
-hash: ccd56edd81d054a00b23493227ff0765b020aa1de24f8a9d9ff54a05c0223885
-updated: 2017-02-03T09:45:05.719219148+01:00
+hash: 860c94db30c9ad5d39dd87456a48bc37402c16e7197ec495cc043f6f52d89c08
+updated: 2017-02-04T22:38:34.802177865Z
 imports:
-- name: bitbucket.org/ww/goautoneg
-  version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
+- name: cloud.google.com/go
+  version: c116c7972ec94f148459a304d07a67ecbc770d4b
+  subpackages:
+  - compute/metadata
+  - internal
 - name: github.com/abbot/go-http-auth
-  version: cb4372376e1e00e9f6ab9ec142e029302c9e7140
+  version: d45c47bedec736d172957bd394786b76626fa8ac
 - name: github.com/ArthurHlt/go-eureka-client
-  version: ba361cd0f9f571b4e871421423d2f02f5689c3d2
+  version: b08682e20db11bfaa41836641512e7bc471e9a1a
   subpackages:
   - eureka
 - name: github.com/ArthurHlt/gominlog
   version: 068c01ce147ad68fca25ef3fa29ae5395ae273ab
 - name: github.com/aws/aws-sdk-go
-  version: 90dec2183a5f5458ee79cbaf4b8e9ab910bc81a6
+  version: 3f8f870ec9939e32b3372abf74d24e468bcd285d
   subpackages:
   - aws
   - aws/awserr
@@ -22,12 +25,14 @@ imports:
   - aws/corehandlers
   - aws/credentials
   - aws/credentials/ec2rolecreds
+  - aws/credentials/endpointcreds
+  - aws/credentials/stscreds
   - aws/defaults
   - aws/ec2metadata
+  - aws/endpoints
   - aws/request
   - aws/session
   - aws/signer/v4
-  - private/endpoints
   - private/protocol
   - private/protocol/query
   - private/protocol/query/queryutil
@@ -36,26 +41,26 @@ imports:
   - private/protocol/xml/xmlutil
   - private/waiter
   - service/route53
+  - service/sts
 - name: github.com/Azure/azure-sdk-for-go
-  version: 1620af6b32398bfc91827ceae54a8cc1f55df04d
+  version: bca168cfd0558e70218bbcb3440e31ad8c1930b2
   subpackages:
   - arm/dns
 - name: github.com/Azure/go-autorest
-  version: 32cc2321122a649b7ba4e323527bcb145134fd47
+  version: c32ee194f47ffceb471abc73a222edf76895c7e9
   subpackages:
   - autorest
   - autorest/azure
   - autorest/date
   - autorest/to
-  - autorest/validation
 - name: github.com/beorn7/perks
-  version: b965b613227fddccbfffe13eae360ed3fa822f8d
+  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
   subpackages:
   - quantile
 - name: github.com/blang/semver
-  version: 3a37c301dda64cbe17f16f661b4c976803c0e2d2
+  version: 4a1e882c79dcf4ec00d2e29fac74b9c8938d5052
 - name: github.com/boltdb/bolt
-  version: 5cc10bbbc5c141029940133bb33c9e969512a698
+  version: e9cf4fae01b5a8ff89d0ec6b32f0d9c9f79aefdd
 - name: github.com/BurntSushi/toml
   version: 99064174e013895bbd9b025c31100bd1d9b590ca
 - name: github.com/BurntSushi/ty
@@ -63,13 +68,13 @@ imports:
   subpackages:
   - fun
 - name: github.com/cenk/backoff
-  version: 8edc80b07f38c27352fb186d971c628a6c32552b
+  version: b02f2bbce11d7ea6b97f282ef1771b0fe2f65ef3
 - name: github.com/codahale/hdrhistogram
   version: 9208b142303c12d8899bae836fd524ac9338b4fd
 - name: github.com/codegangsta/cli
   version: bf4a526f48af7badd25d2cb02d587e1b01be3b50
 - name: github.com/codegangsta/negroni
-  version: dc6b9d037e8dab60cbfc09c61d6932537829be8b
+  version: 61dbefc515b4dede6eb2de7df1e54d49edce892d
 - name: github.com/containous/flaeg
   version: a731c034dda967333efce5f8d276aeff11f8ff87
 - name: github.com/containous/mux
@@ -79,13 +84,15 @@ imports:
 - name: github.com/coreos/etcd
   version: c400d05d0aa73e21e431c16145e558d624098018
   subpackages:
-  - Godeps/_workspace/src/github.com/ugorji/go/codec
-  - Godeps/_workspace/src/golang.org/x/net/context
+  - Godeps/_workspace/src/github.com/coreos/go-systemd/journal
+  - Godeps/_workspace/src/github.com/coreos/pkg/capnslog
   - client
+  - pkg/fileutil
   - pkg/pathutil
   - pkg/types
+  - version
 - name: github.com/coreos/go-oidc
-  version: 9e117111587506b9dc83b7b38263268bf48352ea
+  version: f828b1fc9b58b59bd70ace766bfc190216b58b01
   subpackages:
   - http
   - jose
@@ -93,28 +100,28 @@ imports:
   - oauth2
   - oidc
 - name: github.com/coreos/go-systemd
-  version: 43e4800a6165b4e02bb2a36673c54b230d6f7b26
+  version: 48702e0da86bd25e76cfef347e2adeb434a0d0a6
   subpackages:
   - daemon
 - name: github.com/coreos/pkg
-  version: 2c77715c4df99b5420ffcae14ead08f52104065d
+  version: 3ac0863d7acf3bc44daf49afef8919af12f704ef
   subpackages:
   - capnslog
   - health
   - httputil
   - timeutil
 - name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
   - spew
 - name: github.com/daviddengcn/go-colortext
   version: 3b18c8575a432453d41fdafb340099fff5bba2f7
 - name: github.com/decker502/dnspod-go
-  version: f6b1d56f1c048bd94d7e42ac36efb4d57b069b6f
+  version: 68650ee11e182e30773781d391c66a0c80ccf9f2
 - name: github.com/dgrijalva/jwt-go
-  version: 9ed569b5d1ac936e6494082958d63a6aa4fff99a
+  version: 2268707a8f0843315e2004ee4f1d021dc08baedf
 - name: github.com/docker/distribution
-  version: 87917f30529e6a7fca8eaff2932424915fb11225
+  version: 325b0804fef3a66309d962357aac3c2ce3f4d329
   subpackages:
   - context
   - digest
@@ -123,23 +130,40 @@ imports:
   - registry/api/v2
   - registry/client
   - registry/client/auth
+  - registry/client/auth/challenge
   - registry/client/transport
   - registry/storage/cache
   - registry/storage/cache/memory
   - uuid
 - name: github.com/docker/docker
-  version: 534753663161334baba06f13b8efa4cad22b5bc5
+  version: 49bf474f9ed7ce7143a59d1964ff7b7fd9b52178
   subpackages:
+  - api/types
   - api/types/backend
+  - api/types/blkiodev
+  - api/types/container
+  - api/types/events
+  - api/types/filters
+  - api/types/mount
+  - api/types/network
+  - api/types/reference
+  - api/types/registry
+  - api/types/strslice
+  - api/types/swarm
+  - api/types/time
+  - api/types/versions
+  - api/types/volume
   - builder
   - builder/dockerignore
   - cliconfig
   - cliconfig/configfile
+  - client
   - daemon/graphdriver
   - image
   - image/v1
   - layer
   - namesgenerator
+  - oci
   - opts
   - pkg/archive
   - pkg/chrootarchive
@@ -152,9 +176,9 @@ imports:
   - pkg/jsonlog
   - pkg/jsonmessage
   - pkg/longpath
-  - pkg/mflag
   - pkg/mount
   - pkg/namesgenerator
+  - pkg/plugingetter
   - pkg/plugins
   - pkg/plugins/transport
   - pkg/pools
@@ -171,12 +195,14 @@ imports:
   - pkg/tarsum
   - pkg/term
   - pkg/term/windows
+  - pkg/tlsconfig
   - pkg/urlutil
+  - plugin/v2
   - reference
   - registry
   - runconfig/opts
 - name: github.com/docker/engine-api
-  version: 62043eb79d581a32ea849645277023c550732e52
+  version: 3d1601b9d2436a70b0dfc045a23f6503d19195df
   subpackages:
   - client
   - client/transport
@@ -200,11 +226,11 @@ imports:
   - sockets
   - tlsconfig
 - name: github.com/docker/go-units
-  version: f2d77a61e3c169b43402a0a1e84f06daf29b8190
+  version: 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
 - name: github.com/docker/leadership
-  version: bfc7753dd48af19513b29deec23c364bf0f274eb
+  version: 0a913e2d71a12fd14a028452435cb71ac8d82cb6
 - name: github.com/docker/libkv
-  version: 35d3e2084c650109e7bcc7282655b1bc8ba924ff
+  version: 1d8431073ae03cdaedb198a89722f3aab6d418ef
   subpackages:
   - store
   - store/boltdb
@@ -226,7 +252,7 @@ imports:
   - tokens
   - zones
 - name: github.com/elazarl/go-bindata-assetfs
-  version: 57eb5e1fc594ad4b0b1dbea7b286d299e0cb43c2
+  version: 9a6736ed45b44bf3835afeebb3034b57ed329f3e
 - name: github.com/emicklei/go-restful
   version: 892402ba11a2e2fd5e1295dd633481f27365f14d
   subpackages:
@@ -235,9 +261,9 @@ imports:
 - name: github.com/gambol99/go-marathon
   version: 9ab64d9f0259e8800911d92ebcd4d5b981917919
 - name: github.com/ghodss/yaml
-  version: 04f313413ffd65ce25f2541bfd2b2ceec5c0908c
+  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-ini/ini
-  version: 6f66b0e091edb3c7b380f7c4f0f884274d550b67
+  version: e3c2d47c61e5333f9aa2974695dd94396eb69c75
 - name: github.com/go-kit/kit
   version: f66b0e13579bfc5a48b9e2a94b1209c107ea1f41
   subpackages:
@@ -245,13 +271,13 @@ imports:
   - metrics/internal/lv
   - metrics/prometheus
 - name: github.com/go-openapi/jsonpointer
-  version: 8d96a2dc61536b690bd36b2e9df0b3c0b62825b2
+  version: 779f45308c19820f1a69e9a4cd965f496e0da10f
 - name: github.com/go-openapi/jsonreference
   version: 36d33bfe519efae5632669801b180bf1a245da3b
 - name: github.com/go-openapi/spec
-  version: 34b5ffff717ab4535aef76e3dd90818bddde571b
+  version: 02fb9cd3430ed0581e0ceb4804d5d4b3cc702694
 - name: github.com/go-openapi/swag
-  version: 96d7b9ebd181a1735a1c9ac87914f2b32fbf56c9
+  version: d5f8ebc3b1c55a4cf6489eeae7354f338cfe299e
 - name: github.com/gogo/protobuf
   version: 909568be09de550ed094403c2bf8a261b5bb730a
   subpackages:
@@ -260,60 +286,59 @@ imports:
 - name: github.com/golang/glog
   version: fca8c8854093a154ff1eb580aae10276ad6b1b5f
 - name: github.com/golang/protobuf
-  version: 5677a0e3d5e89854c9974e1256839ee23f8233ca
+  version: 4bd1920723d7b7c925de087aa32e2187708897f7
   subpackages:
   - proto
 - name: github.com/google/go-github
-  version: c8ebe3a4d7f0791a6315b7410353d4084c58805d
+  version: 27c7c32b6d369610435bd2ad7b4d8554f235eb01
   subpackages:
   - github
 - name: github.com/google/go-querystring
-  version: 9235644dd9e52eeae6fa48efd539fdc351a0af53
+  version: 53e6ce116135b80d037921a7fdd5138cf32d7a8a
   subpackages:
   - query
 - name: github.com/google/gofuzz
   version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
+- name: github.com/googleapis/gax-go
+  version: da06d194a00e19ce00d9011a13931c3f6f6887c7
 - name: github.com/gorilla/context
-  version: 1ea25387ff6f684839d82767c1733ff4d4d15d0a
+  version: 215affda49addc4c8ef7e2534915df2c8c35c6cd
 - name: github.com/hashicorp/consul
-  version: fce7d75609a04eeb9d4bf41c8dc592aac18fc97d
+  version: f228812746f270ffbd3bf10e861219f4b2ce1187
   subpackages:
   - api
 - name: github.com/hashicorp/go-cleanhttp
-  version: 875fb671b3ddc66f8e2f0acc33829c8cb989a38d
+  version: ad28ea4487f05916463e2423a55166280e8254b5
 - name: github.com/hashicorp/go-version
-  version: e96d3840402619007766590ecea8dd7af1292276
+  version: 03c5bf6be031b6dd45afec16b1cf94fc8938bc77
 - name: github.com/hashicorp/serf
-  version: 6c4672d66fc6312ddde18399262943e21175d831
+  version: 78349c9fd938fca3f149051b8d816cc891c3851f
   subpackages:
   - coordinate
-  - serf
 - name: github.com/JamesClonk/vultr
   version: 9ec0427d51411407c0402b093a1771cb75af9679
   subpackages:
   - lib
-- name: github.com/jarcoal/httpmock
-  version: 145b10d659265440f062c31ea15326166bae56ee
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/jonboulle/clockwork
-  version: 72f9bd7c4e0c2a40055ab3d0f09654f730cce982
+  version: 2eee05ed794112d45db504eb05aa693efd2b8b09
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/mailgun/manners
   version: a585afd9d65c0e05f6c003f921e71ebc05074f4f
 - name: github.com/mailgun/timetools
-  version: fd192d755b00c968d312d23f521eb0cdc6f66bd0
+  version: 7e6055773c5137efbeb3bd2410d705fe10ab6bfd
 - name: github.com/mailru/easyjson
-  version: 9d6630dc8c577b56cb9687a9cf9e8578aca7298a
+  version: 99e922cf9de1bc0ab38310c277cff32c2147e747
   subpackages:
   - buffer
   - jlexer
   - jwriter
 - name: github.com/mattn/go-shellwords
-  version: 525bedee691b5a8df547cb5cf9f86b7fb1883e24
+  version: 753a2322a99f87c0eff284980e77f53041555bc6
 - name: github.com/matttproud/golang_protobuf_extensions
-  version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
   - pbutil
 - name: github.com/mesos/mesos-go
@@ -339,29 +364,30 @@ imports:
   - records/state
   - util
 - name: github.com/Microsoft/go-winio
-  version: ce2922f643c8fd76b46cadc7f404a06282678b34
+  version: fff283ad5116362ca252298cfc9b95828956d85d
 - name: github.com/miekg/dns
-  version: 5d001d020961ae1c184f9f8152fdc73810481677
+  version: 8060d9f51305bbe024b99679454e62f552cd0b0b
 - name: github.com/mitchellh/mapstructure
-  version: f3009df150dadf309fdee4a54ed65c124afad715
+  version: db1efb556f84b25a0a13a04aad883943538ad2e0
 - name: github.com/mvdan/xurls
-  version: fa08908f19eca8c491d68c6bd8b4b44faea6daf8
+  version: d315b61cf6727664f310fa87b3197e9faf2a8513
 - name: github.com/NYTimes/gziphandler
   version: 6710af535839f57c687b62c4c23d649f9545d885
 - name: github.com/ogier/pflag
   version: 45c278ab3607870051a2ea9040bb85fcb8557481
 - name: github.com/opencontainers/runc
-  version: 1a81e9ab1f138c091fe5c86d0883f87716088527
+  version: 0c21b089e672982299403198dad524d4895bb049
   subpackages:
+  - libcontainer/configs
+  - libcontainer/devices
+  - libcontainer/system
   - libcontainer/user
 - name: github.com/ovh/go-ovh
-  version: a8a4c0bc40e56322142649bda7b2b4bb15145b6e
+  version: d2207178e10e4527e8f222fd8707982df8c3af17
   subpackages:
   - ovh
-- name: github.com/parnurzeal/gorequest
-  version: 045012d33ef41ea146c1b675df9296d0dc1a212d
 - name: github.com/pborman/uuid
-  version: 5007efa264d92316c43112bc573e754bc889b7b1
+  version: 1b00554d822231195d1babd97ff4a781231955c9
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
@@ -376,43 +402,44 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: ffe929a3f4c4faeaa10f2b9535c2b1be3ad15650
+  version: dd2f054febf4a6c00f2343686efb775948a8bff4
   subpackages:
   - expfmt
+  - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: 454a56f35412459b5e684fd5ec0f9211b94f002a
+  version: 1878d9fbb537119d24b21ca07effd591627cd160
 - name: github.com/PuerkitoBio/purell
   version: 0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/pyr/egoscale
-  version: ab4b0d7ff424c462da486aef27f354cdeb29a319
+  version: a976a806b2fd3ce7d69630a720782567769ebfe4
   subpackages:
   - src/egoscale
 - name: github.com/ryanuber/go-glob
-  version: 572520ed46dbddaed19ea3d9541bdd0494163693
+  version: 256dc444b735e061061cf46c809487313d5b0065
 - name: github.com/samuel/go-zookeeper
-  version: e64db453f3512cade908163702045e0f31137843
+  version: 1d7be4effb13d2d908342d349d71a284a7542693
   subpackages:
   - zk
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/Sirupsen/logrus
-  version: a283a10442df8dc09befd873fab202bf8a253d6a
+  version: f7f79f729e0fbe2fcc061db48a9ba0263f588252
 - name: github.com/spf13/pflag
-  version: 5644820622454e71517561946e3d94b9f9db6842
+  version: 08b1a584251b5b62f458943640fc8ebd4d50aaa5
 - name: github.com/streamrail/concurrent-map
-  version: 65a174a3a4188c0b7099acbc6cfa0c53628d3287
+  version: 8bf1e9bacbf65b10c81d0f4314cf2b1ebef728b5
 - name: github.com/stretchr/objx
   version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify
-  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  version: 4d4bfba8f1d1027c4fdbe371823030df51419987
   subpackages:
   - assert
   - mock
 - name: github.com/thoas/stats
-  version: 79b768ff1780f4e5b0ed132e192bfeefe9f85a9c
+  version: 152b5d051953fdb6e45f14b6826962aadc032324
 - name: github.com/timewasted/linode
   version: 37e84520dcf74488f67654f9c775b9752c232dc1
   subpackages:
@@ -424,9 +451,7 @@ imports:
   subpackages:
   - codec
 - name: github.com/unrolled/render
-  version: 198ad4d8b8a4612176b804ca10555b222a086b40
-- name: github.com/urfave/negroni
-  version: fde5e16d32adc7ad637e9cd9ad21d4ebc6192535
+  version: 50716a0a853771bb36bfce61a45cdefdb98c2e6e
 - name: github.com/vdemeester/docker-events
   version: be74d4929ec1ad118df54349fda4b0cba60f849b
 - name: github.com/vulcand/oxy
@@ -442,7 +467,7 @@ imports:
   - stream
   - utils
 - name: github.com/vulcand/predicate
-  version: 19b9dde14240d94c804ae5736ad0e1de10bf8fe6
+  version: cb0bff91a7ab7cf7571e661ff883fc997bc554a3
 - name: github.com/vulcand/route
   version: cb89d787ddbb1c5849a7ac9f79004c1fd12a4a32
 - name: github.com/vulcand/vulcand
@@ -488,18 +513,20 @@ imports:
   - blowfish
   - ocsp
 - name: golang.org/x/net
-  version: d4c55e66d8c3a2f3382d264b08e3e3454a66355a
+  version: 242b6b35177ec3909636b6cf6a47e8c2c6324b5d
   subpackages:
   - context
   - context/ctxhttp
   - http2
   - http2/hpack
   - idna
+  - internal/timeseries
   - lex/httplex
   - proxy
   - publicsuffix
+  - trace
 - name: golang.org/x/oauth2
-  version: 3046bc76d6dfd7d3707f6640f85e42d9c4050f50
+  version: 314dd2c0bf3ebd592ec0d20847d27e79d0dbe8dd
   subpackages:
   - google
   - internal
@@ -511,7 +538,7 @@ imports:
   - unix
   - windows
 - name: golang.org/x/text
-  version: a49bea13b776691cb1b49873e5d8df96ec74831a
+  version: 506f9d5c962f284575e88337e7d9296d27e729d3
   repo: https://github.com/golang/text.git
   vcs: git
   subpackages:
@@ -538,21 +565,28 @@ imports:
   - internal/remote_api
   - internal/urlfetch
   - urlfetch
-- name: google.golang.org/cloud
-  version: f20d6dcccb44ed49de45ae3703312cb46e627db1
+- name: google.golang.org/grpc
+  version: 777daa17ff9b5daef1cfdf915088a2ada3332bf0
   subpackages:
-  - compute/metadata
+  - codes
+  - credentials
+  - grpclog
   - internal
+  - metadata
+  - naming
+  - peer
+  - transport
 - name: gopkg.in/fsnotify.v1
-  version: a8a77c9133d2d6fd8334f3260d06f60e8d80a5fb
+  version: 629574ca2a5df945712d3079857300b5e4da0236
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/ini.v1
-  version: 6f66b0e091edb3c7b380f7c4f0f884274d550b67
+  version: e3c2d47c61e5333f9aa2974695dd94396eb69c75
 - name: gopkg.in/mgo.v2
-  version: 29cc868a5ca65f401ff318143f9408d02f4799cc
+  version: 3f83fa5005286a7fe593b055f0d7771a7dce4655
   subpackages:
   - bson
+  - internal/json
 - name: gopkg.in/ns1/ns1-go.v2
   version: d8d10b7f448291ddbdce48d4594fb1b667014c8b
   subpackages:
@@ -563,12 +597,12 @@ imports:
   - rest/model/filter
   - rest/model/monitor
 - name: gopkg.in/square/go-jose.v1
-  version: e3f973b66b91445ec816dd7411ad1b6495a5a2fc
+  version: aa2e30fdd1fe9dd3394119af66451ae790d50e0d
   subpackages:
   - cipher
   - json
 - name: gopkg.in/yaml.v2
-  version: bef53efd0c76e49e6de55ead051f886bea7e9420
+  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - name: k8s.io/client-go
   version: 843f7c4f28b1f647f664f883697107d5c02c5acc
   subpackages:
@@ -680,16 +714,20 @@ testImports:
   version: fa152c58bc15761d0200cb75fe958b89a9d4888e
   subpackages:
   - winterm
-- name: github.com/cloudfoundry-incubator/candiedyaml
-  version: 99c3df83b51532e3615f851d8c2dbb638f5313bf
 - name: github.com/docker/libcompose
-  version: d1876c1d68527a49c0aac22a0b161acc7296b740
+  version: 5cba1677dc9906646fc639c21a098ed960033d2d
   subpackages:
   - config
   - docker
+  - docker/auth
   - docker/builder
   - docker/client
+  - docker/container
+  - docker/ctx
+  - docker/image
   - docker/network
+  - docker/service
+  - docker/volume
   - labels
   - logger
   - lookup
@@ -702,19 +740,25 @@ testImports:
 - name: github.com/flynn/go-shlex
   version: 3f9db97f856818214da2e1057f8ad84803971cff
 - name: github.com/go-check/check
-  version: 11d3bc7aa68e238947792f30573146a3231fc0f1
+  version: 20d25e2804050c1cd24a7eea1e7a6447dd0e74ec
 - name: github.com/gorilla/mux
   version: e444e69cbd2e2e3e0749a2f3c717cec491552bbf
 - name: github.com/libkermit/compose
-  version: cadc5a3b83a15790174bd7fbc75ea2529785e772
+  version: d18cc8ec55cd7033d6c11c0db3b8f521ddbe339a
   subpackages:
   - check
 - name: github.com/libkermit/docker
-  version: 55e3595409924fcfbb850811e5a7cdbe8960a0b7
+  version: 4585c8ba51a219e3c8df6b9d355438e4d540fe70
 - name: github.com/libkermit/docker-check
-  version: cbe0ef03b3d23070eac4d00ba8828f2cc7f7e5a3
+  version: 182e98fd61f66048b3b794f7645b0262104cbf84
+- name: github.com/opencontainers/runtime-spec
+  version: 794ca7ac88234607f9d2c76da8a6e9bbbade8cb9
+  subpackages:
+  - specs-go
+- name: github.com/pkg/errors
+  version: 248dadf4e9068a0b3e79f02ed0a610d935de5302
 - name: github.com/vbatts/tar-split
-  version: 6810cedb21b2c3d0b9bb8f9af12ff2dc7a2f14df
+  version: bd4c5d64c3e9297f410025a3b1bd0c58f659e721
   subpackages:
   - archive/tar
   - tar/asm
@@ -726,4 +770,8 @@ testImports:
 - name: github.com/xeipuuv/gojsonreference
   version: e02fc20de94c78484cd5ffb007f8af96be030a45
 - name: github.com/xeipuuv/gojsonschema
-  version: 00f9fafb54d2244d291b86ab63d12c38bd5c3886
+  version: f06f290571ce81ab347174c6f7ad2e1865af41a7
+- name: golang.org/x/time
+  version: a4bde12657593d5e90d0533a3e4fd95e635124cb
+  subpackages:
+  - rate

--- a/glide.yaml
+++ b/glide.yaml
@@ -108,7 +108,7 @@ import:
 - package: github.com/mitchellh/mapstructure
   version: f3009df150dadf309fdee4a54ed65c124afad715
 - package: github.com/coreos/go-systemd
-  version: v12
+  version: v14
   subpackages:
   - daemon
 - package: github.com/google/go-github

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,7 +6,6 @@ import:
   - fun
 - package: github.com/Sirupsen/logrus
 - package: github.com/cenk/backoff
-- package: github.com/urfave/negroni
 - package: github.com/containous/flaeg
   version: a731c034dda967333efce5f8d276aeff11f8ff87
 - package: github.com/vulcand/oxy
@@ -23,18 +22,19 @@ import:
 - package: github.com/containous/staert
   version: 1e26a71803e428fd933f5f9c8e50a26878f53147
 - package: github.com/docker/engine-api
-  version: 62043eb79d581a32ea849645277023c550732e52
+  version: v0.4.0
   subpackages:
   - client
   - types
   - types/events
   - types/filters
-- package: github.com/docker/go-units
-  version: v0.3.1
 - package: github.com/docker/go-connections
+  version: v0.2.1
   subpackages:
   - sockets
   - tlsconfig
+- name: github.com/docker/go-units
+  version: 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
 - package: github.com/docker/libkv
   subpackages:
   - store
@@ -48,7 +48,6 @@ import:
   subpackages:
   - api
 - package: github.com/mailgun/manners
-- package: github.com/parnurzeal/gorequest
 - package: github.com/streamrail/concurrent-map
 - package: github.com/stretchr/testify
   subpackages:
@@ -65,13 +64,9 @@ import:
   version: ce8fb060cb8361a9ff8b5fb7c2347fa907b6fcac
   subpackages:
   - acme
-- package: golang.org/x/net
-  version: release-branch.go1.7
-  subpackages:
-  - context
 - package: gopkg.in/fsnotify.v1
 - package: github.com/docker/docker
-  version: 534753663161334baba06f13b8efa4cad22b5bc5
+  version: v1.13.0
   subpackages:
   - namesgenerator
 - package: github.com/mattn/go-shellwords
@@ -83,15 +78,13 @@ import:
   - upid
   - mesosutil
   - detector
-- package: github.com/jarcoal/httpmock
+- package: github.com/miekg/dns
+  version: 8060d9f51305bbe024b99679454e62f552cd0b0b
 - package: github.com/mesosphere/mesos-dns
   version: b47dc4c19f215e98da687b15b4c64e70f629bea5
   repo: https://github.com/containous/mesos-dns.git
   vcs: git
-- package: github.com/tv42/zbase32
 - package: github.com/abbot/go-http-auth
-- package: github.com/miekg/dns
-  version: 5d001d020961ae1c184f9f8152fdc73810481677
 - package: github.com/NYTimes/gziphandler
 - package: github.com/docker/leadership
 - package: github.com/satori/go.uuid
@@ -100,13 +93,9 @@ import:
   version: ^v1.5.0
 - package: github.com/gambol99/go-marathon
   version: ^0.5.1
-- package: github.com/gogo/protobuf
-  version: 0.3
 - package: github.com/ArthurHlt/go-eureka-client
   subpackages:
   - eureka
-- package: github.com/mitchellh/mapstructure
-  version: f3009df150dadf309fdee4a54ed65c124afad715
 - package: github.com/coreos/go-systemd
   version: v14
   subpackages:
@@ -119,3 +108,25 @@ import:
   subpackages:
   - metrics
 - package: github.com/eapache/channels
+  version: v1.1.0
+- package: golang.org/x/net
+  version: 242b6b35177ec3909636b6cf6a47e8c2c6324b5d
+  subpackages:
+  - http2
+  - context
+- package: github.com/docker/distribution
+  version: v2.6.0
+- package: github.com/aws/aws-sdk-go
+  version: v1.6.18
+  subpackages:
+  - aws/endpoints
+- package: cloud.google.com/go
+  version: v0.6.0
+  subpackages:
+  - compute/metadata
+- package: github.com/gogo/protobuf
+  version: v0.3
+  subpackages:
+  - proto
+- package: golang.org/x/oauth2
+  version: 314dd2c0bf3ebd592ec0d20847d27e79d0dbe8dd

--- a/traefik.go
+++ b/traefik.go
@@ -257,13 +257,7 @@ func run(traefikConfiguration *TraefikConfiguration) {
 		go func(interval time.Duration) {
 			tick := time.Tick(interval)
 			for range tick {
-				if server.globalConfiguration.Web != nil {
-					if _, err := http.Head("http://" + server.globalConfiguration.Web.Address + "/ping"); err == nil {
-						daemon.SdNotify(true, "WATCHDOG=1")
-					}
-				} else {
-					daemon.SdNotify(true, "WATCHDOG=1")
-				}
+				daemon.SdNotify(true, "WATCHDOG=1")
 			}
 		}(t)
 	}


### PR DESCRIPTION
Carrying #818 — not sure `glide.lock` is up-to-date but I can't make this tool to work so… 

---

:warning: May be not ready to be merged

This PR add systemd behavior for watchdog

This is a proof of concept:

- [x] Discussion may happen on way to do healthcheck (currently an `HEAD` on /ping)
- [X] PR https://github.com/coreos/go-systemd/pull/209 have to be merged