### PR TITLE
License 2017, Træfɪk => Træfik

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -31,7 +31,7 @@ traefik*
 ###### Setting up your `go` environment
 
 - You need `go` v1.7+
-- It is recommended you clone Træfɪk into a directory like `~/go/src/github.com/containous/traefik` (This is the official golang workspace hierarchy, and will allow dependencies to resolve properly)
+- It is recommended you clone Træfik into a directory like `~/go/src/github.com/containous/traefik` (This is the official golang workspace hierarchy, and will allow dependencies to resolve properly)
 - This will allow your `GOPATH` and `PATH` variable to be set to `~/go` via:
 ```
 $ export GOPATH=~/go

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Containous SAS, Emile Vauge, emile@vauge.com
+Copyright (c) 2016-2017 Containous SAS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 <p align="center">
-<img src="docs/img/traefik.logo.png" alt="Træfɪk" title="Træfɪk" />
+<img src="docs/img/traefik.logo.png" alt="Træfik" title="Træfik" />
 </p>
 
 [![Build Status](https://travis-ci.org/containous/traefik.svg?branch=master)](https://travis-ci.org/containous/traefik)
@@ -28,16 +28,16 @@ But a microservices architecture is dynamic... Services are added, removed, kill
 
 Traditional reverse-proxies are not natively dynamic. You can't change their configuration and hot-reload easily.
 
-Here enters Træfɪk.
+Here enters Træfik.
 
 ![Architecture](docs/img/architecture.png)
 
-Træfɪk can listen to your service registry/orchestrator API, and knows each time a microservice is added, removed, killed or upgraded, and can generate its configuration automatically.
+Træfik can listen to your service registry/orchestrator API, and knows each time a microservice is added, removed, killed or upgraded, and can generate its configuration automatically.
 Routes to your services will be created instantly.
 
 Run it and forget it!
-
-
+  
+  
 
 
 ## Features
@@ -64,15 +64,15 @@ Run it and forget it!
 
 ## Quickstart
 
-You can have a quick look at Træfɪk in this [Katacoda tutorial](https://www.katacoda.com/courses/traefik/deploy-load-balancer) that shows how to load balance requests between multiple Docker containers.
+You can have a quick look at Træfik in this [Katacoda tutorial](https://www.katacoda.com/courses/traefik/deploy-load-balancer) that shows how to load balance requests between multiple Docker containers.
 
 Here is a talk given by [Ed Robinson](https://github.com/errm) at the [ContainerCamp UK](https://container.camp) conference.
-You will learn fundamental Træfɪk features and see some demos with Kubernetes.
+You will learn fundamental Træfik features and see some demos with Kubernetes.
 
 [![Traefik ContainerCamp UK](http://img.youtube.com/vi/aFtpIShV60I/0.jpg)](https://www.youtube.com/watch?v=aFtpIShV60I)
 
-Here is a talk (in French) given by [Emile Vauge](https://github.com/emilevauge) at the [Devoxx France 2016](http://www.devoxx.fr) conference.
-You will learn fundamental Træfɪk features and see some demos with Docker, Mesos/Marathon and Let's Encrypt.
+Here is a talk (in French) given by [Emile Vauge](https://github.com/emilevauge) at the [Devoxx France 2016](http://www.devoxx.fr) conference. 
+You will learn fundamental Træfik features and see some demos with Docker, Mesos/Marathon and Let's Encrypt. 
 
 [![Traefik Devoxx France](http://img.youtube.com/vi/QvAz9mVx5TI/0.jpg)](http://www.youtube.com/watch?v=QvAz9mVx5TI)
 
@@ -126,33 +126,6 @@ Please note that this project is released with a [Contributor Code of Conduct](C
 
 You can join [![Join the chat at https://traefik.herokuapp.com](https://img.shields.io/badge/style-register-green.svg?style=social&label=Slack)](https://traefik.herokuapp.com) to get basic support.
 If you prefer commercial support, please contact [containo.us](https://containo.us) by mail: <mailto:support@containo.us>.
-
-## Træfɪk here and there
-
-These projects use Træfɪk internally. If your company uses Træfɪk, we would be glad to get your feedback :) Contact us on [![Join the chat at https://traefik.herokuapp.com](https://img.shields.io/badge/style-register-green.svg?style=social&label=Slack)](https://traefik.herokuapp.com)
-
-- Project [Mantl](https://mantl.io/) from Cisco
-
-![Web UI Providers](docs/img/mantl-logo.png)
-> Mantl is a modern platform for rapidly deploying globally distributed services. A container orchestrator, docker, a network stack, something to pool your logs, something to monitor health, a sprinkle of service discovery and some automation.
-
-- Project [Apollo](http://capgemini.github.io/devops/apollo/) from Cap Gemini
-
-![Web UI Providers](docs/img/apollo-logo.png)
-> Apollo is an open source project to aid with building and deploying IAAS and PAAS services. It is particularly geared towards managing containerized applications across multiple hosts, and big data type workloads. Apollo leverages other open source components to provide basic mechanisms for deployment, maintenance, and scaling of infrastructure and applications.
-
-## Partners
-
-[![Zenika](docs/img/zenika.logo.png)](https://zenika.com)
-
-Zenika is one of the leading providers of professional Open Source services and agile methodologies in
-Europe. We provide consulting, development, training and support for the world’s leading Open Source
-software products.
-
-
-[![Asteris](docs/img/asteris.logo.png)](https://aster.is)
-
-Founded in 2014, Asteris creates next-generation infrastructure software for the modern datacenter. Asteris writes software that makes it easy for companies to implement continuous delivery and realtime data pipelines. We support the HashiCorp stack, along with Kubernetes, Apache Mesos, Spark and Kafka. We're core committers on mantl.io, consul-cli and mesos-consul.
 
 ## Maintainers
 

--- a/README.md
+++ b/README.md
@@ -140,4 +140,8 @@ If you prefer commercial support, please contact [containo.us](https://containo.
 
 ## Credits
 
-Kudos to [Peka](http://peka.byethost11.com/photoblog/) for his awesome work on the logo ![logo](docs/img/traefik.icon.png)
+Kudos to [Peka](http://peka.byethost11.com/photoblog/) for his awesome work on the logo ![logo](docs/img/traefik.icon.png).
+Traefik's logo licensed under the Creative Commons 3.0 Attributions license.
+
+Traefik's logo was inspired by the gopher stickers made by Takuya Ueda (https://twitter.com/tenntenn).
+The original Go gopher was designed by Renee French (http://reneefrench.blogspot.com/).

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -13,12 +13,12 @@ Let's take our example from the [overview](https://docs.traefik.io/#overview) ag
 
 > ![Architecture](img/architecture.png)
 
-Let's zoom on Træfɪk and have an overview of its internal architecture:
+Let's zoom on Træfik and have an overview of its internal architecture:
 
 
 ![Architecture](img/internal.png)
 
-- Incoming requests end on [entrypoints](#entrypoints), as the name suggests, they are the network entry points into Træfɪk (listening port, SSL, traffic redirection...).
+- Incoming requests end on [entrypoints](#entrypoints), as the name suggests, they are the network entry points into Træfik (listening port, SSL, traffic redirection...).
 - Traffic is then forwarded to a matching [frontend](#frontends). A frontend defines routes from [entrypoints](#entrypoints) to [backends](#backends).
 Routes are created using requests fields (`Host`, `Path`, `Headers`...) and can match or not a request.
 - The [frontend](#frontends) will then send the request to a [backend](#backends). A backend can be composed by one or more [servers](#servers), and by a load-balancing strategy.
@@ -26,7 +26,7 @@ Routes are created using requests fields (`Host`, `Path`, `Headers`...) and can 
 
 ## Entrypoints
 
-Entrypoints are the network entry points into Træfɪk.
+Entrypoints are the network entry points into Træfik.
 They can be defined using:
 
 - a port (80, 443...)
@@ -324,17 +324,17 @@ Here is an example of backends and servers definition:
 
 # Configuration
 
-Træfɪk's configuration has two parts: 
+Træfik's configuration has two parts: 
 
-- The [static Træfɪk configuration](/basics#static-trfk-configuration) which is loaded only at the beginning. 
-- The [dynamic Træfɪk configuration](/basics#dynamic-trfk-configuration) which can be hot-reloaded (no need to restart the process).
+- The [static Træfik configuration](/basics#static-trfk-configuration) which is loaded only at the beginning. 
+- The [dynamic Træfik configuration](/basics#dynamic-trfk-configuration) which can be hot-reloaded (no need to restart the process).
 
 
-## Static Træfɪk configuration
+## Static Træfik configuration
 
 The static configuration is the global configuration which is setting up connections to configuration backends and entrypoints. 
 
-Træfɪk can be configured using many configuration sources with the following precedence order. 
+Træfik can be configured using many configuration sources with the following precedence order. 
 Each item takes precedence over the item below it:
 
 - [Key-value Store](/basics/#key-value-stores)
@@ -346,7 +346,7 @@ It means that arguments override configuration file, and Key-value Store overrid
 
 ### Configuration file
 
-By default, Træfɪk will try to find a `traefik.toml` in the following places:
+By default, Træfik will try to find a `traefik.toml` in the following places:
 
 - `/etc/traefik/`
 - `$HOME/.traefik/`
@@ -372,7 +372,7 @@ Note that all default values will be displayed as well.
 
 ### Key-value stores
 
-Træfɪk supports several Key-value stores:
+Træfik supports several Key-value stores:
 
 - [Consul](https://consul.io)
 - [etcd](https://coreos.com/etcd/)
@@ -381,7 +381,7 @@ Træfɪk supports several Key-value stores:
 
 Please refer to the [User Guide Key-value store configuration](/user-guide/kv-config/) section to get documentation on it.
 
-## Dynamic Træfɪk configuration
+## Dynamic Træfik configuration
 
 The dynamic configuration concerns : 
 
@@ -389,9 +389,9 @@ The dynamic configuration concerns :
 - [Backends](/basics/#backends) 
 - [Servers](/basics/#servers) 
 
-Træfɪk can hot-reload those rules which could be provided by [multiple configuration backends](/toml/#configuration-backends).
+Træfik can hot-reload those rules which could be provided by [multiple configuration backends](/toml/#configuration-backends).
 
-We only need to enable `watch` option to make Træfɪk watch configuration backend changes and generate its configuration automatically.
+We only need to enable `watch` option to make Træfik watch configuration backend changes and generate its configuration automatically.
 Routes to services will be created and updated instantly at any changes.
 
 Please refer to the [configuration backends](/toml/#configuration-backends) section to get documentation on it.
@@ -400,10 +400,10 @@ Please refer to the [configuration backends](/toml/#configuration-backends) sect
 
 Usage: `traefik [command] [--flag=flag_argument]`
 
-List of Træfɪk available commands with description :                                                             
+List of Træfik available commands with description :                                                             
 
 - `version` : Print version 
-- `storeconfig` : Store the static traefik configuration into a Key-value stores. Please refer to the [Store Træfɪk configuration](/user-guide/kv-config/#store-trfk-configuration) section to get documentation on it.
+- `storeconfig` : Store the static traefik configuration into a Key-value stores. Please refer to the [Store Træfik configuration](/user-guide/kv-config/#store-trfk-configuration) section to get documentation on it.
 
 Each command may have related flags. 
 All those related flags will be displayed with :

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 <p align="center">
-<img src="img/traefik.logo.png" alt="Træfɪk" title="Træfɪk" />
+<img src="img/traefik.logo.png" alt="Træfik" title="Træfik" />
 </p>
 
 [![Build Status](https://travis-ci.org/containous/traefik.svg?branch=master)](https://travis-ci.org/containous/traefik)
@@ -26,11 +26,11 @@ But a microservices architecture is dynamic... Services are added, removed, kill
 
 Traditional reverse-proxies are not natively dynamic. You can't change their configuration and hot-reload easily.
 
-Here enters Træfɪk.
+Here enters Træfik.
 
 ![Architecture](img/architecture.png)
 
-Træfɪk can listen to your service registry/orchestrator API, and knows each time a microservice is added, removed, killed or upgraded, and can generate its configuration automatically.
+Træfik can listen to your service registry/orchestrator API, and knows each time a microservice is added, removed, killed or upgraded, and can generate its configuration automatically.
 Routes to your services will be created instantly.
 
 Run it and forget it!
@@ -38,15 +38,15 @@ Run it and forget it!
 
 ## Quickstart
 
-You can have a quick look at Træfɪk in this [Katacoda tutorial](https://www.katacoda.com/courses/traefik/deploy-load-balancer) that shows how to load balance requests between multiple Docker containers.
+You can have a quick look at Træfik in this [Katacoda tutorial](https://www.katacoda.com/courses/traefik/deploy-load-balancer) that shows how to load balance requests between multiple Docker containers.
 
 Here is a talk given by [Ed Robinson](https://github.com/errm) at the [ContainerCamp UK](https://container.camp) conference.
-You will learn fundamental Træfɪk features and see some demos with Kubernetes.
+You will learn fundamental Træfik features and see some demos with Kubernetes.
 
 [![Traefik ContainerCamp UK](http://img.youtube.com/vi/aFtpIShV60I/0.jpg)](https://www.youtube.com/watch?v=aFtpIShV60I)
 
 Here is a talk (in French) given by [Emile Vauge](https://github.com/emilevauge) at the [Devoxx France 2016](http://www.devoxx.fr) conference. 
-You will learn fundamental Træfɪk features and see some demos with Docker, Mesos/Marathon and Let's Encrypt. 
+You will learn fundamental Træfik features and see some demos with Docker, Mesos/Marathon and Let's Encrypt. 
 
 [![Traefik Devoxx France](http://img.youtube.com/vi/QvAz9mVx5TI/0.jpg)](http://www.youtube.com/watch?v=QvAz9mVx5TI)
 
@@ -70,7 +70,7 @@ docker run -d -p 8080:8080 -p 80:80 -v $PWD/traefik.toml:/etc/traefik/traefik.to
 
 ## Test it
 
-You can test Træfɪk easily using [Docker compose](https://docs.docker.com/compose), with this `docker-compose.yml` file in a folder named `traefik`:
+You can test Træfik easily using [Docker compose](https://docs.docker.com/compose), with this `docker-compose.yml` file in a folder named `traefik`:
 
 ```yaml
 version: '2'
@@ -97,7 +97,7 @@ Start it from within the `traefik` folder:
 
     docker-compose up -d
 
-In a browser you may open `http://localhost:8080` to access Træfɪk's dashboard and observe the following magic.
+In a browser you may open `http://localhost:8080` to access Træfik's dashboard and observe the following magic.
 
 Now, create a folder named `test` and create a `docker-compose.yml` in it with this content:
 

--- a/docs/toml.md
+++ b/docs/toml.md
@@ -105,9 +105,9 @@
 
 ### Constraints
 
-In a micro-service architecture, with a central service discovery, setting constraints limits Træfɪk scope to a smaller number of routes.
+In a micro-service architecture, with a central service discovery, setting constraints limits Træfik scope to a smaller number of routes.
 
-Træfɪk filters services according to service attributes/tags set in your configuration backends.
+Træfik filters services according to service attributes/tags set in your configuration backends.
 
 Supported backends:
 
@@ -399,7 +399,7 @@ entryPoint = "https"
 
 ## File backend
 
-Like any other reverse proxy, Træfɪk can be configured with a file. You have two choices:
+Like any other reverse proxy, Træfik can be configured with a file. You have two choices:
 
 - simply add your configuration at the end of the global configuration file `traefik.toml`:
 
@@ -533,7 +533,7 @@ filename = "rules.toml"
     rule = "Path:/test"
 ```
 
-If you want Træfɪk to watch file changes automatically, just add:
+If you want Træfik to watch file changes automatically, just add:
 
 ```toml
 [file]
@@ -621,11 +621,11 @@ OK
 ```sh
 $ curl -s "http://localhost:8080/health" | jq .
 {
-  // Træfɪk PID
+  // Træfik PID
   "pid": 2458,
-  // Træfɪk server uptime (formated time)
+  // Træfik server uptime (formated time)
   "uptime": "39m6.885931127s",
-  //  Træfɪk server uptime in seconds
+  //  Træfik server uptime in seconds
   "uptime_sec": 2346.885931127,
   // current server date
   "time": "2015-10-07 18:32:24.362238909 +0200 CEST",
@@ -635,7 +635,7 @@ $ curl -s "http://localhost:8080/health" | jq .
   "status_code_count": {
     "502": 1
   },
-  // count HTTP response status code since Træfɪk started
+  // count HTTP response status code since Træfik started
   "total_status_code_count": {
     "200": 7,
     "404": 21,
@@ -757,7 +757,7 @@ $ traefik --web.metrics.prometheus --web.metrics.prometheus.buckets="0.1,0.3,1.2
 
 ## Docker backend
 
-Træfɪk can be configured to use Docker as a backend configuration:
+Træfik can be configured to use Docker as a backend configuration:
 
 ```toml
 ################################################################
@@ -839,7 +839,7 @@ Labels can be used on containers to override default behaviour:
 - `traefik.port=80`: register this port. Useful when the container exposes multiples ports.
 - `traefik.protocol=https`: override the default `http` protocol
 - `traefik.weight=10`: assign this weight to the container
-- `traefik.enable=false`: disable this container in Træfɪk
+- `traefik.enable=false`: disable this container in Træfik
 - `traefik.frontend.rule=Host:test.traefik.io`: override the default frontend rule (Default: `Host:{containerName}.{domain}` or `Host:{service}.{project_name}.{domain}` if you are using `docker-compose`).
 - `traefik.frontend.passHostHeader=true`: forward client `Host` header to the backend.
 - `traefik.frontend.priority=10`: override default frontend priority
@@ -858,11 +858,11 @@ If several ports need to be exposed from a container, the services labels can be
 - `traefik.<service-name>.frontend.priority=10`: assign the service frontend priority. Overrides `traefik.frontend.priority`.
 - `traefik.<service-name>.frontend.rule=Path:/foo`: assign the service frontend rule. Overrides `traefik.frontend.rule`.
 
-NB: when running inside a container, Træfɪk will need network access through `docker network connect <network> <traefik-container>`
+NB: when running inside a container, Træfik will need network access through `docker network connect <network> <traefik-container>`
 
 ## Marathon backend
 
-Træfɪk can be configured to use Marathon as a backend configuration:
+Træfik can be configured to use Marathon as a backend configuration:
 
 
 ```toml
@@ -983,7 +983,7 @@ Labels can be used on containers to override default behaviour:
 - `traefik.port=80`: register the explicit application port value. Cannot be used alongside `traefik.portIndex`.
 - `traefik.protocol=https`: override the default `http` protocol
 - `traefik.weight=10`: assign this weight to the application
-- `traefik.enable=false`: disable this application in Træfɪk
+- `traefik.enable=false`: disable this application in Træfik
 - `traefik.frontend.rule=Host:test.traefik.io`: override the default frontend rule (Default: `Host:{containerName}.{domain}`).
 - `traefik.frontend.passHostHeader=true`: forward client `Host` header to the backend.
 - `traefik.frontend.priority=10`: override default frontend priority
@@ -992,7 +992,7 @@ Labels can be used on containers to override default behaviour:
 
 ## Mesos generic backend
 
-Træfɪk can be configured to use Mesos as a backend configuration:
+Træfik can be configured to use Mesos as a backend configuration:
 
 
 ```toml
@@ -1079,7 +1079,7 @@ domain = "mesos.localhost"
 ## Kubernetes Ingress backend
 
 
-Træfɪk can be configured to use Kubernetes Ingress as a backend configuration:
+Træfik can be configured to use Kubernetes Ingress as a backend configuration:
 
 ```toml
 ################################################################
@@ -1155,7 +1155,7 @@ Additionally, an annotation can be used on Kubernetes services to set the [circu
 
 ## Consul backend
 
-Træfɪk can be configured to use Consul as a backend configuration:
+Træfik can be configured to use Consul as a backend configuration:
 
 ```toml
 ################################################################
@@ -1207,7 +1207,7 @@ Please refer to the [Key Value storage structure](/user-guide/kv-config/#key-val
 
 ## Consul catalog backend
 
-Træfɪk can be configured to use service discovery catalog of Consul as a backend configuration:
+Træfik can be configured to use service discovery catalog of Consul as a backend configuration:
 
 ```toml
 ################################################################
@@ -1244,7 +1244,7 @@ used in consul.
 
 Additional settings can be defined using Consul Catalog tags:
 
-- `traefik.enable=false`: disable this container in Træfɪk
+- `traefik.enable=false`: disable this container in Træfik
 - `traefik.protocol=https`: override the default `http` protocol
 - `traefik.backend.weight=10`: assign this weight to the container
 - `traefik.backend.circuitbreaker=NetworkErrorRatio() > 0.5`
@@ -1258,7 +1258,7 @@ Additional settings can be defined using Consul Catalog tags:
 
 ## Etcd backend
 
-Træfɪk can be configured to use Etcd as a backend configuration:
+Træfik can be configured to use Etcd as a backend configuration:
 
 ```toml
 ################################################################
@@ -1311,7 +1311,7 @@ Please refer to the [Key Value storage structure](/user-guide/kv-config/#key-val
 
 ## Zookeeper backend
 
-Træfɪk can be configured to use Zookeeper as a backend configuration:
+Træfik can be configured to use Zookeeper as a backend configuration:
 
 ```toml
 ################################################################
@@ -1353,7 +1353,7 @@ Please refer to the [Key Value storage structure](/user-guide/kv-config/#key-val
 
 ## BoltDB backend
 
-Træfɪk can be configured to use BoltDB as a backend configuration:
+Træfik can be configured to use BoltDB as a backend configuration:
 
 ```toml
 ################################################################
@@ -1393,7 +1393,7 @@ prefix = "/traefik"
 
 ## Eureka backend
 
-Træfɪk can be configured to use Eureka as a backend configuration:
+Træfik can be configured to use Eureka as a backend configuration:
 
 
 ```toml
@@ -1432,7 +1432,7 @@ Please refer to the [Key Value storage structure](/user-guide/kv-config/#key-val
 
 ## ECS backend
 
-Træfɪk can be configured to use Amazon ECS as a backend configuration:
+Træfik can be configured to use Amazon ECS as a backend configuration:
 
 
 ```toml
@@ -1498,7 +1498,7 @@ Labels can be used on task containers to override default behaviour:
 
 - `traefik.protocol=https`: override the default `http` protocol
 - `traefik.weight=10`: assign this weight to the container
-- `traefik.enable=false`: disable this container in Træfɪk
+- `traefik.enable=false`: disable this container in Træfik
 - `traefik.frontend.rule=Host:test.traefik.io`: override the default frontend rule (Default: `Host:{containerName}.{domain}`).
 - `traefik.frontend.passHostHeader=true`: forward client `Host` header to the backend.
 - `traefik.frontend.priority=10`: override default frontend priority
@@ -1510,7 +1510,7 @@ If `AccessKeyID`/`SecretAccessKey` is not given credentials will be resolved in 
 - Shared credentials, determined by `AWS_PROFILE` and `AWS_SHARED_CREDENTIALS_FILE`, defaults to `default` and `~/.aws/credentials`.
 - EC2 instance role or ECS task role
 
-Træfɪk needs the following policy to read ECS information:
+Træfik needs the following policy to read ECS information:
 
 ```json
 {
@@ -1536,7 +1536,7 @@ Træfɪk needs the following policy to read ECS information:
 
 # Rancher backend
 
-Træfɪk can be configured to use Rancher as a backend configuration:
+Træfik can be configured to use Rancher as a backend configuration:
 
 
 ```toml
@@ -1597,7 +1597,7 @@ Labels can be used on task containers to override default behaviour:
 
 - `traefik.protocol=https`: override the default `http` protocol
 - `traefik.weight=10`: assign this weight to the container
-- `traefik.enable=false`: disable this container in Træfɪk
+- `traefik.enable=false`: disable this container in Træfik
 - `traefik.frontend.rule=Host:test.traefik.io`: override the default frontend rule (Default: `Host:{containerName}.{domain}`).
 - `traefik.frontend.passHostHeader=true`: forward client `Host` header to the backend.
 - `traefik.frontend.priority=10`: override default frontend priority
@@ -1607,7 +1607,7 @@ Labels can be used on task containers to override default behaviour:
 
 ## DynamoDB backend
 
-Træfɪk can be configured to use Amazon DynamoDB as a backend configuration:
+Træfik can be configured to use Amazon DynamoDB as a backend configuration:
 
 
 ```toml
@@ -1665,7 +1665,7 @@ RefreshSeconds = 15
 
 ```
 
-Items in the dynamodb table must have three attributes:
+Items in the dynamodb table must have three attributes: 
 
 
 - 'id' : string
@@ -1673,4 +1673,4 @@ Items in the dynamodb table must have three attributes:
 - 'name' : string
     - The name is used as the name of the frontend or backend.
 - 'frontend' or 'backend' : map
-    - This attribute's structure matches exactly the structure of a Frontend or Backend type in traefik. See types/types.go for details. The presence or absence of this attribute determines its type. So an item should never have both a 'frontend' and a 'backend' attribute.
+    - This attribute's structure matches exactly the structure of a Frontend or Backend type in traefik. See types/types.go for details. The presence or absence of this attribute determines its type. So an item should never have both a 'frontend' and a 'backend' attribute. 

--- a/docs/user-guide/cluster.md
+++ b/docs/user-guide/cluster.md
@@ -1,7 +1,7 @@
 # Clustering / High Availability
 
-This guide explains how tu use Træfɪk in high availability mode.
-In order to deploy and configure multiple Træfɪk instances, without copying the same configuration file on each instance, we will use a distributed Key-Value store.
+This guide explains how tu use Træfik in high availability mode.
+In order to deploy and configure multiple Træfik instances, without copying the same configuration file on each instance, we will use a distributed Key-Value store.
 
 ## Prerequisites
 
@@ -9,11 +9,11 @@ You will need a working KV store cluster.
 
 ## File configuration to KV store migration
 
-We created a special Træfɪk command to help configuring your Key Value store from a Træfɪk TOML configuration file.
+We created a special Træfik command to help configuring your Key Value store from a Træfik TOML configuration file.
 Please refer to [this section](/user-guide/kv-config/#store-configuration-in-key-value-store) to get more details.
 
-## Deploy a Træfɪk cluster
+## Deploy a Træfik cluster
 
-Once your Træfɪk configuration is uploaded on your KV store, you can start each Træfɪk instance.
-A Træfɪk cluster is based on a master/slave model. When starting, Træfɪk will elect a master. If this instance fails, another master will be automatically elected.
+Once your Træfik configuration is uploaded on your KV store, you can start each Træfik instance.
+A Træfik cluster is based on a master/slave model. When starting, Træfik will elect a master. If this instance fails, another master will be automatically elected.
  

--- a/docs/user-guide/examples.md
+++ b/docs/user-guide/examples.md
@@ -1,7 +1,7 @@
 
 # Examples
 
-You will find here some configuration examples of Træfɪk.
+You will find here some configuration examples of Træfik.
 
 ## HTTP only
 

--- a/docs/user-guide/kubernetes.md
+++ b/docs/user-guide/kubernetes.md
@@ -1,6 +1,6 @@
 # Kubernetes Ingress Controller
 
-This guide explains how to use Træfɪk as an Ingress controller in a Kubernetes cluster.
+This guide explains how to use Træfik as an Ingress controller in a Kubernetes cluster.
 If you are not familiar with Ingresses in Kubernetes you might want to read the [Kubernetes user guide](http://kubernetes.io/docs/user-guide/ingress/)
 
 The config files used in this guide can be found in the [examples directory](https://github.com/containous/traefik/tree/master/examples/k8s)
@@ -14,7 +14,7 @@ on your machine, as it is the quickest way to get a local Kubernetes cluster set
 
 ## Deploy Træfik using a Deployment object
 
-We are going to deploy Træfɪk with a
+We are going to deploy Træfik with a
 [Deployment](http://kubernetes.io/docs/user-guide/deployments/), as this will
 allow you to easily roll out config changes or update the image.
 
@@ -58,11 +58,11 @@ spec:
 ```
 [examples/k8s/traefik.yaml](https://github.com/containous/traefik/tree/master/examples/k8s/traefik.yaml)
 
-> notice that we binding port 80 on the Træfɪk container to port 80 on the host.
-> With a multi node cluster we might expose Træfɪk with a NodePort or LoadBalancer service
-> and run more than 1 replica of Træfɪk for high availability.
+> notice that we binding port 80 on the Træfik container to port 80 on the host.
+> With a multi node cluster we might expose Træfik with a NodePort or LoadBalancer service
+> and run more than 1 replica of Træfik for high availability.
 
-To deploy Træfɪk to your cluster start by submitting the deployment to the cluster with `kubectl`:
+To deploy Træfik to your cluster start by submitting the deployment to the cluster with `kubectl`:
 
 ```sh
 kubectl apply -f examples/k8s/traefik.yaml
@@ -143,20 +143,20 @@ traefik-ingress-controller-678226159-eqseo   1/1       Running   0          7m
 
 You should see that after submitting the Deployment to Kubernetes it has launched
 a pod, and it is now running. _It might take a few moments for kubernetes to pull
-the Træfɪk image and start the container._
+the Træfik image and start the container._
 
 > You could also check the deployment with the Kubernetes dashboard, run
 > `minikube dashboard` to open it in your browser, then choose the `kube-system`
 > namespace from the menu at the top right of the screen.
 
-You should now be able to access Træfɪk on port 80 of your minikube instance.
+You should now be able to access Træfik on port 80 of your minikube instance.
 
 ```sh
 curl $(minikube ip)
 404 page not found
 ```
 
-> We expect to see a 404 response here as we haven't yet given Træfɪk any configuration.
+> We expect to see a 404 response here as we haven't yet given Træfik any configuration.
 
 ## Deploy Træfik using Helm Chart
 
@@ -173,7 +173,7 @@ For more information, check out [the doc](https://github.com/kubernetes/charts/t
 ## Submitting An Ingress to the cluster.
 
 Lets start by creating a Service and an Ingress that will expose the
-[Træfɪk Web UI](https://github.com/containous/traefik#web-ui).
+[Træfik Web UI](https://github.com/containous/traefik#web-ui).
 
 ```yaml
 apiVersion: v1
@@ -221,7 +221,7 @@ to our cluster.
 echo "$(minikube ip) traefik-ui.local" | sudo tee -a /etc/hosts
 ```
 
-We should now be able to visit [traefik-ui.local](http://traefik-ui.local) in the browser and view the Træfɪk Web UI.
+We should now be able to visit [traefik-ui.local](http://traefik-ui.local) in the browser and view the Træfik Web UI.
 
 ## Name based routing
 
@@ -434,7 +434,7 @@ spec:
 kubectl apply -f examples/k8s/cheese-ingress.yaml
 ```
 
-Now visit the [Træfɪk dashboard](http://traefik-ui.local/) and you should
+Now visit the [Træfik dashboard](http://traefik-ui.local/) and you should
 see a frontend for each host. Along with a backend listing for each service
 with a Server set up for each pod.
 
@@ -486,7 +486,7 @@ spec:
 ```
 [examples/k8s/cheeses-ingress.yaml](https://github.com/containous/traefik/tree/master/examples/k8s/cheeses-ingress.yaml)
 
-> Notice that we are configuring Træfɪk to strip the prefix from the url path
+> Notice that we are configuring Træfik to strip the prefix from the url path
 > with the `traefik.frontend.rule.type` annotation so that we can use
 > the containers from the previous example without modification.
 
@@ -505,7 +505,7 @@ You should now be able to visit the websites in your browser.
 * [cheeses.local/wensleydale](http://cheeses.local/wensleydale/)
 
 ## Disable passing the Host header
-By default Træfɪk will pass the incoming Host header on to the upstream resource. There
+By default Træfik will pass the incoming Host header on to the upstream resource. There
 are times however where you may not want this to be the case. For example if your service
 is of the ExternalName type.
 
@@ -561,8 +561,8 @@ Note: The per ingress annotation overides whatever the global value is set to. S
 could set `disablePassHostHeaders` to true in your toml file and then enable passing
 the host header per ingress if you wanted.
 
-## Excluding an ingress from Træfɪk
-You can control which ingress Træfɪk cares about by using the "kubernetes.io/ingress.class"
-annotation. By default if the annotation is not set at all Træfɪk will include the
+## Excluding an ingress from Træfik
+You can control which ingress Træfik cares about by using the "kubernetes.io/ingress.class"
+annotation. By default if the annotation is not set at all Træfik will include the
 ingress. If the annotation is set to anything other than traefik or a blank string
-Træfɪk will ignore it.
+Træfik will ignore it.

--- a/docs/user-guide/kv-config.md
+++ b/docs/user-guide/kv-config.md
@@ -3,9 +3,9 @@
 
 Both [static global configuration](/user-guide/kv-config/#static-configuration-in-key-value-store) and [dynamic](/user-guide/kv-config/#dynamic-configuration-in-key-value-store) configuration can be sorted in a Key-value store.
 
-This section explains how to launch Træfɪk using a configuration loaded from a Key-value store.
+This section explains how to launch Træfik using a configuration loaded from a Key-value store.
 
-Træfɪk supports several Key-value stores:
+Træfik supports several Key-value stores:
 
 - [Consul](https://consul.io)
 - [etcd](https://coreos.com/etcd/)
@@ -19,7 +19,7 @@ Note that we could do the same with any other Key-value Store.
 
 ## docker-compose file for Consul
 
-The Træfɪk global configuration will be getted from a [Consul](https://consul.io) store. 
+The Træfik global configuration will be getted from a [Consul](https://consul.io) store. 
 
 First we have to launch Consul in a container. 
 The [docker-compose file](https://docs.docker.com/compose/compose-file/) allows us to launch Consul and four instances of the trivial app [emilevauge/whoamI](https://github.com/emilevauge/whoamI) : 
@@ -54,11 +54,11 @@ whoami4:
 
 ## Upload the configuration in the Key-value store
 
-We should now fill the store with the Træfɪk global configuration, as we do with a [TOML file configuration](/toml).
+We should now fill the store with the Træfik global configuration, as we do with a [TOML file configuration](/toml).
 To do that, we can send the Key-value pairs via [curl commands](https://www.consul.io/intro/getting-started/kv.html) or via the [Web UI](https://www.consul.io/intro/getting-started/ui.html).
 
-Fortunately, Træfɪk allows automation of this process using the `storeconfig` subcommand.
-Please refer to the [store Træfɪk configuration](/user-guide/kv-config/#store-configuration-in-key-value-store) section to get documentation on it.
+Fortunately, Træfik allows automation of this process using the `storeconfig` subcommand.
+Please refer to the [store Træfik configuration](/user-guide/kv-config/#store-configuration-in-key-value-store) section to get documentation on it.
 
 Here is the toml configuration we would like to store in the Key-value Store  :
 
@@ -118,10 +118,10 @@ In case you are setting key values manually,:
 
 Note that we can either give path to certificate file or directly the file content itself.
 
-## Launch Træfɪk
+## Launch Træfik
 
-We will now launch Træfɪk in a container.
-We use CLI flags to setup the connection between Træfɪk and Consul.
+We will now launch Træfik in a container.
+We use CLI flags to setup the connection between Træfik and Consul.
 All the rest of the global configuration is stored in Consul.
 
 Here is the [docker-compose file](https://docs.docker.com/compose/compose-file/) :
@@ -142,7 +142,7 @@ NB : Be careful to give the correct IP address and port in the flag `--consul.en
 So far, only [Consul](https://consul.io) and [etcd](https://coreos.com/etcd/) support TLS connections. 
 To set it up, we should enable [consul security](https://www.consul.io/docs/internals/security.html) (or [etcd security](https://coreos.com/etcd/docs/latest/security.html)).
 
-Then, we have to provide CA, Cert and Key to Træfɪk using `consul` flags :
+Then, we have to provide CA, Cert and Key to Træfik using `consul` flags :
 
 - `--consul.tls`
 - `--consul.tls.ca=path/to/the/file`
@@ -161,9 +161,9 @@ Note that we can either give directly directly the file content itself (instead 
 Remember the command `traefik --help` to display the updated list of flags.
 
 # Dynamic configuration in Key-value store
-Following our example, we will provide backends/frontends rules to Træfɪk.
+Following our example, we will provide backends/frontends rules to Træfik.
 
-Note that this section is independent of the way Træfɪk got its static configuration. 
+Note that this section is independent of the way Træfik got its static configuration. 
 It means that the static configuration can either come from the same Key-value store or from any other sources.
 
 ## Key-value storage structure
@@ -259,13 +259,13 @@ And there, the same dynamic configuration in a KV Store (using `prefix = "traefi
 
 ## Atomic configuration changes
 
-Træfɪk can watch the backends/frontends configuration changes and generate its configuration automatically. 
+Træfik can watch the backends/frontends configuration changes and generate its configuration automatically. 
 
-Note that only backends/frontends rules are dynamic, the rest of the Træfɪk configuration stay static. 
+Note that only backends/frontends rules are dynamic, the rest of the Træfik configuration stay static. 
 
-The [Etcd](https://github.com/coreos/etcd/issues/860) and [Consul](https://github.com/hashicorp/consul/issues/886) backends do not support updating multiple keys atomically. As a result, it may be possible for Træfɪk to read an intermediate configuration state despite judicious use of the `--providersThrottleDuration` flag. To solve this problem, Træfɪk supports a special key called `/traefik/alias`. If set, Træfɪk use the value as an alternative key prefix.
+The [Etcd](https://github.com/coreos/etcd/issues/860) and [Consul](https://github.com/hashicorp/consul/issues/886) backends do not support updating multiple keys atomically. As a result, it may be possible for Træfik to read an intermediate configuration state despite judicious use of the `--providersThrottleDuration` flag. To solve this problem, Træfik supports a special key called `/traefik/alias`. If set, Træfik use the value as an alternative key prefix.
 
-Given the key structure below, Træfɪk will use the `http://172.17.0.2:80` as its only backend (frontend keys have been omitted for brevity).
+Given the key structure below, Træfik will use the `http://172.17.0.2:80` as its only backend (frontend keys have been omitted for brevity).
 
 | Key                                                                     | Value                       |
 |-------------------------------------------------------------------------|-----------------------------|
@@ -297,19 +297,19 @@ Once the `/traefik/alias` key is updated, the new `/traefik_configurations/2` co
 | `/traefik_configurations/2/backends/backend1/servers/server2/url`       | `http://172.17.0.4:80`      |
 | `/traefik_configurations/2/backends/backend1/servers/server2/weight`    | `5`                        |
 
-Note that Træfɪk *will not watch for key changes in the `/traefik_configurations` prefix*. It will only watch for changes in the `/traefik/alias`. 
+Note that Træfik *will not watch for key changes in the `/traefik_configurations` prefix*. It will only watch for changes in the `/traefik/alias`. 
 Further, if the `/traefik/alias` key is set, all other configuration with `/traefik/backends` or `/traefik/frontends` prefix are ignored.
 
 # Store configuration in Key-value store
 
-Don't forget to [setup the connection between Træfɪk and Key-value store](/user-guide/kv-config/#launch-trfk).
-The static Træfɪk configuration in a key-value store can be automatically created and updated, using the [`storeconfig` subcommand](/basics/#commands).
+Don't forget to [setup the connection between Træfik and Key-value store](/user-guide/kv-config/#launch-trfk).
+The static Træfik configuration in a key-value store can be automatically created and updated, using the [`storeconfig` subcommand](/basics/#commands).
 
 ```bash
 $ traefik storeconfig [flags] ...
 ```
 This command is here only to automate the [process which upload the configuration into the Key-value store](/user-guide/kv-config/#upload-the-configuration-in-the-key-value-store).
-Træfɪk will not start but the [static configuration](/basics/#static-trfk-configuration) will be uploaded into the Key-value store.
+Træfik will not start but the [static configuration](/basics/#static-trfk-configuration) will be uploaded into the Key-value store.
 If you configured ACME (Let's Encrypt), your registration account and your certificates will also be uploaded.
 
 To upload your ACME certificates to the KV store, get your traefik TOML file and add the new `storage` option in the `acme` section:

--- a/docs/user-guide/swarm-mode.md
+++ b/docs/user-guide/swarm-mode.md
@@ -2,7 +2,7 @@
 
 This section explains how to create a multi-host docker cluster with
 swarm mode using [docker-machine](https://docs.docker.com/machine) and
-how to deploy Træfɪk on it.
+how to deploy Træfik on it.
 
 The cluster consists of:
 
@@ -143,7 +143,7 @@ cgfg5ifzrpgm  whoami1  1/1       emilevauge/whoami
 dtpl249tfghc  traefik  1/1       traefik            --docker --docker.swarmmode --docker.domain=traefik --docker.watch --web
 ```
 
-## Access to your apps through Træfɪk
+## Access to your apps through Træfik
 
 ```sh
 curl -H Host:whoami0.traefik http://$(docker-machine ip manager)
@@ -242,7 +242,7 @@ ab046gpaqtln  whoami0  5/5       emilevauge/whoami
 cgfg5ifzrpgm  whoami1  5/5       emilevauge/whoami
 dtpl249tfghc  traefik  1/1       traefik            --docker --docker.swarmmode --docker.domain=traefik --docker.watch --web
 ```
-## Access to your whoami0 through Træfɪk multiple times.
+## Access to your whoami0 through Træfik multiple times.
 
 Repeat the following command multiple times and note that the Hostname changes each time as Traefik load balances each request against the 5 tasks.
 ```sh

--- a/docs/user-guide/swarm.md
+++ b/docs/user-guide/swarm.md
@@ -1,6 +1,6 @@
 # Swarm cluster
 
-This section explains how to create a multi-host [swarm](https://docs.docker.com/swarm) cluster using [docker-machine](https://docs.docker.com/machine/) and how to deploy Træfɪk on it.
+This section explains how to create a multi-host [swarm](https://docs.docker.com/swarm) cluster using [docker-machine](https://docs.docker.com/machine/) and how to deploy Træfik on it.
 The cluster consists of:
 
 - 2 servers
@@ -70,9 +70,9 @@ eval $(docker-machine env --swarm mhs-demo0)
 docker network create --driver overlay --subnet=10.0.9.0/24 my-net
 ```
 
-## Deploy Træfɪk
+## Deploy Træfik
 
-Deploy Træfɪk:
+Deploy Træfik:
 
 ```sh
 docker $(docker-machine config mhs-demo0) run \
@@ -126,7 +126,7 @@ ba2c21488299        emilevauge/whoami   "/whoamI"                8 seconds ago  
 8fbc39271b4c        traefik             "/traefik -l DEBUG -c"   36 seconds ago      Up 37 seconds       192.168.99.101:80->80/tcp, 192.168.99.101:8080->8080/tcp   mhs-demo0/serene_bhabha
 ```
 
-## Access to your apps through Træfɪk
+## Access to your apps through Træfik
 
 ```sh
 curl -H Host:whoami0.traefik http://$(docker-machine ip mhs-demo0)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
-site_name: Træfɪk
-site_description: Træfɪk Documentation
+site_name: Træfik
+site_description: Træfik Documentation
 site_author: containo.us
 site_url: https://docs.traefik.io
 
@@ -16,7 +16,7 @@ theme: united
 site_favicon: 'img/traefik.icon.png'
 
 # Copyright
-copyright: "Copyright &copy; 2016 Containous SAS"
+copyright: "Copyright &copy; 2016-2017 Containous SAS"
 
 # Options
 extra:

--- a/webui/package.json
+++ b/webui/package.json
@@ -6,7 +6,7 @@
     "Fernandez Ludovic <lfernandez.dev@gmail.com>",
     "Micaël Mbagira <micael.mbagira@icloud.com>"
   ],
-  "description": "Front end for Træfɪk",
+  "description": "Front end for Træfik",
   "license": "MIT",
   "dependencies": {
     "angular": "^1.4.2",

--- a/webui/readme.md
+++ b/webui/readme.md
@@ -1,10 +1,10 @@
-# Træfɪk Web UI
+# Træfik Web UI
 
-Access to Træfɪk Web UI, ex: http://localhost:8080
+Access to Træfik Web UI, ex: http://localhost:8080
 
 ## Interface
 
-Træfɪk Web UI provide 2 types of informations:
+Træfik Web UI provide 2 types of informations:
 - Providers with their backends and frontends information.
 - Health of the web server.
 
@@ -52,7 +52,7 @@ make generate-webui  # Generate static contents in `traefik/static/` folder.
 - Run in development mode :
   - `yarn run serve`
 
-- Træfɪk API connections are defined in:
+- Træfik API connections are defined in:
   - `webui/src/app/core/health.resource.js`
   - `webui/src/app/core/providers.resource.js`
 

--- a/webui/src/index.html
+++ b/webui/src/index.html
@@ -2,7 +2,7 @@
 <html ng-app="traefik">
   <head>
     <meta charset="utf-8">
-    <title>Træfɪk</title>
+    <title>Træfik</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width">
     <link rel="icon" type="image/png" href="traefik.icon.png" />


### PR DESCRIPTION
This PR updates license year to 2017 and replaces  `Træfɪk` by `Træfik` in documentation.

Signed-off-by: Emile Vauge <emile@vauge.com>