### PR TITLE
glide.sh: Push argument to GLIDE_ARGS array.

### DIFF
--- a/script/glide.sh
+++ b/script/glide.sh
@@ -86,7 +86,7 @@ case "${glide_command}" in
       usage
       exit 1
     fi
-    GLIDE_ARGS=("$1" "${GLIDE_ARGS[@]}")
+    GLIDE_ARGS+=("$1")
     shift
     ;;
 


### PR DESCRIPTION
The array is empty in the beginning, so referencing`${GLIDE_ARGS[@]` produces an error due to `nounset`.

/cc @vdemeester 