### PR TITLE
Evaluate glide-hash result without reading $?.

### DIFF
--- a/script/validate-glide
+++ b/script/validate-glide
@@ -2,8 +2,7 @@
 
 source "$(dirname "$BASH_SOURCE")/.validate"
 
-grep `glide-hash` glide.lock
-if [ $? -eq 0 ]; then
+if grep -q "$(glide-hash)" glide.lock; then
 	echo 'Congratulations! glide.lock is unchanged.'
 else
 	{


### PR DESCRIPTION
`validate-glide` is called with `errexit` enabled (in `script/make.sh` that sources `validate-glide`), which means that grep returning a non-zero exit code will cause the script to terminate prematurely. Thus, we will never get to the point where we see the error message.

The fix is to embed the grep check directly inside the if statement.