### PR TITLE
Add filter on task status in addition to desired status (Docker Provider - swarm)

### DIFF
--- a/provider/docker.go
+++ b/provider/docker.go
@@ -690,6 +690,9 @@ func listTasks(ctx context.Context, dockerClient client.APIClient, serviceID str
 	var dockerDataList []dockerData
 
 	for _, task := range taskList {
+		if task.Status.State != swarm.TaskStateRunning {
+			continue
+		}
 		dockerData := parseTasks(task, serviceDockerData, networkMap, isGlobalSvc)
 		dockerDataList = append(dockerDataList, dockerData)
 	}

--- a/provider/docker_test.go
+++ b/provider/docker_test.go
@@ -6,11 +6,15 @@ import (
 	"testing"
 
 	"github.com/containous/traefik/types"
+	"github.com/davecgh/go-spew/spew"
+	dockerclient "github.com/docker/engine-api/client"
 	docker "github.com/docker/engine-api/types"
+	dockertypes "github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
 	"github.com/docker/engine-api/types/network"
 	"github.com/docker/engine-api/types/swarm"
 	"github.com/docker/go-connections/nat"
+	"golang.org/x/net/context"
 )
 
 func TestDockerGetFrontendName(t *testing.T) {
@@ -2189,7 +2193,7 @@ func TestSwarmTaskParsing(t *testing.T) {
 	cases := []struct {
 		service       swarm.Service
 		tasks         []swarm.Task
-		isGlobalSvc   bool
+		isGlobalSVC   bool
 		expectedNames map[string]string
 		networks      map[string]*docker.NetworkResource
 	}{
@@ -2215,7 +2219,7 @@ func TestSwarmTaskParsing(t *testing.T) {
 					Slot: 3,
 				},
 			},
-			isGlobalSvc: false,
+			isGlobalSVC: false,
 			expectedNames: map[string]string{
 				"id1": "container.1",
 				"id2": "container.2",
@@ -2246,7 +2250,7 @@ func TestSwarmTaskParsing(t *testing.T) {
 					ID: "id3",
 				},
 			},
-			isGlobalSvc: true,
+			isGlobalSVC: true,
 			expectedNames: map[string]string{
 				"id1": "container.id1",
 				"id2": "container.id2",
@@ -2264,9 +2268,99 @@ func TestSwarmTaskParsing(t *testing.T) {
 		dockerData := parseService(e.service, e.networks)
 
 		for _, task := range e.tasks {
-			taskDockerData := parseTasks(task, dockerData, map[string]*docker.NetworkResource{}, e.isGlobalSvc)
+			taskDockerData := parseTasks(task, dockerData, map[string]*docker.NetworkResource{}, e.isGlobalSVC)
 			if !reflect.DeepEqual(taskDockerData.Name, e.expectedNames[task.ID]) {
 				t.Fatalf("expect %v, got %v", e.expectedNames[task.ID], taskDockerData.Name)
+			}
+		}
+	}
+}
+
+type fakeTasksClient struct {
+	dockerclient.APIClient
+	tasks []swarm.Task
+	err   error
+}
+
+func (c *fakeTasksClient) TaskList(ctx context.Context, options dockertypes.TaskListOptions) ([]swarm.Task, error) {
+	return c.tasks, c.err
+}
+
+func TestListTasks(t *testing.T) {
+	cases := []struct {
+		service       swarm.Service
+		tasks         []swarm.Task
+		isGlobalSVC   bool
+		expectedTasks []string
+		networks      map[string]*docker.NetworkResource
+	}{
+		{
+			service: swarm.Service{
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Name: "container",
+					},
+				},
+			},
+			tasks: []swarm.Task{
+				{
+					ID:   "id1",
+					Slot: 1,
+					Status: swarm.TaskStatus{
+						State: swarm.TaskStateRunning,
+					},
+				},
+				{
+					ID:   "id2",
+					Slot: 2,
+					Status: swarm.TaskStatus{
+						State: swarm.TaskStatePending,
+					},
+				},
+				{
+					ID:   "id3",
+					Slot: 3,
+				},
+				{
+					ID:   "id4",
+					Slot: 4,
+					Status: swarm.TaskStatus{
+						State: swarm.TaskStateRunning,
+					},
+				},
+				{
+					ID:   "id5",
+					Slot: 5,
+					Status: swarm.TaskStatus{
+						State: swarm.TaskStateFailed,
+					},
+				},
+			},
+			isGlobalSVC: false,
+			expectedTasks: []string{
+				"container.1",
+				"container.4",
+			},
+			networks: map[string]*docker.NetworkResource{
+				"1": {
+					Name: "foo",
+				},
+			},
+		},
+	}
+
+	for _, e := range cases {
+		dockerData := parseService(e.service, e.networks)
+		dockerClient := &fakeTasksClient{tasks: e.tasks}
+		taskDockerData, _ := listTasks(context.Background(), dockerClient, e.service.ID, dockerData, map[string]*docker.NetworkResource{}, e.isGlobalSVC)
+
+		if len(e.expectedTasks) != len(taskDockerData) {
+			t.Fatalf("expected tasks %v, got %v", spew.Sprint(e.expectedTasks), spew.Sprint(taskDockerData))
+		}
+
+		for i, taskID := range e.expectedTasks {
+			if taskDockerData[i].Name != taskID {
+				t.Fatalf("expect task id %v, got %v", taskID, taskDockerData[i].Name)
 			}
 		}
 	}

--- a/provider/docker_test.go
+++ b/provider/docker_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/engine-api/types/swarm"
 	"github.com/docker/go-connections/nat"
 	"golang.org/x/net/context"
+	"strconv"
 )
 
 func TestDockerGetFrontendName(t *testing.T) {
@@ -89,12 +90,16 @@ func TestDockerGetFrontendName(t *testing.T) {
 		},
 	}
 
-	for _, e := range containers {
-		dockerData := parseContainer(e.container)
-		actual := provider.getFrontendName(dockerData)
-		if actual != e.expected {
-			t.Fatalf("expected %q, got %q", e.expected, actual)
-		}
+	for containerID, e := range containers {
+		e := e
+		t.Run(strconv.Itoa(containerID), func(t *testing.T) {
+			t.Parallel()
+			dockerData := parseContainer(e.container)
+			actual := provider.getFrontendName(dockerData)
+			if actual != e.expected {
+				t.Errorf("expected %q, got %q", e.expected, actual)
+			}
+		})
 	}
 }
 
@@ -153,12 +158,16 @@ func TestDockerGetFrontendRule(t *testing.T) {
 		},
 	}
 
-	for _, e := range containers {
-		dockerData := parseContainer(e.container)
-		actual := provider.getFrontendRule(dockerData)
-		if actual != e.expected {
-			t.Fatalf("expected %q, got %q", e.expected, actual)
-		}
+	for containerID, e := range containers {
+		e := e
+		t.Run(strconv.Itoa(containerID), func(t *testing.T) {
+			t.Parallel()
+			dockerData := parseContainer(e.container)
+			actual := provider.getFrontendRule(dockerData)
+			if actual != e.expected {
+				t.Errorf("expected %q, got %q", e.expected, actual)
+			}
+		})
 	}
 }
 
@@ -202,12 +211,16 @@ func TestDockerGetBackend(t *testing.T) {
 		},
 	}
 
-	for _, e := range containers {
-		dockerData := parseContainer(e.container)
-		actual := provider.getBackend(dockerData)
-		if actual != e.expected {
-			t.Fatalf("expected %q, got %q", e.expected, actual)
-		}
+	for containerID, e := range containers {
+		e := e
+		t.Run(strconv.Itoa(containerID), func(t *testing.T) {
+			t.Parallel()
+			dockerData := parseContainer(e.container)
+			actual := provider.getBackend(dockerData)
+			if actual != e.expected {
+				t.Errorf("expected %q, got %q", e.expected, actual)
+			}
+		})
 	}
 }
 
@@ -303,12 +316,16 @@ func TestDockerGetIPAddress(t *testing.T) { // TODO
 		},
 	}
 
-	for _, e := range containers {
-		dockerData := parseContainer(e.container)
-		actual := provider.getIPAddress(dockerData)
-		if actual != e.expected {
-			t.Fatalf("expected %q, got %q", e.expected, actual)
-		}
+	for containerID, e := range containers {
+		e := e
+		t.Run(strconv.Itoa(containerID), func(t *testing.T) {
+			t.Parallel()
+			dockerData := parseContainer(e.container)
+			actual := provider.getIPAddress(dockerData)
+			if actual != e.expected {
+				t.Errorf("expected %q, got %q", e.expected, actual)
+			}
+		})
 	}
 }
 
@@ -416,12 +433,16 @@ func TestDockerGetPort(t *testing.T) {
 		},
 	}
 
-	for _, e := range containers {
-		dockerData := parseContainer(e.container)
-		actual := provider.getPort(dockerData)
-		if actual != e.expected {
-			t.Fatalf("expected %q, got %q", e.expected, actual)
-		}
+	for containerID, e := range containers {
+		e := e
+		t.Run(strconv.Itoa(containerID), func(t *testing.T) {
+			t.Parallel()
+			dockerData := parseContainer(e.container)
+			actual := provider.getPort(dockerData)
+			if actual != e.expected {
+				t.Errorf("expected %q, got %q", e.expected, actual)
+			}
+		})
 	}
 }
 
@@ -456,12 +477,16 @@ func TestDockerGetWeight(t *testing.T) {
 		},
 	}
 
-	for _, e := range containers {
-		dockerData := parseContainer(e.container)
-		actual := provider.getWeight(dockerData)
-		if actual != e.expected {
-			t.Fatalf("expected %q, got %q", e.expected, actual)
-		}
+	for containerID, e := range containers {
+		e := e
+		t.Run(strconv.Itoa(containerID), func(t *testing.T) {
+			t.Parallel()
+			dockerData := parseContainer(e.container)
+			actual := provider.getWeight(dockerData)
+			if actual != e.expected {
+				t.Errorf("expected %q, got %q", e.expected, actual)
+			}
+		})
 	}
 }
 
@@ -498,12 +523,16 @@ func TestDockerGetDomain(t *testing.T) {
 		},
 	}
 
-	for _, e := range containers {
-		dockerData := parseContainer(e.container)
-		actual := provider.getDomain(dockerData)
-		if actual != e.expected {
-			t.Fatalf("expected %q, got %q", e.expected, actual)
-		}
+	for containerID, e := range containers {
+		e := e
+		t.Run(strconv.Itoa(containerID), func(t *testing.T) {
+			t.Parallel()
+			dockerData := parseContainer(e.container)
+			actual := provider.getDomain(dockerData)
+			if actual != e.expected {
+				t.Errorf("expected %q, got %q", e.expected, actual)
+			}
+		})
 	}
 }
 
@@ -538,12 +567,16 @@ func TestDockerGetProtocol(t *testing.T) {
 		},
 	}
 
-	for _, e := range containers {
-		dockerData := parseContainer(e.container)
-		actual := provider.getProtocol(dockerData)
-		if actual != e.expected {
-			t.Fatalf("expected %q, got %q", e.expected, actual)
-		}
+	for containerID, e := range containers {
+		e := e
+		t.Run(strconv.Itoa(containerID), func(t *testing.T) {
+			t.Parallel()
+			dockerData := parseContainer(e.container)
+			actual := provider.getProtocol(dockerData)
+			if actual != e.expected {
+				t.Errorf("expected %q, got %q", e.expected, actual)
+			}
+		})
 	}
 }
 
@@ -577,12 +610,16 @@ func TestDockerGetPassHostHeader(t *testing.T) {
 		},
 	}
 
-	for _, e := range containers {
-		dockerData := parseContainer(e.container)
-		actual := provider.getPassHostHeader(dockerData)
-		if actual != e.expected {
-			t.Fatalf("expected %q, got %q", e.expected, actual)
-		}
+	for containerID, e := range containers {
+		e := e
+		t.Run(strconv.Itoa(containerID), func(t *testing.T) {
+			t.Parallel()
+			dockerData := parseContainer(e.container)
+			actual := provider.getPassHostHeader(dockerData)
+			if actual != e.expected {
+				t.Errorf("expected %q, got %q", e.expected, actual)
+			}
+		})
 	}
 }
 
@@ -615,18 +652,22 @@ func TestDockerGetLabel(t *testing.T) {
 		},
 	}
 
-	for _, e := range containers {
-		dockerData := parseContainer(e.container)
-		label, err := getLabel(dockerData, "foo")
-		if e.expected != "" {
-			if err == nil || !strings.Contains(err.Error(), e.expected) {
-				t.Fatalf("expected an error with %q, got %v", e.expected, err)
+	for containerID, e := range containers {
+		e := e
+		t.Run(strconv.Itoa(containerID), func(t *testing.T) {
+			t.Parallel()
+			dockerData := parseContainer(e.container)
+			label, err := getLabel(dockerData, "foo")
+			if e.expected != "" {
+				if err == nil || !strings.Contains(err.Error(), e.expected) {
+					t.Errorf("expected an error with %q, got %v", e.expected, err)
+				}
+			} else {
+				if label != "bar" {
+					t.Errorf("expected label 'bar', got %s", label)
+				}
 			}
-		} else {
-			if label != "bar" {
-				t.Fatalf("expected label 'bar', got %s", label)
-			}
-		}
+		})
 	}
 }
 
@@ -682,17 +723,21 @@ func TestDockerGetLabels(t *testing.T) {
 		},
 	}
 
-	for _, e := range containers {
-		dockerData := parseContainer(e.container)
-		labels, err := getLabels(dockerData, []string{"foo", "bar"})
-		if !reflect.DeepEqual(labels, e.expectedLabels) {
-			t.Fatalf("expect %v, got %v", e.expectedLabels, labels)
-		}
-		if e.expectedError != "" {
-			if err == nil || !strings.Contains(err.Error(), e.expectedError) {
-				t.Fatalf("expected an error with %q, got %v", e.expectedError, err)
+	for containerID, e := range containers {
+		e := e
+		t.Run(strconv.Itoa(containerID), func(t *testing.T) {
+			t.Parallel()
+			dockerData := parseContainer(e.container)
+			labels, err := getLabels(dockerData, []string{"foo", "bar"})
+			if !reflect.DeepEqual(labels, e.expectedLabels) {
+				t.Errorf("expect %v, got %v", e.expectedLabels, labels)
 			}
-		}
+			if e.expectedError != "" {
+				if err == nil || !strings.Contains(err.Error(), e.expectedError) {
+					t.Errorf("expected an error with %q, got %v", e.expectedError, err)
+				}
+			}
+		})
 	}
 }
 
@@ -916,13 +961,17 @@ func TestDockerTraefikFilter(t *testing.T) {
 		},
 	}
 
-	for _, e := range containers {
-		provider.ExposedByDefault = e.exposedByDefault
-		dockerData := parseContainer(e.container)
-		actual := provider.containerFilter(dockerData)
-		if actual != e.expected {
-			t.Fatalf("expected %v for %+v, got %+v", e.expected, e, actual)
-		}
+	for containerID, e := range containers {
+		e := e
+		t.Run(strconv.Itoa(containerID), func(t *testing.T) {
+			t.Parallel()
+			provider.ExposedByDefault = e.exposedByDefault
+			dockerData := parseContainer(e.container)
+			actual := provider.containerFilter(dockerData)
+			if actual != e.expected {
+				t.Errorf("expected %v for %+v, got %+v", e.expected, e, actual)
+			}
+		})
 	}
 }
 
@@ -1138,21 +1187,25 @@ func TestDockerLoadDockerConfig(t *testing.T) {
 		ExposedByDefault: true,
 	}
 
-	for _, c := range cases {
-		var dockerDataList []dockerData
-		for _, container := range c.containers {
-			dockerData := parseContainer(container)
-			dockerDataList = append(dockerDataList, dockerData)
-		}
+	for caseID, c := range cases {
+		c := c
+		t.Run(strconv.Itoa(caseID), func(t *testing.T) {
+			t.Parallel()
+			var dockerDataList []dockerData
+			for _, container := range c.containers {
+				dockerData := parseContainer(container)
+				dockerDataList = append(dockerDataList, dockerData)
+			}
 
-		actualConfig := provider.loadDockerConfig(dockerDataList)
-		// Compare backends
-		if !reflect.DeepEqual(actualConfig.Backends, c.expectedBackends) {
-			t.Fatalf("expected %#v, got %#v", c.expectedBackends, actualConfig.Backends)
-		}
-		if !reflect.DeepEqual(actualConfig.Frontends, c.expectedFrontends) {
-			t.Fatalf("expected %#v, got %#v", c.expectedFrontends, actualConfig.Frontends)
-		}
+			actualConfig := provider.loadDockerConfig(dockerDataList)
+			// Compare backends
+			if !reflect.DeepEqual(actualConfig.Backends, c.expectedBackends) {
+				t.Errorf("expected %#v, got %#v", c.expectedBackends, actualConfig.Backends)
+			}
+			if !reflect.DeepEqual(actualConfig.Frontends, c.expectedFrontends) {
+				t.Errorf("expected %#v, got %#v", c.expectedFrontends, actualConfig.Frontends)
+			}
+		})
 	}
 }
 
@@ -1236,12 +1289,16 @@ func TestSwarmGetFrontendName(t *testing.T) {
 		},
 	}
 
-	for _, e := range services {
-		dockerData := parseService(e.service, e.networks)
-		actual := provider.getFrontendName(dockerData)
-		if actual != e.expected {
-			t.Fatalf("expected %q, got %q", e.expected, actual)
-		}
+	for serviceID, e := range services {
+		e := e
+		t.Run(strconv.Itoa(serviceID), func(t *testing.T) {
+			t.Parallel()
+			dockerData := parseService(e.service, e.networks)
+			actual := provider.getFrontendName(dockerData)
+			if actual != e.expected {
+				t.Errorf("expected %q, got %q", e.expected, actual)
+			}
+		})
 	}
 }
 
@@ -1308,12 +1365,16 @@ func TestSwarmGetFrontendRule(t *testing.T) {
 		},
 	}
 
-	for _, e := range services {
-		dockerData := parseService(e.service, e.networks)
-		actual := provider.getFrontendRule(dockerData)
-		if actual != e.expected {
-			t.Fatalf("expected %q, got %q", e.expected, actual)
-		}
+	for serviceID, e := range services {
+		e := e
+		t.Run(strconv.Itoa(serviceID), func(t *testing.T) {
+			t.Parallel()
+			dockerData := parseService(e.service, e.networks)
+			actual := provider.getFrontendRule(dockerData)
+			if actual != e.expected {
+				t.Errorf("expected %q, got %q", e.expected, actual)
+			}
+		})
 	}
 }
 
@@ -1365,12 +1426,16 @@ func TestSwarmGetBackend(t *testing.T) {
 		},
 	}
 
-	for _, e := range services {
-		dockerData := parseService(e.service, e.networks)
-		actual := provider.getBackend(dockerData)
-		if actual != e.expected {
-			t.Fatalf("expected %q, got %q", e.expected, actual)
-		}
+	for serviceID, e := range services {
+		e := e
+		t.Run(strconv.Itoa(serviceID), func(t *testing.T) {
+			t.Parallel()
+			dockerData := parseService(e.service, e.networks)
+			actual := provider.getBackend(dockerData)
+			if actual != e.expected {
+				t.Errorf("expected %q, got %q", e.expected, actual)
+			}
+		})
 	}
 }
 
@@ -1462,12 +1527,16 @@ func TestSwarmGetIPAddress(t *testing.T) {
 		},
 	}
 
-	for _, e := range services {
-		dockerData := parseService(e.service, e.networks)
-		actual := provider.getIPAddress(dockerData)
-		if actual != e.expected {
-			t.Fatalf("expected %q, got %q", e.expected, actual)
-		}
+	for serviceID, e := range services {
+		e := e
+		t.Run(strconv.Itoa(serviceID), func(t *testing.T) {
+			t.Parallel()
+			dockerData := parseService(e.service, e.networks)
+			actual := provider.getIPAddress(dockerData)
+			if actual != e.expected {
+				t.Errorf("expected %q, got %q", e.expected, actual)
+			}
+		})
 	}
 }
 
@@ -1500,12 +1569,16 @@ func TestSwarmGetPort(t *testing.T) {
 		},
 	}
 
-	for _, e := range services {
-		dockerData := parseService(e.service, e.networks)
-		actual := provider.getPort(dockerData)
-		if actual != e.expected {
-			t.Fatalf("expected %q, got %q", e.expected, actual)
-		}
+	for serviceID, e := range services {
+		e := e
+		t.Run(strconv.Itoa(serviceID), func(t *testing.T) {
+			t.Parallel()
+			dockerData := parseService(e.service, e.networks)
+			actual := provider.getPort(dockerData)
+			if actual != e.expected {
+				t.Errorf("expected %q, got %q", e.expected, actual)
+			}
+		})
 	}
 }
 
@@ -1552,12 +1625,16 @@ func TestSwarmGetWeight(t *testing.T) {
 		},
 	}
 
-	for _, e := range services {
-		dockerData := parseService(e.service, e.networks)
-		actual := provider.getWeight(dockerData)
-		if actual != e.expected {
-			t.Fatalf("expected %q, got %q", e.expected, actual)
-		}
+	for serviceID, e := range services {
+		e := e
+		t.Run(strconv.Itoa(serviceID), func(t *testing.T) {
+			t.Parallel()
+			dockerData := parseService(e.service, e.networks)
+			actual := provider.getWeight(dockerData)
+			if actual != e.expected {
+				t.Errorf("expected %q, got %q", e.expected, actual)
+			}
+		})
 	}
 }
 
@@ -1605,12 +1682,16 @@ func TestSwarmGetDomain(t *testing.T) {
 		},
 	}
 
-	for _, e := range services {
-		dockerData := parseService(e.service, e.networks)
-		actual := provider.getDomain(dockerData)
-		if actual != e.expected {
-			t.Fatalf("expected %q, got %q", e.expected, actual)
-		}
+	for serviceID, e := range services {
+		e := e
+		t.Run(strconv.Itoa(serviceID), func(t *testing.T) {
+			t.Parallel()
+			dockerData := parseService(e.service, e.networks)
+			actual := provider.getDomain(dockerData)
+			if actual != e.expected {
+				t.Errorf("expected %q, got %q", e.expected, actual)
+			}
+		})
 	}
 }
 
@@ -1657,12 +1738,16 @@ func TestSwarmGetProtocol(t *testing.T) {
 		},
 	}
 
-	for _, e := range services {
-		dockerData := parseService(e.service, e.networks)
-		actual := provider.getProtocol(dockerData)
-		if actual != e.expected {
-			t.Fatalf("expected %q, got %q", e.expected, actual)
-		}
+	for serviceID, e := range services {
+		e := e
+		t.Run(strconv.Itoa(serviceID), func(t *testing.T) {
+			t.Parallel()
+			dockerData := parseService(e.service, e.networks)
+			actual := provider.getProtocol(dockerData)
+			if actual != e.expected {
+				t.Errorf("expected %q, got %q", e.expected, actual)
+			}
+		})
 	}
 }
 
@@ -1709,17 +1794,20 @@ func TestSwarmGetPassHostHeader(t *testing.T) {
 		},
 	}
 
-	for _, e := range services {
-		dockerData := parseService(e.service, e.networks)
-		actual := provider.getPassHostHeader(dockerData)
-		if actual != e.expected {
-			t.Fatalf("expected %q, got %q", e.expected, actual)
-		}
+	for serviceID, e := range services {
+		e := e
+		t.Run(strconv.Itoa(serviceID), func(t *testing.T) {
+			t.Parallel()
+			dockerData := parseService(e.service, e.networks)
+			actual := provider.getPassHostHeader(dockerData)
+			if actual != e.expected {
+				t.Errorf("expected %q, got %q", e.expected, actual)
+			}
+		})
 	}
 }
 
 func TestSwarmGetLabel(t *testing.T) {
-
 	services := []struct {
 		service  swarm.Service
 		expected string
@@ -1758,18 +1846,22 @@ func TestSwarmGetLabel(t *testing.T) {
 		},
 	}
 
-	for _, e := range services {
-		dockerData := parseService(e.service, e.networks)
-		label, err := getLabel(dockerData, "foo")
-		if e.expected != "" {
-			if err == nil || !strings.Contains(err.Error(), e.expected) {
-				t.Fatalf("expected an error with %q, got %v", e.expected, err)
+	for serviceID, e := range services {
+		e := e
+		t.Run(strconv.Itoa(serviceID), func(t *testing.T) {
+			t.Parallel()
+			dockerData := parseService(e.service, e.networks)
+			label, err := getLabel(dockerData, "foo")
+			if e.expected != "" {
+				if err == nil || !strings.Contains(err.Error(), e.expected) {
+					t.Errorf("expected an error with %q, got %v", e.expected, err)
+				}
+			} else {
+				if label != "bar" {
+					t.Errorf("expected label 'bar', got %s", label)
+				}
 			}
-		} else {
-			if label != "bar" {
-				t.Fatalf("expected label 'bar', got %s", label)
-			}
-		}
+		})
 	}
 }
 
@@ -1830,17 +1922,21 @@ func TestSwarmGetLabels(t *testing.T) {
 		},
 	}
 
-	for _, e := range services {
-		dockerData := parseService(e.service, e.networks)
-		labels, err := getLabels(dockerData, []string{"foo", "bar"})
-		if !reflect.DeepEqual(labels, e.expectedLabels) {
-			t.Fatalf("expect %v, got %v", e.expectedLabels, labels)
-		}
-		if e.expectedError != "" {
-			if err == nil || !strings.Contains(err.Error(), e.expectedError) {
-				t.Fatalf("expected an error with %q, got %v", e.expectedError, err)
+	for serviceID, e := range services {
+		e := e
+		t.Run(strconv.Itoa(serviceID), func(t *testing.T) {
+			t.Parallel()
+			dockerData := parseService(e.service, e.networks)
+			labels, err := getLabels(dockerData, []string{"foo", "bar"})
+			if !reflect.DeepEqual(labels, e.expectedLabels) {
+				t.Errorf("expect %v, got %v", e.expectedLabels, labels)
 			}
-		}
+			if e.expectedError != "" {
+				if err == nil || !strings.Contains(err.Error(), e.expectedError) {
+					t.Errorf("expected an error with %q, got %v", e.expectedError, err)
+				}
+			}
+		})
 	}
 }
 
@@ -1994,13 +2090,17 @@ func TestSwarmTraefikFilter(t *testing.T) {
 		},
 	}
 
-	for _, e := range services {
-		dockerData := parseService(e.service, e.networks)
-		provider.ExposedByDefault = e.exposedByDefault
-		actual := provider.containerFilter(dockerData)
-		if actual != e.expected {
-			t.Fatalf("expected %v for %+v, got %+v", e.expected, e, actual)
-		}
+	for serviceID, e := range services {
+		e := e
+		t.Run(strconv.Itoa(serviceID), func(t *testing.T) {
+			t.Parallel()
+			dockerData := parseService(e.service, e.networks)
+			provider.ExposedByDefault = e.exposedByDefault
+			actual := provider.containerFilter(dockerData)
+			if actual != e.expected {
+				t.Errorf("expected %v for %+v, got %+v", e.expected, e, actual)
+			}
+		})
 	}
 }
 
@@ -2171,21 +2271,25 @@ func TestSwarmLoadDockerConfig(t *testing.T) {
 		SwarmMode:        true,
 	}
 
-	for _, c := range cases {
-		var dockerDataList []dockerData
-		for _, service := range c.services {
-			dockerData := parseService(service, c.networks)
-			dockerDataList = append(dockerDataList, dockerData)
-		}
+	for caseID, c := range cases {
+		c := c
+		t.Run(strconv.Itoa(caseID), func(t *testing.T) {
+			t.Parallel()
+			var dockerDataList []dockerData
+			for _, service := range c.services {
+				dockerData := parseService(service, c.networks)
+				dockerDataList = append(dockerDataList, dockerData)
+			}
 
-		actualConfig := provider.loadDockerConfig(dockerDataList)
-		// Compare backends
-		if !reflect.DeepEqual(actualConfig.Backends, c.expectedBackends) {
-			t.Fatalf("expected %#v, got %#v", c.expectedBackends, actualConfig.Backends)
-		}
-		if !reflect.DeepEqual(actualConfig.Frontends, c.expectedFrontends) {
-			t.Fatalf("expected %#v, got %#v", c.expectedFrontends, actualConfig.Frontends)
-		}
+			actualConfig := provider.loadDockerConfig(dockerDataList)
+			// Compare backends
+			if !reflect.DeepEqual(actualConfig.Backends, c.expectedBackends) {
+				t.Errorf("expected %#v, got %#v", c.expectedBackends, actualConfig.Backends)
+			}
+			if !reflect.DeepEqual(actualConfig.Frontends, c.expectedFrontends) {
+				t.Errorf("expected %#v, got %#v", c.expectedFrontends, actualConfig.Frontends)
+			}
+		})
 	}
 }
 
@@ -2264,15 +2368,19 @@ func TestSwarmTaskParsing(t *testing.T) {
 		},
 	}
 
-	for _, e := range cases {
-		dockerData := parseService(e.service, e.networks)
+	for caseID, e := range cases {
+		e := e
+		t.Run(strconv.Itoa(caseID), func(t *testing.T) {
+			t.Parallel()
+			dockerData := parseService(e.service, e.networks)
 
-		for _, task := range e.tasks {
-			taskDockerData := parseTasks(task, dockerData, map[string]*docker.NetworkResource{}, e.isGlobalSVC)
-			if !reflect.DeepEqual(taskDockerData.Name, e.expectedNames[task.ID]) {
-				t.Fatalf("expect %v, got %v", e.expectedNames[task.ID], taskDockerData.Name)
+			for _, task := range e.tasks {
+				taskDockerData := parseTasks(task, dockerData, map[string]*docker.NetworkResource{}, e.isGlobalSVC)
+				if !reflect.DeepEqual(taskDockerData.Name, e.expectedNames[task.ID]) {
+					t.Errorf("expect %v, got %v", e.expectedNames[task.ID], taskDockerData.Name)
+				}
 			}
-		}
+		})
 	}
 }
 
@@ -2349,19 +2457,23 @@ func TestListTasks(t *testing.T) {
 		},
 	}
 
-	for _, e := range cases {
-		dockerData := parseService(e.service, e.networks)
-		dockerClient := &fakeTasksClient{tasks: e.tasks}
-		taskDockerData, _ := listTasks(context.Background(), dockerClient, e.service.ID, dockerData, map[string]*docker.NetworkResource{}, e.isGlobalSVC)
+	for caseID, e := range cases {
+		e := e
+		t.Run(strconv.Itoa(caseID), func(t *testing.T) {
+			t.Parallel()
+			dockerData := parseService(e.service, e.networks)
+			dockerClient := &fakeTasksClient{tasks: e.tasks}
+			taskDockerData, _ := listTasks(context.Background(), dockerClient, e.service.ID, dockerData, map[string]*docker.NetworkResource{}, e.isGlobalSVC)
 
-		if len(e.expectedTasks) != len(taskDockerData) {
-			t.Fatalf("expected tasks %v, got %v", spew.Sprint(e.expectedTasks), spew.Sprint(taskDockerData))
-		}
-
-		for i, taskID := range e.expectedTasks {
-			if taskDockerData[i].Name != taskID {
-				t.Fatalf("expect task id %v, got %v", taskID, taskDockerData[i].Name)
+			if len(e.expectedTasks) != len(taskDockerData) {
+				t.Errorf("expected tasks %v, got %v", spew.Sdump(e.expectedTasks), spew.Sdump(taskDockerData))
 			}
-		}
+
+			for i, taskID := range e.expectedTasks {
+				if taskDockerData[i].Name != taskID {
+					t.Errorf("expect task id %v, got %v", taskID, taskDockerData[i].Name)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
This PR solves the issue of passing traffic to a container before it's ready when using docker provider with swarm-mode and Traefik load-balancer (traefik.backend.loadbalancer.swarm=false), which is currently (V1.2-rc2) the default. (See issue #1238)

Current Tasks filter is based only on checking desired state, this PR adds an additional check on the current task state. 
For reference, check lifecycle model in swarmkit: https://github.com/docker/swarmkit/blob/master/design/task_model.md#task-lifecycle

Fixes #1238