### PR TITLE
Allow traefik.port to not be in the list of marathon ports

### DIFF
--- a/provider/marathon.go
+++ b/provider/marathon.go
@@ -235,22 +235,9 @@ func (provider *Marathon) taskFilter(task marathon.Task, applications *marathon.
 		}
 	}
 	if portValueLabel != "" {
-		port, err := strconv.Atoi((*application.Labels)["traefik.port"])
+		_, err := strconv.Atoi((*application.Labels)["traefik.port"])
 		if err != nil {
 			log.Debugf("Filtering marathon task %s with unexpected value for traefik.port label", task.AppID)
-			return false
-		}
-
-		var foundPort bool
-		for _, exposedPort := range ports {
-			if port == exposedPort {
-				foundPort = true
-				break
-			}
-		}
-
-		if !foundPort {
-			log.Debugf("Filtering marathon task %s without a matching port for traefik.port label", task.AppID)
 			return false
 		}
 	}

--- a/provider/marathon_test.go
+++ b/provider/marathon_test.go
@@ -519,39 +519,19 @@ func TestMarathonTaskFilter(t *testing.T) {
 		{
 			task: marathon.Task{
 				AppID: "specify-port-number",
-				Ports: []int{80, 443},
+				Ports: []int{80},
 			},
 			applications: &marathon.Applications{
 				Apps: []marathon.Application{
 					{
-						ID:    "specify-port-number",
-						Ports: []int{80, 443},
-						Labels: &map[string]string{
-							"traefik.port": "80",
-						},
-					},
-				},
-			},
-			expected:         true,
-			exposedByDefault: true,
-		},
-		{
-			task: marathon.Task{
-				AppID: "specify-unknown-port-number",
-				Ports: []int{80, 443},
-			},
-			applications: &marathon.Applications{
-				Apps: []marathon.Application{
-					{
-						ID:    "specify-unknown-port-number",
-						Ports: []int{80, 443},
+						ID: "specify-port-number",
 						Labels: &map[string]string{
 							"traefik.port": "8080",
 						},
 					},
 				},
 			},
-			expected:         false,
+			expected:         true,
 			exposedByDefault: true,
 		},
 		{


### PR DESCRIPTION
This PR supersedes https://github.com/containous/traefik/pull/1309.
Fixes #261 
Original author: @nicgrayson 