### PR TITLE
[WIP] Deflake integration tests.

### DIFF
--- a/integration/access_log_test.go
+++ b/integration/access_log_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containous/traefik/integration/utils"
 	"github.com/go-check/check"
 	shellwords "github.com/mattn/go-shellwords"
 
@@ -34,7 +35,12 @@ func (s *AccessLogSuite) TestAccessLog(c *check.C) {
 	defer os.Remove("access.log")
 	defer os.Remove("traefik.log")
 
-	time.Sleep(500 * time.Millisecond)
+	utils.Try(1*time.Second, func() error {
+		if _, err := os.Stat("traefik.log"); err != nil {
+			return fmt.Errorf("could not get stats for log file: %s", err)
+		}
+		return nil
+	})
 
 	// Verify Traefik started OK
 	traefikLog, err := ioutil.ReadFile("traefik.log")

--- a/integration/basic_test.go
+++ b/integration/basic_test.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"net/http"
 	"os/exec"
 	"time"
 
+	"github.com/containous/traefik/integration/utils"
 	"github.com/go-check/check"
 
 	"bytes"
+
 	checker "github.com/vdemeester/shakers"
 )
 
@@ -35,12 +36,12 @@ func (s *SimpleSuite) TestSimpleDefaultConfig(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	defer cmd.Process.Kill()
 
-	time.Sleep(500 * time.Millisecond)
 	// TODO validate : run on 80
-	resp, err := http.Get("http://127.0.0.1:8000/")
+	resp, err := utils.TryGetResponse("http://127.0.0.1:8000/", 1*time.Second)
+	c.Assert(err, checker.IsNil)
+	defer resp.Body.Close()
 
 	// Expected a 404 as we did not configure anything
-	c.Assert(err, checker.IsNil)
 	c.Assert(resp.StatusCode, checker.Equals, 404)
 }
 
@@ -50,11 +51,11 @@ func (s *SimpleSuite) TestWithWebConfig(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	defer cmd.Process.Kill()
 
-	time.Sleep(500 * time.Millisecond)
-
-	resp, err := http.Get("http://127.0.0.1:8080/api")
-	// Expected a 200
+	resp, err := utils.TryGetResponse("http://127.0.0.1:8080/api", 1*time.Second)
 	c.Assert(err, checker.IsNil)
+	defer resp.Body.Close()
+
+	// Expected a 200
 	c.Assert(resp.StatusCode, checker.Equals, 200)
 }
 

--- a/integration/eureka_test.go
+++ b/integration/eureka_test.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"bytes"
-	"errors"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -41,12 +39,7 @@ func (s *EurekaSuite) TestSimpleConfiguration(c *check.C) {
 	eurekaURL := "http://" + eurekaHost + ":8761/eureka/apps"
 
 	// wait for eureka
-	err = utils.TryRequest(eurekaURL, 60*time.Second, func(res *http.Response) error {
-		if err != nil {
-			return err
-		}
-		return nil
-	})
+	err = utils.TryRequest(eurekaURL, 60*time.Second, nil)
 	c.Assert(err, checker.IsNil)
 
 	eurekaTemplate := `
@@ -81,16 +74,7 @@ func (s *EurekaSuite) TestSimpleConfiguration(c *check.C) {
 	c.Assert(resp.StatusCode, checker.Equals, 204)
 
 	// wait for traefik
-	err = utils.TryRequest("http://127.0.0.1:8080/api/providers", 60*time.Second, func(res *http.Response) error {
-		body, err := ioutil.ReadAll(res.Body)
-		if err != nil {
-			return err
-		}
-		if !strings.Contains(string(body), "Host:tests-integration-traefik") {
-			return errors.New("Incorrect traefik config")
-		}
-		return nil
-	})
+	err = utils.TryRequest("http://127.0.0.1:8080/api/providers", 60*time.Second, utils.BodyContains("Host:tests-integration-traefik"))
 	c.Assert(err, checker.IsNil)
 
 	client := &http.Client{}

--- a/integration/healthcheck_test.go
+++ b/integration/healthcheck_test.go
@@ -2,12 +2,9 @@ package main
 
 import (
 	"bytes"
-	"errors"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
-	"strings"
 	"time"
 
 	"github.com/containous/traefik/integration/utils"
@@ -42,16 +39,7 @@ func (s *HealchCheckSuite) TestSimpleConfiguration(c *check.C) {
 	defer cmd.Process.Kill()
 
 	// wait for traefik
-	err = utils.TryRequest("http://127.0.0.1:8080/api/providers", 60*time.Second, func(res *http.Response) error {
-		body, err := ioutil.ReadAll(res.Body)
-		if err != nil {
-			return err
-		}
-		if !strings.Contains(string(body), "Host:test.localhost") {
-			return errors.New("Incorrect traefik config: " + string(body))
-		}
-		return nil
-	})
+	err = utils.TryRequest("http://127.0.0.1:8080/api/providers", 60*time.Second, utils.BodyContains("Host:test.localhost"))
 	c.Assert(err, checker.IsNil)
 
 	client := &http.Client{}

--- a/integration/marathon_test.go
+++ b/integration/marathon_test.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"time"
 
+	"github.com/containous/traefik/integration/utils"
 	"github.com/go-check/check"
 
 	checker "github.com/vdemeester/shakers"
@@ -17,17 +18,8 @@ func (s *MarathonSuite) SetUpSuite(c *check.C) {
 	s.createComposeProject(c, "marathon")
 	s.composeProject.Start(c)
 	// wait for marathon
-	// err := utils.TryRequest("http://127.0.0.1:8080/ping", 60*time.Second, func(res *http.Response) error {
-	// 	body, err := ioutil.ReadAll(res.Body)
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// 	if !strings.Contains(string(body), "ping") {
-	// 		return errors.New("Incorrect marathon config")
-	// 	}
-	// 	return nil
-	// })
-	// c.Assert(err, checker.IsNil)
+	err := utils.TryRequest("http://127.0.0.1:8080/ping", 60*time.Second, nil)
+	c.Assert(err, checker.IsNil)
 }
 
 func (s *MarathonSuite) TestSimpleConfiguration(c *check.C) {

--- a/integration/utils/try.go
+++ b/integration/utils/try.go
@@ -1,35 +1,73 @@
 package utils
 
 import (
-	"errors"
-	"github.com/cenk/backoff"
+	"fmt"
+	"io/ioutil"
+	"math"
 	"net/http"
-	"strconv"
+	"strings"
 	"time"
 )
 
-// TryRequest try operation timeout, and retry backoff
-func TryRequest(url string, timeout time.Duration, condition Condition) error {
-	exponentialBackOff := backoff.NewExponentialBackOff()
-	exponentialBackOff.MaxElapsedTime = timeout
-	var res *http.Response
-	err := backoff.Retry(func() error {
-		var err error
-		res, err = http.Get(url)
-		if err != nil {
-			return err
-		}
-		return condition(res)
-	}, exponentialBackOff)
-	return err
+const maxWaitTime = 5 * time.Second
+
+// TryGetResponse is like TryRequest, but returns the response for further
+// processing at the call site.
+// Conditions are not allowed since it would complicate signaling if the
+// response body needs to be closed or not. Callers are expected to close on
+// their own if the function returns a nil error.
+func TryGetResponse(url string, timeout time.Duration) (*http.Response, error) {
+	return tryGetResponse(url, timeout)
 }
 
-// Try try operation timeout, and retry backoff
+// TryRequest is like Try, but runs a request against the given URL and applies
+// the condition on the response.
+// Condition may be nil, in which case only the request against the URL must
+// succeed.
+func TryRequest(url string, timeout time.Duration, condition Condition) error {
+	resp, err := tryGetResponse(url, timeout)
+	if err != nil {
+		return err
+	}
+
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	if condition != nil {
+		return condition(resp)
+	}
+
+	return nil
+}
+
+// Try repeatedly executes an operation until no error condition occurs or the
+// given timeout is reached, whatever comes first.
 func Try(timeout time.Duration, operation func() error) error {
-	exponentialBackOff := backoff.NewExponentialBackOff()
-	exponentialBackOff.MaxElapsedTime = timeout
-	err := backoff.Retry(operation, exponentialBackOff)
-	return err
+	if timeout <= 0 {
+		panic("timeout must be larger than zero")
+	}
+
+	wait := time.Duration(math.Ceil(float64(timeout) / 10.0))
+	if wait > maxWaitTime {
+		wait = maxWaitTime
+	}
+
+	var err error
+	if err = operation(); err == nil {
+		return nil
+	}
+
+	for {
+		select {
+		case <-time.After(timeout):
+			return fmt.Errorf("try operation failed: %s", err)
+		case <-time.Tick(wait):
+			if err = operation(); err == nil {
+				return nil
+			}
+		}
+	}
 }
 
 // Condition is a retry condition function.
@@ -37,14 +75,40 @@ func Try(timeout time.Duration, operation func() error) error {
 // if the response failed the condition.
 type Condition func(*http.Response) error
 
-// ErrorIfStatusCodeIsNot returns a retry condition function.
-// The condition returns an error
-// if the given response's status code is not the given HTTP status code.
-func ErrorIfStatusCodeIsNot(status int) Condition {
+// BodyContains returns a retry condition function.
+// The condition returns an error if the request body does not contain the given
+// string.
+func BodyContains(s string) Condition {
 	return func(res *http.Response) error {
-		if res.StatusCode != status {
-			return errors.New("Bad status. Got: " + res.Status + ", expected:" + strconv.Itoa(status))
+		body, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return fmt.Errorf("failed to read response body: %s", err)
+		}
+
+		if !strings.Contains(string(body), s) {
+			return fmt.Errorf("could not find '%s' in body '%s'", s, string(body))
 		}
 		return nil
 	}
+}
+
+// StatusCodeIs returns a retry condition function.
+// The condition returns an error if the given response's status code is not the
+// given HTTP status code.
+func StatusCodeIs(status int) Condition {
+	return func(res *http.Response) error {
+		if res.StatusCode != status {
+			return fmt.Errorf("got status code %d, wanted %d", res.StatusCode, status)
+		}
+		return nil
+	}
+}
+
+func tryGetResponse(url string, timeout time.Duration) (*http.Response, error) {
+	var resp *http.Response
+	return resp, Try(timeout, func() error {
+		var err error
+		resp, err = http.Get(url)
+		return err
+	})
 }


### PR DESCRIPTION
This PR refactors and improves the `integration/utils/Try*` functions and replaces a number of hard-coded `time.Sleep()` calls in our integration test fixtures by retry-based timeouts. We also stop backing off exponentially since there's little value in doing so during integration tests where we want feedback as quickly as possible.

Refs #1266.

TODO:

- [ ] Run repeatedly to see if we have caught all flaky tests.
- [ ] Look at the remaining `time.Sleep` calls and see if we can replace them by retries.