### PR TITLE
Use docker-compose labels for frontend and backend names

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -823,7 +823,7 @@ Labels can be used on containers to override default behaviour:
 - `traefik.protocol=https`: override the default `http` protocol
 - `traefik.weight=10`: assign this weight to the container
 - `traefik.enable=false`: disable this container in Træfɪk
-- `traefik.frontend.rule=Host:test.traefik.io`: override the default frontend rule (Default: `Host:{containerName}.{domain}`).
+- `traefik.frontend.rule=Host:test.traefik.io`: override the default frontend rule (Default: `Host:{containerName}.{domain}` or `Host:{project_name}-{service}.{domain}` if you are using `docker-compose`).
 - `traefik.frontend.passHostHeader=true`: forward client `Host` header to the backend.
 - `traefik.frontend.priority=10`: override default frontend priority
 - `traefik.frontend.entryPoints=http,https`: assign this frontend to entry points `http` and `https`. Overrides `defaultEntryPoints`.

--- a/docs/toml.md
+++ b/docs/toml.md
@@ -823,7 +823,7 @@ Labels can be used on containers to override default behaviour:
 - `traefik.protocol=https`: override the default `http` protocol
 - `traefik.weight=10`: assign this weight to the container
 - `traefik.enable=false`: disable this container in Træfɪk
-- `traefik.frontend.rule=Host:test.traefik.io`: override the default frontend rule (Default: `Host:{containerName}.{domain}` or `Host:{project_name}-{service}.{domain}` if you are using `docker-compose`).
+- `traefik.frontend.rule=Host:test.traefik.io`: override the default frontend rule (Default: `Host:{containerName}.{domain}` or `Host:{service}.{project_name}.{domain}` if you are using `docker-compose`).
 - `traefik.frontend.passHostHeader=true`: forward client `Host` header to the backend.
 - `traefik.frontend.priority=10`: override default frontend priority
 - `traefik.frontend.entryPoints=http,https`: assign this frontend to entry points `http` and `https`. Overrides `defaultEntryPoints`.

--- a/provider/docker.go
+++ b/provider/docker.go
@@ -525,12 +525,19 @@ func (provider *Docker) getFrontendRule(container dockerData) string {
 	if label, err := getLabel(container, "traefik.frontend.rule"); err == nil {
 		return label
 	}
+	if labels, err := getLabels(container, []string{"com.docker.compose.project", "com.docker.compose.service"}); err == nil {
+		return "Host:" + provider.getSubDomain(labels["com.docker.compose.project"]+"_"+labels["com.docker.compose.service"]) + "." + provider.Domain
+	}
+
 	return "Host:" + provider.getSubDomain(container.ServiceName) + "." + provider.Domain
 }
 
 func (provider *Docker) getBackend(container dockerData) string {
 	if label, err := getLabel(container, "traefik.backend"); err == nil {
 		return normalize(label)
+	}
+	if labels, err := getLabels(container, []string{"com.docker.compose.project", "com.docker.compose.service"}); err == nil {
+		return normalize(labels["com.docker.compose.project"] + "_" + labels["com.docker.compose.service"])
 	}
 	return normalize(container.ServiceName)
 }

--- a/provider/docker.go
+++ b/provider/docker.go
@@ -526,7 +526,7 @@ func (provider *Docker) getFrontendRule(container dockerData) string {
 		return label
 	}
 	if labels, err := getLabels(container, []string{"com.docker.compose.project", "com.docker.compose.service"}); err == nil {
-		return "Host:" + provider.getSubDomain(labels["com.docker.compose.project"]+"_"+labels["com.docker.compose.service"]) + "." + provider.Domain
+		return "Host:" + provider.getSubDomain(labels["com.docker.compose.service"]+"."+labels["com.docker.compose.project"]) + "." + provider.Domain
 	}
 
 	return "Host:" + provider.getSubDomain(container.ServiceName) + "." + provider.Domain
@@ -537,7 +537,7 @@ func (provider *Docker) getBackend(container dockerData) string {
 		return normalize(label)
 	}
 	if labels, err := getLabels(container, []string{"com.docker.compose.project", "com.docker.compose.service"}); err == nil {
-		return normalize(labels["com.docker.compose.project"] + "_" + labels["com.docker.compose.service"])
+		return normalize(labels["com.docker.compose.service"] + "_" + labels["com.docker.compose.project"])
 	}
 	return normalize(container.ServiceName)
 }

--- a/provider/docker_test.go
+++ b/provider/docker_test.go
@@ -56,7 +56,7 @@ func TestDockerGetFrontendName(t *testing.T) {
 					},
 				},
 			},
-			expected: "Host-foo-bar-docker-localhost",
+			expected: "Host-bar-foo-docker-localhost",
 		},
 		{
 			container: docker.ContainerJSON{
@@ -159,7 +159,7 @@ func TestDockerGetFrontendRule(t *testing.T) {
 					},
 				},
 			},
-			expected: "Host:foo-bar.docker.localhost",
+			expected: "Host:bar.foo.docker.localhost",
 		},
 		{
 			container: docker.ContainerJSON{
@@ -235,7 +235,7 @@ func TestDockerGetBackend(t *testing.T) {
 					},
 				},
 			},
-			expected: "foo-bar",
+			expected: "bar-foo",
 		},
 	}
 

--- a/provider/docker_test.go
+++ b/provider/docker_test.go
@@ -47,6 +47,20 @@ func TestDockerGetFrontendName(t *testing.T) {
 		{
 			container: docker.ContainerJSON{
 				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "mycontainer",
+				},
+				Config: &container.Config{
+					Labels: map[string]string{
+						"com.docker.compose.project": "foo",
+						"com.docker.compose.service": "bar",
+					},
+				},
+			},
+			expected: "Host-foo-bar-docker-localhost",
+		},
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
 					Name: "test",
 				},
 				Config: &container.Config{
@@ -133,6 +147,19 @@ func TestDockerGetFrontendRule(t *testing.T) {
 				},
 			},
 			expected: "Host:foo.bar",
+		}, {
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "test",
+				},
+				Config: &container.Config{
+					Labels: map[string]string{
+						"com.docker.compose.project": "foo",
+						"com.docker.compose.service": "bar",
+					},
+				},
+			},
+			expected: "Host:foo-bar.docker.localhost",
 		},
 		{
 			container: docker.ContainerJSON{
@@ -195,6 +222,20 @@ func TestDockerGetBackend(t *testing.T) {
 				},
 			},
 			expected: "foobar",
+		},
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "test",
+				},
+				Config: &container.Config{
+					Labels: map[string]string{
+						"com.docker.compose.project": "foo",
+						"com.docker.compose.service": "bar",
+					},
+				},
+			},
+			expected: "foo-bar",
 		},
 	}
 


### PR DESCRIPTION
Actually with a project "foo" and service "bar", traefik add a frontend and a backend for each container (foo-bar-1, foo-bar-2...)

Now, frontend and backend are named foo-bar and all the instances of a service are grouped in a single backend.