### PR TITLE
Fix default timeouts for Marathon provider.

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -371,8 +371,8 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 	defaultMarathon.Endpoint = "http://127.0.0.1:8080"
 	defaultMarathon.ExposedByDefault = true
 	defaultMarathon.Constraints = types.Constraints{}
-	defaultMarathon.DialerTimeout = 60
-	defaultMarathon.KeepAlive = 10
+	defaultMarathon.DialerTimeout = flaeg.Duration(60 * time.Second)
+	defaultMarathon.KeepAlive = flaeg.Duration(10 * time.Second)
 
 	// default Consul
 	var defaultConsul consul.Provider


### PR DESCRIPTION
The timeouts were given without a unit, which caused nanoseconds scale to be applied when we switched the type from `int` to `flaeg.Duration`.

Fixes a regression introduced by #1350.

Discovered along #1390.

