### PR TITLE
IP Whitelists for Frontend (with Docker- & Kubernetes-Provider Support)

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -479,6 +479,13 @@ defaultEntryPoints = ["http", "https"]
   backend = "backend1"
   passHostHeader = true
   priority = 10
+
+  # restrict access to this frontend to the specified list of IPv4/IPv6 CIDR Nets
+  # an unset or empty list allows all Source-IPs to access
+  # if one of the Net-Specifications are invalid, the whole list is invalid
+  # and allows all Source-IPs to access.
+  whitelistSourceRange = ["10.42.0.0/16", "152.89.1.33/32", "afed:be44::/16"]
+
   entrypoints = ["https"] # overrides defaultEntryPoints
     [frontends.frontend2.routes.test_1]
     rule = "Host:{subdomain:[a-z]+}.localhost"
@@ -867,7 +874,7 @@ Labels can be used on containers to override default behaviour:
 - `traefik.frontend.priority=10`: override default frontend priority
 - `traefik.frontend.entryPoints=http,https`: assign this frontend to entry points `http` and `https`. Overrides `defaultEntryPoints`.
 - `traefik.frontend.auth.basic=test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/,test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0`: Sets a Basic Auth for that frontend with the users test:test and test2:test2
-- `traefik.docker.network`: Set the docker network to use for connections to this container. If a container is linked to several networks, be sure to set the proper network name (you can check with docker inspect <container_id>) otherwise it will randomly pick one (depending on how docker is returning them). For instance when deploying docker `stack` from compose files, the compose defined networks will be prefixed with the `stack` name.
+- `traefik.frontend.whitelistSourceRange: "1.2.3.0/24, fe80::/16"`: List of IP-Ranges which are allowed to access. An unset or empty list allows all Source-IPs to access. If one of the Net-Specifications are invalid, the whole list is invalid and allows all Source-IPs to access.- `traefik.docker.network`: Set the docker network to use for connections to this container. If a container is linked to several networks, be sure to set the proper network name (you can check with docker inspect <container_id>) otherwise it will randomly pick one (depending on how docker is returning them). For instance when deploying docker `stack` from compose files, the compose defined networks will be prefixed with the `stack` name.
 
 If several ports need to be exposed from a container, the services labels can be used
 - `traefik.<service-name>.port=443`: create a service binding with frontend/backend using this port. Overrides `traefik.port`.
@@ -1186,6 +1193,13 @@ You can find here an example [ingress](https://raw.githubusercontent.com/contain
 Additionally, an annotation can be used on Kubernetes services to set the [circuit breaker expression](https://docs.traefik.io/basics/#backends) for a backend.
 
 - `traefik.backend.circuitbreaker: <expression>`: set the circuit breaker expression for the backend (Default: nil).
+
+As known from nginx when used as Kubernetes Ingress Controller, a List of IP-Ranges which are allowed to access can be configured by using an ingress annotation:
+
+- `ingress.kubernetes.io/whitelist-source-range: "1.2.3.0/24, fe80::/16"`
+
+An unset or empty list allows all Source-IPs to access. If one of the Net-Specifications are invalid, the whole list is invalid and allows all Source-IPs to access.
+
 
 ### Authentication
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,4 +1,4 @@
-hash: 1aa32496b865dda72d76c7cba3458f1c2c467acf0b99aab4609323f109aa64f6
+hash: e59e8244152a823cd3633fb09cdd583c4e5be78d7b50fb7047ba6b6a9ed5e8ec
 updated: 2017-05-02T11:46:23.91434995-04:00
 imports:
 - name: cloud.google.com/go

--- a/glide.lock
+++ b/glide.lock
@@ -391,6 +391,7 @@ imports:
   subpackages:
   - assert
   - mock
+  - require
 - name: github.com/thoas/stats
   version: 152b5d051953fdb6e45f14b6826962aadc032324
 - name: github.com/timewasted/linode

--- a/glide.yaml
+++ b/glide.yaml
@@ -49,7 +49,9 @@ import:
 - package: github.com/streamrail/concurrent-map
 - package: github.com/stretchr/testify
   subpackages:
+  - assert
   - mock
+  - require
 - package: github.com/thoas/stats
   version: 152b5d051953fdb6e45f14b6826962aadc032324
 - package: github.com/unrolled/render

--- a/middlewares/ip_whitelister_test.go
+++ b/middlewares/ip_whitelister_test.go
@@ -1,0 +1,308 @@
+package middlewares
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/codegangsta/negroni"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewIPWhitelister(t *testing.T) {
+	cases := []struct {
+		desc               string
+		whitelistStrings   []string
+		expectedWhitelists []*net.IPNet
+		errMessage         string
+	}{
+		{
+			desc:               "nil whitelist",
+			whitelistStrings:   nil,
+			expectedWhitelists: nil,
+			errMessage:         "no whitelists provided",
+		}, {
+			desc:               "empty whitelist",
+			whitelistStrings:   []string{},
+			expectedWhitelists: nil,
+			errMessage:         "no whitelists provided",
+		}, {
+			desc: "whitelist containing empty string",
+			whitelistStrings: []string{
+				"1.2.3.4/24",
+				"",
+				"fe80::/16",
+			},
+			expectedWhitelists: nil,
+			errMessage:         "parsing CIDR whitelist <nil>: invalid CIDR address: ",
+		}, {
+			desc: "whitelist containing only an empty string",
+			whitelistStrings: []string{
+				"",
+			},
+			expectedWhitelists: nil,
+			errMessage:         "parsing CIDR whitelist <nil>: invalid CIDR address: ",
+		}, {
+			desc: "whitelist containing an invalid string",
+			whitelistStrings: []string{
+				"foo",
+			},
+			expectedWhitelists: nil,
+			errMessage:         "parsing CIDR whitelist <nil>: invalid CIDR address: foo",
+		}, {
+			desc: "IPv4 & IPv6 whitelist",
+			whitelistStrings: []string{
+				"1.2.3.4/24",
+				"fe80::/16",
+			},
+			expectedWhitelists: []*net.IPNet{
+				{IP: net.IPv4(1, 2, 3, 0).To4(), Mask: net.IPv4Mask(255, 255, 255, 0)},
+				{IP: net.ParseIP("fe80::"), Mask: net.IPMask(net.ParseIP("ffff::"))},
+			},
+			errMessage: "",
+		}, {
+			desc: "IPv4 only",
+			whitelistStrings: []string{
+				"127.0.0.1/8",
+			},
+			expectedWhitelists: []*net.IPNet{
+				{IP: net.IPv4(127, 0, 0, 0).To4(), Mask: net.IPv4Mask(255, 0, 0, 0)},
+			},
+			errMessage: "",
+		},
+	}
+
+	for _, test := range cases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+			whitelister, err := NewIPWhitelister(test.whitelistStrings)
+			if test.errMessage != "" {
+				require.EqualError(t, err, test.errMessage)
+			} else {
+				require.NoError(t, err)
+				for index, actual := range whitelister.whitelists {
+					expected := test.expectedWhitelists[index]
+					assert.Equal(t, expected.IP, actual.IP)
+					assert.Equal(t, expected.Mask.String(), actual.Mask.String())
+				}
+			}
+		})
+	}
+}
+
+func TestIPWhitelisterHandle(t *testing.T) {
+	cases := []struct {
+		desc             string
+		whitelistStrings []string
+		passIPs          []string
+		rejectIPs        []string
+	}{
+		{
+			desc: "IPv4",
+			whitelistStrings: []string{
+				"1.2.3.4/24",
+			},
+			passIPs: []string{
+				"1.2.3.1",
+				"1.2.3.32",
+				"1.2.3.156",
+				"1.2.3.255",
+			},
+			rejectIPs: []string{
+				"1.2.16.1",
+				"1.2.32.1",
+				"127.0.0.1",
+				"8.8.8.8",
+			},
+		},
+		{
+			desc: "IPv4 single IP",
+			whitelistStrings: []string{
+				"8.8.8.8/32",
+			},
+			passIPs: []string{
+				"8.8.8.8",
+			},
+			rejectIPs: []string{
+				"8.8.8.7",
+				"8.8.8.9",
+				"8.8.8.0",
+				"8.8.8.255",
+				"4.4.4.4",
+				"127.0.0.1",
+			},
+		},
+		{
+			desc: "multiple IPv4",
+			whitelistStrings: []string{
+				"1.2.3.4/24",
+				"8.8.8.8/8",
+			},
+			passIPs: []string{
+				"1.2.3.1",
+				"1.2.3.32",
+				"1.2.3.156",
+				"1.2.3.255",
+				"8.8.4.4",
+				"8.0.0.1",
+				"8.32.42.128",
+				"8.255.255.255",
+			},
+			rejectIPs: []string{
+				"1.2.16.1",
+				"1.2.32.1",
+				"127.0.0.1",
+				"4.4.4.4",
+				"4.8.8.8",
+			},
+		},
+		{
+			desc: "IPv6",
+			whitelistStrings: []string{
+				"2a03:4000:6:d080::/64",
+			},
+			passIPs: []string{
+				"[2a03:4000:6:d080::]",
+				"[2a03:4000:6:d080::1]",
+				"[2a03:4000:6:d080:dead:beef:ffff:ffff]",
+				"[2a03:4000:6:d080::42]",
+			},
+			rejectIPs: []string{
+				"[2a03:4000:7:d080::]",
+				"[2a03:4000:7:d080::1]",
+				"[fe80::]",
+				"[4242::1]",
+			},
+		},
+		{
+			desc: "IPv6 single IP",
+			whitelistStrings: []string{
+				"2a03:4000:6:d080::42/128",
+			},
+			passIPs: []string{
+				"[2a03:4000:6:d080::42]",
+			},
+			rejectIPs: []string{
+				"[2a03:4000:6:d080::1]",
+				"[2a03:4000:6:d080:dead:beef:ffff:ffff]",
+				"[2a03:4000:6:d080::43]",
+			},
+		},
+		{
+			desc: "multiple IPv6",
+			whitelistStrings: []string{
+				"2a03:4000:6:d080::/64",
+				"fe80::/16",
+			},
+			passIPs: []string{
+				"[2a03:4000:6:d080::]",
+				"[2a03:4000:6:d080::1]",
+				"[2a03:4000:6:d080:dead:beef:ffff:ffff]",
+				"[2a03:4000:6:d080::42]",
+				"[fe80::1]",
+				"[fe80:aa00:00bb:4232:ff00:eeee:00ff:1111]",
+				"[fe80::fe80]",
+			},
+			rejectIPs: []string{
+				"[2a03:4000:7:d080::]",
+				"[2a03:4000:7:d080::1]",
+				"[4242::1]",
+			},
+		},
+		{
+			desc: "multiple IPv6 & IPv4",
+			whitelistStrings: []string{
+				"2a03:4000:6:d080::/64",
+				"fe80::/16",
+				"1.2.3.4/24",
+				"8.8.8.8/8",
+			},
+			passIPs: []string{
+				"[2a03:4000:6:d080::]",
+				"[2a03:4000:6:d080::1]",
+				"[2a03:4000:6:d080:dead:beef:ffff:ffff]",
+				"[2a03:4000:6:d080::42]",
+				"[fe80::1]",
+				"[fe80:aa00:00bb:4232:ff00:eeee:00ff:1111]",
+				"[fe80::fe80]",
+				"1.2.3.1",
+				"1.2.3.32",
+				"1.2.3.156",
+				"1.2.3.255",
+				"8.8.4.4",
+				"8.0.0.1",
+				"8.32.42.128",
+				"8.255.255.255",
+			},
+			rejectIPs: []string{
+				"[2a03:4000:7:d080::]",
+				"[2a03:4000:7:d080::1]",
+				"[4242::1]",
+				"1.2.16.1",
+				"1.2.32.1",
+				"127.0.0.1",
+				"4.4.4.4",
+				"4.8.8.8",
+			},
+		},
+		{
+			desc: "broken IP-addresses",
+			whitelistStrings: []string{
+				"127.0.0.1/32",
+			},
+			passIPs: nil,
+			rejectIPs: []string{
+				"foo",
+				"10.0.0.350",
+				"fe:::80",
+				"",
+				"\\&$§&/(",
+			},
+		},
+	}
+
+	for _, test := range cases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+			whitelister, err := NewIPWhitelister(test.whitelistStrings)
+
+			require.NoError(t, err)
+			require.NotNil(t, whitelister)
+
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintln(w, "traefik")
+			})
+			n := negroni.New(whitelister)
+			n.UseHandler(handler)
+
+			for _, testIP := range test.passIPs {
+				req, err := http.NewRequest("GET", "/", nil)
+				require.NoError(t, err)
+
+				req.RemoteAddr = testIP + ":2342"
+				recorder := httptest.NewRecorder()
+				n.ServeHTTP(recorder, req)
+
+				assert.Equal(t, http.StatusOK, recorder.Code, testIP+" should have passed "+test.desc)
+				assert.Contains(t, recorder.Body.String(), "traefik")
+			}
+
+			for _, testIP := range test.rejectIPs {
+				req, err := http.NewRequest("GET", "/", nil)
+				require.NoError(t, err)
+
+				req.RemoteAddr = testIP + ":2342"
+				recorder := httptest.NewRecorder()
+				n.ServeHTTP(recorder, req)
+
+				assert.Equal(t, http.StatusForbidden, recorder.Code, testIP+" should not have passed "+test.desc)
+				assert.NotContains(t, recorder.Body.String(), "traefik")
+			}
+		})
+	}
+}

--- a/middlewares/ip_witelister.go
+++ b/middlewares/ip_witelister.go
@@ -1,0 +1,83 @@
+package middlewares
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/codegangsta/negroni"
+	"github.com/containous/traefik/log"
+)
+
+// IPWhitelister is a middleware that provides Checks of the Requesting IP against a set of Whitelists
+type IPWhitelister struct {
+	handler    negroni.Handler
+	whitelists []*net.IPNet
+}
+
+// NewIPWhitelister builds a new IPWhitelister given a list of CIDR-Strings to whitelist
+func NewIPWhitelister(whitelistStrings []string) (*IPWhitelister, error) {
+	whitelister := IPWhitelister{}
+
+	if len(whitelistStrings) == 0 {
+		return nil, fmt.Errorf("no whitelists provided")
+	}
+
+	for _, whitelistString := range whitelistStrings {
+		_, whitelist, err := net.ParseCIDR(whitelistString)
+		if err != nil {
+			return nil, fmt.Errorf("parsing CIDR whitelist %s: %v", whitelist, err)
+		}
+		whitelister.whitelists = append(whitelister.whitelists, whitelist)
+	}
+
+	whitelister.handler = negroni.HandlerFunc(whitelister.handle)
+	log.Debugf("configured %u IP whitelists: %s", len(whitelister.whitelists), whitelister.whitelists)
+
+	return &whitelister, nil
+}
+
+func (whitelister *IPWhitelister) handle(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	remoteIP, err := ipFromRemoteAddr(r.RemoteAddr)
+	if err != nil {
+		log.Warnf("unable to parse remote-address from header: %s - rejecting", r.RemoteAddr)
+		reject(w)
+		return
+	}
+
+	for _, whitelist := range whitelister.whitelists {
+		if whitelist.Contains(*remoteIP) {
+			log.Debugf("source-IP %s matched whitelist %s - passing", remoteIP, whitelist)
+			next.ServeHTTP(w, r)
+			return
+		}
+	}
+
+	log.Debugf("source-IP %s matched none of the whitelists - rejecting", remoteIP)
+	reject(w)
+	return
+}
+
+func reject(w http.ResponseWriter) {
+	statusCode := http.StatusForbidden
+
+	w.WriteHeader(statusCode)
+	w.Write([]byte(http.StatusText(statusCode)))
+}
+func ipFromRemoteAddr(addr string) (*net.IP, error) {
+	ip, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("can't extract IP/Port from address %s: %s", addr, err)
+	}
+
+	userIP := net.ParseIP(ip)
+	if userIP == nil {
+		return nil, fmt.Errorf("can't parse IP from address %s", ip)
+	}
+
+	return &userIP, nil
+}
+
+func (whitelister *IPWhitelister) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	whitelister.handler.ServeHTTP(rw, r, next)
+}

--- a/provider/docker/docker.go
+++ b/provider/docker/docker.go
@@ -272,6 +272,7 @@ func (p *Provider) loadDockerConfig(containersInspected []dockerData) *types.Con
 		"getServicePassHostHeader":    p.getServicePassHostHeader,
 		"getServicePriority":          p.getServicePriority,
 		"getServiceBackend":           p.getServiceBackend,
+		"getWhitelistSourceRange":     p.getWhitelistSourceRange,
 	}
 	// filter containers
 	filteredContainers := fun.Filter(func(container dockerData) bool {
@@ -661,6 +662,15 @@ func (p *Provider) getPassHostHeader(container dockerData) string {
 		return passHostHeader
 	}
 	return "true"
+}
+
+func (p *Provider) getWhitelistSourceRange(container dockerData) []string {
+	var whitelistSourceRange []string
+
+	if whitelistSourceRangeLabel, err := getLabel(container, "traefik.frontend.whitelistSourceRange"); err == nil {
+		whitelistSourceRange = provider.SplitAndTrimString(whitelistSourceRangeLabel)
+	}
+	return whitelistSourceRange
 }
 
 func (p *Provider) getPriority(container dockerData) string {

--- a/provider/string_util.go
+++ b/provider/string_util.go
@@ -1,0 +1,19 @@
+package provider
+
+import "strings"
+
+// SplitAndTrimString splits separatedString at the comma character and trims each
+// piece, filtering out empty pieces. Returns the list of pieces or nil if the input
+// did not contain a non-empty piece.
+func SplitAndTrimString(separatedString string) []string {
+	listOfStrings := strings.Split(separatedString, ",")
+	var trimmedListOfStrings []string
+	for _, s := range listOfStrings {
+		s = strings.TrimSpace(s)
+		if len(s) > 0 {
+			trimmedListOfStrings = append(trimmedListOfStrings, s)
+		}
+	}
+
+	return trimmedListOfStrings
+}

--- a/provider/string_util_test.go
+++ b/provider/string_util_test.go
@@ -1,0 +1,61 @@
+package provider
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSplitAndTrimString(t *testing.T) {
+	cases := []struct {
+		desc     string
+		input    string
+		expected []string
+	}{
+		{
+			desc:     "empty string",
+			input:    "",
+			expected: nil,
+		}, {
+			desc:     "one piece",
+			input:    "foo",
+			expected: []string{"foo"},
+		}, {
+			desc:     "two pieces",
+			input:    "foo,bar",
+			expected: []string{"foo", "bar"},
+		}, {
+			desc:     "three pieces",
+			input:    "foo,bar,zoo",
+			expected: []string{"foo", "bar", "zoo"},
+		}, {
+			desc:     "two pieces with whitespace",
+			input:    " foo   ,  bar     ",
+			expected: []string{"foo", "bar"},
+		}, {
+			desc:     "consecutive commas",
+			input:    " foo   ,,  bar     ",
+			expected: []string{"foo", "bar"},
+		}, {
+			desc:     "consecutive commas with witespace",
+			input:    " foo   , ,  bar     ",
+			expected: []string{"foo", "bar"},
+		}, {
+			desc:     "leading and trailing commas",
+			input:    ",, foo   , ,  bar,, , ",
+			expected: []string{"foo", "bar"},
+		}, {
+			desc:     "no valid pieces",
+			input:    ",  , , ,, ,",
+			expected: nil,
+		},
+	}
+
+	for _, test := range cases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+			actual := SplitAndTrimString(test.input)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}

--- a/templates/docker.tmpl
+++ b/templates/docker.tmpl
@@ -43,6 +43,11 @@
   [frontends."frontend-{{getServiceBackend $container $serviceName}}"]
   backend = "backend-{{getServiceBackend $container $serviceName}}"
   passHostHeader = {{getServicePassHostHeader $container $serviceName}}
+  {{if getWhitelistSourceRange $container}}
+    whitelistSourceRange = [{{range getWhitelistSourceRange $container}}
+      "{{.}}",
+    {{end}}]
+  {{end}}
   priority = {{getServicePriority $container $serviceName}}
   entryPoints = [{{range getServiceEntryPoints $container $serviceName}}
     "{{.}}",
@@ -57,6 +62,11 @@
   [frontends."frontend-{{$frontend}}"]
   backend = "backend-{{getBackend $container}}"
   passHostHeader = {{getPassHostHeader $container}}
+  {{if getWhitelistSourceRange $container}}
+    whitelistSourceRange = [{{range getWhitelistSourceRange $container}}
+      "{{.}}",
+    {{end}}]
+  {{end}}
   priority = {{getPriority $container}}
   entryPoints = [{{range getEntryPoints $container}}
     "{{.}}",

--- a/templates/kubernetes.tmpl
+++ b/templates/kubernetes.tmpl
@@ -23,6 +23,9 @@
   basicAuth = [{{range $frontend.BasicAuth}}
       "{{.}}",
   {{end}}]
+  whitelistSourceRange = [{{range $frontend.WhitelistSourceRange}}
+    "{{.}}",
+  {{end}}]
     {{range $routeName, $route := $frontend.Routes}}
     [frontends."{{$frontendName}}".routes."{{$routeName}}"]
     rule = "{{$route.Rule}}"

--- a/types/types.go
+++ b/types/types.go
@@ -56,12 +56,13 @@ type Route struct {
 
 // Frontend holds frontend configuration.
 type Frontend struct {
-	EntryPoints    []string         `json:"entryPoints,omitempty"`
-	Backend        string           `json:"backend,omitempty"`
-	Routes         map[string]Route `json:"routes,omitempty"`
-	PassHostHeader bool             `json:"passHostHeader,omitempty"`
-	Priority       int              `json:"priority"`
-	BasicAuth      []string         `json:"basicAuth"`
+	EntryPoints          []string         `json:"entryPoints,omitempty"`
+	Backend              string           `json:"backend,omitempty"`
+	Routes               map[string]Route `json:"routes,omitempty"`
+	PassHostHeader       bool             `json:"passHostHeader,omitempty"`
+	Priority             int              `json:"priority"`
+	BasicAuth            []string         `json:"basicAuth"`
+	WhitelistSourceRange []string         `json:"whitelistSourceRange,omitempty"`
 }
 
 // LoadBalancerMethod holds the method of load balancing to use.

--- a/vendor/github.com/stretchr/testify/require/doc.go
+++ b/vendor/github.com/stretchr/testify/require/doc.go
@@ -1,0 +1,28 @@
+// Package require implements the same assertions as the `assert` package but
+// stops test execution when a test fails.
+//
+// Example Usage
+//
+// The following is a complete example using require in a standard test function:
+//    import (
+//      "testing"
+//      "github.com/stretchr/testify/require"
+//    )
+//
+//    func TestSomething(t *testing.T) {
+//
+//      var a string = "Hello"
+//      var b string = "Hello"
+//
+//      require.Equal(t, a, b, "The two words should be the same.")
+//
+//    }
+//
+// Assertions
+//
+// The `require` package have same global functions as in the `assert` package,
+// but instead of returning a boolean result they call `t.FailNow()`.
+//
+// Every assertion function also takes an optional string message as the final argument,
+// allowing custom error messages to be appended to the message the assertion method outputs.
+package require

--- a/vendor/github.com/stretchr/testify/require/forward_requirements.go
+++ b/vendor/github.com/stretchr/testify/require/forward_requirements.go
@@ -1,0 +1,16 @@
+package require
+
+// Assertions provides assertion methods around the
+// TestingT interface.
+type Assertions struct {
+	t TestingT
+}
+
+// New makes a new Assertions object for the specified TestingT.
+func New(t TestingT) *Assertions {
+	return &Assertions{
+		t: t,
+	}
+}
+
+//go:generate go run ../_codegen/main.go -output-package=require -template=require_forward.go.tmpl

--- a/vendor/github.com/stretchr/testify/require/require.go
+++ b/vendor/github.com/stretchr/testify/require/require.go
@@ -1,0 +1,429 @@
+/*
+* CODE GENERATED AUTOMATICALLY WITH github.com/stretchr/testify/_codegen
+* THIS FILE MUST NOT BE EDITED BY HAND
+ */
+
+package require
+
+import (
+	assert "github.com/stretchr/testify/assert"
+	http "net/http"
+	url "net/url"
+	time "time"
+)
+
+// Condition uses a Comparison to assert a complex condition.
+func Condition(t TestingT, comp assert.Comparison, msgAndArgs ...interface{}) {
+	if !assert.Condition(t, comp, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Contains asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//    assert.Contains(t, "Hello World", "World", "But 'Hello World' does contain 'World'")
+//    assert.Contains(t, ["Hello", "World"], "World", "But ["Hello", "World"] does contain 'World'")
+//    assert.Contains(t, {"Hello": "World"}, "Hello", "But {'Hello': 'World'} does contain 'Hello'")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if !assert.Contains(t, s, contains, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  assert.Empty(t, obj)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if !assert.Empty(t, object, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Equal asserts that two objects are equal.
+//
+//    assert.Equal(t, 123, 123, "123 and 123 should be equal")
+//
+// Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if !assert.Equal(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// EqualError asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//   actualObj, err := SomeFunction()
+//   assert.EqualError(t, err,  expectedErrorString, "An error was expected")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) {
+	if !assert.EqualError(t, theError, errString, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// EqualValues asserts that two objects are equal or convertable to the same types
+// and equal.
+//
+//    assert.EqualValues(t, uint32(123), int32(123), "123 and 123 should be equal")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if !assert.EqualValues(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Error asserts that a function returned an error (i.e. not `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if assert.Error(t, err, "An error was expected") {
+// 	   assert.Equal(t, err, expectedError)
+//   }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Error(t TestingT, err error, msgAndArgs ...interface{}) {
+	if !assert.Error(t, err, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Exactly asserts that two objects are equal is value and type.
+//
+//    assert.Exactly(t, int32(123), int64(123), "123 and 123 should NOT be equal")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if !assert.Exactly(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Fail reports a failure through
+func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
+	if !assert.Fail(t, failureMessage, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// FailNow fails test
+func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
+	if !assert.FailNow(t, failureMessage, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// False asserts that the specified value is false.
+//
+//    assert.False(t, myBool, "myBool should be false")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func False(t TestingT, value bool, msgAndArgs ...interface{}) {
+	if !assert.False(t, value, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// HTTPBodyContains asserts that a specified handler returns a
+// body that contains a string.
+//
+//  assert.HTTPBodyContains(t, myHandler, "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) {
+	if !assert.HTTPBodyContains(t, handler, method, url, values, str) {
+		t.FailNow()
+	}
+}
+
+// HTTPBodyNotContains asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//  assert.HTTPBodyNotContains(t, myHandler, "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) {
+	if !assert.HTTPBodyNotContains(t, handler, method, url, values, str) {
+		t.FailNow()
+	}
+}
+
+// HTTPError asserts that a specified handler returns an error status code.
+//
+//  assert.HTTPError(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values) {
+	if !assert.HTTPError(t, handler, method, url, values) {
+		t.FailNow()
+	}
+}
+
+// HTTPRedirect asserts that a specified handler returns a redirect status code.
+//
+//  assert.HTTPRedirect(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values) {
+	if !assert.HTTPRedirect(t, handler, method, url, values) {
+		t.FailNow()
+	}
+}
+
+// HTTPSuccess asserts that a specified handler returns a success status code.
+//
+//  assert.HTTPSuccess(t, myHandler, "POST", "http://www.google.com", nil)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values) {
+	if !assert.HTTPSuccess(t, handler, method, url, values) {
+		t.FailNow()
+	}
+}
+
+// Implements asserts that an object is implemented by the specified interface.
+//
+//    assert.Implements(t, (*MyInterface)(nil), new(MyObject), "MyObject")
+func Implements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if !assert.Implements(t, interfaceObject, object, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// InDelta asserts that the two numerals are within delta of each other.
+//
+// 	 assert.InDelta(t, math.Pi, (22 / 7.0), 0.01)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if !assert.InDelta(t, expected, actual, delta, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// InDeltaSlice is the same as InDelta, except it compares two slices.
+func InDeltaSlice(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if !assert.InDeltaSlice(t, expected, actual, delta, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// InEpsilon asserts that expected and actual have a relative error less than epsilon
+//
+// Returns whether the assertion was successful (true) or not (false).
+func InEpsilon(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if !assert.InEpsilon(t, expected, actual, epsilon, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
+func InEpsilonSlice(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if !assert.InEpsilonSlice(t, expected, actual, epsilon, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// IsType asserts that the specified objects are of the same type.
+func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if !assert.IsType(t, expectedType, object, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// JSONEq asserts that two JSON strings are equivalent.
+//
+//  assert.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
+	if !assert.JSONEq(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Len asserts that the specified object has specific length.
+// Len also fails if the object has a type that len() not accept.
+//
+//    assert.Len(t, mySlice, 3, "The size of slice is not 3")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) {
+	if !assert.Len(t, object, length, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Nil asserts that the specified object is nil.
+//
+//    assert.Nil(t, err, "err should be nothing")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if !assert.Nil(t, object, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NoError asserts that a function returned no error (i.e. `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if assert.NoError(t, err) {
+// 	   assert.Equal(t, actualObj, expectedObj)
+//   }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
+	if !assert.NoError(t, err, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//    assert.NotContains(t, "Hello World", "Earth", "But 'Hello World' does NOT contain 'Earth'")
+//    assert.NotContains(t, ["Hello", "World"], "Earth", "But ['Hello', 'World'] does NOT contain 'Earth'")
+//    assert.NotContains(t, {"Hello": "World"}, "Earth", "But {'Hello': 'World'} does NOT contain 'Earth'")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if !assert.NotContains(t, s, contains, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  if assert.NotEmpty(t, obj) {
+//    assert.Equal(t, "two", obj[1])
+//  }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if !assert.NotEmpty(t, object, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotEqual asserts that the specified values are NOT equal.
+//
+//    assert.NotEqual(t, obj1, obj2, "two objects shouldn't be equal")
+//
+// Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if !assert.NotEqual(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotNil asserts that the specified object is not nil.
+//
+//    assert.NotNil(t, err, "err should be something")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if !assert.NotNil(t, object, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//   assert.NotPanics(t, func(){
+//     RemainCalm()
+//   }, "Calling RemainCalm() should NOT panic")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if !assert.NotPanics(t, f, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotRegexp asserts that a specified regexp does not match a string.
+//
+//  assert.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
+//  assert.NotRegexp(t, "^start", "it's not starting")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if !assert.NotRegexp(t, rx, str, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotZero asserts that i is not the zero value for its type and returns the truth.
+func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
+	if !assert.NotZero(t, i, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Panics asserts that the code inside the specified PanicTestFunc panics.
+//
+//   assert.Panics(t, func(){
+//     GoCrazy()
+//   }, "Calling GoCrazy() should panic")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if !assert.Panics(t, f, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Regexp asserts that a specified regexp matches a string.
+//
+//  assert.Regexp(t, regexp.MustCompile("start"), "it's starting")
+//  assert.Regexp(t, "start...$", "it's not starting")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if !assert.Regexp(t, rx, str, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// True asserts that the specified value is true.
+//
+//    assert.True(t, myBool, "myBool should be true")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func True(t TestingT, value bool, msgAndArgs ...interface{}) {
+	if !assert.True(t, value, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// WithinDuration asserts that the two times are within duration delta of each other.
+//
+//   assert.WithinDuration(t, time.Now(), time.Now(), 10*time.Second, "The difference should not be more than 10s")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
+	if !assert.WithinDuration(t, expected, actual, delta, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Zero asserts that i is the zero value for its type and returns the truth.
+func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
+	if !assert.Zero(t, i, msgAndArgs...) {
+		t.FailNow()
+	}
+}

--- a/vendor/github.com/stretchr/testify/require/require_forward.go
+++ b/vendor/github.com/stretchr/testify/require/require_forward.go
@@ -1,0 +1,353 @@
+/*
+* CODE GENERATED AUTOMATICALLY WITH github.com/stretchr/testify/_codegen
+* THIS FILE MUST NOT BE EDITED BY HAND
+ */
+
+package require
+
+import (
+	assert "github.com/stretchr/testify/assert"
+	http "net/http"
+	url "net/url"
+	time "time"
+)
+
+// Condition uses a Comparison to assert a complex condition.
+func (a *Assertions) Condition(comp assert.Comparison, msgAndArgs ...interface{}) {
+	Condition(a.t, comp, msgAndArgs...)
+}
+
+// Contains asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//    a.Contains("Hello World", "World", "But 'Hello World' does contain 'World'")
+//    a.Contains(["Hello", "World"], "World", "But ["Hello", "World"] does contain 'World'")
+//    a.Contains({"Hello": "World"}, "Hello", "But {'Hello': 'World'} does contain 'Hello'")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	Contains(a.t, s, contains, msgAndArgs...)
+}
+
+// Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  a.Empty(obj)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) {
+	Empty(a.t, object, msgAndArgs...)
+}
+
+// Equal asserts that two objects are equal.
+//
+//    a.Equal(123, 123, "123 and 123 should be equal")
+//
+// Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	Equal(a.t, expected, actual, msgAndArgs...)
+}
+
+// EqualError asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//   actualObj, err := SomeFunction()
+//   a.EqualError(err,  expectedErrorString, "An error was expected")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) {
+	EqualError(a.t, theError, errString, msgAndArgs...)
+}
+
+// EqualValues asserts that two objects are equal or convertable to the same types
+// and equal.
+//
+//    a.EqualValues(uint32(123), int32(123), "123 and 123 should be equal")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	EqualValues(a.t, expected, actual, msgAndArgs...)
+}
+
+// Error asserts that a function returned an error (i.e. not `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if a.Error(err, "An error was expected") {
+// 	   assert.Equal(t, err, expectedError)
+//   }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Error(err error, msgAndArgs ...interface{}) {
+	Error(a.t, err, msgAndArgs...)
+}
+
+// Exactly asserts that two objects are equal is value and type.
+//
+//    a.Exactly(int32(123), int64(123), "123 and 123 should NOT be equal")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	Exactly(a.t, expected, actual, msgAndArgs...)
+}
+
+// Fail reports a failure through
+func (a *Assertions) Fail(failureMessage string, msgAndArgs ...interface{}) {
+	Fail(a.t, failureMessage, msgAndArgs...)
+}
+
+// FailNow fails test
+func (a *Assertions) FailNow(failureMessage string, msgAndArgs ...interface{}) {
+	FailNow(a.t, failureMessage, msgAndArgs...)
+}
+
+// False asserts that the specified value is false.
+//
+//    a.False(myBool, "myBool should be false")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) False(value bool, msgAndArgs ...interface{}) {
+	False(a.t, value, msgAndArgs...)
+}
+
+// HTTPBodyContains asserts that a specified handler returns a
+// body that contains a string.
+//
+//  a.HTTPBodyContains(myHandler, "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) {
+	HTTPBodyContains(a.t, handler, method, url, values, str)
+}
+
+// HTTPBodyNotContains asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//  a.HTTPBodyNotContains(myHandler, "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) {
+	HTTPBodyNotContains(a.t, handler, method, url, values, str)
+}
+
+// HTTPError asserts that a specified handler returns an error status code.
+//
+//  a.HTTPError(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url string, values url.Values) {
+	HTTPError(a.t, handler, method, url, values)
+}
+
+// HTTPRedirect asserts that a specified handler returns a redirect status code.
+//
+//  a.HTTPRedirect(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url string, values url.Values) {
+	HTTPRedirect(a.t, handler, method, url, values)
+}
+
+// HTTPSuccess asserts that a specified handler returns a success status code.
+//
+//  a.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url string, values url.Values) {
+	HTTPSuccess(a.t, handler, method, url, values)
+}
+
+// Implements asserts that an object is implemented by the specified interface.
+//
+//    a.Implements((*MyInterface)(nil), new(MyObject), "MyObject")
+func (a *Assertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	Implements(a.t, interfaceObject, object, msgAndArgs...)
+}
+
+// InDelta asserts that the two numerals are within delta of each other.
+//
+// 	 a.InDelta(math.Pi, (22 / 7.0), 0.01)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	InDelta(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InDeltaSlice is the same as InDelta, except it compares two slices.
+func (a *Assertions) InDeltaSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	InDeltaSlice(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InEpsilon asserts that expected and actual have a relative error less than epsilon
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) InEpsilon(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	InEpsilon(a.t, expected, actual, epsilon, msgAndArgs...)
+}
+
+// InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
+func (a *Assertions) InEpsilonSlice(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	InEpsilonSlice(a.t, expected, actual, epsilon, msgAndArgs...)
+}
+
+// IsType asserts that the specified objects are of the same type.
+func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
+	IsType(a.t, expectedType, object, msgAndArgs...)
+}
+
+// JSONEq asserts that two JSON strings are equivalent.
+//
+//  a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) {
+	JSONEq(a.t, expected, actual, msgAndArgs...)
+}
+
+// Len asserts that the specified object has specific length.
+// Len also fails if the object has a type that len() not accept.
+//
+//    a.Len(mySlice, 3, "The size of slice is not 3")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) {
+	Len(a.t, object, length, msgAndArgs...)
+}
+
+// Nil asserts that the specified object is nil.
+//
+//    a.Nil(err, "err should be nothing")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) {
+	Nil(a.t, object, msgAndArgs...)
+}
+
+// NoError asserts that a function returned no error (i.e. `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if a.NoError(err) {
+// 	   assert.Equal(t, actualObj, expectedObj)
+//   }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) {
+	NoError(a.t, err, msgAndArgs...)
+}
+
+// NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//    a.NotContains("Hello World", "Earth", "But 'Hello World' does NOT contain 'Earth'")
+//    a.NotContains(["Hello", "World"], "Earth", "But ['Hello', 'World'] does NOT contain 'Earth'")
+//    a.NotContains({"Hello": "World"}, "Earth", "But {'Hello': 'World'} does NOT contain 'Earth'")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	NotContains(a.t, s, contains, msgAndArgs...)
+}
+
+// NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  if a.NotEmpty(obj) {
+//    assert.Equal(t, "two", obj[1])
+//  }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) {
+	NotEmpty(a.t, object, msgAndArgs...)
+}
+
+// NotEqual asserts that the specified values are NOT equal.
+//
+//    a.NotEqual(obj1, obj2, "two objects shouldn't be equal")
+//
+// Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	NotEqual(a.t, expected, actual, msgAndArgs...)
+}
+
+// NotNil asserts that the specified object is not nil.
+//
+//    a.NotNil(err, "err should be something")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) {
+	NotNil(a.t, object, msgAndArgs...)
+}
+
+// NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//   a.NotPanics(func(){
+//     RemainCalm()
+//   }, "Calling RemainCalm() should NOT panic")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotPanics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	NotPanics(a.t, f, msgAndArgs...)
+}
+
+// NotRegexp asserts that a specified regexp does not match a string.
+//
+//  a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
+//  a.NotRegexp("^start", "it's not starting")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	NotRegexp(a.t, rx, str, msgAndArgs...)
+}
+
+// NotZero asserts that i is not the zero value for its type and returns the truth.
+func (a *Assertions) NotZero(i interface{}, msgAndArgs ...interface{}) {
+	NotZero(a.t, i, msgAndArgs...)
+}
+
+// Panics asserts that the code inside the specified PanicTestFunc panics.
+//
+//   a.Panics(func(){
+//     GoCrazy()
+//   }, "Calling GoCrazy() should panic")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Panics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	Panics(a.t, f, msgAndArgs...)
+}
+
+// Regexp asserts that a specified regexp matches a string.
+//
+//  a.Regexp(regexp.MustCompile("start"), "it's starting")
+//  a.Regexp("start...$", "it's not starting")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	Regexp(a.t, rx, str, msgAndArgs...)
+}
+
+// True asserts that the specified value is true.
+//
+//    a.True(myBool, "myBool should be true")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) True(value bool, msgAndArgs ...interface{}) {
+	True(a.t, value, msgAndArgs...)
+}
+
+// WithinDuration asserts that the two times are within duration delta of each other.
+//
+//   a.WithinDuration(time.Now(), time.Now(), 10*time.Second, "The difference should not be more than 10s")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
+	WithinDuration(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// Zero asserts that i is the zero value for its type and returns the truth.
+func (a *Assertions) Zero(i interface{}, msgAndArgs ...interface{}) {
+	Zero(a.t, i, msgAndArgs...)
+}

--- a/vendor/github.com/stretchr/testify/require/requirements.go
+++ b/vendor/github.com/stretchr/testify/require/requirements.go
@@ -1,0 +1,9 @@
+package require
+
+// TestingT is an interface wrapper around *testing.T
+type TestingT interface {
+	Errorf(format string, args ...interface{})
+	FailNow()
+}
+
+//go:generate go run ../_codegen/main.go -output-package=require -template=require.go.tmpl

--- a/webui/src/app/sections/providers/frontend-monitor/frontend-monitor.html
+++ b/webui/src/app/sections/providers/frontend-monitor/frontend-monitor.html
@@ -15,9 +15,14 @@
     </table>
   </div>
   <div data-bg-show="frontendCtrl.frontend.backend" class="panel-footer">
-    <span data-ng-repeat="entryPoint in frontendCtrl.frontend.entryPoints"><span class="label label-primary">{{entryPoint}}</span><span data-ng-hide="$last">&nbsp;</span></span>
+    <span data-ng-repeat="entryPoint in frontendCtrl.frontend.entryPoints">
+      <span class="label label-primary">{{entryPoint}}</span><span data-ng-hide="$last">&nbsp;</span>
+    </span>
     <span class="label label-warning" role="button" data-toggle="collapse" href="#{{frontendCtrl.frontend.backend}}" aria-expanded="false">Backend:{{frontendCtrl.frontend.backend}}</span>
     <span data-ng-show="frontendCtrl.frontend.passHostHeader" class="label label-warning">PassHostHeader</span>
+    <span data-ng-repeat="whitelistSourceRange in frontendCtrl.frontend.whitelistSourceRange">
+      <span class="label label-warning">Whitelist {{ whitelistSourceRange }}</span>
+    </span>
     <span data-ng-show="frontendCtrl.frontend.priority" class="label label-warning">Priority:{{frontendCtrl.frontend.priority}}</span>
   </div>
 </div>


### PR DESCRIPTION
This PR fixes #816. It adds the ability to specify a List of CIDR Whitelists per Frontend. If Whitelists are configured and the Request-IP does not match one of them, it is aborted with a 403 Forbidden.

This obviously requires traefik to be directly mapped on public ips, if the incoming requests are nat'ed, ie through dockers publish-functionality or docker-compose ports, traefik will only see an ip of the internal network and won't be able to filter according to the source-ip.

This PR adds support for the Docker-Provider and the Kubernetes-Provider, but it should be trivial to extend the support to other Providers, I just have no test-setup for those. For both it parses the Annoatation/Label "traefik.frontend.whitelistSourceRange", for Kubernetes it also accepts the quasi-standard "ingress.kubernetes.io/whitelist-source-range". They can take a Comma-Separated List of CIDR Nets (IPv4 & v6), like this:
```yml
machine:
  image: katacoda/docker-http-server
  labels:
    - "traefik.backend=local-only-echo"
    - "traefik.frontend.whitelistSourceRange="10.42.0.0/16, 152.89.1.33/32, afed:be44::/16"
    - "traefik.frontend.rule=Host:local-only-echo.example.com"
```

or for Kubernetes:
```yml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: hello-minikube
  annotations:
    traefik.frontend.whitelistSourceRange: "10.42.0.0/16, 152.89.1.33/32, afed:be44::/16"
spec:
  rules:
  - host: echo.kube
    http:
      paths:
      - path: /
        backend:
          serviceName: hello-minikube
          servicePort: web
```

For File-Based Config, there's the `whitelistSourceRange` property, which takes an array of CIDR Net-Strings:
```toml
[frontends]
  [frontends.frontend2]
  backend = "backend1"
  passHostHeader = true
  priority = 10
  whitelistSourceRange = ["10.42.0.0/16", "152.89.1.33/32", "afed:be44::/16"]
```

The applied Whitelists are Displayed on the Dashboard:
![whitelists-dashboard](https://cloud.githubusercontent.com/assets/142237/24220320/1c183ffe-0f4a-11e7-9407-94a139c704b9.png)

For my own personal use and for easy testing, I pushed a Docker-Image based on this PR:
https://hub.docker.com/r/mazdermind/traefik/tags/

I'd be happy to receive some feedback, because Go is still fairly new.
Best Regards,
Peter