### PR TITLE
[Marathon] Detect proper hostname automatically.

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -969,6 +969,16 @@ domain = "marathon.localhost"
 # Default: "10s"
 #
 # keepAlive = "10s"
+
+# By default, a task's IP address (as returned by the Marathon API) is used as 
+# backend server if an IP-per-task configuration can be found; otherwise, the
+# name of the host running the task is used.
+# The latter behavior can be enforced by enabling this switch.
+# 
+# Optional
+# Default: false
+#
+# forceTaskHostname: false 
 ```
 
 Labels can be used on containers to override default behaviour:

--- a/provider/marathon/marathon_test.go
+++ b/provider/marathon/marathon_test.go
@@ -1,7 +1,6 @@
 package marathon
 
 import (
-	"encoding/json"
 	"errors"
 	"reflect"
 	"testing"
@@ -11,6 +10,7 @@ import (
 	"github.com/containous/traefik/mocks"
 	"github.com/containous/traefik/testhelpers"
 	"github.com/containous/traefik/types"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/gambol99/go-marathon"
 	"github.com/stretchr/testify/mock"
 )
@@ -360,14 +360,10 @@ func TestMarathonLoadConfig(t *testing.T) {
 			} else {
 				// Compare backends
 				if !reflect.DeepEqual(actualConfig.Backends, c.expectedBackends) {
-					expected, _ := json.Marshal(c.expectedBackends)
-					actual, _ := json.Marshal(actualConfig.Backends)
-					t.Fatalf("expected\t %s\n, \tgot %s\n", expected, actual)
+					t.Errorf("got %v, want %v", spew.Sdump(actualConfig.Backends), spew.Sdump(c.expectedBackends))
 				}
 				if !reflect.DeepEqual(actualConfig.Frontends, c.expectedFrontends) {
-					expected, _ := json.Marshal(c.expectedFrontends)
-					actual, _ := json.Marshal(actualConfig.Frontends)
-					t.Fatalf("expected\t %s\n, got\t %s\n", expected, actual)
+					t.Errorf("got %v, want %v", spew.Sdump(actualConfig.Frontends), spew.Sdump(c.expectedFrontends))
 				}
 			}
 		})

--- a/provider/marathon/marathon_test.go
+++ b/provider/marathon/marathon_test.go
@@ -344,7 +344,8 @@ func TestMarathonLoadConfig(t *testing.T) {
 		if len(c.applications.Apps) > 0 {
 			appID = c.applications.Apps[0].ID
 		}
-		t.Run(fmt.Sprintf("Running case: %s", appID), func(t *testing.T) {
+		t.Run(fmt.Sprintf("app ID: %s", appID), func(t *testing.T) {
+			t.Parallel()
 			fakeClient := newFakeClient(c.applicationsError, c.applications, c.tasksError, c.tasks)
 			provider := &Provider{
 				Domain:           "docker.localhost",
@@ -355,15 +356,15 @@ func TestMarathonLoadConfig(t *testing.T) {
 			fakeClient.AssertExpectations(t)
 			if c.expectedNil {
 				if actualConfig != nil {
-					t.Fatalf("Should have been nil, got %v", actualConfig)
+					t.Fatalf("configuration should have been nil, got %v", actualConfig)
 				}
 			} else {
 				// Compare backends
 				if !reflect.DeepEqual(actualConfig.Backends, c.expectedBackends) {
-					t.Errorf("got %v, want %v", spew.Sdump(actualConfig.Backends), spew.Sdump(c.expectedBackends))
+					t.Errorf("got backend %v, want %v", spew.Sdump(actualConfig.Backends), spew.Sdump(c.expectedBackends))
 				}
 				if !reflect.DeepEqual(actualConfig.Frontends, c.expectedFrontends) {
-					t.Errorf("got %v, want %v", spew.Sdump(actualConfig.Frontends), spew.Sdump(c.expectedFrontends))
+					t.Errorf("got frontend %v, want %v", spew.Sdump(actualConfig.Frontends), spew.Sdump(c.expectedFrontends))
 				}
 			}
 		})
@@ -1510,7 +1511,7 @@ func TestGetBackendServer(t *testing.T) {
 	}
 
 	for _, app := range applications {
-		t.Run(fmt.Sprintf("running %s", app.application.ID), func(t *testing.T) {
+		t.Run(app.application.ID, func(t *testing.T) {
 			provider := &Provider{}
 			provider.ForceTaskHostname = app.forceTaskHostname
 

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -599,6 +599,16 @@
 #
 # keepAlive = "10s"
 
+# By default, a task's IP address (as returned by the Marathon API) is used as 
+# backend server if an IP-per-task configuration can be found; otherwise, the
+# name of the host running the task is used.
+# The latter behavior can be enforced by enabling this switch.
+# 
+# Optional
+# Default: false
+#
+# forceTaskHostname: false 
+
 ################################################################
 # Mesos configuration backend
 ################################################################


### PR DESCRIPTION
  The IP-Per-Task feature changed the behavior for
clients without this configuration (using the task IP instead
of task hostname). This patch make the new behavior available
just for Mesos installation with IP-Per-Task enabled. It also
make it possible to force the use of task's hostname.