### PR TITLE
Support cluster-external Kubernetes client.

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -1042,17 +1042,46 @@ Træfɪk can be configured to use Kubernetes Ingress as a backend configuration:
 
 # Kubernetes server endpoint
 #
-# When deployed as a replication controller in Kubernetes,
-# Traefik will use env variable KUBERNETES_SERVICE_HOST
-# and KUBERNETES_SERVICE_PORT_HTTPS as endpoint
+# When deployed as a replication controller in Kubernetes, Traefik will use
+# the environment variables KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT
+# to construct the endpoint.
 # Secure token will be found in /var/run/secrets/kubernetes.io/serviceaccount/token
 # and SSL CA cert in /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
 #
-# Optional
+# The endpoint may be given to override the environment variable values.
+#
+# When the environment variables are not found, Traefik will try to connect to
+# the Kubernetes API server with an external-cluster client. In this case, the
+# endpoint is required. Specifically, it may be set to the URL used by
+# `kubectl proxy` to connect to a Kubernetes cluster from localhost.
+#
+# Optional for in-cluster configuration, required otherwise
+# Default: empty
 #
 # endpoint = "http://localhost:8080"
-# namespaces = ["default","production"]
+
+# Bearer token used for the Kubernetes client configuration.
 #
+# Optional
+# Default: empty
+#
+# token = "my token"
+
+# Path to the certificate authority file used for the Kubernetes client
+# configuration.
+#
+# Optional
+# Default: empty
+#
+# certAuthFilePath = "/my/ca.crt"
+
+# Array of namespaces to watch.
+#
+# Optional
+# Default: ["default"].
+#
+# namespaces = ["default", "production"]
+
 # See: http://kubernetes.io/docs/user-guide/labels/#list-and-watch-filtering
 # labelselector = "A and not B"
 #

--- a/server.go
+++ b/server.go
@@ -385,13 +385,14 @@ func (server *Server) configureProviders() {
 func (server *Server) startProviders() {
 	// start providers
 	for _, provider := range server.providers {
+		providerType := reflect.TypeOf(provider)
 		jsonConf, _ := json.Marshal(provider)
-		log.Infof("Starting provider %v %s", reflect.TypeOf(provider), jsonConf)
+		log.Infof("Starting provider %v %s", providerType, jsonConf)
 		currentProvider := provider
 		safe.Go(func() {
 			err := currentProvider.Provide(server.configurationChan, server.routinesPool, server.globalConfiguration.Constraints)
 			if err != nil {
-				log.Errorf("Error starting provider %s", err)
+				log.Errorf("Error starting provider %v: %s", providerType, err)
 			}
 		})
 	}

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -665,17 +665,46 @@
 
 # Kubernetes server endpoint
 #
-# When deployed as a replication controller in Kubernetes,
-# Traefik will use env variable KUBERNETES_SERVICE_HOST
-# and KUBERNETES_SERVICE_PORT_HTTPS as endpoint
+# When deployed as a replication controller in Kubernetes, Traefik will use
+# the environment variables KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT
+# to construct the endpoint.
 # Secure token will be found in /var/run/secrets/kubernetes.io/serviceaccount/token
 # and SSL CA cert in /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
 #
+# The endpoint may be given to override the environment variable values.
+#
+# When the environment variables are not found, Traefik will try to connect to
+# the Kubernetes API server with an external-cluster client. In this case, the
+# endpoint is required. Specifically, it may be set to the URL used by
+# `kubectl proxy` to connect to a Kubernetes cluster from localhost.
+#
+# Optional for in-cluster configuration, required otherwise
+# Default: empty
+#
+# endpoint = "http://127.0.0.1:8001"
+
+# Bearer token used for the Kubernetes client configuration.
+#
 # Optional
+# Default: empty
 #
-# endpoint = "http://localhost:8080"
+# token = "my token"
+
+# Path to the certificate authority file used for the Kubernetes client
+# configuration.
+#
+# Optional
+# Default: empty
+#
+# certAuthFilePath = "/my/ca.crt"
+
+# Array of namespaces to watch.
+#
+# Optional
+# Default: ["default"].
+#
 # namespaces = ["default"]
-#
+
 # See: http://kubernetes.io/docs/user-guide/labels/#list-and-watch-filtering
 # labelselector = "A and not B"
 


### PR DESCRIPTION
Detect whether in-cluster or cluster-external Kubernetes client should be used based on the `KUBERNETES_SERVICE_{HOST,PORT}` environment variables.

My main motivation for this PR was to enable connecting to a Kubernetes cluster via `kubectl proxy`, which technically is not an in-cluster usage.
Given a bearer token and CA cert files, it's also possible to connect without a proxy while running outside of a cluster.

I will add some more tests once we agree on the general direction of this PR.

/cc @emilevauge @errm @dtomcej