### PR TITLE
[WIP] Add basic plugin support

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/containous/flaeg"
 	"github.com/containous/traefik/acme"
+	"github.com/containous/traefik/plugin"
 	"github.com/containous/traefik/provider"
 	"github.com/containous/traefik/types"
 )
@@ -40,6 +41,7 @@ type GlobalConfiguration struct {
 	IdleTimeout               flaeg.Duration          `description:"maximum amount of time an idle (keep-alive) connection will remain idle before closing itself."`
 	InsecureSkipVerify        bool                    `description:"Disable SSL certificate verification"`
 	Retry                     *Retry                  `description:"Enable retry sending request if network error"`
+	Plugins                   plugin.Plugins          `description:"External plugins definition"`
 	Docker                    *provider.Docker        `description:"Enable Docker backend"`
 	File                      *provider.File          `description:"Enable File backend"`
 	Web                       *WebProvider            `description:"Enable Web backend"`
@@ -470,6 +472,7 @@ func NewTraefikConfiguration() *TraefikConfiguration {
 			MaxIdleConnsPerHost:       200,
 			IdleTimeout:               flaeg.Duration(180 * time.Second),
 			CheckNewVersion:           true,
+			Plugins:                   plugin.Plugins{},
 		},
 		ConfigFile: "",
 	}

--- a/integration/resources/compose/plugin.yml
+++ b/integration/resources/compose/plugin.yml
@@ -1,0 +1,18 @@
+whoami:
+  image: emilevauge/whoami
+  labels:
+    traefik.frontend.rule: Host:test.localhost
+
+plugin-sample:
+  image: golang
+  command: go build -buildmode=plugin -o plugin/sample/plugin.so plugin/sample/plugin.go
+  volumes:
+    - ../plugin:/plugin
+    - ../../../:/go/src/github.com/containous/traefik
+
+bad-load:
+  image: golang
+  command: go build -buildmode=plugin -o plugin/bad-load/plugin.so plugin/bad-load/plugin.go
+  working_dir: /go/src/github.com/containous/traefik/integration/resources
+  volumes:
+    - ../../../:/go/src/github.com/containous/traefik

--- a/integration/resources/plugin/bad-load/plugin.go
+++ b/integration/resources/plugin/bad-load/plugin.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"github.com/containous/traefik/plugin"
+	"net/http"
+)
+
+var _ plugin.Middleware = (*BadLoad)(nil)
+
+type BadLoad struct {
+}
+
+func Load() string {
+	return "bad load!"
+}
+
+func (s *BadLoad) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+}

--- a/integration/resources/plugin/no-interface/plugin.go
+++ b/integration/resources/plugin/no-interface/plugin.go
@@ -1,0 +1,10 @@
+package main
+
+import ()
+
+type NoInterface struct {
+}
+
+func Load() interface{} {
+	return &NoInterface{}
+}

--- a/integration/resources/plugin/no-load/plugin.go
+++ b/integration/resources/plugin/no-load/plugin.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"github.com/containous/traefik/plugin"
+	"net/http"
+)
+
+var _ plugin.Middleware = (*NoLoad)(nil)
+
+type NoLoad struct {
+}
+
+func (s *NoLoad) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+}

--- a/integration/resources/plugin/sample/plugin.go
+++ b/integration/resources/plugin/sample/plugin.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"bytes"
+	"github.com/containous/traefik/plugin"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+var _ plugin.Middleware = (*Sample)(nil)
+
+type Sample struct {
+}
+
+func Load() interface{} {
+	return &Sample{}
+}
+
+func (s *Sample) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	r.Header.Add("Traefik-Plugin-Sample", "sample.request.header")
+	w.Header().Add("Traefik-Plugin-Sample", "sample.response.header")
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "can't read body", http.StatusBadRequest)
+		return
+	}
+
+	body = append(body, []byte("\nsample.reponse.body")...)
+	r.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+
+	// Create a response wrapper:
+	mrw := &MyResponseWriter{
+		ResponseWriter: w,
+		buf:            &bytes.Buffer{},
+	}
+
+	next(w, r)
+
+	if _, err := io.Copy(w, mrw.buf); err != nil {
+		return
+	}
+}
+
+type MyResponseWriter struct {
+	http.ResponseWriter
+	buf *bytes.Buffer
+}
+
+func (mrw *MyResponseWriter) Write(p []byte) (int, error) {
+	return mrw.buf.Write(p)
+}

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -1,0 +1,50 @@
+package plugin
+
+import (
+	"fmt"
+	goplugin "plugin"
+)
+
+// Manager is in charge of instantiating plugins and storing those in memory
+type Manager struct {
+	middlewares []*Middleware
+}
+
+// NewManager builds a new manager
+func NewManager() *Manager {
+	return &Manager{
+		middlewares: []*Middleware{},
+	}
+}
+
+// Load loads a plugin
+func (m *Manager) Load(plugin Plugin) error {
+	p, err := goplugin.Open(plugin.Path)
+	if err != nil {
+		return fmt.Errorf("error opening plugin: %s", err)
+	}
+	loader, err := p.Lookup("Load")
+	if err != nil {
+		return fmt.Errorf("error in plugin Lookup: %s", err)
+	}
+	load, ok := loader.(func() interface{})
+	if !ok {
+		return fmt.Errorf("plugin from %+v does not implement Load() interface{} function", plugin)
+	}
+	instance := load()
+	if instance == nil {
+		return fmt.Errorf("plugin from %+v does not implement Load() interface{} function", plugin)
+	}
+	if middleware, ok := instance.(Middleware); ok {
+		// if Middleware, add to middleware list
+		m.middlewares = append(m.middlewares, &middleware)
+	} else {
+		return fmt.Errorf("plugin from %+v does not implement any plugin interface", plugin)
+	}
+	return nil
+}
+
+// GetMiddlewares return a list of all Middleware plugins
+func (m *Manager) GetMiddlewares() []*Middleware {
+	return m.middlewares
+}

--- a/plugin/middleware.go
+++ b/plugin/middleware.go
@@ -1,0 +1,15 @@
+package plugin
+
+import (
+	"net/http"
+)
+
+// Middleware defines functions that should be implemented by a Middleware plugin
+type Middleware interface {
+	Handler
+}
+
+// Handler handler is an interface that objects can implement to be registered to serve as middleware
+type Handler interface {
+	ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc)
+}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -1,0 +1,42 @@
+package plugin
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Plugin defines a plugin configuration in traefik
+type Plugin struct {
+	Path string
+}
+
+// Plugins defines a set of Plugin
+type Plugins []Plugin
+
+//Set Plugins from a string expression
+func (p *Plugins) Set(str string) error {
+	exps := strings.Split(str, ",")
+	if len(exps) == 0 {
+		return fmt.Errorf("bad Plugin format: %s", str)
+	}
+	for _, exp := range exps {
+		*p = append(*p, Plugin{Path: exp})
+	}
+	return nil
+}
+
+//Get returns Plugins instances
+func (p *Plugins) Get() interface{} { return []Plugin(*p) }
+
+//String returns Plugins formated in string
+func (p *Plugins) String() string { return fmt.Sprintf("%+v", *p) }
+
+//SetValue sets Plugins into the parser
+func (p *Plugins) SetValue(val interface{}) {
+	*p = Plugins(val.(Plugins))
+}
+
+// Type exports the Plugins type as a string
+func (p *Plugins) Type() string {
+	return "plugins"
+}


### PR DESCRIPTION
This PR is a proposal for adding basic plugin support in Traefik using the new Golang 1.8 plugin mechanism.

Right now, only `Middleware` plugin type is available.
Build your plugin using:

```sh
go build -buildmode=plugin -o sample.so sample.go
```

Then add in you Traefik toml file:

```toml
[[plugins]]
path = "sample.so"
```

Please, give your feedback on this basic implementation :)

/cc @containous/traefik 

Fixes #1336
Fixes #1048
Part of #30

Signed-off-by: Emile Vauge <emile@vauge.com>