### PR TITLE
k8s: Do not log service fields when GetService is failing.

### DIFF
--- a/provider/kubernetes.go
+++ b/provider/kubernetes.go
@@ -161,12 +161,12 @@ func (provider *Kubernetes) loadIngresses(k8sClient k8s.Client) (*types.Configur
 				}
 				service, exists, err := k8sClient.GetService(i.ObjectMeta.Namespace, pa.Backend.ServiceName)
 				if err != nil {
-					log.Errorf("Error while retrieving service information from k8s API %s/%s: %v", service.ObjectMeta.Namespace, pa.Backend.ServiceName, err)
+					log.Errorf("Error while retrieving service information from k8s API %s/%s: %v", i.ObjectMeta.Namespace, pa.Backend.ServiceName, err)
 					return nil, err
 				}
 
 				if !exists {
-					log.Errorf("Service not found for %s/%s", service.ObjectMeta.Namespace, pa.Backend.ServiceName)
+					log.Errorf("Service not found for %s/%s", i.ObjectMeta.Namespace, pa.Backend.ServiceName)
 					delete(templateObjects.Frontends, r.Host+pa.Path)
 					continue
 				}

--- a/provider/kubernetes_test.go
+++ b/provider/kubernetes_test.go
@@ -1821,7 +1821,7 @@ func (c clientMock) GetIngresses(namespaces k8s.Namespaces) []*v1beta1.Ingress {
 
 func (c clientMock) GetService(namespace, name string) (*v1.Service, bool, error) {
 	if c.apiServiceError != nil {
-		return &v1.Service{}, false, c.apiServiceError
+		return nil, false, c.apiServiceError
 	}
 
 	for _, service := range c.services {
@@ -1829,12 +1829,12 @@ func (c clientMock) GetService(namespace, name string) (*v1.Service, bool, error
 			return service, true, nil
 		}
 	}
-	return &v1.Service{}, false, nil
+	return nil, false, nil
 }
 
 func (c clientMock) GetEndpoints(namespace, name string) (*v1.Endpoints, bool, error) {
 	if c.apiEndpointsError != nil {
-		return &v1.Endpoints{}, false, c.apiEndpointsError
+		return nil, false, c.apiEndpointsError
 	}
 
 	for _, endpoints := range c.endpoints {
@@ -1844,7 +1844,7 @@ func (c clientMock) GetEndpoints(namespace, name string) (*v1.Endpoints, bool, e
 	}
 
 	if c.properExists {
-		return &v1.Endpoints{}, false, nil
+		return nil, false, nil
 	}
 
 	return &v1.Endpoints{}, true, nil


### PR DESCRIPTION
Update tests too.

Fixes #1330.

@Regner @containous/traefik please take a look.