### PR TITLE
[WIP at best] Quick and dirty tcp support

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -154,6 +154,7 @@ func (ep *EntryPoints) Set(value string) error {
 		TLS:      tls,
 		Redirect: redirect,
 		Compress: compress,
+		Mode:     "http",
 	}
 
 	return nil
@@ -182,6 +183,7 @@ type EntryPoint struct {
 	Redirect *Redirect
 	Auth     *types.Auth
 	Compress bool
+	Mode	string
 }
 
 // Redirect configures a redirection of an entry point to another, or to an URL

--- a/server.go
+++ b/server.go
@@ -9,7 +9,10 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -166,10 +169,73 @@ func (server *Server) stopLeadership() {
 	}
 }
 
+func (server *Server) forward2(conn net.Conn) {
+//	client, err := net.Dial("tcp", "192.168.10.50:80")
+//	if err != nil {
+//		log.Fatalf("Dial failed: %v", err)
+//	}
+	log.Printf("Connected to something %v\n", conn)
+	currentConfigurations := server.currentConfigurations.Get().(configs)
+	for _, configuration := range currentConfigurations {
+//		fmt.Println(configuration)
+		for _, frontend := range configuration.Frontends {
+			for _, entrypoint := range frontend.EntryPoints {
+				if server.globalConfiguration.EntryPoints[entrypoint].Mode == "tcp" {
+					fmt.Println("We found a entrypoint, yeh..", )
+					if backend := configuration.Backends[frontend.Backend]; backend != nil {
+						if len(backend.Servers) != 0 {
+							fmt.Println("Servers, yeh..")
+							for _, server := range backend.Servers {
+								client, err := net.Dial("tcp", server.URL)
+								if err != nil {
+									log.Fatalf("Dial failed: %v", err)
+								}
+								cp := func(dst io.Writer, src io.Reader) {
+									defer client.Close()
+									defer conn.Close()
+									defer fmt.Println("Goodbye :(")
+									io.Copy(dst, src)
+								}
+								go cp(client, conn)
+								go cp(conn, client)
+								fmt.Println(server.URL)
+								break
+							}
+						}
+						fmt.Println(configuration.Backends[frontend.Backend])
+					}
+					break
+				}
+			}
+			fmt.Println(frontend)
+		}
+	}
+}
+
 func (server *Server) startHTTPServers() {
 	server.serverEntryPoints = server.buildEntryPoints(server.globalConfiguration)
 
 	for newServerEntryPointName, newServerEntryPoint := range server.serverEntryPoints {
+		if server.globalConfiguration.EntryPoints[newServerEntryPointName].Mode == "tcp" {
+			fmt.Println("everyone loves tcp (for now)")
+			// http://blog.evilissimo.net/simple-port-fowarder-in-golang
+			// https://github.com/yhat/wsutil/blob/master/wsutil.go
+			listener, err := net.Listen("tcp", server.globalConfiguration.EntryPoints[newServerEntryPointName].Address)
+			if err != nil {
+				log.Fatalf("Failed to setup listener: %v", err)
+			}
+			go func() {
+				for {
+					conn, err := listener.Accept()
+					if err != nil {
+						log.Fatalf("ERROR: failed to accept listener: %v", err)
+					}
+					log.Printf("Accepted connection %v\n", conn)
+					go server.forward2(conn)
+				}
+			}()
+			continue
+		}
 		serverMiddlewares := []negroni.Handler{server.loggerMiddleware, metrics}
 		if server.globalConfiguration.Web != nil && server.globalConfiguration.Web.Metrics != nil {
 			if server.globalConfiguration.Web.Metrics.Prometheus != nil {
@@ -286,8 +352,10 @@ func (server *Server) listenConfigurations(stop chan bool) {
 			newServerEntryPoints, err := server.loadConfig(newConfigurations, server.globalConfiguration)
 			if err == nil {
 				for newServerEntryPointName, newServerEntryPoint := range newServerEntryPoints {
-					server.serverEntryPoints[newServerEntryPointName].httpRouter.UpdateHandler(newServerEntryPoint.httpRouter.GetHandler())
-					log.Infof("Server configuration reloaded on %s", server.serverEntryPoints[newServerEntryPointName].httpServer.Addr)
+					if server.serverEntryPoints[newServerEntryPointName].httpRouter == nil {
+						server.serverEntryPoints[newServerEntryPointName].httpRouter.UpdateHandler(newServerEntryPoint.httpRouter.GetHandler())
+						log.Infof("Server configuration reloaded on %s", server.serverEntryPoints[newServerEntryPointName].httpServer.Addr)
+					}
 				}
 				server.currentConfigurations.Set(newConfigurations)
 				server.postLoadConfig()
@@ -648,8 +716,8 @@ func (server *Server) loadConfig(configurations configs, globalConfiguration Glo
 								url, err := url.Parse(server.URL)
 								if err != nil {
 									log.Errorf("Error parsing server URL %s: %v", server.URL, err)
-									log.Errorf("Skipping frontend %s...", frontendName)
-									continue frontend
+//									log.Errorf("Skipping frontend %s...", frontendName)
+//									continue frontend
 								}
 								backend2FrontendMap[url.String()] = frontendName
 								log.Debugf("Creating server %s at %s with weight %d", serverName, url.String(), server.Weight)


### PR DESCRIPTION
Featuring:
* Improper error management
* Impropper shutdown/reload support
* Bad code
* Breaking code
* Ineffective code
* A lot of "funny" prints/noise.

Config like:
```
[entryPoints]
  [entryPoints.tcp]
  mode = "tcp"
  address = ":2222"

[file]
[backends]
  [backends.backend1]
    [backends.backend1.servers.server1]
    url = "192.168.10.50:22"

[frontends]
  [frontends.frontend1]
  backend = "backend1"
  entrypoints = ["tcp"]
    [frontends.frontend2.routes.test_1]
    rule = "Host:backend2.com"
```