### PR TITLE
Move make cross binary to Travis deploy step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,9 @@ script:
   - travis_retry make test-integration
 after_failure:
   - docker ps
-after_success:
+before_deploy:
   - make crossbinary
   - make image
-before_deploy:
   - mkdocs build --clean
   - tar cfz dist/traefik-${VERSION}.src.tar.gz --exclude-vcs --exclude dist .
 deploy:


### PR DESCRIPTION
Currently `make crossbinary` takes ~ 20 min on Travis, I propose to move `make crossbinary` & `make image` from `after_success` to `before_deploy`

Signed-off-by: Emile Vauge <emile@vauge.com>