### PR TITLE
Docker: Added warning if network could not be found

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -816,7 +816,7 @@ Labels can be used on containers to override default behaviour:
 - `traefik.frontend.passHostHeader=true`: forward client `Host` header to the backend.
 - `traefik.frontend.priority=10`: override default frontend priority
 - `traefik.frontend.entryPoints=http,https`: assign this frontend to entry points `http` and `https`. Overrides `defaultEntryPoints`.
-- `traefik.docker.network`: Set the docker network to use for connections to this container
+- `traefik.docker.network`: Set the docker network to use for connections to this container. If a container is linked to several networks, be sure to set the proper network name (you can check with docker inspect <container_id>) otherwise it will randomly pick one (depending on how docker is returning them). For instance when deploying docker `stack` from compose files, the compose defined networks will be prefixed with the `stack` name.
 
 NB: when running inside a container, Træfɪk will need network access through `docker network connect <network> <traefik-container>`
 

--- a/provider/docker.go
+++ b/provider/docker.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"net"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 	"text/template"
@@ -412,6 +413,8 @@ func (provider *Docker) getIPAddress(container dockerData) string {
 			if network != nil {
 				return network.Addr
 			}
+
+			log.Warn("Could not find network named '%s' for container '%s'! Maybe you're missing the project's prefix in the label? Defaulting to first available network.", label, container.Name)
 		}
 	}
 

--- a/provider/docker.go
+++ b/provider/docker.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"net"
 	"net/http"
-	"regexp"
 	"strconv"
 	"strings"
 	"text/template"

--- a/provider/docker.go
+++ b/provider/docker.go
@@ -413,7 +413,7 @@ func (provider *Docker) getIPAddress(container dockerData) string {
 				return network.Addr
 			}
 
-			log.Warn("Could not find network named '%s' for container '%s'! Maybe you're missing the project's prefix in the label? Defaulting to first available network.", label, container.Name)
+			log.Warnf("Could not find network named '%s' for container '%s'! Maybe you're missing the project's prefix in the label? Defaulting to first available network.", label, container.Name)
 		}
 	}
 


### PR DESCRIPTION
Closes #1308 - avoids rebase entanglements and general time-travel-related corruption :)