### PR TITLE
Improve rancher provider handling of service and container health states

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -1604,12 +1604,25 @@ domain = "rancher.localhost"
 #
 Watch = true
 
+# Polling interval (in seconds)
+#
+# Optional
+#
+RefreshSeconds = 15
+
 # Expose Rancher services by default in traefik
 #
 # Optional
 # Default: true
 #
 ExposedByDefault = false
+
+# Filter services with unhealthy states and health states
+#
+# Optional
+# Default: false
+#
+EnableServiceHealthFilter = false
 
 # Endpoint to use when connecting to Rancher
 #

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -446,6 +446,8 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 	var defaultRancher rancher.Provider
 	defaultRancher.Watch = true
 	defaultRancher.ExposedByDefault = true
+	defaultRancher.RefreshSeconds = 15
+	defaultRancher.EnableServiceHealthFilter = false
 
 	// default DynamoDB
 	var defaultDynamoDB dynamodb.Provider

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -1046,12 +1046,25 @@
 #
 # Watch = true
 
+# Polling interval (in seconds)
+#
+# Optional
+#
+# RefreshSeconds = 15
+
 # Expose Rancher services by default in traefik
 #
 # Optional
 # Default: true
 #
 # ExposedByDefault = false
+
+# Filter services with unhealthy states and health states
+#
+# Optional
+# Default: false
+#
+# EnableServiceHealthFilter = false
 
 # Endpoint to use when connecting to Rancher
 #


### PR DESCRIPTION
This pull request aims to fix some basic issues which impact the usability of the rancher provider. During my testing with the rancher provider I found that services which did not have a healthy state were removed from the traefik config. In practice we should not care about the health of a service, but only about the health of that services individual containers. As a result I've made the following changes:

1. By default, we no longer filter services by their `HealthState`. A modified version of this functionality may be enabled using the 'EnableServiceHealthFilter' configuration toggle. This is particularly useful for 'advanced' configurations such as doing blue/green deployments.
2. A `RefreshSeconds` configuration parameter has been added (much like in the ECS provider) for configuring how often the Rancher API is queried.
2. Both containers and services are filtered by a combination of their `HealthState` and `State` due to the behavior of the Rancher API.
3. `healthy` and `upgrading-healthy` are considered to be a healthy `HealthState` for containers and services.
4.  `active`, `updating-active` and `upgraded` are considered to be a healthy `State` for services.
5. `running` and `updating-running` are considered to be a healthy `State` for containers.

If anyone has any feedback or test results please feel free to share them with me here or in #rancher on the Traefik Slack.

Fixes #1253 