### PR TITLE
Remove .gitattributes file.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-glide.lock binary


### PR DESCRIPTION
Makes git diff Glide lock files as text, which is helpful to see changes introduced by a `glide update` run.

@emilevauge as discussed on Slack. Please review. :-)