### PR TITLE
Update DefaultMaxIdleConnsPerHost default in docs.

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -62,11 +62,13 @@
 #
 # ProvidersThrottleDuration = "5"
 
-# If non-zero, controls the maximum idle (keep-alive) to keep per-host.  If zero, DefaultMaxIdleConnsPerHost is used.
-# If you encounter 'too many open files' errors, you can either change this value, or change `ulimit` value.
+# Controls the maximum idle (keep-alive) connections to keep per-host. If zero, DefaultMaxIdleConnsPerHost
+# from the Go standard library net/http module is used.
+# If you encounter 'too many open files' errors, you can either increase this
+# value or change the `ulimit`.
 #
 # Optional
-# Default: http.DefaultMaxIdleConnsPerHost
+# Default: 200
 #
 # MaxIdleConnsPerHost = 200
 

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -53,11 +53,13 @@
 #
 # ProvidersThrottleDuration = "5"
 
-# If non-zero, controls the maximum idle (keep-alive) to keep per-host.  If zero, DefaultMaxIdleConnsPerHost is used.
-# If you encounter 'too many open files' errors, you can either change this value, or change `ulimit` value.
+# Controls the maximum idle (keep-alive) connections to keep per-host. If zero, DefaultMaxIdleConnsPerHost
+# from the Go standard library net/http module is used.
+# If you encounter 'too many open files' errors, you can either increase this
+# value or change the `ulimit`.
 #
 # Optional
-# Default: http.DefaultMaxIdleConnsPerHost
+# Default: 200
 #
 # MaxIdleConnsPerHost = 200
 


### PR DESCRIPTION
This complements a change to the default value made in #224.

The PR targets the v1.2 branch.

@containous/traefik PTAL.

@emilevauge: As discussed on Slack.