### PR TITLE
Support frontend rule type annotations on k8s Services.

### DIFF
--- a/provider/kubernetes_test.go
+++ b/provider/kubernetes_test.go
@@ -2,7 +2,9 @@ package provider
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/containous/traefik/provider/k8s"
@@ -277,230 +279,141 @@ func TestLoadIngresses(t *testing.T) {
 }
 
 func TestRuleType(t *testing.T) {
-	ingresses := []*v1beta1.Ingress{
+	tests := []struct {
+		desc             string
+		ingressRuleType  string
+		serviceRuleType  string
+		frontendRuleType string
+	}{
 		{
-			ObjectMeta: v1.ObjectMeta{
-				Annotations: map[string]string{"traefik.frontend.rule.type": "PathPrefixStrip"}, //camel case
-			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
-					{
-						Host: "foo1",
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
-									{
-										Path: "/bar1",
-										Backend: v1beta1.IngressBackend{
-											ServiceName: "service1",
-											ServicePort: intstr.FromInt(801),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			desc:             "implicit default",
+			ingressRuleType:  "",
+			frontendRuleType: ruleTypePathPrefix,
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
-				Annotations: map[string]string{"traefik.frontend.rule.type": "path"}, //lower case
-			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
-					{
-						Host: "foo1",
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
-									{
-										Path: "/bar2",
-										Backend: v1beta1.IngressBackend{
-											ServiceName: "service1",
-											ServicePort: intstr.FromInt(801),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			desc:             "unknown ingress / explicit default",
+			ingressRuleType:  "unknown",
+			frontendRuleType: ruleTypePathPrefix,
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
-				Annotations: map[string]string{"traefik.frontend.rule.type": "PathPrefix"}, //path prefix
-			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
-					{
-						Host: "foo2",
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
-									{
-										Path: "/bar1",
-										Backend: v1beta1.IngressBackend{
-											ServiceName: "service1",
-											ServicePort: intstr.FromInt(801),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			desc:             "explicit ingress",
+			ingressRuleType:  ruleTypePath,
+			frontendRuleType: ruleTypePath,
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
-				Annotations: map[string]string{"traefik.frontend.rule.type": "PathStrip"}, //path strip
-			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
-					{
-						Host: "foo2",
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
-									{
-										Path: "/bar2",
-										Backend: v1beta1.IngressBackend{
-											ServiceName: "service1",
-											ServicePort: intstr.FromInt(801),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			desc:             "overriding service",
+			ingressRuleType:  ruleTypePath,
+			serviceRuleType:  ruleTypePathPrefixStrip,
+			frontendRuleType: ruleTypePathPrefixStrip,
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
-				Annotations: map[string]string{"traefik.frontend.rule.type": "PathXXStrip"}, //wrong rule
-			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
-					{
-						Host: "foo1",
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
-									{
-										Path: "/bar3",
-										Backend: v1beta1.IngressBackend{
-											ServiceName: "service1",
-											ServicePort: intstr.FromInt(801),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			desc:             "unknown service",
+			ingressRuleType:  ruleTypePath,
+			serviceRuleType:  "unknown",
+			frontendRuleType: ruleTypePath,
 		},
-	}
-	services := []*v1.Service{
 		{
-			ObjectMeta: v1.ObjectMeta{
-				Name: "service1",
-				UID:  "1",
-			},
-			Spec: v1.ServiceSpec{
-				ClusterIP: "10.0.0.1",
-				Ports: []v1.ServicePort{
-					{
-						Name: "http",
-						Port: 801,
-					},
-				},
-			},
+			desc:             "service only",
+			serviceRuleType:  ruleTypePath,
+			frontendRuleType: ruleTypePath,
 		},
-	}
-	watchChan := make(chan interface{})
-	client := clientMock{
-		ingresses: ingresses,
-		services:  services,
-		watchChan: watchChan,
-	}
-	provider := Kubernetes{DisablePassHostHeaders: true}
-	actualConfig, err := provider.loadIngresses(client)
-	actual := actualConfig.Frontends
-	if err != nil {
-		t.Fatalf("error %+v", err)
+		{
+			desc:             "equal ingress and service",
+			ingressRuleType:  ruleTypePath,
+			serviceRuleType:  ruleTypePath,
+			frontendRuleType: ruleTypePath,
+		},
 	}
 
-	expected := map[string]*types.Frontend{
-		"foo1/bar1": {
-			Backend:  "foo1/bar1",
-			Priority: len("/bar1"),
-			Routes: map[string]types.Route{
-				"/bar1": {
-					Rule: "PathPrefixStrip:/bar1",
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+			ingress := &v1beta1.Ingress{
+				Spec: v1beta1.IngressSpec{
+					Rules: []v1beta1.IngressRule{
+						{
+							Host: "host",
+							IngressRuleValue: v1beta1.IngressRuleValue{
+								HTTP: &v1beta1.HTTPIngressRuleValue{
+									Paths: []v1beta1.HTTPIngressPath{
+										{
+											Path: "/path",
+											Backend: v1beta1.IngressBackend{
+												ServiceName: "service",
+												ServicePort: intstr.FromInt(80),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
 				},
-				"foo1": {
-					Rule: "Host:foo1",
-				},
-			},
-		},
-		"foo1/bar2": {
-			Backend:  "foo1/bar2",
-			Priority: len("/bar2"),
-			Routes: map[string]types.Route{
-				"/bar2": {
-					Rule: "Path:/bar2",
-				},
-				"foo1": {
-					Rule: "Host:foo1",
-				},
-			},
-		},
-		"foo2/bar1": {
-			Backend:  "foo2/bar1",
-			Priority: len("/bar1"),
-			Routes: map[string]types.Route{
-				"/bar1": {
-					Rule: "PathPrefix:/bar1",
-				},
-				"foo2": {
-					Rule: "Host:foo2",
-				},
-			},
-		},
-		"foo2/bar2": {
-			Backend:  "foo2/bar2",
-			Priority: len("/bar2"),
-			Routes: map[string]types.Route{
-				"/bar2": {
-					Rule: "PathStrip:/bar2",
-				},
-				"foo2": {
-					Rule: "Host:foo2",
-				},
-			},
-		},
-		"foo1/bar3": {
-			Backend:  "foo1/bar3",
-			Priority: len("/bar3"),
-			Routes: map[string]types.Route{
-				"/bar3": {
-					Rule: "PathPrefix:/bar3",
-				},
-				"foo1": {
-					Rule: "Host:foo1",
-				},
-			},
-		},
-	}
-	actualJSON, _ := json.Marshal(actual)
-	expectedJSON, _ := json.Marshal(expected)
+			}
 
-	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("expected %+v, got %+v", string(expectedJSON), string(actualJSON))
+			if test.ingressRuleType != "" {
+				ingress.ObjectMeta.Annotations = map[string]string{
+					annotationFrontendRuleType: test.ingressRuleType,
+				}
+			}
+
+			service := &v1.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "service",
+					UID:  "1",
+				},
+				Spec: v1.ServiceSpec{
+					ClusterIP: "10.0.0.1",
+					Ports: []v1.ServicePort{
+						{
+							Name: "http",
+							Port: 801,
+						},
+					},
+				},
+			}
+
+			if test.serviceRuleType != "" {
+				service.ObjectMeta.Annotations = map[string]string{
+					annotationFrontendRuleType: test.serviceRuleType,
+				}
+			}
+
+			watchChan := make(chan interface{})
+			client := clientMock{
+				ingresses: []*v1beta1.Ingress{ingress},
+				services:  []*v1.Service{service},
+				watchChan: watchChan,
+			}
+			provider := Kubernetes{DisablePassHostHeaders: true}
+			actualConfig, err := provider.loadIngresses(client)
+			if err != nil {
+				t.Fatalf("error loading ingresses: %+v", err)
+			}
+
+			actual := actualConfig.Frontends
+			expected := map[string]*types.Frontend{
+				"host/path": {
+					Backend:  "host/path",
+					Priority: len("/path"),
+					Routes: map[string]types.Route{
+						"/path": {
+							Rule: fmt.Sprintf("%s:/path", test.frontendRuleType),
+						},
+						"host": {
+							Rule: "Host:host",
+						},
+					},
+				},
+			}
+
+			if !reflect.DeepEqual(expected, actual) {
+				expectedJSON, _ := json.Marshal(expected)
+				actualJSON, _ := json.Marshal(actual)
+				t.Fatalf("expected %+v, got %+v", string(expectedJSON), string(actualJSON))
+			}
+		})
 	}
 }
 
@@ -1521,6 +1434,65 @@ func TestServiceAnnotations(t *testing.T) {
 
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("expected %+v, got %+v", string(expectedJSON), string(actualJSON))
+	}
+}
+
+func TestGetRuleTypeFromAnnotation(t *testing.T) {
+	tests := []struct {
+		in            string
+		wantedUnknown bool
+	}{
+		{
+			in:            ruleTypePathPrefixStrip,
+			wantedUnknown: false,
+		},
+		{
+			in:            ruleTypePathStrip,
+			wantedUnknown: false,
+		},
+		{
+			in:            ruleTypePath,
+			wantedUnknown: false,
+		},
+		{
+			in:            ruleTypePathPrefix,
+			wantedUnknown: false,
+		},
+		{
+			wantedUnknown: false,
+		},
+		{
+			in:            "Unknown",
+			wantedUnknown: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		inputs := []string{test.in, strings.ToLower(test.in)}
+		if inputs[0] == inputs[1] {
+			// Lower-casing makes no difference -- truncating to single case.
+			inputs = inputs[:1]
+		}
+		for _, input := range inputs {
+			t.Run(fmt.Sprintf("in='%s'", input), func(t *testing.T) {
+				t.Parallel()
+				annotations := map[string]string{}
+				if test.in != "" {
+					annotations[annotationFrontendRuleType] = test.in
+				}
+
+				gotRuleType, gotUnknown := getRuleTypeFromAnnotation(annotations)
+
+				if gotUnknown != test.wantedUnknown {
+					t.Errorf("got unknown '%t', wanted '%t'", gotUnknown, test.wantedUnknown)
+				}
+
+				if gotRuleType != test.in {
+					t.Errorf("got rule type '%s', wanted '%s'", gotRuleType, test.in)
+				}
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
This PR brings support for overriding Ingress-level rule type annotations in Kubernetes by Services. The motivation is that individual Services may have differing needs as to how the path should be matched (as is the case for us).

Apart from the business logic changes, we also extend and refactor the existing tests: The new test `TestGetRuleTypeFromAnnotation` makes sure that the newly introduced `GetRuleTypeFromAnnotation` function works as intended, including all combinations of lower-case / upper-case inputs. In consequence, we can trim down `TestRuleType` while also extending it by the new Service-overriding logic at the same time.