### PR TITLE
Add global health check interval parameter.

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -269,6 +269,27 @@ Supported filters:
 # attempts = 3
 ```
 
+## Health check configuration
+```toml
+# Enable custom health check options.
+#
+# Optional
+#
+[healthcheck]
+
+# Set the default health check interval. Will only be effective if health check
+# paths are defined. Given provider-specific support, the value may be
+# overridden on a per-backend basis.
+# Can be provided in a format supported by [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration) or as raw
+# values (digits). If no units are provided, the value is parsed assuming
+# seconds.
+#
+# Optional
+# Default: "30s"
+#
+# interval = "30s"
+```
+
 ## ACME (Let's Encrypt) configuration
 
 ```toml

--- a/healthcheck/healthcheck.go
+++ b/healthcheck/healthcheck.go
@@ -2,6 +2,7 @@ package healthcheck
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 	"sync"
@@ -11,9 +12,6 @@ import (
 	"github.com/containous/traefik/safe"
 	"github.com/vulcand/oxy/roundrobin"
 )
-
-// DefaultInterval is the default health check interval.
-const DefaultInterval = 30 * time.Second
 
 var singleton *HealthCheck
 var once sync.Once
@@ -31,6 +29,10 @@ type Options struct {
 	Path     string
 	Interval time.Duration
 	LB       LoadBalancer
+}
+
+func (opt Options) String() string {
+	return fmt.Sprintf("[Path: %s Interval: %s]", opt.Path, opt.Interval)
 }
 
 // BackendHealthCheck HealthCheck configuration for a backend

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -27,6 +27,9 @@ import (
 	"github.com/containous/traefik/types"
 )
 
+// DefaultHealthCheckInterval is the default health check interval.
+const DefaultHealthCheckInterval = 30 * time.Second
+
 // TraefikConfiguration holds GlobalConfiguration and other stuff
 type TraefikConfiguration struct {
 	GlobalConfiguration `mapstructure:",squash"`
@@ -52,6 +55,7 @@ type GlobalConfiguration struct {
 	IdleTimeout               flaeg.Duration          `description:"maximum amount of time an idle (keep-alive) connection will remain idle before closing itself."`
 	InsecureSkipVerify        bool                    `description:"Disable SSL certificate verification"`
 	Retry                     *Retry                  `description:"Enable retry sending request if network error"`
+	HealthCheck               *HealthCheckConfig      `description:"Health check parameters"`
 	Docker                    *docker.Provider        `description:"Enable Docker backend"`
 	File                      *file.Provider          `description:"Enable File backend"`
 	Web                       *WebProvider            `description:"Enable Web backend"`
@@ -337,6 +341,11 @@ type Retry struct {
 	Attempts int `description:"Number of attempts"`
 }
 
+// HealthCheckConfig contains health check configuration parameters.
+type HealthCheckConfig struct {
+	Interval flaeg.Duration `description:"Default periodicity of enabled health checks"`
+}
+
 // NewTraefikDefaultPointersConfiguration creates a TraefikConfiguration with pointers default values
 func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 	//default Docker
@@ -461,6 +470,7 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 		Rancher:       &defaultRancher,
 		DynamoDB:      &defaultDynamoDB,
 		Retry:         &Retry{},
+		HealthCheck:   &HealthCheckConfig{},
 	}
 
 	//default Rancher
@@ -485,7 +495,10 @@ func NewTraefikConfiguration() *TraefikConfiguration {
 			ProvidersThrottleDuration: flaeg.Duration(2 * time.Second),
 			MaxIdleConnsPerHost:       200,
 			IdleTimeout:               flaeg.Duration(180 * time.Second),
-			CheckNewVersion:           true,
+			HealthCheck: &HealthCheckConfig{
+				Interval: flaeg.Duration(DefaultHealthCheckInterval),
+			},
+			CheckNewVersion: true,
 		},
 		ConfigFile: "",
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -659,8 +659,9 @@ func (server *Server) loadConfig(configurations configs, globalConfiguration Glo
 									log.Errorf("Skipping frontend %s...", frontendName)
 									continue frontend
 								}
-								hcOpts := parseHealthCheckOptions(rebalancer, frontend.Backend, configuration.Backends[frontend.Backend].HealthCheck)
+								hcOpts := parseHealthCheckOptions(rebalancer, frontend.Backend, configuration.Backends[frontend.Backend].HealthCheck, *globalConfiguration.HealthCheck)
 								if hcOpts != nil {
+									log.Debugf("Setting up backend health check %s", *hcOpts)
 									backendsHealthcheck[frontend.Backend] = healthcheck.NewBackendHealthCheck(*hcOpts)
 								}
 							}
@@ -685,8 +686,9 @@ func (server *Server) loadConfig(configurations configs, globalConfiguration Glo
 									continue frontend
 								}
 							}
-							hcOpts := parseHealthCheckOptions(rr, frontend.Backend, configuration.Backends[frontend.Backend].HealthCheck)
+							hcOpts := parseHealthCheckOptions(rr, frontend.Backend, configuration.Backends[frontend.Backend].HealthCheck, *globalConfiguration.HealthCheck)
 							if hcOpts != nil {
+								log.Debugf("Setting up backend health check %s", *hcOpts)
 								backendsHealthcheck[frontend.Backend] = healthcheck.NewBackendHealthCheck(*hcOpts)
 							}
 						}
@@ -847,12 +849,12 @@ func (server *Server) buildDefaultHTTPRouter() *mux.Router {
 	return router
 }
 
-func parseHealthCheckOptions(lb healthcheck.LoadBalancer, backend string, hc *types.HealthCheck) *healthcheck.Options {
+func parseHealthCheckOptions(lb healthcheck.LoadBalancer, backend string, hc *types.HealthCheck, hcConfig HealthCheckConfig) *healthcheck.Options {
 	if hc == nil || hc.Path == "" {
 		return nil
 	}
 
-	interval := healthcheck.DefaultInterval
+	interval := time.Duration(hcConfig.Interval)
 	if hc.Interval != "" {
 		intervalOverride, err := time.ParseDuration(hc.Interval)
 		switch {

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -311,6 +311,24 @@
 #
 # attempts = 3
 
+# Enable custom health check options.
+#
+# Optional
+#
+# [healthcheck]
+
+# Set the default health check interval. Will only be effective if health check
+# paths are defined. Given provider-specific support, the value may be
+# overridden on a per-backend basis.
+# Can be provided in a format supported by Go's time.ParseDuration function or
+# as raw values (digits). If no units are provided, the value is parsed assuming
+# seconds.
+#
+# Optional
+# Default: "30s"
+#
+# interval = "30s"
+
 ################################################################
 # Web configuration backend
 ################################################################


### PR DESCRIPTION
The new parameter allows to set a health check interval valid for all backends. Custom values set per provider may override the global one.

@containous/traefik Please review.