### PR TITLE
Fix glide go units

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ test-integration: build ## run the integration tests
 	$(DOCKER_RUN_TRAEFIK) ./script/make.sh generate test-integration
 
 validate: build  ## validate gofmt, golint and go vet
-	$(DOCKER_RUN_TRAEFIK) ./script/make.sh  validate-gofmt validate-govet validate-golint validate-misspell
+	$(DOCKER_RUN_TRAEFIK) ./script/make.sh  validate-glide validate-gofmt validate-govet validate-golint validate-misspell
 
 build: dist
 	docker build $(DOCKER_BUILD_ARGS) -t "$(TRAEFIK_DEV_IMAGE)" -f build.Dockerfile .

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -3,7 +3,8 @@ FROM golang:1.7
 RUN go get github.com/jteeuwen/go-bindata/... \
 && go get github.com/golang/lint/golint \
 && go get github.com/kisielk/errcheck \
-&& go get github.com/client9/misspell/cmd/misspell
+&& go get github.com/client9/misspell/cmd/misspell \
+&& go get github.com/mattfarina/glide-hash
 
 # Which docker version to test on
 ARG DOCKER_VERSION=1.10.3

--- a/glide.lock
+++ b/glide.lock
@@ -1,15 +1,16 @@
-hash: 860c94db30c9ad5d39dd87456a48bc37402c16e7197ec495cc043f6f52d89c08
-updated: 2017-02-04T22:38:34.802177865Z
+hash: 2a2f73984ec9cccd62220c0eba5ddc82dec96b0044ffed48b25d964e2f3eee05
+updated: 2017-02-05T17:22:02.550162979+01:00
 imports:
+- name: bitbucket.org/ww/goautoneg
+  version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
 - name: cloud.google.com/go
   version: c116c7972ec94f148459a304d07a67ecbc770d4b
   subpackages:
   - compute/metadata
-  - internal
 - name: github.com/abbot/go-http-auth
-  version: d45c47bedec736d172957bd394786b76626fa8ac
+  version: cb4372376e1e00e9f6ab9ec142e029302c9e7140
 - name: github.com/ArthurHlt/go-eureka-client
-  version: b08682e20db11bfaa41836641512e7bc471e9a1a
+  version: ba361cd0f9f571b4e871421423d2f02f5689c3d2
   subpackages:
   - eureka
 - name: github.com/ArthurHlt/gominlog
@@ -43,24 +44,25 @@ imports:
   - service/route53
   - service/sts
 - name: github.com/Azure/azure-sdk-for-go
-  version: bca168cfd0558e70218bbcb3440e31ad8c1930b2
+  version: 1620af6b32398bfc91827ceae54a8cc1f55df04d
   subpackages:
   - arm/dns
 - name: github.com/Azure/go-autorest
-  version: c32ee194f47ffceb471abc73a222edf76895c7e9
+  version: 32cc2321122a649b7ba4e323527bcb145134fd47
   subpackages:
   - autorest
   - autorest/azure
   - autorest/date
   - autorest/to
+  - autorest/validation
 - name: github.com/beorn7/perks
-  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+  version: b965b613227fddccbfffe13eae360ed3fa822f8d
   subpackages:
   - quantile
 - name: github.com/blang/semver
-  version: 4a1e882c79dcf4ec00d2e29fac74b9c8938d5052
+  version: 3a37c301dda64cbe17f16f661b4c976803c0e2d2
 - name: github.com/boltdb/bolt
-  version: e9cf4fae01b5a8ff89d0ec6b32f0d9c9f79aefdd
+  version: 5cc10bbbc5c141029940133bb33c9e969512a698
 - name: github.com/BurntSushi/toml
   version: 99064174e013895bbd9b025c31100bd1d9b590ca
 - name: github.com/BurntSushi/ty
@@ -68,13 +70,13 @@ imports:
   subpackages:
   - fun
 - name: github.com/cenk/backoff
-  version: b02f2bbce11d7ea6b97f282ef1771b0fe2f65ef3
+  version: 8edc80b07f38c27352fb186d971c628a6c32552b
 - name: github.com/codahale/hdrhistogram
   version: 9208b142303c12d8899bae836fd524ac9338b4fd
 - name: github.com/codegangsta/cli
   version: bf4a526f48af7badd25d2cb02d587e1b01be3b50
 - name: github.com/codegangsta/negroni
-  version: 61dbefc515b4dede6eb2de7df1e54d49edce892d
+  version: dc6b9d037e8dab60cbfc09c61d6932537829be8b
 - name: github.com/containous/flaeg
   version: a731c034dda967333efce5f8d276aeff11f8ff87
 - name: github.com/containous/mux
@@ -84,15 +86,13 @@ imports:
 - name: github.com/coreos/etcd
   version: c400d05d0aa73e21e431c16145e558d624098018
   subpackages:
-  - Godeps/_workspace/src/github.com/coreos/go-systemd/journal
-  - Godeps/_workspace/src/github.com/coreos/pkg/capnslog
+  - Godeps/_workspace/src/github.com/ugorji/go/codec
+  - Godeps/_workspace/src/golang.org/x/net/context
   - client
-  - pkg/fileutil
   - pkg/pathutil
   - pkg/types
-  - version
 - name: github.com/coreos/go-oidc
-  version: f828b1fc9b58b59bd70ace766bfc190216b58b01
+  version: 9e117111587506b9dc83b7b38263268bf48352ea
   subpackages:
   - http
   - jose
@@ -104,22 +104,22 @@ imports:
   subpackages:
   - daemon
 - name: github.com/coreos/pkg
-  version: 3ac0863d7acf3bc44daf49afef8919af12f704ef
+  version: 2c77715c4df99b5420ffcae14ead08f52104065d
   subpackages:
   - capnslog
   - health
   - httputil
   - timeutil
 - name: github.com/davecgh/go-spew
-  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
 - name: github.com/daviddengcn/go-colortext
   version: 3b18c8575a432453d41fdafb340099fff5bba2f7
 - name: github.com/decker502/dnspod-go
-  version: 68650ee11e182e30773781d391c66a0c80ccf9f2
+  version: f6b1d56f1c048bd94d7e42ac36efb4d57b069b6f
 - name: github.com/dgrijalva/jwt-go
-  version: 2268707a8f0843315e2004ee4f1d021dc08baedf
+  version: 9ed569b5d1ac936e6494082958d63a6aa4fff99a
 - name: github.com/docker/distribution
   version: 325b0804fef3a66309d962357aac3c2ce3f4d329
   subpackages:
@@ -142,22 +142,17 @@ imports:
   - api/types/backend
   - api/types/blkiodev
   - api/types/container
-  - api/types/events
   - api/types/filters
   - api/types/mount
   - api/types/network
-  - api/types/reference
   - api/types/registry
   - api/types/strslice
   - api/types/swarm
-  - api/types/time
   - api/types/versions
-  - api/types/volume
   - builder
   - builder/dockerignore
   - cliconfig
   - cliconfig/configfile
-  - client
   - daemon/graphdriver
   - image
   - image/v1
@@ -195,7 +190,6 @@ imports:
   - pkg/tarsum
   - pkg/term
   - pkg/term/windows
-  - pkg/tlsconfig
   - pkg/urlutil
   - plugin/v2
   - reference
@@ -228,9 +222,9 @@ imports:
 - name: github.com/docker/go-units
   version: 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
 - name: github.com/docker/leadership
-  version: 0a913e2d71a12fd14a028452435cb71ac8d82cb6
+  version: bfc7753dd48af19513b29deec23c364bf0f274eb
 - name: github.com/docker/libkv
-  version: 1d8431073ae03cdaedb198a89722f3aab6d418ef
+  version: 35d3e2084c650109e7bcc7282655b1bc8ba924ff
   subpackages:
   - store
   - store/boltdb
@@ -252,7 +246,7 @@ imports:
   - tokens
   - zones
 - name: github.com/elazarl/go-bindata-assetfs
-  version: 9a6736ed45b44bf3835afeebb3034b57ed329f3e
+  version: 57eb5e1fc594ad4b0b1dbea7b286d299e0cb43c2
 - name: github.com/emicklei/go-restful
   version: 892402ba11a2e2fd5e1295dd633481f27365f14d
   subpackages:
@@ -261,9 +255,9 @@ imports:
 - name: github.com/gambol99/go-marathon
   version: 9ab64d9f0259e8800911d92ebcd4d5b981917919
 - name: github.com/ghodss/yaml
-  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
+  version: 04f313413ffd65ce25f2541bfd2b2ceec5c0908c
 - name: github.com/go-ini/ini
-  version: e3c2d47c61e5333f9aa2974695dd94396eb69c75
+  version: 6f66b0e091edb3c7b380f7c4f0f884274d550b67
 - name: github.com/go-kit/kit
   version: f66b0e13579bfc5a48b9e2a94b1209c107ea1f41
   subpackages:
@@ -271,13 +265,13 @@ imports:
   - metrics/internal/lv
   - metrics/prometheus
 - name: github.com/go-openapi/jsonpointer
-  version: 779f45308c19820f1a69e9a4cd965f496e0da10f
+  version: 8d96a2dc61536b690bd36b2e9df0b3c0b62825b2
 - name: github.com/go-openapi/jsonreference
   version: 36d33bfe519efae5632669801b180bf1a245da3b
 - name: github.com/go-openapi/spec
-  version: 02fb9cd3430ed0581e0ceb4804d5d4b3cc702694
+  version: 34b5ffff717ab4535aef76e3dd90818bddde571b
 - name: github.com/go-openapi/swag
-  version: d5f8ebc3b1c55a4cf6489eeae7354f338cfe299e
+  version: 96d7b9ebd181a1735a1c9ac87914f2b32fbf56c9
 - name: github.com/gogo/protobuf
   version: 909568be09de550ed094403c2bf8a261b5bb730a
   subpackages:
@@ -286,35 +280,34 @@ imports:
 - name: github.com/golang/glog
   version: fca8c8854093a154ff1eb580aae10276ad6b1b5f
 - name: github.com/golang/protobuf
-  version: 4bd1920723d7b7c925de087aa32e2187708897f7
+  version: 5677a0e3d5e89854c9974e1256839ee23f8233ca
   subpackages:
   - proto
 - name: github.com/google/go-github
-  version: 27c7c32b6d369610435bd2ad7b4d8554f235eb01
+  version: c8ebe3a4d7f0791a6315b7410353d4084c58805d
   subpackages:
   - github
 - name: github.com/google/go-querystring
-  version: 53e6ce116135b80d037921a7fdd5138cf32d7a8a
+  version: 9235644dd9e52eeae6fa48efd539fdc351a0af53
   subpackages:
   - query
 - name: github.com/google/gofuzz
   version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
-- name: github.com/googleapis/gax-go
-  version: da06d194a00e19ce00d9011a13931c3f6f6887c7
 - name: github.com/gorilla/context
-  version: 215affda49addc4c8ef7e2534915df2c8c35c6cd
+  version: 1ea25387ff6f684839d82767c1733ff4d4d15d0a
 - name: github.com/hashicorp/consul
-  version: f228812746f270ffbd3bf10e861219f4b2ce1187
+  version: fce7d75609a04eeb9d4bf41c8dc592aac18fc97d
   subpackages:
   - api
 - name: github.com/hashicorp/go-cleanhttp
-  version: ad28ea4487f05916463e2423a55166280e8254b5
+  version: 875fb671b3ddc66f8e2f0acc33829c8cb989a38d
 - name: github.com/hashicorp/go-version
-  version: 03c5bf6be031b6dd45afec16b1cf94fc8938bc77
+  version: e96d3840402619007766590ecea8dd7af1292276
 - name: github.com/hashicorp/serf
-  version: 78349c9fd938fca3f149051b8d816cc891c3851f
+  version: 6c4672d66fc6312ddde18399262943e21175d831
   subpackages:
   - coordinate
+  - serf
 - name: github.com/JamesClonk/vultr
   version: 9ec0427d51411407c0402b093a1771cb75af9679
   subpackages:
@@ -322,23 +315,23 @@ imports:
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/jonboulle/clockwork
-  version: 2eee05ed794112d45db504eb05aa693efd2b8b09
+  version: 72f9bd7c4e0c2a40055ab3d0f09654f730cce982
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/mailgun/manners
   version: a585afd9d65c0e05f6c003f921e71ebc05074f4f
 - name: github.com/mailgun/timetools
-  version: 7e6055773c5137efbeb3bd2410d705fe10ab6bfd
+  version: fd192d755b00c968d312d23f521eb0cdc6f66bd0
 - name: github.com/mailru/easyjson
-  version: 99e922cf9de1bc0ab38310c277cff32c2147e747
+  version: 9d6630dc8c577b56cb9687a9cf9e8578aca7298a
   subpackages:
   - buffer
   - jlexer
   - jwriter
 - name: github.com/mattn/go-shellwords
-  version: 753a2322a99f87c0eff284980e77f53041555bc6
+  version: 525bedee691b5a8df547cb5cf9f86b7fb1883e24
 - name: github.com/matttproud/golang_protobuf_extensions
-  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
+  version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
   subpackages:
   - pbutil
 - name: github.com/mesos/mesos-go
@@ -364,30 +357,30 @@ imports:
   - records/state
   - util
 - name: github.com/Microsoft/go-winio
-  version: fff283ad5116362ca252298cfc9b95828956d85d
+  version: ce2922f643c8fd76b46cadc7f404a06282678b34
 - name: github.com/miekg/dns
   version: 8060d9f51305bbe024b99679454e62f552cd0b0b
 - name: github.com/mitchellh/mapstructure
-  version: db1efb556f84b25a0a13a04aad883943538ad2e0
+  version: f3009df150dadf309fdee4a54ed65c124afad715
 - name: github.com/mvdan/xurls
-  version: d315b61cf6727664f310fa87b3197e9faf2a8513
+  version: fa08908f19eca8c491d68c6bd8b4b44faea6daf8
 - name: github.com/NYTimes/gziphandler
-  version: 6710af535839f57c687b62c4c23d649f9545d885
+  version: f6438dbf4a82c56684964b03956aa727b0d7816b
 - name: github.com/ogier/pflag
   version: 45c278ab3607870051a2ea9040bb85fcb8557481
 - name: github.com/opencontainers/runc
-  version: 0c21b089e672982299403198dad524d4895bb049
+  version: 1a81e9ab1f138c091fe5c86d0883f87716088527
   subpackages:
   - libcontainer/configs
   - libcontainer/devices
   - libcontainer/system
   - libcontainer/user
 - name: github.com/ovh/go-ovh
-  version: d2207178e10e4527e8f222fd8707982df8c3af17
+  version: a8a4c0bc40e56322142649bda7b2b4bb15145b6e
   subpackages:
   - ovh
 - name: github.com/pborman/uuid
-  version: 1b00554d822231195d1babd97ff4a781231955c9
+  version: 5007efa264d92316c43112bc573e754bc889b7b1
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
@@ -402,44 +395,43 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: dd2f054febf4a6c00f2343686efb775948a8bff4
+  version: ffe929a3f4c4faeaa10f2b9535c2b1be3ad15650
   subpackages:
   - expfmt
-  - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: 1878d9fbb537119d24b21ca07effd591627cd160
+  version: 454a56f35412459b5e684fd5ec0f9211b94f002a
 - name: github.com/PuerkitoBio/purell
   version: 0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/pyr/egoscale
-  version: a976a806b2fd3ce7d69630a720782567769ebfe4
+  version: ab4b0d7ff424c462da486aef27f354cdeb29a319
   subpackages:
   - src/egoscale
 - name: github.com/ryanuber/go-glob
-  version: 256dc444b735e061061cf46c809487313d5b0065
+  version: 572520ed46dbddaed19ea3d9541bdd0494163693
 - name: github.com/samuel/go-zookeeper
-  version: 1d7be4effb13d2d908342d349d71a284a7542693
+  version: e64db453f3512cade908163702045e0f31137843
   subpackages:
   - zk
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/Sirupsen/logrus
-  version: f7f79f729e0fbe2fcc061db48a9ba0263f588252
+  version: a283a10442df8dc09befd873fab202bf8a253d6a
 - name: github.com/spf13/pflag
-  version: 08b1a584251b5b62f458943640fc8ebd4d50aaa5
+  version: 5644820622454e71517561946e3d94b9f9db6842
 - name: github.com/streamrail/concurrent-map
-  version: 8bf1e9bacbf65b10c81d0f4314cf2b1ebef728b5
+  version: 65a174a3a4188c0b7099acbc6cfa0c53628d3287
 - name: github.com/stretchr/objx
   version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify
-  version: 4d4bfba8f1d1027c4fdbe371823030df51419987
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
   - mock
 - name: github.com/thoas/stats
-  version: 152b5d051953fdb6e45f14b6826962aadc032324
+  version: 79b768ff1780f4e5b0ed132e192bfeefe9f85a9c
 - name: github.com/timewasted/linode
   version: 37e84520dcf74488f67654f9c775b9752c232dc1
   subpackages:
@@ -451,7 +443,7 @@ imports:
   subpackages:
   - codec
 - name: github.com/unrolled/render
-  version: 50716a0a853771bb36bfce61a45cdefdb98c2e6e
+  version: 198ad4d8b8a4612176b804ca10555b222a086b40
 - name: github.com/vdemeester/docker-events
   version: be74d4929ec1ad118df54349fda4b0cba60f849b
 - name: github.com/vulcand/oxy
@@ -467,7 +459,7 @@ imports:
   - stream
   - utils
 - name: github.com/vulcand/predicate
-  version: cb0bff91a7ab7cf7571e661ff883fc997bc554a3
+  version: 19b9dde14240d94c804ae5736ad0e1de10bf8fe6
 - name: github.com/vulcand/route
   version: cb89d787ddbb1c5849a7ac9f79004c1fd12a4a32
 - name: github.com/vulcand/vulcand
@@ -520,13 +512,11 @@ imports:
   - http2
   - http2/hpack
   - idna
-  - internal/timeseries
   - lex/httplex
   - proxy
   - publicsuffix
-  - trace
 - name: golang.org/x/oauth2
-  version: 314dd2c0bf3ebd592ec0d20847d27e79d0dbe8dd
+  version: 3046bc76d6dfd7d3707f6640f85e42d9c4050f50
   subpackages:
   - google
   - internal
@@ -538,7 +528,7 @@ imports:
   - unix
   - windows
 - name: golang.org/x/text
-  version: 506f9d5c962f284575e88337e7d9296d27e729d3
+  version: a49bea13b776691cb1b49873e5d8df96ec74831a
   repo: https://github.com/golang/text.git
   vcs: git
   subpackages:
@@ -565,28 +555,21 @@ imports:
   - internal/remote_api
   - internal/urlfetch
   - urlfetch
-- name: google.golang.org/grpc
-  version: 777daa17ff9b5daef1cfdf915088a2ada3332bf0
+- name: google.golang.org/cloud
+  version: f20d6dcccb44ed49de45ae3703312cb46e627db1
   subpackages:
-  - codes
-  - credentials
-  - grpclog
+  - compute/metadata
   - internal
-  - metadata
-  - naming
-  - peer
-  - transport
 - name: gopkg.in/fsnotify.v1
-  version: 629574ca2a5df945712d3079857300b5e4da0236
+  version: a8a77c9133d2d6fd8334f3260d06f60e8d80a5fb
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/ini.v1
-  version: e3c2d47c61e5333f9aa2974695dd94396eb69c75
+  version: 6f66b0e091edb3c7b380f7c4f0f884274d550b67
 - name: gopkg.in/mgo.v2
-  version: 3f83fa5005286a7fe593b055f0d7771a7dce4655
+  version: 29cc868a5ca65f401ff318143f9408d02f4799cc
   subpackages:
   - bson
-  - internal/json
 - name: gopkg.in/ns1/ns1-go.v2
   version: d8d10b7f448291ddbdce48d4594fb1b667014c8b
   subpackages:
@@ -597,12 +580,12 @@ imports:
   - rest/model/filter
   - rest/model/monitor
 - name: gopkg.in/square/go-jose.v1
-  version: aa2e30fdd1fe9dd3394119af66451ae790d50e0d
+  version: e3f973b66b91445ec816dd7411ad1b6495a5a2fc
   subpackages:
   - cipher
   - json
 - name: gopkg.in/yaml.v2
-  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
+  version: bef53efd0c76e49e6de55ead051f886bea7e9420
 - name: k8s.io/client-go
   version: 843f7c4f28b1f647f664f883697107d5c02c5acc
   subpackages:
@@ -714,20 +697,16 @@ testImports:
   version: fa152c58bc15761d0200cb75fe958b89a9d4888e
   subpackages:
   - winterm
+- name: github.com/cloudfoundry-incubator/candiedyaml
+  version: 99c3df83b51532e3615f851d8c2dbb638f5313bf
 - name: github.com/docker/libcompose
-  version: 5cba1677dc9906646fc639c21a098ed960033d2d
+  version: d1876c1d68527a49c0aac22a0b161acc7296b740
   subpackages:
   - config
   - docker
-  - docker/auth
   - docker/builder
   - docker/client
-  - docker/container
-  - docker/ctx
-  - docker/image
   - docker/network
-  - docker/service
-  - docker/volume
   - labels
   - logger
   - lookup
@@ -740,25 +719,25 @@ testImports:
 - name: github.com/flynn/go-shlex
   version: 3f9db97f856818214da2e1057f8ad84803971cff
 - name: github.com/go-check/check
-  version: 20d25e2804050c1cd24a7eea1e7a6447dd0e74ec
+  version: 11d3bc7aa68e238947792f30573146a3231fc0f1
 - name: github.com/gorilla/mux
   version: e444e69cbd2e2e3e0749a2f3c717cec491552bbf
 - name: github.com/libkermit/compose
-  version: d18cc8ec55cd7033d6c11c0db3b8f521ddbe339a
+  version: cadc5a3b83a15790174bd7fbc75ea2529785e772
   subpackages:
   - check
 - name: github.com/libkermit/docker
-  version: 4585c8ba51a219e3c8df6b9d355438e4d540fe70
+  version: 55e3595409924fcfbb850811e5a7cdbe8960a0b7
 - name: github.com/libkermit/docker-check
-  version: 182e98fd61f66048b3b794f7645b0262104cbf84
+  version: cbe0ef03b3d23070eac4d00ba8828f2cc7f7e5a3
 - name: github.com/opencontainers/runtime-spec
-  version: 794ca7ac88234607f9d2c76da8a6e9bbbade8cb9
+  version: 06479209bdc0d4135911688c18157bd39bd99c22
   subpackages:
   - specs-go
 - name: github.com/pkg/errors
   version: 248dadf4e9068a0b3e79f02ed0a610d935de5302
 - name: github.com/vbatts/tar-split
-  version: bd4c5d64c3e9297f410025a3b1bd0c58f659e721
+  version: 6810cedb21b2c3d0b9bb8f9af12ff2dc7a2f14df
   subpackages:
   - archive/tar
   - tar/asm
@@ -770,7 +749,7 @@ testImports:
 - name: github.com/xeipuuv/gojsonreference
   version: e02fc20de94c78484cd5ffb007f8af96be030a45
 - name: github.com/xeipuuv/gojsonschema
-  version: f06f290571ce81ab347174c6f7ad2e1865af41a7
+  version: 00f9fafb54d2244d291b86ab63d12c38bd5c3886
 - name: golang.org/x/time
   version: a4bde12657593d5e90d0533a3e4fd95e635124cb
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -33,7 +33,7 @@ import:
   subpackages:
   - sockets
   - tlsconfig
-- name: github.com/docker/go-units
+- package: github.com/docker/go-units
   version: 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
 - package: github.com/docker/libkv
   subpackages:
@@ -128,5 +128,3 @@ import:
   version: v0.3
   subpackages:
   - proto
-- package: golang.org/x/oauth2
-  version: 314dd2c0bf3ebd592ec0d20847d27e79d0dbe8dd

--- a/script/validate-glide
+++ b/script/validate-glide
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+source "$(dirname "$BASH_SOURCE")/.validate"
+
+grep `glide-hash` glide.lock
+if [ $? -eq 0 ]; then
+	echo 'Congratulations! glide.lock is unchanged.'
+else
+	{
+		echo "Error: glide.lock has been manually changed. Don't do this. Use glide up instead."
+		echo
+	} >&2
+	false
+fi


### PR DESCRIPTION
This PR fixes a regression introduced here https://github.com/containous/traefik/pull/1116/commits/99f251451e072b39cd8c7ca58c4d75051ecf24a5#diff-395f41b2a27b70ce44399c91c82158c2R36 (name instead of package).
This commit was merged because `glide.lock` has been manually changed, which is never a good idea. This PR also adds a check to avoid manual changes in `glide.lock`.
/cc @containous/traefik 