### PR TITLE
Fix error in documentation for Docker labels

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -829,7 +829,7 @@ swarmmode = false
 
 Labels can be used on containers to override default behaviour:
 
-- `traefik.backend=foo`: assign the container to `foo` backend
+- `traefik.backend=foo`: give the name `backend-foo` to the generated backend for this container.
 - `traefik.backend.maxconn.amount=10`: set a maximum number of connections to the backend. Must be used in conjunction with the below label to take effect.
 - `traefik.backend.maxconn.extractorfunc=client.ip`: set the function to be used against the request to determine what to limit maximum connections to the backend by. Must be used in conjunction with the above label to take effect.
 - `traefik.backend.loadbalancer.method=drr`: override the default `wrr` load balancer algorithm


### PR DESCRIPTION
Hello,

Here is a fix in the documentation for an error I had spotted when working on a Docker Swarm project lastly.

Cheers