### PR TITLE
Add IdleConnTimeout to Traefik's http.server settings

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -36,7 +36,7 @@ type GlobalConfiguration struct {
 	DefaultEntryPoints        DefaultEntryPoints      `description:"Entrypoints to be used by frontends that do not specify any entrypoint"`
 	ProvidersThrottleDuration time.Duration           `description:"Backends throttle duration: minimum duration between 2 events from providers before applying a new configuration. It avoids unnecessary reloads if multiples events are sent in a short amount of time."`
 	MaxIdleConnsPerHost       int                     `description:"If non-zero, controls the maximum idle (keep-alive) to keep per-host.  If zero, DefaultMaxIdleConnsPerHost is used"`
-	IdleTimeout               time.Duration           `description:"maximum amount of time an idle (keep-alive) connection will remain idle before closing itself."`
+	IdleTimeout               flaeg.Duration          `description:"maximum amount of time an idle (keep-alive) connection will remain idle before closing itself."`
 	InsecureSkipVerify        bool                    `description:"Disable SSL certificate verification"`
 	Retry                     *Retry                  `description:"Enable retry sending request if network error"`
 	Docker                    *provider.Docker        `description:"Enable Docker backend"`
@@ -467,7 +467,7 @@ func NewTraefikConfiguration() *TraefikConfiguration {
 			DefaultEntryPoints:        []string{},
 			ProvidersThrottleDuration: time.Duration(2 * time.Second),
 			MaxIdleConnsPerHost:       200,
-			IdleTimeout:               time.Duration(180 * time.Second),
+			IdleTimeout:               flaeg.Duration(180 * time.Second),
 			CheckNewVersion:           true,
 		},
 		ConfigFile: "",

--- a/configuration.go
+++ b/configuration.go
@@ -36,6 +36,7 @@ type GlobalConfiguration struct {
 	DefaultEntryPoints        DefaultEntryPoints      `description:"Entrypoints to be used by frontends that do not specify any entrypoint"`
 	ProvidersThrottleDuration time.Duration           `description:"Backends throttle duration: minimum duration between 2 events from providers before applying a new configuration. It avoids unnecessary reloads if multiples events are sent in a short amount of time."`
 	MaxIdleConnsPerHost       int                     `description:"If non-zero, controls the maximum idle (keep-alive) to keep per-host.  If zero, DefaultMaxIdleConnsPerHost is used"`
+	IdleConnTimeout           time.Duration           `description:"maximum amount of time an idle (keep-alive) connection will remain idle before closing itself."`
 	InsecureSkipVerify        bool                    `description:"Disable SSL certificate verification"`
 	Retry                     *Retry                  `description:"Enable retry sending request if network error"`
 	Docker                    *provider.Docker        `description:"Enable Docker backend"`
@@ -466,6 +467,7 @@ func NewTraefikConfiguration() *TraefikConfiguration {
 			DefaultEntryPoints:        []string{},
 			ProvidersThrottleDuration: time.Duration(2 * time.Second),
 			MaxIdleConnsPerHost:       200,
+			IdleConnTimeout:           time.Duration(180 * time.Second),
 			CheckNewVersion:           true,
 		},
 		ConfigFile: "",

--- a/configuration.go
+++ b/configuration.go
@@ -36,7 +36,7 @@ type GlobalConfiguration struct {
 	DefaultEntryPoints        DefaultEntryPoints      `description:"Entrypoints to be used by frontends that do not specify any entrypoint"`
 	ProvidersThrottleDuration time.Duration           `description:"Backends throttle duration: minimum duration between 2 events from providers before applying a new configuration. It avoids unnecessary reloads if multiples events are sent in a short amount of time."`
 	MaxIdleConnsPerHost       int                     `description:"If non-zero, controls the maximum idle (keep-alive) to keep per-host.  If zero, DefaultMaxIdleConnsPerHost is used"`
-	IdleConnTimeout           time.Duration           `description:"maximum amount of time an idle (keep-alive) connection will remain idle before closing itself."`
+	IdleTimeout               time.Duration           `description:"maximum amount of time an idle (keep-alive) connection will remain idle before closing itself."`
 	InsecureSkipVerify        bool                    `description:"Disable SSL certificate verification"`
 	Retry                     *Retry                  `description:"Enable retry sending request if network error"`
 	Docker                    *provider.Docker        `description:"Enable Docker backend"`
@@ -467,7 +467,7 @@ func NewTraefikConfiguration() *TraefikConfiguration {
 			DefaultEntryPoints:        []string{},
 			ProvidersThrottleDuration: time.Duration(2 * time.Second),
 			MaxIdleConnsPerHost:       200,
-			IdleConnTimeout:           time.Duration(180 * time.Second),
+			IdleTimeout:               time.Duration(180 * time.Second),
 			CheckNewVersion:           true,
 		},
 		ConfigFile: "",

--- a/docs/toml.md
+++ b/docs/toml.md
@@ -69,6 +69,8 @@
 
 # IdleTimeout: maximum amount of time an idle (keep-alive) connection will remain idle before closing itself.
 # This is set to enforce closing of stale client connections.
+# Can be provided in a format supported by [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration) or as raw
+# values (digits). If no units are provided, the value is parsed assuming seconds.
 #
 # Optional
 # Default: "180s"

--- a/docs/toml.md
+++ b/docs/toml.md
@@ -62,6 +62,14 @@
 #
 # ProvidersThrottleDuration = "5"
 
+# IdleTimeout: maximum amount of time an idle (keep-alive) connection will remain idle before closing itself.
+# This is set to enforce closing of stale client connections.
+#
+# Optional
+# Default: "180s"
+#
+# IdleTimeout = "360s"
+
 # If non-zero, controls the maximum idle (keep-alive) to keep per-host.  If zero, DefaultMaxIdleConnsPerHost is used.
 # If you encounter 'too many open files' errors, you can either change this value, or change `ulimit` value.
 #
@@ -1637,7 +1645,7 @@ RefreshSeconds = 15
 
 ```
 
-Items in the dynamodb table must have three attributes: 
+Items in the dynamodb table must have three attributes:
 
 
 - 'id' : string
@@ -1645,4 +1653,4 @@ Items in the dynamodb table must have three attributes:
 - 'name' : string
     - The name is used as the name of the frontend or backend.
 - 'frontend' or 'backend' : map
-    - This attribute's structure matches exactly the structure of a Frontend or Backend type in traefik. See types/types.go for details. The presence or absence of this attribute determines its type. So an item should never have both a 'frontend' and a 'backend' attribute. 
+    - This attribute's structure matches exactly the structure of a Frontend or Backend type in traefik. See types/types.go for details. The presence or absence of this attribute determines its type. So an item should never have both a 'frontend' and a 'backend' attribute.

--- a/docs/user-guide/examples.md
+++ b/docs/user-guide/examples.md
@@ -131,3 +131,10 @@ defaultEntryPoints = ["http"]
     [entryPoints.http.auth.basic]
     users = ["test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/", "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"]
 ```
+
+## Override the Traefik HTTP server IdleTimeout and/or throttle configurations from re-loading too quickly
+
+```
+IdleTimeout = "360s"
+ProvidersThrottleDuration = "5s"
+```

--- a/server.go
+++ b/server.go
@@ -533,7 +533,7 @@ func (server *Server) prepareServer(entryPointName string, router *middlewares.H
 		Addr:        entryPoint.Address,
 		Handler:     negroni,
 		TLSConfig:   tlsConfig,
-		IdleTimeout: server.globalConfiguration.IdleConnTimeout,
+		IdleTimeout: server.globalConfiguration.IdleTimeout,
 	}, nil
 }
 

--- a/server.go
+++ b/server.go
@@ -21,8 +21,6 @@ import (
 	"syscall"
 	"time"
 
-	"sync"
-
 	"github.com/codegangsta/negroni"
 	"github.com/containous/mux"
 	"github.com/containous/traefik/cluster"
@@ -536,7 +534,7 @@ func (server *Server) prepareServer(entryPointName string, router *middlewares.H
 		Addr:        entryPoint.Address,
 		Handler:     negroni,
 		TLSConfig:   tlsConfig,
-		IdleTimeout: server.globalConfiguration.IdleTimeout,
+		IdleTimeout: time.Duration(server.globalConfiguration.IdleTimeout),
 	}, nil
 }
 

--- a/server.go
+++ b/server.go
@@ -17,10 +17,9 @@ import (
 	"reflect"
 	"regexp"
 	"sort"
+	"sync"
 	"syscall"
 	"time"
-
-	"sync"
 
 	"github.com/codegangsta/negroni"
 	"github.com/containous/mux"

--- a/server.go
+++ b/server.go
@@ -20,6 +20,8 @@ import (
 	"syscall"
 	"time"
 
+	"sync"
+
 	"github.com/codegangsta/negroni"
 	"github.com/containous/mux"
 	"github.com/containous/traefik/cluster"
@@ -35,7 +37,6 @@ import (
 	"github.com/vulcand/oxy/forward"
 	"github.com/vulcand/oxy/roundrobin"
 	"github.com/vulcand/oxy/utils"
-	"sync"
 )
 
 var oxyLogger = &OxyLogger{}
@@ -529,9 +530,10 @@ func (server *Server) prepareServer(entryPointName string, router *middlewares.H
 	}
 
 	return &http.Server{
-		Addr:      entryPoint.Address,
-		Handler:   negroni,
-		TLSConfig: tlsConfig,
+		Addr:        entryPoint.Address,
+		Handler:     negroni,
+		TLSConfig:   tlsConfig,
+		IdleTimeout: server.globalConfiguration.IdleConnTimeout,
 	}, nil
 }
 


### PR DESCRIPTION
Without enforcing a timeout Traefik is susceptible to resource leakage, particularly when deployed as a public facing proxy exposed to the Internet.

Make sure IdleTimeout is configurable via the traefik.toml file

Set the default to be 180 seconds