### PR TITLE
Pass stripped prefix downstream as header (#985)

### DIFF
--- a/middlewares/stripPrefix.go
+++ b/middlewares/stripPrefix.go
@@ -5,6 +5,10 @@ import (
 	"strings"
 )
 
+const (
+	forwardedPrefixHeader = "X-Forwarded-Prefix"
+)
+
 // StripPrefix is a middleware used to strip prefix from an URL request
 type StripPrefix struct {
 	Handler  http.Handler
@@ -15,6 +19,7 @@ func (s *StripPrefix) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	for _, prefix := range s.Prefixes {
 		if p := strings.TrimPrefix(r.URL.Path, strings.TrimSpace(prefix)); len(p) < len(r.URL.Path) {
 			r.URL.Path = p
+			r.Header[forwardedPrefixHeader] = []string{prefix}
 			r.RequestURI = r.URL.RequestURI()
 			s.Handler.ServeHTTP(w, r)
 			return


### PR DESCRIPTION
This PR resolves #985, making Traefik more accessible to those of us making use of the HATEOAS constraint when building out REST APIs.