### PR TITLE
Create Header Middleware

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -209,7 +209,7 @@ The following rules are both `Matchers` and `Modifiers`, so the `Matcher` portio
 3. `PathStripRegex`
 4. `PathPrefixStripRegex`
 5. `AddPrefix`
-6. `ReplacePath` 
+6. `ReplacePath`
 
 ### Priorities
 
@@ -235,6 +235,46 @@ You can customize priority by frontend:
 ```
 
 Here, `frontend1` will be matched before `frontend2` (`10 > 5`).
+
+### Custom headers
+
+Custom headers can be configured through the frontends, to add headers to either requests or responses that match the frontend's rules. This allows for setting headers such as `X-Script-Name` to be added to the request, or custom headers to be added to the response:
+
+```toml
+[frontends]
+  [frontends.frontend1]
+  backend = "backend1"
+    [frontends.frontend1.headers.customresponseheaders]
+    X-Custom-Response-Header = "True"
+    [frontends.frontend1.headers.customrequestheaders]
+    X-Script-Name = "test"
+    [frontends.frontend1.routes.test_1]
+    rule = "PathPrefixStrip:/cheese"
+```
+
+In this example, all matches to the path `/cheese` will have the `X-Script-Name` header added to the proxied request, and the `X-Custom-Response-Header` added to the response.
+
+### Security headers
+
+Security related headers (HSTS headers, SSL redirection, Browser XSS filter, etc) can be added and configured per frontend in a similar manner to the custom headers above. This functionality allows for some easy security features to quickly be set. An example of some of the security headers:
+
+```toml
+[frontends]
+  [frontends.frontend1]
+  backend = "backend1"
+    [frontends.frontend1.headers]
+    FrameDeny = true
+    [frontends.frontend1.routes.test_1]
+    rule = "PathPrefixStrip:/cheddar"
+  [frontends.frontend2]
+  backend = "backend2"
+    [frontends.frontend2.headers]
+    SSLRedirect = true
+    [frontends.frontend2.routes.test_1]
+    rule = "PathPrefixStrip:/stilton"
+```
+
+In this example, traffic routed through the first frontend will have the `X-Frame-Options` header set to `DENY`, and the second will only allow HTTPS request through, otherwise will return a 301 HTTPS redirect.
 
 ## Backends
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 46037b3adbc77e0fd1df2e8a5a0fe8106807cd0804213abaf2d473eb06fb53eb
-updated: 2017-05-19T23:30:19.890844996+02:00
+hash: 6535e5faaf0a87d89bb74841d60988f6d13ead827efa02d509fd1914aeb6e4d4
+updated: 2017-06-13T23:30:19.890844996+02:00
 imports:
 - name: cloud.google.com/go
   version: 2e6a95edb1071d750f6d7db777bf66cd2997af6c
@@ -400,6 +400,8 @@ imports:
   - codec
 - name: github.com/unrolled/render
   version: 50716a0a853771bb36bfce61a45cdefdb98c2e6e
+- name: github.com/unrolled/secure
+  version: 824e85271811af89640ea25620c67f6c2eed987e
 - name: github.com/vdemeester/docker-events
   version: be74d4929ec1ad118df54349fda4b0cba60f849b
 - name: github.com/vulcand/oxy

--- a/glide.yaml
+++ b/glide.yaml
@@ -169,3 +169,5 @@ import:
   version: 9af46dd5a1713e8b5cd71106287eba3cefdde50b
 - package: google.golang.org/grpc
   version: v1.2.0
+- package: github.com/unrolled/secure
+  version: 824e85271811af89640ea25620c67f6c2eed987e

--- a/middlewares/headers.go
+++ b/middlewares/headers.go
@@ -1,0 +1,79 @@
+package middlewares
+
+//Middleware based on https://github.com/unrolled/secure
+
+import (
+	"github.com/containous/traefik/types"
+	"net/http"
+)
+
+// HeaderOptions is a struct for specifying configuration options for the headers middleware.
+type HeaderOptions struct {
+	// If Custom request headers are set, these will be added to the request
+	CustomRequestHeaders map[string]string
+	// If Custom response headers are set, these will be added to the ResponseWriter
+	CustomResponseHeaders map[string]string
+}
+
+// HeaderStruct is a middleware that helps setup a few basic security features. A single headerOptions struct can be
+// provided to configure which features should be enabled, and the ability to override a few of the default values.
+type HeaderStruct struct {
+	// Customize headers with a headerOptions struct.
+	opt HeaderOptions
+}
+
+// NewHeaderFromStruct constructs a new header instance from supplied frontend header struct.
+func NewHeaderFromStruct(headers types.Headers) *HeaderStruct {
+	o := HeaderOptions{
+		CustomRequestHeaders:  headers.CustomRequestHeaders,
+		CustomResponseHeaders: headers.CustomResponseHeaders,
+	}
+
+	return &HeaderStruct{
+		opt: o,
+	}
+}
+
+// NewHeader constructs a new header instance with supplied options.
+func NewHeader(options ...HeaderOptions) *HeaderStruct {
+	var o HeaderOptions
+	if len(options) == 0 {
+		o = HeaderOptions{}
+	} else {
+		o = options[0]
+	}
+
+	return &HeaderStruct{
+		opt: o,
+	}
+}
+
+// Handler implements the http.HandlerFunc for integration with the standard net/http lib.
+func (s *HeaderStruct) Handler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Let headers process the request.
+		s.Process(w, r)
+		h.ServeHTTP(w, r)
+	})
+}
+
+func (s *HeaderStruct) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	s.Process(w, r)
+	// If there is a next, call it.
+	if next != nil {
+		next(w, r)
+	}
+}
+
+// Process runs the actual checks and returns an error if the middleware chain should stop.
+func (s *HeaderStruct) Process(w http.ResponseWriter, r *http.Request) {
+	// Loop through Custom request headers
+	for header, value := range s.opt.CustomRequestHeaders {
+		r.Header.Set(header, value)
+	}
+
+	// Loop through Custom response headers
+	for header, value := range s.opt.CustomResponseHeaders {
+		w.Header().Add(header, value)
+	}
+}

--- a/middlewares/headers_test.go
+++ b/middlewares/headers_test.go
@@ -1,0 +1,59 @@
+package middlewares
+
+//Middleware tests based on https://github.com/unrolled/secure
+
+import (
+	"github.com/containous/traefik/testhelpers"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+var myHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("bar"))
+})
+
+func TestNoConfig(t *testing.T) {
+	s := NewHeader()
+
+	res := httptest.NewRecorder()
+	req := testhelpers.MustNewRequest(http.MethodGet, "http://example.com/foo", nil)
+
+	s.Handler(myHandler).ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusOK, res.Code, "Status not OK")
+	assert.Equal(t, "bar", res.Body.String(), "Body not the expected")
+}
+
+func TestCustomResponseHeader(t *testing.T) {
+	s := NewHeader(HeaderOptions{
+		CustomResponseHeaders: map[string]string{
+			"X-Custom-Response-Header": "test_response",
+		},
+	})
+
+	res := httptest.NewRecorder()
+	req := testhelpers.MustNewRequest(http.MethodGet, "/foo", nil)
+
+	s.Handler(myHandler).ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusOK, res.Code, "Status not OK")
+	assert.Equal(t, "test_response", res.Header().Get("X-Custom-Response-Header"), "Did not get expected header")
+}
+
+func TestCustomRequestHeader(t *testing.T) {
+	s := NewHeader(HeaderOptions{
+		CustomRequestHeaders: map[string]string{
+			"X-Custom-Request-Header": "test_request",
+		},
+	})
+
+	res := httptest.NewRecorder()
+	req := testhelpers.MustNewRequest(http.MethodGet, "/foo", nil)
+
+	s.Handler(myHandler).ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusOK, res.Code, "Status not OK")
+	assert.Equal(t, "test_request", req.Header.Get("X-Custom-Request-Header"), "Did not get expected header")
+}

--- a/middlewares/secure.go
+++ b/middlewares/secure.go
@@ -1,0 +1,31 @@
+package middlewares
+
+import (
+	"github.com/containous/traefik/types"
+	"github.com/unrolled/secure"
+)
+
+// NewSecure constructs a new Secure instance with supplied options.
+func NewSecure(headers types.Headers) *secure.Secure {
+	opt := secure.Options{
+		AllowedHosts:            headers.AllowedHosts,
+		HostsProxyHeaders:       headers.HostsProxyHeaders,
+		SSLRedirect:             headers.SSLRedirect,
+		SSLTemporaryRedirect:    headers.SSLTemporaryRedirect,
+		SSLHost:                 headers.SSLHost,
+		SSLProxyHeaders:         headers.SSLProxyHeaders,
+		STSSeconds:              headers.STSSeconds,
+		STSIncludeSubdomains:    headers.STSIncludeSubdomains,
+		STSPreload:              headers.STSPreload,
+		ForceSTSHeader:          headers.ForceSTSHeader,
+		FrameDeny:               headers.FrameDeny,
+		CustomFrameOptionsValue: headers.CustomFrameOptionsValue,
+		ContentTypeNosniff:      headers.ContentTypeNosniff,
+		BrowserXssFilter:        headers.BrowserXSSFilter,
+		ContentSecurityPolicy:   headers.ContentSecurityPolicy,
+		PublicKey:               headers.PublicKey,
+		ReferrerPolicy:          headers.ReferrerPolicy,
+		IsDevelopment:           headers.IsDevelopment,
+	}
+	return secure.New(opt)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -819,6 +819,17 @@ func (server *Server) loadConfig(configurations configs, globalConfiguration Glo
 						}
 					}
 
+					if frontend.Headers.HasCustomHeadersDefined() {
+						headerMiddleware := middlewares.NewHeaderFromStruct(frontend.Headers)
+						log.Debugf("Adding header middleware for frontend %s", frontendName)
+						negroni.Use(headerMiddleware)
+					}
+					if frontend.Headers.HasSecureHeadersDefined() {
+						secureMiddleware := middlewares.NewSecure(frontend.Headers)
+						log.Debugf("Adding secure middleware for frontend %s", frontendName)
+						negroni.UseFunc(secureMiddleware.HandlerFuncWithNext)
+					}
+
 					if configuration.Backends[frontend.Backend].CircuitBreaker != nil {
 						log.Debugf("Creating circuit breaker %s", configuration.Backends[frontend.Backend].CircuitBreaker.Expression)
 						cbreaker, err := middlewares.NewCircuitBreaker(lb, configuration.Backends[frontend.Backend].CircuitBreaker.Expression, cbreaker.Logger(oxyLogger))

--- a/types/types.go
+++ b/types/types.go
@@ -54,6 +54,58 @@ type Route struct {
 	Rule string `json:"rule,omitempty"`
 }
 
+// Headers holds the custom header configuration
+type Headers struct {
+	CustomRequestHeaders    map[string]string `json:"customRequestHeaders,omitempty"`
+	CustomResponseHeaders   map[string]string `json:"customResponseHeaders,omitempty"`
+	AllowedHosts            []string          `json:"allowedHosts,omitempty"`
+	HostsProxyHeaders       []string          `json:"hostsProxyHeaders,omitempty"`
+	SSLRedirect             bool              `json:"sslRedirect,omitempty"`
+	SSLTemporaryRedirect    bool              `json:"sslTemporaryRedirect,omitempty"`
+	SSLHost                 string            `json:"sslHost,omitempty"`
+	SSLProxyHeaders         map[string]string `json:"sslProxyHeaders,omitempty"`
+	STSSeconds              int64             `json:"stsSeconds,omitempty"`
+	STSIncludeSubdomains    bool              `json:"stsIncludeSubdomains,omitempty"`
+	STSPreload              bool              `json:"stsPreload,omitempty"`
+	ForceSTSHeader          bool              `json:"forceSTSHeader,omitempty"`
+	FrameDeny               bool              `json:"frameDeny,omitempty"`
+	CustomFrameOptionsValue string            `json:"customFrameOptionsValue,omitempty"`
+	ContentTypeNosniff      bool              `json:"contentTypeNosniff,omitempty"`
+	BrowserXSSFilter        bool              `json:"browserXssFilter,omitempty"`
+	ContentSecurityPolicy   string            `json:"contentSecurityPolicy,omitempty"`
+	PublicKey               string            `json:"publicKey,omitempty"`
+	ReferrerPolicy          string            `json:"referrerPolicy,omitempty"`
+	IsDevelopment           bool              `json:"isDevelopment,omitempty"`
+}
+
+// HasCustomHeadersDefined checks to see if any of the custom header elements have been set
+func (h Headers) HasCustomHeadersDefined() bool {
+	return len(h.CustomResponseHeaders) != 0 ||
+		len(h.CustomRequestHeaders) != 0
+}
+
+// HasSecureHeadersDefined checks to see if any of the secure header elements have been set
+func (h Headers) HasSecureHeadersDefined() bool {
+	return len(h.AllowedHosts) != 0 ||
+		len(h.HostsProxyHeaders) != 0 ||
+		h.SSLRedirect ||
+		h.SSLTemporaryRedirect ||
+		h.SSLHost != "" ||
+		len(h.SSLProxyHeaders) != 0 ||
+		h.STSSeconds != 0 ||
+		h.STSIncludeSubdomains ||
+		h.STSPreload ||
+		h.ForceSTSHeader ||
+		h.FrameDeny ||
+		h.CustomFrameOptionsValue != "" ||
+		h.ContentTypeNosniff ||
+		h.BrowserXSSFilter ||
+		h.ContentSecurityPolicy != "" ||
+		h.PublicKey != "" ||
+		h.ReferrerPolicy != "" ||
+		h.IsDevelopment
+}
+
 // Frontend holds frontend configuration.
 type Frontend struct {
 	EntryPoints          []string         `json:"entryPoints,omitempty"`
@@ -64,6 +116,7 @@ type Frontend struct {
 	Priority             int              `json:"priority"`
 	BasicAuth            []string         `json:"basicAuth"`
 	WhitelistSourceRange []string         `json:"whitelistSourceRange,omitempty"`
+	Headers              Headers          `json:"headers,omitempty"`
 }
 
 // LoadBalancerMethod holds the method of load balancing to use.

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -1,0 +1,37 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHeaders_ShouldReturnFalseWhenNotHasCustomHeadersDefined(t *testing.T) {
+	headers := Headers{}
+
+	assert.False(t, headers.HasCustomHeadersDefined())
+}
+
+func TestHeaders_ShouldReturnTrueWhenHasCustomHeadersDefined(t *testing.T) {
+	headers := Headers{}
+
+	headers.CustomRequestHeaders = map[string]string{
+		"foo": "bar",
+	}
+
+	assert.True(t, headers.HasCustomHeadersDefined())
+}
+
+func TestHeaders_ShouldReturnFalseWhenNotHasSecureHeadersDefined(t *testing.T) {
+	headers := Headers{}
+
+	assert.False(t, headers.HasSecureHeadersDefined())
+}
+
+func TestHeaders_ShouldReturnTrueWhenHasSecureHeadersDefined(t *testing.T) {
+	headers := Headers{}
+
+	headers.SSLRedirect = true
+
+	assert.True(t, headers.HasSecureHeadersDefined())
+}

--- a/vendor/github.com/unrolled/secure/LICENSE
+++ b/vendor/github.com/unrolled/secure/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Cory Jacobsen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/unrolled/secure/doc.go
+++ b/vendor/github.com/unrolled/secure/doc.go
@@ -1,0 +1,25 @@
+/*Package secure is an HTTP middleware for Go that facilitates some quick security wins.
+
+  package main
+
+  import (
+      "net/http"
+
+      "github.com/unrolled/secure"  // or "gopkg.in/unrolled/secure.v1"
+  )
+
+  var myHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+      w.Write([]byte("hello world"))
+  })
+
+  func main() {
+      secureMiddleware := secure.New(secure.Options{
+          AllowedHosts: []string{"www.example.com", "sub.example.com"},
+          SSLRedirect:  true,
+      })
+
+      app := secureMiddleware.Handler(myHandler)
+      http.ListenAndServe("127.0.0.1:3000", app)
+  }
+*/
+package secure

--- a/vendor/github.com/unrolled/secure/secure.go
+++ b/vendor/github.com/unrolled/secure/secure.go
@@ -1,0 +1,230 @@
+package secure
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+const (
+	stsHeader            = "Strict-Transport-Security"
+	stsSubdomainString   = "; includeSubdomains"
+	stsPreloadString     = "; preload"
+	frameOptionsHeader   = "X-Frame-Options"
+	frameOptionsValue    = "DENY"
+	contentTypeHeader    = "X-Content-Type-Options"
+	contentTypeValue     = "nosniff"
+	xssProtectionHeader  = "X-XSS-Protection"
+	xssProtectionValue   = "1; mode=block"
+	cspHeader            = "Content-Security-Policy"
+	hpkpHeader           = "Public-Key-Pins"
+	referrerPolicyHeader = "Referrer-Policy"
+)
+
+func defaultBadHostHandler(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "Bad Host", http.StatusInternalServerError)
+}
+
+// Options is a struct for specifying configuration options for the secure.Secure middleware.
+type Options struct {
+	// AllowedHosts is a list of fully qualified domain names that are allowed. Default is empty list, which allows any and all host names.
+	AllowedHosts []string
+	// HostsProxyHeaders is a set of header keys that may hold a proxied hostname value for the request.
+	HostsProxyHeaders []string
+	// If SSLRedirect is set to true, then only allow https requests. Default is false.
+	SSLRedirect bool
+	// If SSLTemporaryRedirect is true, the a 302 will be used while redirecting. Default is false (301).
+	SSLTemporaryRedirect bool
+	// SSLHost is the host name that is used to redirect http requests to https. Default is "", which indicates to use the same host.
+	SSLHost string
+	// SSLProxyHeaders is set of header keys with associated values that would indicate a valid https request. Useful when using Nginx: `map[string]string{"X-Forwarded-Proto": "https"}`. Default is blank map.
+	SSLProxyHeaders map[string]string
+	// STSSeconds is the max-age of the Strict-Transport-Security header. Default is 0, which would NOT include the header.
+	STSSeconds int64
+	// If STSIncludeSubdomains is set to true, the `includeSubdomains` will be appended to the Strict-Transport-Security header. Default is false.
+	STSIncludeSubdomains bool
+	// If STSPreload is set to true, the `preload` flag will be appended to the Strict-Transport-Security header. Default is false.
+	STSPreload bool
+	// If ForceSTSHeader is set to true, the STS header will be added even when the connection is HTTP. Default is false.
+	ForceSTSHeader bool
+	// If FrameDeny is set to true, adds the X-Frame-Options header with the value of `DENY`. Default is false.
+	FrameDeny bool
+	// CustomFrameOptionsValue allows the X-Frame-Options header value to be set with a custom value. This overrides the FrameDeny option.
+	CustomFrameOptionsValue string
+	// If ContentTypeNosniff is true, adds the X-Content-Type-Options header with the value `nosniff`. Default is false.
+	ContentTypeNosniff bool
+	// If BrowserXssFilter is true, adds the X-XSS-Protection header with the value `1; mode=block`. Default is false.
+	BrowserXssFilter bool
+	// ContentSecurityPolicy allows the Content-Security-Policy header value to be set with a custom value. Default is "".
+	ContentSecurityPolicy string
+	// PublicKey implements HPKP to prevent MITM attacks with forged certificates. Default is "".
+	PublicKey string
+	// Referrer Policy allows sites to control when browsers will pass the Referer header to other sites. Default is "".
+	ReferrerPolicy string
+	// When developing, the AllowedHosts, SSL, and STS options can cause some unwanted effects. Usually testing happens on http, not https, and on localhost, not your production domain... so set this to true for dev environment.
+	// If you would like your development environment to mimic production with complete Host blocking, SSL redirects, and STS headers, leave this as false. Default if false.
+	IsDevelopment bool
+}
+
+// Secure is a middleware that helps setup a few basic security features. A single secure.Options struct can be
+// provided to configure which features should be enabled, and the ability to override a few of the default values.
+type Secure struct {
+	// Customize Secure with an Options struct.
+	opt Options
+
+	// Handlers for when an error occurs (ie bad host).
+	badHostHandler http.Handler
+}
+
+// New constructs a new Secure instance with supplied options.
+func New(options ...Options) *Secure {
+	var o Options
+	if len(options) == 0 {
+		o = Options{}
+	} else {
+		o = options[0]
+	}
+
+	return &Secure{
+		opt:            o,
+		badHostHandler: http.HandlerFunc(defaultBadHostHandler),
+	}
+}
+
+// SetBadHostHandler sets the handler to call when secure rejects the host name.
+func (s *Secure) SetBadHostHandler(handler http.Handler) {
+	s.badHostHandler = handler
+}
+
+// Handler implements the http.HandlerFunc for integration with the standard net/http lib.
+func (s *Secure) Handler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Let secure process the request. If it returns an error,
+		// that indicates the request should not continue.
+		err := s.Process(w, r)
+
+		// If there was an error, do not continue.
+		if err != nil {
+			return
+		}
+
+		h.ServeHTTP(w, r)
+	})
+}
+
+// HandlerFuncWithNext is a special implementation for Negroni, but could be used elsewhere.
+func (s *Secure) HandlerFuncWithNext(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	err := s.Process(w, r)
+
+	// If there was an error, do not call next.
+	if err == nil && next != nil {
+		next(w, r)
+	}
+}
+
+// Process runs the actual checks and returns an error if the middleware chain should stop.
+func (s *Secure) Process(w http.ResponseWriter, r *http.Request) error {
+	// Resolve the host for the request, using proxy headers if present.
+	host := r.Host
+	for _, header := range s.opt.HostsProxyHeaders {
+		if h := r.Header.Get(header); h != "" {
+			host = h
+			break
+		}
+	}
+
+	// Allowed hosts check.
+	if len(s.opt.AllowedHosts) > 0 && !s.opt.IsDevelopment {
+		isGoodHost := false
+		for _, allowedHost := range s.opt.AllowedHosts {
+			if strings.EqualFold(allowedHost, host) {
+				isGoodHost = true
+				break
+			}
+		}
+
+		if !isGoodHost {
+			s.badHostHandler.ServeHTTP(w, r)
+			return fmt.Errorf("Bad host name: %s", host)
+		}
+	}
+
+	// Determine if we are on HTTPS.
+	isSSL := strings.EqualFold(r.URL.Scheme, "https") || r.TLS != nil
+	if !isSSL {
+		for k, v := range s.opt.SSLProxyHeaders {
+			if r.Header.Get(k) == v {
+				isSSL = true
+				break
+			}
+		}
+	}
+
+	// SSL check.
+	if s.opt.SSLRedirect && !isSSL && !s.opt.IsDevelopment {
+		url := r.URL
+		url.Scheme = "https"
+		url.Host = host
+
+		if len(s.opt.SSLHost) > 0 {
+			url.Host = s.opt.SSLHost
+		}
+
+		status := http.StatusMovedPermanently
+		if s.opt.SSLTemporaryRedirect {
+			status = http.StatusTemporaryRedirect
+		}
+
+		http.Redirect(w, r, url.String(), status)
+		return fmt.Errorf("Redirecting to HTTPS")
+	}
+
+	// Strict Transport Security header. Only add header when we know it's an SSL connection.
+	// See https://tools.ietf.org/html/rfc6797#section-7.2 for details.
+	if s.opt.STSSeconds != 0 && (isSSL || s.opt.ForceSTSHeader) && !s.opt.IsDevelopment {
+		stsSub := ""
+		if s.opt.STSIncludeSubdomains {
+			stsSub = stsSubdomainString
+		}
+
+		if s.opt.STSPreload {
+			stsSub += stsPreloadString
+		}
+
+		w.Header().Add(stsHeader, fmt.Sprintf("max-age=%d%s", s.opt.STSSeconds, stsSub))
+	}
+
+	// Frame Options header.
+	if len(s.opt.CustomFrameOptionsValue) > 0 {
+		w.Header().Add(frameOptionsHeader, s.opt.CustomFrameOptionsValue)
+	} else if s.opt.FrameDeny {
+		w.Header().Add(frameOptionsHeader, frameOptionsValue)
+	}
+
+	// Content Type Options header.
+	if s.opt.ContentTypeNosniff {
+		w.Header().Add(contentTypeHeader, contentTypeValue)
+	}
+
+	// XSS Protection header.
+	if s.opt.BrowserXssFilter {
+		w.Header().Add(xssProtectionHeader, xssProtectionValue)
+	}
+
+	// HPKP header.
+	if len(s.opt.PublicKey) > 0 && isSSL && !s.opt.IsDevelopment {
+		w.Header().Add(hpkpHeader, s.opt.PublicKey)
+	}
+
+	// Content Security Policy header.
+	if len(s.opt.ContentSecurityPolicy) > 0 {
+		w.Header().Add(cspHeader, s.opt.ContentSecurityPolicy)
+	}
+
+	// Referrer Policy header.
+	if len(s.opt.ReferrerPolicy) > 0 {
+		w.Header().Add(referrerPolicyHeader, s.opt.ReferrerPolicy)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This is a middleware based on github.com/unrolled/secure that allows us to control, and inject request and response headers.