### PR TITLE
[ci] Don't run binary twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ install:
   - make pull-images
 before_script:
   - make validate
-  - make binary
 script: travis_retry make test-unit && travis_retry make test-integration
 after_failure:
   - docker ps


### PR DESCRIPTION
`test-integration` already run `binary` so let's not compile twice for nothing 👼 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>