### PR TITLE
Allow multiple rules from docker labels containers with traefik.<servicename>.* properties

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -823,6 +823,17 @@ Labels can be used on containers to override default behaviour:
 - `traefik.frontend.entryPoints=http,https`: assign this frontend to entry points `http` and `https`. Overrides `defaultEntryPoints`.
 - `traefik.docker.network`: Set the docker network to use for connections to this container
 
+If several ports need to be exposed from a container, the services labels can be used
+- `traefik.<service-name>.port=443`: create a service binding with frontend/backend using this port. Overrides `traefik.port`.
+- `traefik.<service-name>.protocol=https`: assign `https` protocol. Overrides `traefik.protocol`.
+- `traefik.<service-name>.weight=10`: assign this service weight. Overrides `traefik.weight`.
+- `traefik.<service-name>.frontend.backend=fooBackend`: assign this service frontend to `foobackend`. Default is to assign to the service backend.
+- `traefik.<service-name>.frontend.entryPoints=http`: assign this service entrypoints. Overrides `traefik.frontend.entrypoints`.
+- `traefik.<service-name>.frontend.passHostHeader=true`: Forward client `Host` header to the backend. Overrides `traefik.frontend.passHostHeader`.
+- `traefik.<service-name>.frontend.priority=10`: assign the service frontend priority. Overrides `traefik.frontend.priority`.
+- `traefik.<service-name>.frontend.rule=Path:/foo`: assign the service frontend rule. Overrides `traefik.frontend.rule`.
+
+
 NB: when running inside a container, Træfɪk will need network access through `docker network connect <network> <traefik-container>`
 
 ## Marathon backend

--- a/provider/docker_test.go
+++ b/provider/docker_test.go
@@ -2271,3 +2271,613 @@ func TestSwarmTaskParsing(t *testing.T) {
 		}
 	}
 }
+
+func TestDockerGetServiceProtocol(t *testing.T) {
+	provider := &Docker{}
+
+	containers := []struct {
+		container docker.ContainerJSON
+		expected  string
+	}{
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "foo",
+				},
+				Config: &container.Config{},
+			},
+			expected: "http",
+		},
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "another",
+				},
+				Config: &container.Config{
+					Labels: map[string]string{
+						"traefik.protocol": "https",
+					},
+				},
+			},
+			expected: "https",
+		},
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "test",
+				},
+				Config: &container.Config{
+					Labels: map[string]string{
+						"traefik.myservice.protocol": "https",
+					},
+				},
+			},
+			expected: "https",
+		},
+	}
+
+	for _, e := range containers {
+		dockerData := parseContainer(e.container)
+		actual := provider.getServiceProtocol(dockerData, "myservice")
+		if actual != e.expected {
+			t.Fatalf("expected %q, got %q", e.expected, actual)
+		}
+	}
+}
+
+func TestDockerGetServiceWeight(t *testing.T) {
+	provider := &Docker{}
+
+	containers := []struct {
+		container docker.ContainerJSON
+		expected  string
+	}{
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "foo",
+				},
+				Config: &container.Config{},
+			},
+			expected: "0",
+		},
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "another",
+				},
+				Config: &container.Config{
+					Labels: map[string]string{
+						"traefik.weight": "200",
+					},
+				},
+			},
+			expected: "200",
+		},
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "test",
+				},
+				Config: &container.Config{
+					Labels: map[string]string{
+						"traefik.myservice.weight": "31337",
+					},
+				},
+			},
+			expected: "31337",
+		},
+	}
+
+	for _, e := range containers {
+		dockerData := parseContainer(e.container)
+		actual := provider.getServiceWeight(dockerData, "myservice")
+		if actual != e.expected {
+			t.Fatalf("expected %q, got %q", e.expected, actual)
+		}
+	}
+}
+
+func TestDockerGetServicePort(t *testing.T) {
+	provider := &Docker{}
+
+	containers := []struct {
+		container docker.ContainerJSON
+		expected  string
+	}{
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "foo",
+				},
+				Config: &container.Config{},
+			},
+			expected: "",
+		},
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "another",
+				},
+				Config: &container.Config{
+					Labels: map[string]string{
+						"traefik.port": "2500",
+					},
+				},
+			},
+			expected: "2500",
+		},
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "test",
+				},
+				Config: &container.Config{
+					Labels: map[string]string{
+						"traefik.myservice.port": "1234",
+					},
+				},
+			},
+			expected: "1234",
+		},
+	}
+
+	for _, e := range containers {
+		dockerData := parseContainer(e.container)
+		actual := provider.getServicePort(dockerData, "myservice")
+		if actual != e.expected {
+			t.Fatalf("expected %q, got %q", e.expected, actual)
+		}
+	}
+}
+
+func TestDockerGetServiceFrontendRule(t *testing.T) {
+	provider := &Docker{}
+
+	containers := []struct {
+		container docker.ContainerJSON
+		expected  string
+	}{
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "foo",
+				},
+				Config: &container.Config{},
+			},
+			expected: "Host:foo.",
+		},
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "another",
+				},
+				Config: &container.Config{
+					Labels: map[string]string{
+						"traefik.frontend.rule": "Path:/helloworld",
+					},
+				},
+			},
+			expected: "Path:/helloworld",
+		},
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "test",
+				},
+				Config: &container.Config{
+					Labels: map[string]string{
+						"traefik.myservice.frontend.rule": "Path:/mycustomservicepath",
+					},
+				},
+			},
+			expected: "Path:/mycustomservicepath",
+		},
+	}
+
+	for _, e := range containers {
+		dockerData := parseContainer(e.container)
+		actual := provider.getServiceFrontendRule(dockerData, "myservice")
+		if actual != e.expected {
+			t.Fatalf("expected %q, got %q", e.expected, actual)
+		}
+	}
+}
+
+func TestDockerGetServiceBackend(t *testing.T) {
+	provider := &Docker{}
+
+	containers := []struct {
+		container docker.ContainerJSON
+		expected  string
+	}{
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "foo",
+				},
+				Config: &container.Config{},
+			},
+			expected: "foo-myservice",
+		},
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "another",
+				},
+				Config: &container.Config{
+					Labels: map[string]string{
+						"traefik.backend": "another-backend",
+					},
+				},
+			},
+			expected: "another-backend-myservice",
+		},
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "test",
+				},
+				Config: &container.Config{
+					Labels: map[string]string{
+						"traefik.myservice.frontend.backend": "custom-backend",
+					},
+				},
+			},
+			expected: "custom-backend",
+		},
+	}
+
+	for _, e := range containers {
+		dockerData := parseContainer(e.container)
+		actual := provider.getServiceBackend(dockerData, "myservice")
+		if actual != e.expected {
+			t.Fatalf("expected %q, got %q", e.expected, actual)
+		}
+	}
+}
+
+func TestDockerGetServicePriority(t *testing.T) {
+	provider := &Docker{}
+
+	containers := []struct {
+		container docker.ContainerJSON
+		expected  string
+	}{
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "foo",
+				},
+				Config: &container.Config{},
+			},
+			expected: "0",
+		},
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "another",
+				},
+				Config: &container.Config{
+					Labels: map[string]string{
+						"traefik.frontend.priority": "33",
+					},
+				},
+			},
+			expected: "33",
+		},
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "test",
+				},
+				Config: &container.Config{
+					Labels: map[string]string{
+						"traefik.myservice.frontend.priority": "2503",
+					},
+				},
+			},
+			expected: "2503",
+		},
+	}
+
+	for _, e := range containers {
+		dockerData := parseContainer(e.container)
+		actual := provider.getServicePriority(dockerData, "myservice")
+		if actual != e.expected {
+			t.Fatalf("expected %q, got %q", e.expected, actual)
+		}
+	}
+}
+
+func TestDockerGetServicePassHostHeader(t *testing.T) {
+	provider := &Docker{}
+
+	containers := []struct {
+		container docker.ContainerJSON
+		expected  string
+	}{
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "foo",
+				},
+				Config: &container.Config{},
+			},
+			expected: "true",
+		},
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "another",
+				},
+				Config: &container.Config{
+					Labels: map[string]string{
+						"traefik.frontend.passHostHeader": "false",
+					},
+				},
+			},
+			expected: "false",
+		},
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "test",
+				},
+				Config: &container.Config{
+					Labels: map[string]string{
+						"traefik.myservice.frontend.passHostHeader": "false",
+					},
+				},
+			},
+			expected: "false",
+		},
+	}
+
+	for _, e := range containers {
+		dockerData := parseContainer(e.container)
+		actual := provider.getServicePassHostHeader(dockerData, "myservice")
+		if actual != e.expected {
+			t.Fatalf("expected %q, got %q", e.expected, actual)
+		}
+	}
+}
+
+func TestDockerGetServiceEntryPoints(t *testing.T) {
+	provider := &Docker{}
+
+	containers := []struct {
+		container docker.ContainerJSON
+		expected  []string
+	}{
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "foo",
+				},
+				Config: &container.Config{},
+			},
+			expected: []string{},
+		},
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "another",
+				},
+				Config: &container.Config{
+					Labels: map[string]string{
+						"traefik.frontend.entryPoints": "http,https",
+					},
+				},
+			},
+			expected: []string{"http", "https"},
+		},
+		{
+			container: docker.ContainerJSON{
+				ContainerJSONBase: &docker.ContainerJSONBase{
+					Name: "test",
+				},
+				Config: &container.Config{
+					Labels: map[string]string{
+						"traefik.myservice.frontend.entryPoints": "http,https",
+					},
+				},
+			},
+			expected: []string{"http", "https"},
+		},
+	}
+
+	for _, e := range containers {
+		dockerData := parseContainer(e.container)
+		actual := provider.getServiceEntryPoints(dockerData, "myservice")
+		if !reflect.DeepEqual(actual, e.expected) {
+			t.Fatalf("expected %q, got %q for container %q", e.expected, actual, dockerData.Name)
+		}
+	}
+}
+
+func TestDockerLoadDockerServiceConfig(t *testing.T) {
+	cases := []struct {
+		containers        []docker.ContainerJSON
+		expectedFrontends map[string]*types.Frontend
+		expectedBackends  map[string]*types.Backend
+	}{
+		{
+			containers:        []docker.ContainerJSON{},
+			expectedFrontends: map[string]*types.Frontend{},
+			expectedBackends:  map[string]*types.Backend{},
+		},
+		{
+			containers: []docker.ContainerJSON{
+				{
+					ContainerJSONBase: &docker.ContainerJSONBase{
+						Name: "foo",
+					},
+					Config: &container.Config{
+						Labels: map[string]string{
+							"traefik.service.port":                 "2503",
+							"traefik.service.frontend.entryPoints": "http,https",
+						},
+					},
+					NetworkSettings: &docker.NetworkSettings{
+						NetworkSettingsBase: docker.NetworkSettingsBase{
+							Ports: nat.PortMap{
+								"80/tcp": {},
+							},
+						},
+						Networks: map[string]*network.EndpointSettings{
+							"bridge": {
+								IPAddress: "127.0.0.1",
+							},
+						},
+					},
+				},
+			},
+			expectedFrontends: map[string]*types.Frontend{
+				"frontend-foo-service": {
+					Backend:        "backend-foo-service",
+					PassHostHeader: true,
+					EntryPoints:    []string{"http", "https"},
+					Routes: map[string]types.Route{
+						"service-service": {
+							Rule: "Host:foo.docker.localhost",
+						},
+					},
+				},
+			},
+			expectedBackends: map[string]*types.Backend{
+				"backend-foo-service": {
+					Servers: map[string]types.Server{
+						"service": {
+							URL:    "http://127.0.0.1:2503",
+							Weight: 0,
+						},
+					},
+					CircuitBreaker: nil,
+				},
+			},
+		},
+		{
+			containers: []docker.ContainerJSON{
+				{
+					ContainerJSONBase: &docker.ContainerJSONBase{
+						Name: "test1",
+					},
+					Config: &container.Config{
+						Labels: map[string]string{
+							"traefik.service.port":                    "2503",
+							"traefik.service.protocol":                "https",
+							"traefik.service.weight":                  "80",
+							"traefik.service.frontend.backend":        "foobar",
+							"traefik.service.frontend.passHostHeader": "false",
+							"traefik.service.frontend.rule":           "Path:/mypath",
+							"traefik.service.frontend.priority":       "5000",
+							"traefik.service.frontend.entryPoints":    "http,https,ws",
+						},
+					},
+					NetworkSettings: &docker.NetworkSettings{
+						NetworkSettingsBase: docker.NetworkSettingsBase{
+							Ports: nat.PortMap{
+								"80/tcp": {},
+							},
+						},
+						Networks: map[string]*network.EndpointSettings{
+							"bridge": {
+								IPAddress: "127.0.0.1",
+							},
+						},
+					},
+				},
+				{
+					ContainerJSONBase: &docker.ContainerJSONBase{
+						Name: "test2",
+					},
+					Config: &container.Config{
+						Labels: map[string]string{
+							"traefik.anotherservice.port":          "8079",
+							"traefik.anotherservice.weight":        "33",
+							"traefik.anotherservice.frontend.rule": "Path:/anotherpath",
+						},
+					},
+					NetworkSettings: &docker.NetworkSettings{
+						NetworkSettingsBase: docker.NetworkSettingsBase{
+							Ports: nat.PortMap{
+								"80/tcp": {},
+							},
+						},
+						Networks: map[string]*network.EndpointSettings{
+							"bridge": {
+								IPAddress: "127.0.0.1",
+							},
+						},
+					},
+				},
+			},
+			expectedFrontends: map[string]*types.Frontend{
+				"frontend-foobar": {
+					Backend:        "backend-foobar",
+					PassHostHeader: false,
+					Priority:       5000,
+					EntryPoints:    []string{"http", "https", "ws"},
+					Routes: map[string]types.Route{
+						"service-service": {
+							Rule: "Path:/mypath",
+						},
+					},
+				},
+				"frontend-test2-anotherservice": {
+					Backend:        "backend-test2-anotherservice",
+					PassHostHeader: true,
+					EntryPoints:    []string{},
+					Routes: map[string]types.Route{
+						"service-anotherservice": {
+							Rule: "Path:/anotherpath",
+						},
+					},
+				},
+			},
+			expectedBackends: map[string]*types.Backend{
+				"backend-foobar": {
+					Servers: map[string]types.Server{
+						"service": {
+							URL:    "https://127.0.0.1:2503",
+							Weight: 80,
+						},
+					},
+					CircuitBreaker: nil,
+				},
+				"backend-test2-anotherservice": {
+					Servers: map[string]types.Server{
+						"service": {
+							URL:    "http://127.0.0.1:8079",
+							Weight: 33,
+						},
+					},
+					CircuitBreaker: nil,
+				},
+			},
+		},
+	}
+
+	provider := &Docker{
+		Domain:           "docker.localhost",
+		ExposedByDefault: true,
+	}
+
+	for _, c := range cases {
+		var dockerDataList []dockerData
+		for _, container := range c.containers {
+			dockerData := parseContainer(container)
+			dockerDataList = append(dockerDataList, dockerData)
+		}
+
+		actualConfig := provider.loadDockerConfig(dockerDataList)
+		// Compare backends
+		if !reflect.DeepEqual(actualConfig.Backends, c.expectedBackends) {
+			t.Fatalf("expected %#v, got %#v", c.expectedBackends, actualConfig.Backends)
+		}
+		if !reflect.DeepEqual(actualConfig.Frontends, c.expectedFrontends) {
+			t.Fatalf("expected %#v, got %#v", c.expectedFrontends, actualConfig.Frontends)
+		}
+	}
+}

--- a/templates/docker.tmpl
+++ b/templates/docker.tmpl
@@ -19,15 +19,39 @@
 
     {{$servers := index $backendServers $backendName}}
     {{range $serverName, $server := $servers}}
+    {{if hasServices $server}}
+      {{$services := getServiceNames $server}}
+      {{range $serviceIndex, $serviceName := $services}}
+      [backends.backend-{{getServiceBackend $server $serviceName}}.servers.service]
+      url = "{{getServiceProtocol $server $serviceName}}://{{getIPAddress $server}}:{{getServicePort $server $serviceName}}"
+      weight = {{getServiceWeight $server $serviceName}}
+      {{end}}
+    {{else}}
       [backends.backend-{{$backendName}}.servers.server-{{$server.Name | replace "/" "" | replace "." "-"}}]
       url = "{{getProtocol $server}}://{{getIPAddress $server}}:{{getPort $server}}"
       weight = {{getWeight $server}}
+    {{end}}
     {{end}}
 
 {{end}}
 
 [frontends]{{range $frontend, $containers := .Frontends}}
-  [frontends."frontend-{{$frontend}}"]{{$container := index $containers 0}}
+  {{$container := index $containers 0}}
+  {{if hasServices $container}}
+  {{$services := getServiceNames $container}}
+  {{range $serviceIndex, $serviceName := $services}}
+  [frontends."frontend-{{getServiceBackend $container $serviceName}}"]
+  backend = "backend-{{getServiceBackend $container $serviceName}}"
+  passHostHeader = {{getServicePassHostHeader $container $serviceName}}
+  priority = {{getServicePriority $container $serviceName}}
+  entryPoints = [{{range getServiceEntryPoints $container $serviceName}}
+    "{{.}}",
+  {{end}}]
+    [frontends."frontend-{{getServiceBackend $container $serviceName}}".routes."service-{{$serviceName | replace "/" "" | replace "." "-"}}"]
+    rule = "{{getServiceFrontendRule $container $serviceName}}"
+  {{end}}
+  {{else}}
+  [frontends."frontend-{{$frontend}}"]
   backend = "backend-{{getBackend $container}}"
   passHostHeader = {{getPassHostHeader $container}}
   priority = {{getPriority $container}}
@@ -36,4 +60,5 @@
   {{end}}]
     [frontends."frontend-{{$frontend}}".routes."route-frontend-{{$frontend}}"]
     rule = "{{getFrontendRule $container}}"
+  {{end}}
 {{end}}


### PR DESCRIPTION
It matches expectation of #444 
If labels contain for example:
   - `traefik.mycustomservice.port=443`
  -  `traefik.mycustomservice.frontend.rule=Path:/mycustomservice`
   - `traefik.anothercustomservice.port=8080`
  -  `traefik.anothercustomservice.frontend.rule=Path:/anotherservice`

all traffic to frontend on path `/mycustomservice` is redirected to the port `443` of the container defining the label while using path `/anotherservice` will redirect to the port `8080` of the docker container defining the label

Available properties are 
`traefik.<service-name>.port`
`traefik.<service-name>.weight`
`traefik.<service-name>.protocol`
`traefik.<service-name>.frontend.backend`
`traefik.<service-name>.frontend.entryPoints`
`traefik.<service-name>.frontend.rule`
`traefik.<service-name>.frontend.passHostHeader`
`traefik.<service-name>.frontend.priority`
`traefik.<service-name>.frontend.rule`


- More documentation in the docs/toml.md file
- new tests added to docker_tests.go

Change-Id: Ifaa3bb00ef0a0f38aa189e0ca1586fde8c5ed862
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>