### PR TITLE
Adding support for the ProxyProtocol

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -105,7 +105,7 @@ func (ep *EntryPoints) String() string {
 // Set's argument is a string to be parsed to set the flag.
 // It's a comma-separated list, so we split it.
 func (ep *EntryPoints) Set(value string) error {
-	regex := regexp.MustCompile("(?:Name:(?P<Name>\\S*))\\s*(?:Address:(?P<Address>\\S*))?\\s*(?:TLS:(?P<TLS>\\S*))?\\s*((?P<TLSACME>TLS))?\\s*(?:CA:(?P<CA>\\S*))?\\s*(?:Redirect.EntryPoint:(?P<RedirectEntryPoint>\\S*))?\\s*(?:Redirect.Regex:(?P<RedirectRegex>\\S*))?\\s*(?:Redirect.Replacement:(?P<RedirectReplacement>\\S*))?\\s*(?:Compress:(?P<Compress>\\S*))?")
+	regex := regexp.MustCompile("(?:Name:(?P<Name>\\S*))\\s*(?:Address:(?P<Address>\\S*))?\\s*(?:TLS:(?P<TLS>\\S*))?\\s*((?P<TLSACME>TLS))?\\s*(?:CA:(?P<CA>\\S*))?\\s*(?:Redirect.EntryPoint:(?P<RedirectEntryPoint>\\S*))?\\s*(?:Redirect.Regex:(?P<RedirectRegex>\\S*))?\\s*(?:Redirect.Replacement:(?P<RedirectReplacement>\\S*))?\\s*(?:Compress:(?P<Compress>\\S*))?\\s*(?:ProxyProtocol:(?P<ProxyProtocol>\\S*))?")
 	match := regex.FindAllStringSubmatch(value, -1)
 	if match == nil {
 		return errors.New("Bad EntryPoints format: " + value)
@@ -149,11 +149,17 @@ func (ep *EntryPoints) Set(value string) error {
 		compress = strings.EqualFold(result["Compress"], "enable") || strings.EqualFold(result["Compress"], "on")
 	}
 
+	proxyprotocol := false
+	if len(result["ProxyProtocol"]) > 0 {
+		proxyprotocol = strings.EqualFold(result["ProxyProtocol"], "enable") || strings.EqualFold(result["ProxyProtocol"], "on")
+	}
+
 	(*ep)[result["Name"]] = &EntryPoint{
-		Address:  result["Address"],
-		TLS:      tls,
-		Redirect: redirect,
-		Compress: compress,
+		Address:       result["Address"],
+		TLS:           tls,
+		Redirect:      redirect,
+		Compress:      compress,
+		ProxyProtocol: proxyprotocol,
 	}
 
 	return nil
@@ -176,12 +182,13 @@ func (ep *EntryPoints) Type() string {
 
 // EntryPoint holds an entry point configuration of the reverse proxy (ip, port, TLS...)
 type EntryPoint struct {
-	Network  string
-	Address  string
-	TLS      *TLS
-	Redirect *Redirect
-	Auth     *types.Auth
-	Compress bool
+	Network       string
+	Address       string
+	TLS           *TLS
+	Redirect      *Redirect
+	Auth          *types.Auth
+	Compress      bool
+	ProxyProtocol bool
 }
 
 // Redirect configures a redirection of an entry point to another, or to an URL

--- a/docs/toml.md
+++ b/docs/toml.md
@@ -226,6 +226,12 @@ Supported filters:
 #   address = ":80"
 #   compress = true
 
+# To enable use parsing of ProxyProtocol:
+# [entryPoints]
+#   [entryPoints.http]
+#   address = ":80"
+#   proxyprotocol = true
+
 [entryPoints]
   [entryPoints.http]
   address = ":80"

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b2ac93355c3f551a75216a800337cee9321f6c9a04a18ab1fa8d8152e89b7595
-updated: 2017-02-05T23:00:24.927243212+01:00
+hash: a94aaaac36b5953a904ab271961baaafb367fdc2f9ef23cd74140ad5afc84281
+updated: 2017-02-08T15:44:41.533464297-08:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -9,6 +9,8 @@ imports:
   - compute/metadata
 - name: github.com/abbot/go-http-auth
   version: cb4372376e1e00e9f6ab9ec142e029302c9e7140
+- name: github.com/armon/go-proxyproto
+  version: 3daa90aec0039a806299b9078f4422fee950f33c
 - name: github.com/ArthurHlt/go-eureka-client
   version: ba361cd0f9f571b4e871421423d2f02f5689c3d2
   subpackages:
@@ -422,8 +424,6 @@ imports:
   version: 2c43ff300f3eafcbd7d0b89b10427fc630efdc1e
   subpackages:
   - client
-- name: github.com/rcrowley/go-metrics
-  version: 1f30fe9094a513ce4c700b9a54458bbb0c96996c
 - name: github.com/ryanuber/go-glob
   version: 572520ed46dbddaed19ea3d9541bdd0494163693
 - name: github.com/samuel/go-zookeeper
@@ -602,7 +602,7 @@ imports:
 - name: gopkg.in/yaml.v2
   version: bef53efd0c76e49e6de55ead051f886bea7e9420
 - name: k8s.io/client-go
-  version: 843f7c4f28b1f647f664f883697107d5c02c5acc
+  version: 1195e3a8ee1a529d53eed7c624527a68555ddf1f
   subpackages:
   - 1.5/discovery
   - 1.5/kubernetes

--- a/glide.yaml
+++ b/glide.yaml
@@ -138,3 +138,4 @@ import:
   - proto
 - package: github.com/rancher/go-rancher
   version: 2c43ff300f3eafcbd7d0b89b10427fc630efdc1e
+- package: github.com/armon/go-proxyproto

--- a/server.go
+++ b/server.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -20,6 +21,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/armon/go-proxyproto"
 	"github.com/codegangsta/negroni"
 	"github.com/containous/mux"
 	"github.com/containous/traefik/cluster"
@@ -518,12 +520,22 @@ func (server *Server) prepareServer(entryPointName string, router *middlewares.H
 	}
 
 	if oldServer == nil {
-		return manners.NewWithServer(
-			&http.Server{
-				Addr:      entryPoint.Address,
-				Handler:   negroni,
-				TLSConfig: tlsConfig,
-			}), nil
+		httpServer := &http.Server{
+			Addr:      entryPoint.Address,
+			Handler:   negroni,
+			TLSConfig: tlsConfig,
+		}
+		if entryPoint.ProxyProtocol {
+			newListener, err := net.Listen("tcp", entryPoint.Address)
+			if err != nil {
+				log.Error("Error opening listener ", err)
+			}
+			proxyListener := &proxyproto.Listener{Listener: newListener}
+
+			return manners.NewWithOptions(manners.Options{Server: httpServer, Listener: proxyListener}), nil
+		} else {
+			return manners.NewWithServer(httpServer), nil
+		}
 	}
 	gracefulServer, err := oldServer.HijackListener(&http.Server{
 		Addr:      entryPoint.Address,

--- a/server.go
+++ b/server.go
@@ -533,9 +533,8 @@ func (server *Server) prepareServer(entryPointName string, router *middlewares.H
 			proxyListener := &proxyproto.Listener{Listener: newListener}
 
 			return manners.NewWithOptions(manners.Options{Server: httpServer, Listener: proxyListener}), nil
-		} else {
-			return manners.NewWithServer(httpServer), nil
 		}
+		return manners.NewWithServer(httpServer), nil
 	}
 	gracefulServer, err := oldServer.HijackListener(&http.Server{
 		Addr:      entryPoint.Address,


### PR DESCRIPTION
Tests and docs are still in the works, but I wanted to go ahead and open a PR in case I've gone in the wrong direction with this.

Adds a new config item "ProxyProtocol" to endPoints. When enabled, this causes the endPoint's listener to be wrapped with https://github.com/armon/go-proxyproto 