### PR TITLE
Make toml Bucket array homogeneous

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -556,7 +556,7 @@ address = ":8080"
 #
 # To enable Traefik to export internal metrics to Prometheus
 # [web.metrics.prometheus]
-#   Buckets=[0.1,0.3,1.2,5]
+#   Buckets=[0.1,0.3,1.2,5.0]
 #
 # To enable basic auth on the webui
 # with 2 user/pass: test:test and test2:test2
@@ -735,7 +735,7 @@ $ curl -s "http://localhost:8080/api" | jq .
 - `/metrics`: You can enable Traefik to export internal metrics to different monitoring systems (Only Prometheus is supported at the moment).
 
 ```bash
-$ traefik --web.metrics.prometheus --web.metrics.prometheus.buckets="0.1,0.3,1.2,5"
+$ traefik --web.metrics.prometheus --web.metrics.prometheus.buckets="0.1,0.3,1.2,5.0"
 ```
 
 ## Docker backend


### PR DESCRIPTION
This solves the following error:

```
Error reading TOML config file /etc/traefik/traefik.toml : Near line 24 (last key parsed 'web.metrics.prometheus.Buckets'): Array contains values of type 'Float' and 'Integer', but arrays must be homogeneous.
```