### PR TITLE
Bump go-rancher version

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f2a0b9af55c8312762e4148bd876e5bd2451c240b407fbb6d4a5dbc56bf46c05
-updated: 2017-02-07T14:15:03.854561081+01:00
+hash: b4e99f1210c5bfb7784b55c9ec5b54629fadaea0625b29e540979b1acbd7dc09
+updated: 2017-03-02T09:39:03.718549862+01:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -258,7 +258,7 @@ imports:
   - log
   - swagger
 - name: github.com/gambol99/go-marathon
-  version: 9ab64d9f0259e8800911d92ebcd4d5b981917919
+  version: 6b00a5b651b1beb2c6821863f7c60df490bd46c8
 - name: github.com/ghodss/yaml
   version: 04f313413ffd65ce25f2541bfd2b2ceec5c0908c
 - name: github.com/go-ini/ini
@@ -301,7 +301,7 @@ imports:
 - name: github.com/gorilla/context
   version: 1ea25387ff6f684839d82767c1733ff4d4d15d0a
 - name: github.com/gorilla/websocket
-  version: c36f2fe5c330f0ac404b616b96c438b8616b1aaf
+  version: 4873052237e4eeda85cf50c071ef33836fe8e139
 - name: github.com/hashicorp/consul
   version: fce7d75609a04eeb9d4bf41c8dc592aac18fc97d
   subpackages:
@@ -389,7 +389,7 @@ imports:
 - name: github.com/pborman/uuid
   version: 5007efa264d92316c43112bc573e754bc889b7b1
 - name: github.com/pkg/errors
-  version: 248dadf4e9068a0b3e79f02ed0a610d935de5302
+  version: bfd5150e4e41705ded2129ec33379de1cb90b513
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
@@ -419,7 +419,7 @@ imports:
   subpackages:
   - src/egoscale
 - name: github.com/rancher/go-rancher
-  version: 2c43ff300f3eafcbd7d0b89b10427fc630efdc1e
+  version: 5b8f6cc26b355ba03d7611fce3844155b7baf05b
   subpackages:
   - client
 - name: github.com/ryanuber/go-glob
@@ -600,7 +600,7 @@ imports:
 - name: gopkg.in/yaml.v2
   version: bef53efd0c76e49e6de55ead051f886bea7e9420
 - name: k8s.io/client-go
-  version: 843f7c4f28b1f647f664f883697107d5c02c5acc
+  version: 1195e3a8ee1a529d53eed7c624527a68555ddf1f
   subpackages:
   - 1.5/discovery
   - 1.5/kubernetes

--- a/glide.yaml
+++ b/glide.yaml
@@ -138,4 +138,4 @@ import:
   subpackages:
   - proto
 - package: github.com/rancher/go-rancher
-  version: 2c43ff300f3eafcbd7d0b89b10427fc630efdc1e
+  version: 5b8f6cc26b355ba03d7611fce3844155b7baf05b


### PR DESCRIPTION
Bump go-rancher version to be compatible with rancher 1.4 and above. 

Fixes #1218 