### PR TITLE
Exclude vendor directories from Makefile SRCS variable.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ TRAEFIK_ENVS := \
 	-e VERSION \
 	-e CODENAME
 
-SRCS = $(shell git ls-files '*.go' | grep -v '^external/')
+SRCS = $(shell git ls-files '*.go' | grep -v -e '^external/' -e '^vendor/' -e '^integration/vendor/')
 
 BIND_DIR := "dist"
 TRAEFIK_MOUNT := -v "$(CURDIR)/$(BIND_DIR):/go/src/github.com/containous/traefik/$(BIND_DIR)"


### PR DESCRIPTION
While it did not hurt to include those when gofmt'ing, it's not needed and may turn out to become a source of problems in the future should `SRCS` be used more extensively.