### PR TITLE
Add Basic Auth per Frontend

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -844,6 +844,7 @@ Labels can be used on containers to override default behaviour:
 - `traefik.frontend.passHostHeader=true`: forward client `Host` header to the backend.
 - `traefik.frontend.priority=10`: override default frontend priority
 - `traefik.frontend.entryPoints=http,https`: assign this frontend to entry points `http` and `https`. Overrides `defaultEntryPoints`.
+- `traefik.frontend.auth.basic=test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/,test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0`: Sets a Basic Auth for that frontend with the users test:test and test2:test2
 - `traefik.docker.network`: Set the docker network to use for connections to this container. If a container is linked to several networks, be sure to set the proper network name (you can check with docker inspect <container_id>) otherwise it will randomly pick one (depending on how docker is returning them). For instance when deploying docker `stack` from compose files, the compose defined networks will be prefixed with the `stack` name.
 
 If several ports need to be exposed from a container, the services labels can be used
@@ -852,10 +853,10 @@ If several ports need to be exposed from a container, the services labels can be
 - `traefik.<service-name>.weight=10`: assign this service weight. Overrides `traefik.weight`.
 - `traefik.<service-name>.frontend.backend=fooBackend`: assign this service frontend to `foobackend`. Default is to assign to the service backend.
 - `traefik.<service-name>.frontend.entryPoints=http`: assign this service entrypoints. Overrides `traefik.frontend.entrypoints`.
+- `traefik.<service-name>.frontend.auth.basic=test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/,test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0` Sets a Basic Auth for that frontend with the users test:test and test2:test2.
 - `traefik.<service-name>.frontend.passHostHeader=true`: Forward client `Host` header to the backend. Overrides `traefik.frontend.passHostHeader`.
 - `traefik.<service-name>.frontend.priority=10`: assign the service frontend priority. Overrides `traefik.frontend.priority`.
 - `traefik.<service-name>.frontend.rule=Path:/foo`: assign the service frontend rule. Overrides `traefik.frontend.rule`.
-
 
 NB: when running inside a container, Træfɪk will need network access through `docker network connect <network> <traefik-container>`
 
@@ -1601,6 +1602,7 @@ Labels can be used on task containers to override default behaviour:
 - `traefik.frontend.passHostHeader=true`: forward client `Host` header to the backend.
 - `traefik.frontend.priority=10`: override default frontend priority
 - `traefik.frontend.entryPoints=http,https`: assign this frontend to entry points `http` and `https`. Overrides `defaultEntryPoints`.
+- `traefik.frontend.auth.basic=test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/,test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0`: Sets a Basic Auth for that frontend with the users test:test and test2:test2
 
 
 ## DynamoDB backend

--- a/provider/docker/docker.go
+++ b/provider/docker/docker.go
@@ -250,6 +250,7 @@ func (p *Provider) loadDockerConfig(containersInspected []dockerData) *types.Con
 		"getPassHostHeader":           p.getPassHostHeader,
 		"getPriority":                 p.getPriority,
 		"getEntryPoints":              p.getEntryPoints,
+		"getBasicAuth":                p.getBasicAuth,
 		"getFrontendRule":             p.getFrontendRule,
 		"hasCircuitBreakerLabel":      p.hasCircuitBreakerLabel,
 		"getCircuitBreakerExpression": p.getCircuitBreakerExpression,
@@ -266,6 +267,7 @@ func (p *Provider) loadDockerConfig(containersInspected []dockerData) *types.Con
 		"getServiceWeight":            p.getServiceWeight,
 		"getServiceProtocol":          p.getServiceProtocol,
 		"getServiceEntryPoints":       p.getServiceEntryPoints,
+		"getServiceBasicAuth":         p.getServiceBasicAuth,
 		"getServiceFrontendRule":      p.getServiceFrontendRule,
 		"getServicePassHostHeader":    p.getServicePassHostHeader,
 		"getServicePriority":          p.getServicePriority,
@@ -374,6 +376,15 @@ func (p *Provider) getServiceEntryPoints(container dockerData, serviceName strin
 		return strings.Split(entryPoints, ",")
 	}
 	return p.getEntryPoints(container)
+
+}
+
+// Extract basic auth from labels for a given service and a given docker container
+func (p *Provider) getServiceBasicAuth(container dockerData, serviceName string) []string {
+	if basicAuth, ok := getContainerServiceLabel(container, serviceName, "frontend.auth.basic"); ok {
+		return strings.Split(basicAuth, ",")
+	}
+	return p.getBasicAuth(container)
 
 }
 
@@ -642,6 +653,14 @@ func (p *Provider) getEntryPoints(container dockerData) []string {
 	if entryPoints, err := getLabel(container, "traefik.frontend.entryPoints"); err == nil {
 		return strings.Split(entryPoints, ",")
 	}
+	return []string{}
+}
+
+func (p *Provider) getBasicAuth(container dockerData) []string {
+	if basicAuth, err := getLabel(container, "traefik.frontend.auth.basic"); err == nil {
+		return strings.Split(basicAuth, ",")
+	}
+
 	return []string{}
 }
 

--- a/provider/docker/docker_test.go
+++ b/provider/docker/docker_test.go
@@ -662,6 +662,7 @@ func TestDockerLoadDockerConfig(t *testing.T) {
 					Backend:        "backend-test",
 					PassHostHeader: true,
 					EntryPoints:    []string{},
+					BasicAuth:      []string{},
 					Routes: map[string]types.Route{
 						"route-frontend-Host-test-docker-localhost": {
 							Rule: "Host:test.docker.localhost",
@@ -688,6 +689,7 @@ func TestDockerLoadDockerConfig(t *testing.T) {
 					labels(map[string]string{
 						"traefik.backend":              "foobar",
 						"traefik.frontend.entryPoints": "http,https",
+						"traefik.frontend.auth.basic":  "test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/,test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0",
 					}),
 					ports(nat.PortMap{
 						"80/tcp": {},
@@ -710,6 +712,7 @@ func TestDockerLoadDockerConfig(t *testing.T) {
 					Backend:        "backend-foobar",
 					PassHostHeader: true,
 					EntryPoints:    []string{"http", "https"},
+					BasicAuth:      []string{"test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/", "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"},
 					Routes: map[string]types.Route{
 						"route-frontend-Host-test1-docker-localhost": {
 							Rule: "Host:test1.docker.localhost",
@@ -720,6 +723,7 @@ func TestDockerLoadDockerConfig(t *testing.T) {
 					Backend:        "backend-foobar",
 					PassHostHeader: true,
 					EntryPoints:    []string{},
+					BasicAuth:      []string{},
 					Routes: map[string]types.Route{
 						"route-frontend-Host-test2-docker-localhost": {
 							Rule: "Host:test2.docker.localhost",
@@ -766,6 +770,7 @@ func TestDockerLoadDockerConfig(t *testing.T) {
 					Backend:        "backend-foobar",
 					PassHostHeader: true,
 					EntryPoints:    []string{"http", "https"},
+					BasicAuth:      []string{},
 					Routes: map[string]types.Route{
 						"route-frontend-Host-test1-docker-localhost": {
 							Rule: "Host:test1.docker.localhost",

--- a/provider/docker/service_test.go
+++ b/provider/docker/service_test.go
@@ -332,6 +332,7 @@ func TestDockerLoadDockerServiceConfig(t *testing.T) {
 					labels(map[string]string{
 						"traefik.service.port":                 "2503",
 						"traefik.service.frontend.entryPoints": "http,https",
+						"traefik.service.frontend.auth.basic":  "test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/,test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0",
 					}),
 					ports(nat.PortMap{
 						"80/tcp": {},
@@ -344,6 +345,7 @@ func TestDockerLoadDockerServiceConfig(t *testing.T) {
 					Backend:        "backend-foo-service",
 					PassHostHeader: true,
 					EntryPoints:    []string{"http", "https"},
+					BasicAuth:      []string{"test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/", "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"},
 					Routes: map[string]types.Route{
 						"service-service": {
 							Rule: "Host:foo.docker.localhost",
@@ -376,6 +378,7 @@ func TestDockerLoadDockerServiceConfig(t *testing.T) {
 						"traefik.service.frontend.rule":           "Path:/mypath",
 						"traefik.service.frontend.priority":       "5000",
 						"traefik.service.frontend.entryPoints":    "http,https,ws",
+						"traefik.service.frontend.auth.basic":     "test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/,test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0",
 					}),
 					ports(nat.PortMap{
 						"80/tcp": {},
@@ -401,6 +404,7 @@ func TestDockerLoadDockerServiceConfig(t *testing.T) {
 					PassHostHeader: false,
 					Priority:       5000,
 					EntryPoints:    []string{"http", "https", "ws"},
+					BasicAuth:      []string{"test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/", "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"},
 					Routes: map[string]types.Route{
 						"service-service": {
 							Rule: "Path:/mypath",
@@ -411,6 +415,7 @@ func TestDockerLoadDockerServiceConfig(t *testing.T) {
 					Backend:        "backend-test2-anotherservice",
 					PassHostHeader: true,
 					EntryPoints:    []string{},
+					BasicAuth:      []string{},
 					Routes: map[string]types.Route{
 						"service-anotherservice": {
 							Rule: "Path:/anotherpath",

--- a/provider/docker/swarm_test.go
+++ b/provider/docker/swarm_test.go
@@ -641,6 +641,7 @@ func TestSwarmLoadDockerConfig(t *testing.T) {
 					Backend:        "backend-test",
 					PassHostHeader: true,
 					EntryPoints:    []string{},
+					BasicAuth:      []string{},
 					Routes: map[string]types.Route{
 						"route-frontend-Host-test-docker-localhost": {
 							Rule: "Host:test.docker.localhost",
@@ -674,6 +675,7 @@ func TestSwarmLoadDockerConfig(t *testing.T) {
 						"traefik.port":                 "80",
 						"traefik.backend":              "foobar",
 						"traefik.frontend.entryPoints": "http,https",
+						"traefik.frontend.auth.basic":  "test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/,test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0",
 					}),
 					withEndpointSpec(modeVIP),
 					withEndpoint(virtualIP("1", "127.0.0.1/24")),
@@ -693,6 +695,7 @@ func TestSwarmLoadDockerConfig(t *testing.T) {
 					Backend:        "backend-foobar",
 					PassHostHeader: true,
 					EntryPoints:    []string{"http", "https"},
+					BasicAuth:      []string{"test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/", "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"},
 					Routes: map[string]types.Route{
 						"route-frontend-Host-test1-docker-localhost": {
 							Rule: "Host:test1.docker.localhost",
@@ -703,6 +706,7 @@ func TestSwarmLoadDockerConfig(t *testing.T) {
 					Backend:        "backend-foobar",
 					PassHostHeader: true,
 					EntryPoints:    []string{},
+					BasicAuth:      []string{},
 					Routes: map[string]types.Route{
 						"route-frontend-Host-test2-docker-localhost": {
 							Rule: "Host:test2.docker.localhost",

--- a/provider/rancher/rancher.go
+++ b/provider/rancher/rancher.go
@@ -88,6 +88,13 @@ func (p *Provider) getFrontendRule(service rancherData) string {
 	return "Host:" + strings.ToLower(strings.Replace(service.Name, "/", ".", -1)) + "." + p.Domain
 }
 
+func (p *Provider) getBasicAuth(service rancherData) []string {
+	if basicAuth, err := getServiceLabel(service, "traefik.frontend.auth.basic"); err == nil {
+		return strings.Split(basicAuth, ",")
+	}
+	return []string{}
+}
+
 func (p *Provider) getFrontendName(service rancherData) string {
 	// Replace '.' with '-' in quoted keys because of this issue https://github.com/BurntSushi/toml/issues/78
 	return provider.Normalize(p.getFrontendRule(service))
@@ -411,6 +418,7 @@ func (p *Provider) loadRancherConfig(services []rancherData) *types.Configuratio
 		"getPassHostHeader":           p.getPassHostHeader,
 		"getPriority":                 p.getPriority,
 		"getEntryPoints":              p.getEntryPoints,
+		"getBasicAuth":                p.getBasicAuth,
 		"getFrontendRule":             p.getFrontendRule,
 		"hasCircuitBreakerLabel":      p.hasCircuitBreakerLabel,
 		"getCircuitBreakerExpression": p.getCircuitBreakerExpression,

--- a/provider/rancher/rancher_test.go
+++ b/provider/rancher/rancher_test.go
@@ -396,7 +396,8 @@ func TestRancherLoadRancherConfig(t *testing.T) {
 				{
 					Name: "test/service",
 					Labels: map[string]string{
-						"traefik.port": "80",
+						"traefik.port":                "80",
+						"traefik.frontend.auth.basic": "test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/,test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0",
 					},
 					Health:     "healthy",
 					Containers: []string{"127.0.0.1"},
@@ -407,6 +408,7 @@ func TestRancherLoadRancherConfig(t *testing.T) {
 					Backend:        "backend-test-service",
 					PassHostHeader: true,
 					EntryPoints:    []string{},
+					BasicAuth:      []string{"test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/", "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"},
 					Priority:       0,
 
 					Routes: map[string]types.Route{

--- a/templates/docker.tmpl
+++ b/templates/docker.tmpl
@@ -47,6 +47,9 @@
   entryPoints = [{{range getServiceEntryPoints $container $serviceName}}
     "{{.}}",
   {{end}}]
+  basicAuth = [{{range getServiceBasicAuth $container $serviceName}}
+    "{{.}}",
+  {{end}}]
     [frontends."frontend-{{getServiceBackend $container $serviceName}}".routes."service-{{$serviceName | replace "/" "" | replace "." "-"}}"]
     rule = "{{getServiceFrontendRule $container $serviceName}}"
   {{end}}
@@ -56,6 +59,9 @@
   passHostHeader = {{getPassHostHeader $container}}
   priority = {{getPriority $container}}
   entryPoints = [{{range getEntryPoints $container}}
+    "{{.}}",
+  {{end}}]
+  basicAuth = [{{range getBasicAuth $container}}
     "{{.}}",
   {{end}}]
     [frontends."frontend-{{$frontend}}".routes."route-frontend-{{$frontend}}"]

--- a/templates/rancher.tmpl
+++ b/templates/rancher.tmpl
@@ -33,6 +33,9 @@
     entryPoints = [{{range getEntryPoints $service}}
         "{{.}}",
     {{end}}]
+    basicAuth = [{{range getBasicAuth $service}}
+        "{{.}}",
+    {{end}}]
     [frontends."frontend-{{$frontendName}}".routes."route-frontend-{{$frontendName}}"]
     rule = "{{getFrontendRule $service}}"
 {{end}}

--- a/types/types.go
+++ b/types/types.go
@@ -61,6 +61,7 @@ type Frontend struct {
 	Routes         map[string]Route `json:"routes,omitempty"`
 	PassHostHeader bool             `json:"passHostHeader,omitempty"`
 	Priority       int              `json:"priority"`
+	BasicAuth      []string         `json:"basicAuth"`
 }
 
 // LoadBalancerMethod holds the method of load balancing to use.


### PR DESCRIPTION
Fixes #751

Currently, only Basic Auth and the docker & rancher provider are supported.