### PR TITLE
kv: Ignore backend servers with no url

### DIFF
--- a/provider/kv.go
+++ b/provider/kv.go
@@ -162,7 +162,11 @@ func (provider *Kv) list(keys ...string) []string {
 func (provider *Kv) listServers(backend string) []string {
 	serverNames := provider.list(backend, "/servers/")
 	return fun.Filter(func(serverName string) bool {
-		if _, err := provider.kvclient.Get(fmt.Sprint(serverName, "/url")); err != nil {
+		key := fmt.Sprint(serverName, "/url")
+		if _, err := provider.kvclient.Get(key); err != nil {
+			if err != store.ErrKeyNotFound {
+				log.Errorf("Failed to retrieve value for key %s: %s", key, err)
+			}
 			return false
 		}
 		return provider.checkConstraints(serverName, "/tags")

--- a/provider/kv.go
+++ b/provider/kv.go
@@ -162,6 +162,9 @@ func (provider *Kv) list(keys ...string) []string {
 func (provider *Kv) listServers(backend string) []string {
 	serverNames := provider.list(backend, "/servers/")
 	return fun.Filter(func(serverName string) bool {
+		if _, err := provider.kvclient.Get(fmt.Sprint(serverName, "/url")); err != nil {
+			return false
+		}
 		return provider.checkConstraints(serverName, "/tags")
 	}, serverNames).([]string)
 }

--- a/provider/kv_test.go
+++ b/provider/kv_test.go
@@ -304,7 +304,7 @@ func (s *Mock) Get(key string) (*store.KVPair, error) {
 			return kvPair, nil
 		}
 	}
-	return nil, nil
+	return nil, store.ErrKeyNotFound
 }
 
 func (s *Mock) Delete(key string) error {
@@ -408,6 +408,14 @@ func TestKVLoadConfig(t *testing.T) {
 				},
 				{
 					Key:   "traefik/backends/backend.with.dot.too/servers/server.with.dot/weight",
+					Value: []byte("0"),
+				},
+				{
+					Key:   "traefik/backends/backend.with.dot.too/servers/server.with.dot.without.url",
+					Value: []byte(""),
+				},
+				{
+					Key:   "traefik/backends/backend.with.dot.too/servers/server.with.dot.without.url/weight",
 					Value: []byte("0"),
 				},
 			},


### PR DESCRIPTION
Currently with a kv tree like:
/traefik/backends/b1/servers/ẁeb1
/traefik/backends/b1/servers/web2
/traefik/backends/b1/servers/web2/url
Traefik would try to forward traffic to web1, which is impossible as
traefik doesn't know the url of web1.

This commit solve that, by ignoring backend server with no url "key"
when generating the config.

This is very useful, for people who use etcd TTL feature. They can then
just "renew" the url key every X second, and if the server goes down, it
is automatic removed from traefik after the TTL.