### PR TITLE
Fix wrong url with multiple rancher environments

### DIFF
--- a/provider/rancher.go
+++ b/provider/rancher.go
@@ -286,11 +286,14 @@ func (provider *Rancher) Provide(configurationChan chan<- types.ConfigMessage, p
 	return nil
 }
 
-func listRancherEnvironments(client *rancher.RancherClient) []*rancher.Environment {
+func listRancherEnvironments(client *rancher.RancherClient) []*rancher.Project {
 
-	var environmentList = []*rancher.Environment{}
+	// Rancher Environment in frontend UI is actually project in API
+	// https://forums.rancher.com/t/api-key-for-all-environments/279/9
+	
+	var environmentList = []*rancher.Project{}
 
-	environments, err := client.Environment.List(nil)
+	environments, err := client.Project.List(nil)
 
 	if err != nil {
 		log.Errorf("Cannot get Rancher Environments %+v", err)
@@ -353,7 +356,7 @@ func listRancherContainer(client *rancher.RancherClient) []*rancher.Container {
 	return containerList
 }
 
-func parseRancherData(environments []*rancher.Environment, services []*rancher.Service, containers []*rancher.Container) []rancherData {
+func parseRancherData(environments []*rancher.Project, services []*rancher.Service, containers []*rancher.Container) []rancherData {
 	var rancherDataList []rancherData
 
 	for _, environment := range environments {


### PR DESCRIPTION
Scenario:
Traefik running inside rancher with admin api key for multiple environments.

In rancher I've got 2 environments.
![image](https://cloud.githubusercontent.com/assets/1452937/24889187/f36bb18c-1eab-11e7-8e9b-f5f34444b6cb.png)

In both environment there's a service with the same name.
![image](https://cloud.githubusercontent.com/assets/1452937/24889206/12d21066-1eac-11e7-87e3-083834a04f5d.png)
![image](https://cloud.githubusercontent.com/assets/1452937/24889217/1c2eb754-1eac-11e7-9e7c-5326b9b8d74a.png)

When I'm using traefik with accesskey and secret option there is only one frontend url get created.
![image](https://cloud.githubusercontent.com/assets/1452937/24889363/e3888424-1eac-11e7-94ca-7d1ce1c492ef.png)

The issue is because environments on rancher ui is not environment in rancher api, but is project in api.
https://forums.rancher.com/t/api-key-for-all-environments/279/9
![image](https://cloud.githubusercontent.com/assets/1452937/24889447/4be5d35a-1ead-11e7-9569-3d186a02536d.png)

So this fix is to look at project instead of environment in api.




