### PR TITLE
Convert LoadBalancer.Sticky to a string

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -237,7 +237,7 @@ For example:
 [backends]
   [backends.backend1]
     [backends.backend1.loadbalancer]
-      sticky = true
+      sticky = "cookie"
 ```
 
 Healthcheck URL can be configured with a relative URL for `healthcheck.URL`.

--- a/docs/toml.md
+++ b/docs/toml.md
@@ -831,7 +831,7 @@ Labels can be used on containers to override default behaviour:
 - `traefik.backend.maxconn.amount=10`: set a maximum number of connections to the backend. Must be used in conjunction with the below label to take effect.
 - `traefik.backend.maxconn.extractorfunc=client.ip`: set the function to be used against the request to determine what to limit maximum connections to the backend by. Must be used in conjunction with the above label to take effect.
 - `traefik.backend.loadbalancer.method=drr`: override the default `wrr` load balancer algorithm
-- `traefik.backend.loadbalancer.sticky=true`: enable backend sticky sessions
+- `traefik.backend.loadbalancer.sticky=cookie`: enable backend sticky sessions
 - `traefik.backend.loadbalancer.swarm=true `: use Swarm's inbuilt load balancer (only relevant under Swarm Mode).
 - `traefik.backend.circuitbreaker.expression=NetworkErrorRatio() > 0.5`: create a [circuit breaker](/basics/#backends) to be used against the backend
 - `traefik.port=80`: register this port. Useful when the container exposes multiples ports.
@@ -974,7 +974,7 @@ Labels can be used on containers to override default behaviour:
 - `traefik.backend.maxconn.amount=10`: set a maximum number of connections to the backend. Must be used in conjunction with the below label to take effect.
 - `traefik.backend.maxconn.extractorfunc=client.ip`: set the function to be used against the request to determine what to limit maximum connections to the backend by. Must be used in conjunction with the above label to take effect.
 - `traefik.backend.loadbalancer.method=drr`: override the default `wrr` load balancer algorithm
-- `traefik.backend.loadbalancer.sticky=true`: enable backend sticky sessions
+- `traefik.backend.loadbalancer.sticky=cookie`: enable backend sticky sessions
 - `traefik.backend.circuitbreaker.expression=NetworkErrorRatio() > 0.5`: create a [circuit breaker](/basics/#backends) to be used against the backend
 - `traefik.portIndex=1`: register port by index in the application's ports array. Useful when the application exposes multiple ports.
 - `traefik.port=80`: register the explicit application port value. Cannot be used alongside `traefik.portIndex`.
@@ -1139,7 +1139,7 @@ Annotations can be used on containers to override default behaviour for the whol
 Annotations can be used on the Kubernetes service to override default behaviour:
 
 - `traefik.backend.loadbalancer.method=drr`: override the default `wrr` load balancer algorithm
-- `traefik.backend.loadbalancer.sticky=true`: enable backend sticky sessions
+- `traefik.backend.loadbalancer.sticky=cookie`: enable backend sticky sessions
 
 You can find here an example [ingress](https://raw.githubusercontent.com/containous/traefik/master/examples/k8s/cheese-ingress.yaml) and [replication controller](https://raw.githubusercontent.com/containous/traefik/master/examples/k8s/traefik.yaml).
 

--- a/docs/user-guide/swarm-mode.md
+++ b/docs/user-guide/swarm-mode.md
@@ -126,11 +126,11 @@ docker-machine ssh manager "docker service create \
 	--name whoami1 \
 	--label traefik.port=80 \
 	--network traefik-net \
-	--label traefik.backend.loadbalancer.sticky=true \
+	--label traefik.backend.loadbalancer.sticky=cookie \
 	emilevauge/whoami"
 ```
 
-Note that we set whoami1 to use sticky sessions (`--label traefik.backend.loadbalancer.sticky=true`).  We'll demonstrate that later.
+Note that we set whoami1 to use sticky sessions (`--label traefik.backend.loadbalancer.sticky=cookie`).  We'll demonstrate that later.
 If using `docker stack deploy`, there is [a specific way that the labels must be defined in the docker-compose file](https://github.com/containous/traefik/issues/994#issuecomment-269095109).
 
 Check that everything is scheduled and started:

--- a/provider/docker.go
+++ b/provider/docker.go
@@ -594,8 +594,11 @@ func (provider *Docker) getWeight(container dockerData) string {
 }
 
 func (provider *Docker) getSticky(container dockerData) string {
-	if label, err := getLabel(container, "traefik.backend.loadbalancer.sticky"); err == nil {
-		return label
+	if sticky, err := getLabel(container, "traefik.backend.loadbalancer.sticky"); err == nil {
+		if sticky == "true" {
+			return "cookie"
+		}
+		return sticky
 	}
 	return "false"
 }

--- a/provider/docker_test.go
+++ b/provider/docker_test.go
@@ -1160,6 +1160,7 @@ func TestDockerLoadDockerConfig(t *testing.T) {
 					},
 					LoadBalancer: &types.LoadBalancer{
 						Method: "drr",
+						Sticky: "false",
 					},
 					MaxConn: &types.MaxConn{
 						Amount:        1000,

--- a/provider/kubernetes.go
+++ b/provider/kubernetes.go
@@ -142,7 +142,7 @@ func (provider *Kubernetes) loadIngresses(k8sClient k8s.Client) (*types.Configur
 					templateObjects.Backends[r.Host+pa.Path] = &types.Backend{
 						Servers: make(map[string]types.Server),
 						LoadBalancer: &types.LoadBalancer{
-							Sticky: false,
+							Sticky: "false",
 							Method: "wrr",
 						},
 					}
@@ -212,9 +212,12 @@ func (provider *Kubernetes) loadIngresses(k8sClient k8s.Client) (*types.Configur
 				if service.Annotations["traefik.backend.loadbalancer.method"] == "drr" {
 					templateObjects.Backends[r.Host+pa.Path].LoadBalancer.Method = "drr"
 				}
-				if service.Annotations["traefik.backend.loadbalancer.sticky"] == "true" {
-					templateObjects.Backends[r.Host+pa.Path].LoadBalancer.Sticky = true
+
+				stickyType := service.Annotations["traefik.backend.loadbalancer.sticky"]
+				if stickyType == "true" {
+					stickyType = "cookie"
 				}
+				templateObjects.Backends[r.Host+pa.Path].LoadBalancer.Sticky = stickyType
 
 				protocol := "http"
 				for _, port := range service.Spec.Ports {

--- a/provider/kubernetes_test.go
+++ b/provider/kubernetes_test.go
@@ -244,7 +244,6 @@ func TestLoadIngresses(t *testing.T) {
 				},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -257,7 +256,6 @@ func TestLoadIngresses(t *testing.T) {
 				},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -278,7 +276,6 @@ func TestLoadIngresses(t *testing.T) {
 				},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -505,7 +502,6 @@ func TestGetPassHostHeader(t *testing.T) {
 				},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -617,7 +613,6 @@ func TestOnlyReferencesServicesFromOwnNamespace(t *testing.T) {
 				},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -806,7 +801,6 @@ func TestLoadNamespacedIngresses(t *testing.T) {
 				},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -823,7 +817,6 @@ func TestLoadNamespacedIngresses(t *testing.T) {
 				},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -1050,7 +1043,6 @@ func TestLoadMultipleNamespacedIngresses(t *testing.T) {
 				},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -1067,7 +1059,6 @@ func TestLoadMultipleNamespacedIngresses(t *testing.T) {
 				},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -1080,7 +1071,6 @@ func TestLoadMultipleNamespacedIngresses(t *testing.T) {
 				},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -1197,7 +1187,6 @@ func TestHostlessIngress(t *testing.T) {
 				},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -1290,7 +1279,7 @@ func TestServiceAnnotations(t *testing.T) {
 				Namespace: "testing",
 				Annotations: map[string]string{
 					"traefik.backend.circuitbreaker":      "",
-					"traefik.backend.loadbalancer.sticky": "true",
+					"traefik.backend.loadbalancer.sticky": "cookie",
 				},
 			},
 			Spec: v1.ServiceSpec{
@@ -1404,7 +1393,6 @@ func TestServiceAnnotations(t *testing.T) {
 				},
 				LoadBalancer: &types.LoadBalancer{
 					Method: "drr",
-					Sticky: false,
 				},
 			},
 			"bar": {
@@ -1421,7 +1409,7 @@ func TestServiceAnnotations(t *testing.T) {
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
 					Method: "wrr",
-					Sticky: true,
+					Sticky: "cookie",
 				},
 			},
 		},
@@ -1592,7 +1580,6 @@ func TestIngressAnnotations(t *testing.T) {
 				},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -1605,7 +1592,6 @@ func TestIngressAnnotations(t *testing.T) {
 				},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -1725,7 +1711,6 @@ func TestInvalidPassHostHeaderValue(t *testing.T) {
 				},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},

--- a/provider/marathon.go
+++ b/provider/marathon.go
@@ -354,6 +354,9 @@ func (provider *Marathon) getProtocol(task marathon.Task, applications []maratho
 
 func (provider *Marathon) getSticky(application marathon.Application) string {
 	if sticky, err := provider.getLabel(application, "traefik.backend.loadbalancer.sticky"); err == nil {
+		if sticky == "true" {
+			return "cookie"
+		}
 		return sticky
 	}
 	return "false"

--- a/provider/marathon_test.go
+++ b/provider/marathon_test.go
@@ -169,6 +169,7 @@ func TestMarathonLoadConfig(t *testing.T) {
 					},
 					LoadBalancer: &types.LoadBalancer{
 						Method: "drr",
+						Sticky: "false",
 					},
 				},
 			},

--- a/provider/rancher.go
+++ b/provider/rancher.go
@@ -114,8 +114,11 @@ func (provider *Rancher) getCircuitBreakerExpression(service rancherData) string
 }
 
 func (provider *Rancher) getSticky(service rancherData) string {
-	if _, err := getServiceLabel(service, "traefik.backend.loadbalancer.sticky"); err == nil {
-		return "true"
+	if sticky, err := getServiceLabel(service, "traefik.backend.loadbalancer.sticky"); err == nil {
+		if sticky == "true" {
+			return "cookie"
+		}
+		return sticky
 	}
 	return "false"
 }

--- a/templates/docker.tmpl
+++ b/templates/docker.tmpl
@@ -8,7 +8,7 @@
     {{if hasLoadBalancerLabel $backend}}
     [backends.backend-{{$backendName}}.loadbalancer]
       method = "{{getLoadBalancerMethod $backend}}"
-      sticky = {{getSticky $backend}}
+      sticky = "{{getSticky $backend}}"
     {{end}}
 
     {{if hasMaxConnLabels $backend}}

--- a/templates/kubernetes.tmpl
+++ b/templates/kubernetes.tmpl
@@ -5,9 +5,7 @@
     {{end}}
     [backends."{{$backendName}}".loadbalancer]
       method = "{{$backend.LoadBalancer.Method}}"
-      {{if $backend.LoadBalancer.Sticky}}
-          sticky = true
-      {{end}}
+      sticky = "{{$backend.LoadBalancer.Sticky}}"
     {{range $serverName, $server := $backend.Servers}}
     [backends."{{$backendName}}".servers."{{$serverName}}"]
     url = "{{$server.URL}}"

--- a/templates/kv.tmpl
+++ b/templates/kv.tmpl
@@ -16,7 +16,7 @@
 {{with $loadBalancer}}
 [backends."{{Last $backend}}".loadBalancer]
     method = "{{$loadBalancer}}"
-    sticky = {{$sticky}}
+    sticky = "{{$sticky}}"
 {{end}}
 
 {{$maxConnAmt := Get "" . "/maxconn/" "amount"}}

--- a/templates/marathon.tmpl
+++ b/templates/marathon.tmpl
@@ -14,7 +14,7 @@
 {{ if hasLoadBalancerLabels . }}
       [backends."backend{{getFrontendBackend . }}".loadbalancer]
         method = "{{getLoadBalancerMethod . }}"
-        sticky = {{getSticky .}}
+        sticky = "{{getSticky .}}"
 {{end}}
 {{ if hasCircuitBreakerLabels . }}
       [backends."backend{{getFrontendBackend . }}".circuitbreaker]

--- a/templates/rancher.tmpl
+++ b/templates/rancher.tmpl
@@ -8,7 +8,7 @@
     {{if hasLoadBalancerLabel $backend}}
     [backends.backend-{{$backendName}}.loadbalancer]
       method = "{{getLoadBalancerMethod $backend}}"
-      sticky = {{getSticky $backend}}
+      sticky = "{{getSticky $backend}}"
     {{end}}
 
     {{if hasMaxConnLabels $backend}}

--- a/types/types.go
+++ b/types/types.go
@@ -29,7 +29,7 @@ type MaxConn struct {
 // LoadBalancer holds load balancing configuration.
 type LoadBalancer struct {
 	Method string `json:"method,omitempty"`
-	Sticky bool   `json:"sticky,omitempty"`
+	Sticky string `json:"sticky,omitempty"`
 }
 
 // CircuitBreaker holds circuit breaker configuration.


### PR DESCRIPTION
Previously it had only true/false value which indicated the use of
cookie based sticky sessions. There however can be other types of sticky
sessions (e.g. ip address, custom headers, custom functions). Using a
string to choose a type is more appropriate here.

Using "true" value will still default to "cookie" for backwards
compatibility.

Should be useful for https://github.com/containous/traefik/issues/1207