### PR TITLE
Adding support for Traefik to respect the K8s ingress class annotation

### DIFF
--- a/docs/user-guide/kubernetes.md
+++ b/docs/user-guide/kubernetes.md
@@ -123,6 +123,8 @@ kind: Ingress
 metadata:
   name: traefik-web-ui
   namespace: kube-system
+  annotations:
+    kubernetes.io/ingress.class: traefik
 spec:
   rules:
   - host: traefik-ui.local
@@ -328,6 +330,8 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: cheese
+  annotations:
+    kubernetes.io/ingress.class: traefik
 spec:
   rules:
   - host: stilton.local
@@ -390,6 +394,7 @@ kind: Ingress
 metadata:
   name: cheeses
   annotations:
+    kubernetes.io/ingress.class: traefik
     traefik.frontend.rule.type: pathprefixstrip
 spec:
   rules:
@@ -451,6 +456,7 @@ kind: Ingress
 metadata:
   name: example
   annotations:
+    kubernetes.io/ingress.class: traefik
     traefik.frontend.passHostHeader: "false"
 spec:
   rules:
@@ -484,3 +490,9 @@ request with the Host header being static.otherdomain.com.
 Note: The per ingress annotation overides whatever the global value is set to. So you
 could set `disablePassHostHeaders` to true in your toml file and then enable passing
 the host header per ingress if you wanted.
+
+## Excluding an ingress from Træfɪk
+You can control which ingress Træfɪk cares about by using the "kubernetes.io/ingress.class"
+annotation. By default if the annotation is not set at all Træfɪk will include the
+ingress. If the annotation is set to another other than traefik or a blank string
+Træfɪk will ignore it.

--- a/docs/user-guide/kubernetes.md
+++ b/docs/user-guide/kubernetes.md
@@ -494,5 +494,5 @@ the host header per ingress if you wanted.
 ## Excluding an ingress from Træfɪk
 You can control which ingress Træfɪk cares about by using the "kubernetes.io/ingress.class"
 annotation. By default if the annotation is not set at all Træfɪk will include the
-ingress. If the annotation is set to another other than traefik or a blank string
+ingress. If the annotation is set to anything other than traefik or a blank string
 Træfɪk will ignore it.

--- a/provider/kubernetes.go
+++ b/provider/kubernetes.go
@@ -108,6 +108,12 @@ func (provider *Kubernetes) loadIngresses(k8sClient k8s.Client) (*types.Configur
 		map[string]*types.Frontend{},
 	}
 	for _, i := range ingresses {
+		ingressClass := i.Annotations["kubernetes.io/ingress.class"]
+
+		if ingressClass != "" && strings.ToLower(ingressClass) != "traefik" {
+			continue
+		}
+
 		for _, r := range i.Spec.Rules {
 			if r.HTTP == nil {
 				log.Warnf("Error in ingress: HTTP is nil")

--- a/provider/kubernetes.go
+++ b/provider/kubernetes.go
@@ -110,7 +110,7 @@ func (provider *Kubernetes) loadIngresses(k8sClient k8s.Client) (*types.Configur
 	for _, i := range ingresses {
 		ingressClass := i.Annotations["kubernetes.io/ingress.class"]
 
-		if processIngress(ingressClass) {
+		if shouldProcessIngress(ingressClass) {
 			for _, r := range i.Spec.Rules {
 				if r.HTTP == nil {
 					log.Warnf("Error in ingress: HTTP is nil")
@@ -284,7 +284,7 @@ func equalPorts(servicePort v1.ServicePort, ingressPort intstr.IntOrString) bool
 	return false
 }
 
-func processIngress(ingressClass string) bool {
+func shouldProcessIngress(ingressClass string) bool {
 	switch ingressClass {
 	case "":
 		return true

--- a/provider/kubernetes.go
+++ b/provider/kubernetes.go
@@ -286,9 +286,7 @@ func equalPorts(servicePort v1.ServicePort, ingressPort intstr.IntOrString) bool
 
 func shouldProcessIngress(ingressClass string) bool {
 	switch ingressClass {
-	case "":
-		return true
-	case "traefik":
+	case "", "traefik":
 		return true
 	default:
 		return false

--- a/provider/kubernetes.go
+++ b/provider/kubernetes.go
@@ -110,148 +110,150 @@ func (provider *Kubernetes) loadIngresses(k8sClient k8s.Client) (*types.Configur
 	for _, i := range ingresses {
 		ingressClass := i.Annotations["kubernetes.io/ingress.class"]
 
-		if shouldProcessIngress(ingressClass) {
-			for _, r := range i.Spec.Rules {
-				if r.HTTP == nil {
-					log.Warnf("Error in ingress: HTTP is nil")
+		if !shouldProcessIngress(ingressClass) {
+			continue
+		}
+
+		for _, r := range i.Spec.Rules {
+			if r.HTTP == nil {
+				log.Warnf("Error in ingress: HTTP is nil")
+				continue
+			}
+			for _, pa := range r.HTTP.Paths {
+				if _, exists := templateObjects.Backends[r.Host+pa.Path]; !exists {
+					templateObjects.Backends[r.Host+pa.Path] = &types.Backend{
+						Servers: make(map[string]types.Server),
+						LoadBalancer: &types.LoadBalancer{
+							Sticky: false,
+							Method: "wrr",
+						},
+					}
+				}
+
+				PassHostHeader := provider.getPassHostHeader()
+
+				passHostHeaderAnnotation := i.Annotations["traefik.frontend.passHostHeader"]
+				switch passHostHeaderAnnotation {
+				case "true":
+					PassHostHeader = true
+				case "false":
+					PassHostHeader = false
+				default:
+					log.Warnf("Unknown value of %s for traefik.frontend.passHostHeader, falling back to %s", passHostHeaderAnnotation, PassHostHeader)
+				}
+
+				if _, exists := templateObjects.Frontends[r.Host+pa.Path]; !exists {
+					templateObjects.Frontends[r.Host+pa.Path] = &types.Frontend{
+						Backend:        r.Host + pa.Path,
+						PassHostHeader: PassHostHeader,
+						Routes:         make(map[string]types.Route),
+						Priority:       len(pa.Path),
+					}
+				}
+				if len(r.Host) > 0 {
+					rule := "Host:" + r.Host
+
+					if strings.Contains(r.Host, "*") {
+						rule = "HostRegexp:" + strings.Replace(r.Host, "*", "{subdomain:[A-Za-z0-9-_]+}", 1)
+					}
+
+					if _, exists := templateObjects.Frontends[r.Host+pa.Path].Routes[r.Host]; !exists {
+						templateObjects.Frontends[r.Host+pa.Path].Routes[r.Host] = types.Route{
+							Rule: rule,
+						}
+					}
+				}
+				if len(pa.Path) > 0 {
+					ruleType := i.Annotations["traefik.frontend.rule.type"]
+
+					switch strings.ToLower(ruleType) {
+					case "pathprefixstrip":
+						ruleType = "PathPrefixStrip"
+					case "pathstrip":
+						ruleType = "PathStrip"
+					case "path":
+						ruleType = "Path"
+					case "pathprefix":
+						ruleType = "PathPrefix"
+					case "":
+						ruleType = "PathPrefix"
+					default:
+						log.Warnf("Unknown RuleType %s for %s/%s, falling back to PathPrefix", ruleType, i.ObjectMeta.Namespace, i.ObjectMeta.Name)
+						ruleType = "PathPrefix"
+					}
+
+					templateObjects.Frontends[r.Host+pa.Path].Routes[pa.Path] = types.Route{
+						Rule: ruleType + ":" + pa.Path,
+					}
+				}
+				service, exists, err := k8sClient.GetService(i.ObjectMeta.Namespace, pa.Backend.ServiceName)
+				if err != nil || !exists {
+					log.Warnf("Error retrieving service %s/%s: %v", i.ObjectMeta.Namespace, pa.Backend.ServiceName, err)
+					delete(templateObjects.Frontends, r.Host+pa.Path)
 					continue
 				}
-				for _, pa := range r.HTTP.Paths {
-					if _, exists := templateObjects.Backends[r.Host+pa.Path]; !exists {
-						templateObjects.Backends[r.Host+pa.Path] = &types.Backend{
-							Servers: make(map[string]types.Server),
-							LoadBalancer: &types.LoadBalancer{
-								Sticky: false,
-								Method: "wrr",
-							},
-						}
+
+				if expression := service.Annotations["traefik.backend.circuitbreaker"]; expression != "" {
+					templateObjects.Backends[r.Host+pa.Path].CircuitBreaker = &types.CircuitBreaker{
+						Expression: expression,
 					}
+				}
+				if service.Annotations["traefik.backend.loadbalancer.method"] == "drr" {
+					templateObjects.Backends[r.Host+pa.Path].LoadBalancer.Method = "drr"
+				}
+				if service.Annotations["traefik.backend.loadbalancer.sticky"] == "true" {
+					templateObjects.Backends[r.Host+pa.Path].LoadBalancer.Sticky = true
+				}
 
-					PassHostHeader := provider.getPassHostHeader()
-
-					passHostHeaderAnnotation := i.Annotations["traefik.frontend.passHostHeader"]
-					switch passHostHeaderAnnotation {
-					case "true":
-						PassHostHeader = true
-					case "false":
-						PassHostHeader = false
-					default:
-						log.Warnf("Unknown value of %s for traefik.frontend.passHostHeader, falling back to %s", passHostHeaderAnnotation, PassHostHeader)
-					}
-
-					if _, exists := templateObjects.Frontends[r.Host+pa.Path]; !exists {
-						templateObjects.Frontends[r.Host+pa.Path] = &types.Frontend{
-							Backend:        r.Host + pa.Path,
-							PassHostHeader: PassHostHeader,
-							Routes:         make(map[string]types.Route),
-							Priority:       len(pa.Path),
+				protocol := "http"
+				for _, port := range service.Spec.Ports {
+					if equalPorts(port, pa.Backend.ServicePort) {
+						if port.Port == 443 {
+							protocol = "https"
 						}
-					}
-					if len(r.Host) > 0 {
-						rule := "Host:" + r.Host
+						if service.Spec.Type == "ExternalName" {
+							url := protocol + "://" + service.Spec.ExternalName
+							name := url
 
-						if strings.Contains(r.Host, "*") {
-							rule = "HostRegexp:" + strings.Replace(r.Host, "*", "{subdomain:[A-Za-z0-9-_]+}", 1)
-						}
-
-						if _, exists := templateObjects.Frontends[r.Host+pa.Path].Routes[r.Host]; !exists {
-							templateObjects.Frontends[r.Host+pa.Path].Routes[r.Host] = types.Route{
-								Rule: rule,
+							templateObjects.Backends[r.Host+pa.Path].Servers[name] = types.Server{
+								URL:    url,
+								Weight: 1,
 							}
-						}
-					}
-					if len(pa.Path) > 0 {
-						ruleType := i.Annotations["traefik.frontend.rule.type"]
-
-						switch strings.ToLower(ruleType) {
-						case "pathprefixstrip":
-							ruleType = "PathPrefixStrip"
-						case "pathstrip":
-							ruleType = "PathStrip"
-						case "path":
-							ruleType = "Path"
-						case "pathprefix":
-							ruleType = "PathPrefix"
-						case "":
-							ruleType = "PathPrefix"
-						default:
-							log.Warnf("Unknown RuleType %s for %s/%s, falling back to PathPrefix", ruleType, i.ObjectMeta.Namespace, i.ObjectMeta.Name)
-							ruleType = "PathPrefix"
-						}
-
-						templateObjects.Frontends[r.Host+pa.Path].Routes[pa.Path] = types.Route{
-							Rule: ruleType + ":" + pa.Path,
-						}
-					}
-					service, exists, err := k8sClient.GetService(i.ObjectMeta.Namespace, pa.Backend.ServiceName)
-					if err != nil || !exists {
-						log.Warnf("Error retrieving service %s/%s: %v", i.ObjectMeta.Namespace, pa.Backend.ServiceName, err)
-						delete(templateObjects.Frontends, r.Host+pa.Path)
-						continue
-					}
-
-					if expression := service.Annotations["traefik.backend.circuitbreaker"]; expression != "" {
-						templateObjects.Backends[r.Host+pa.Path].CircuitBreaker = &types.CircuitBreaker{
-							Expression: expression,
-						}
-					}
-					if service.Annotations["traefik.backend.loadbalancer.method"] == "drr" {
-						templateObjects.Backends[r.Host+pa.Path].LoadBalancer.Method = "drr"
-					}
-					if service.Annotations["traefik.backend.loadbalancer.sticky"] == "true" {
-						templateObjects.Backends[r.Host+pa.Path].LoadBalancer.Sticky = true
-					}
-
-					protocol := "http"
-					for _, port := range service.Spec.Ports {
-						if equalPorts(port, pa.Backend.ServicePort) {
-							if port.Port == 443 {
-								protocol = "https"
+						} else {
+							endpoints, exists, err := k8sClient.GetEndpoints(service.ObjectMeta.Namespace, service.ObjectMeta.Name)
+							if err != nil {
+								log.Errorf("Error while retrieving endpoints from k8s API %s/%s: %v", service.ObjectMeta.Namespace, service.ObjectMeta.Name, err)
+								continue
 							}
-							if service.Spec.Type == "ExternalName" {
-								url := protocol + "://" + service.Spec.ExternalName
-								name := url
 
-								templateObjects.Backends[r.Host+pa.Path].Servers[name] = types.Server{
-									URL:    url,
+							if !exists {
+								log.Errorf("Service not found for %s/%s", service.ObjectMeta.Namespace, service.ObjectMeta.Name)
+								continue
+							}
+
+							if len(endpoints.Subsets) == 0 {
+								log.Warnf("Endpoints not found for %s/%s, falling back to Service ClusterIP", service.ObjectMeta.Namespace, service.ObjectMeta.Name)
+								templateObjects.Backends[r.Host+pa.Path].Servers[string(service.UID)] = types.Server{
+									URL:    protocol + "://" + service.Spec.ClusterIP + ":" + strconv.Itoa(int(port.Port)),
 									Weight: 1,
 								}
 							} else {
-								endpoints, exists, err := k8sClient.GetEndpoints(service.ObjectMeta.Namespace, service.ObjectMeta.Name)
-								if err != nil {
-									log.Errorf("Error while retrieving endpoints from k8s API %s/%s: %v", service.ObjectMeta.Namespace, service.ObjectMeta.Name, err)
-									continue
-								}
-
-								if !exists {
-									log.Errorf("Service not found for %s/%s", service.ObjectMeta.Namespace, service.ObjectMeta.Name)
-									continue
-								}
-
-								if len(endpoints.Subsets) == 0 {
-									log.Warnf("Endpoints not found for %s/%s, falling back to Service ClusterIP", service.ObjectMeta.Namespace, service.ObjectMeta.Name)
-									templateObjects.Backends[r.Host+pa.Path].Servers[string(service.UID)] = types.Server{
-										URL:    protocol + "://" + service.Spec.ClusterIP + ":" + strconv.Itoa(int(port.Port)),
-										Weight: 1,
-									}
-								} else {
-									for _, subset := range endpoints.Subsets {
-										for _, address := range subset.Addresses {
-											url := protocol + "://" + address.IP + ":" + strconv.Itoa(endpointPortNumber(port, subset.Ports))
-											name := url
-											if address.TargetRef != nil && address.TargetRef.Name != "" {
-												name = address.TargetRef.Name
-											}
-											templateObjects.Backends[r.Host+pa.Path].Servers[name] = types.Server{
-												URL:    url,
-												Weight: 1,
-											}
+								for _, subset := range endpoints.Subsets {
+									for _, address := range subset.Addresses {
+										url := protocol + "://" + address.IP + ":" + strconv.Itoa(endpointPortNumber(port, subset.Ports))
+										name := url
+										if address.TargetRef != nil && address.TargetRef.Name != "" {
+											name = address.TargetRef.Name
+										}
+										templateObjects.Backends[r.Host+pa.Path].Servers[name] = types.Server{
+											URL:    url,
+											Weight: 1,
 										}
 									}
 								}
 							}
-							break
 						}
+						break
 					}
 				}
 			}

--- a/provider/kubernetes_test.go
+++ b/provider/kubernetes_test.go
@@ -1609,7 +1609,7 @@ func TestIngressAnnotations(t *testing.T) {
 			ObjectMeta: v1.ObjectMeta{
 				Namespace: "testing",
 				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": "traefik",
+					"kubernetes.io/ingress.class":     "traefik",
 					"traefik.frontend.passHostHeader": "true",
 				},
 			},

--- a/provider/kubernetes_test.go
+++ b/provider/kubernetes_test.go
@@ -1609,6 +1609,7 @@ func TestIngressAnnotations(t *testing.T) {
 			ObjectMeta: v1.ObjectMeta{
 				Namespace: "testing",
 				Annotations: map[string]string{
+					"kubernetes.io/ingress.class": "traefik",
 					"traefik.frontend.passHostHeader": "true",
 				},
 			},
@@ -1623,6 +1624,34 @@ func TestIngressAnnotations(t *testing.T) {
 										Path: "/stuff",
 										Backend: v1beta1.IngressBackend{
 											ServiceName: "service1",
+											ServicePort: intstr.FromInt(80),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace: "testing",
+				Annotations: map[string]string{
+					"kubernetes.io/ingress.class": "somethingOtherThanTraefik",
+				},
+			},
+			Spec: v1beta1.IngressSpec{
+				Rules: []v1beta1.IngressRule{
+					{
+						Host: "herp",
+						IngressRuleValue: v1beta1.IngressRuleValue{
+							HTTP: &v1beta1.HTTPIngressRuleValue{
+								Paths: []v1beta1.HTTPIngressPath{
+									{
+										Path: "/derp",
+										Backend: v1beta1.IngressBackend{
+											ServiceName: "service2",
 											ServicePort: intstr.FromInt(80),
 										},
 									},


### PR DESCRIPTION
This is a first pass of making Traefik understand and respect the kubernetes.io/ingress.class annotation in Kubernetes.

There is a discussion in #1163 about how this should be handled. The objective of this PR is to have Traefik respond to the annotation in the same way other ingress controllers such as NGINX handle it. That being:
* Use ingress that have an annotation matching "traefik"
* Use ingress that have an annotation matching "" (a blank string)
* Use ingress that do not have the annotation at all
* Ignore all ingress that have an annotation of anything else

There is also discussion in the above mentioned issue about support for configuring what the annotation matches, for example being able to say "accept annotations that match traefik-internal" instead of matching on traefik. There doesn't seem to be clear consensus on how that should be handled. I think that should be spun out as a separate issue and done in isolation of this PR.

Fixes #1163 

Pinging @emilevauge @SantoDE @errm @dtomcej @vdemeester