### PR TITLE
Fix Rancher backend left in uncommented state

### DIFF
--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -996,28 +996,28 @@
 #
 # Optional
 #
-[rancher]
+#[rancher]
 
 # Default domain used.
 # Can be overridden by setting the "traefik.domain" label on an service.
 #
 # Required
 #
-domain = "rancher.localhost"
+#domain = "rancher.localhost"
 
 # Enable watch Rancher changes
 #
 # Optional
 # Default: true
 #
-Watch = true
+#Watch = true
 
 # Expose Rancher services by default in traefik
 #
 # Optional
 # Default: true
 #
-ExposedByDefault = false
+#ExposedByDefault = false
 
 # Endpoint to use when connecting to Rancher
 #


### PR DESCRIPTION
Re-commenting the Rancher backend in the sample config

Resolves #1454 