### PR TITLE
Fix prometheus metrics example

### DIFF
--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -329,7 +329,7 @@
 #
 # To enable Traefik to export internal metrics to Prometheus
 # [web.metrics.prometheus]
-#   Buckets=[0.1,0.3,1.2,5]
+#   Buckets=[0.1,0.3,1.2,5.0]
 #
 
 # To enable basic auth on the webui


### PR DESCRIPTION
Traefik won’t start correctly if heterogeneous numbers in a toml array.  This commit makes all numbers homogene.

**Error Message Output:**

```bash
traefik_1   | 2017/02/13 10:39:19 Error reading TOML config file /var/traefik/traefik.toml : Near line 96 (last key parsed 'web.metrics.prometheus.Buckets'): Array contains values of type 'Float' and 'Integer', but arrays must be homogeneous.
```


Signed-off-by: solidnerd <niclas@mietz.io>