### PR TITLE
Update docker tests to use testify

### DIFF
--- a/provider/docker/docker_test.go
+++ b/provider/docker/docker_test.go
@@ -1,7 +1,6 @@
 package docker
 
 import (
-	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -9,6 +8,7 @@ import (
 	"github.com/containous/traefik/types"
 	docker "github.com/docker/engine-api/types"
 	"github.com/docker/go-connections/nat"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDockerGetFrontendName(t *testing.T) {
@@ -63,9 +63,7 @@ func TestDockerGetFrontendName(t *testing.T) {
 			t.Parallel()
 			dockerData := parseContainer(e.container)
 			actual := provider.getFrontendName(dockerData)
-			if actual != e.expected {
-				t.Errorf("expected %q, got %q", e.expected, actual)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -113,9 +111,7 @@ func TestDockerGetFrontendRule(t *testing.T) {
 			t.Parallel()
 			dockerData := parseContainer(e.container)
 			actual := provider.getFrontendRule(dockerData)
-			if actual != e.expected {
-				t.Errorf("expected %q, got %q", e.expected, actual)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -156,9 +152,7 @@ func TestDockerGetBackend(t *testing.T) {
 			t.Parallel()
 			dockerData := parseContainer(e.container)
 			actual := provider.getBackend(dockerData)
-			if actual != e.expected {
-				t.Errorf("expected %q, got %q", e.expected, actual)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -209,9 +203,7 @@ func TestDockerGetIPAddress(t *testing.T) {
 			t.Parallel()
 			dockerData := parseContainer(e.container)
 			actual := provider.getIPAddress(dockerData)
-			if actual != e.expected {
-				t.Errorf("expected %q, got %q", e.expected, actual)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -272,9 +264,7 @@ func TestDockerGetPort(t *testing.T) {
 			t.Parallel()
 			dockerData := parseContainer(e.container)
 			actual := provider.getPort(dockerData)
-			if actual != e.expected {
-				t.Errorf("expected %q, got %q", e.expected, actual)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -304,9 +294,7 @@ func TestDockerGetWeight(t *testing.T) {
 			t.Parallel()
 			dockerData := parseContainer(e.container)
 			actual := provider.getWeight(dockerData)
-			if actual != e.expected {
-				t.Errorf("expected %q, got %q", e.expected, actual)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -338,9 +326,7 @@ func TestDockerGetDomain(t *testing.T) {
 			t.Parallel()
 			dockerData := parseContainer(e.container)
 			actual := provider.getDomain(dockerData)
-			if actual != e.expected {
-				t.Errorf("expected %q, got %q", e.expected, actual)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -370,9 +356,7 @@ func TestDockerGetProtocol(t *testing.T) {
 			t.Parallel()
 			dockerData := parseContainer(e.container)
 			actual := provider.getProtocol(dockerData)
-			if actual != e.expected {
-				t.Errorf("expected %q, got %q", e.expected, actual)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -401,9 +385,7 @@ func TestDockerGetPassHostHeader(t *testing.T) {
 			t.Parallel()
 			dockerData := parseContainer(e.container)
 			actual := provider.getPassHostHeader(dockerData)
-			if actual != e.expected {
-				t.Errorf("expected %q, got %q", e.expected, actual)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -483,14 +465,12 @@ func TestDockerGetLabels(t *testing.T) {
 			t.Parallel()
 			dockerData := parseContainer(e.container)
 			labels, err := getLabels(dockerData, []string{"foo", "bar"})
-			if !reflect.DeepEqual(labels, e.expectedLabels) {
-				t.Errorf("expect %v, got %v", e.expectedLabels, labels)
-			}
 			if e.expectedError != "" {
 				if err == nil || !strings.Contains(err.Error(), e.expectedError) {
 					t.Errorf("expected an error with %q, got %v", e.expectedError, err)
 				}
 			}
+			assert.Equal(t, e.expectedLabels, labels)
 		})
 	}
 }
@@ -629,9 +609,7 @@ func TestDockerTraefikFilter(t *testing.T) {
 			provider.ExposedByDefault = e.exposedByDefault
 			dockerData := parseContainer(e.container)
 			actual := provider.containerFilter(dockerData)
-			if actual != e.expected {
-				t.Errorf("expected %v for %+v (%+v, %+v), got %+v", e.expected, e.container, e.container.NetworkSettings, e.container.ContainerJSONBase, actual)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -812,13 +790,8 @@ func TestDockerLoadDockerConfig(t *testing.T) {
 			}
 
 			actualConfig := provider.loadDockerConfig(dockerDataList)
-			// Compare backends
-			if !reflect.DeepEqual(actualConfig.Backends, c.expectedBackends) {
-				t.Errorf("expected %#v, got %#v", c.expectedBackends, actualConfig.Backends)
-			}
-			if !reflect.DeepEqual(actualConfig.Frontends, c.expectedFrontends) {
-				t.Errorf("expected %#v, got %#v", c.expectedFrontends, actualConfig.Frontends)
-			}
+			assert.Equal(t, c.expectedBackends, actualConfig.Backends)
+			assert.Equal(t, c.expectedFrontends, actualConfig.Frontends)
 		})
 	}
 }

--- a/provider/docker/service_test.go
+++ b/provider/docker/service_test.go
@@ -1,13 +1,13 @@
 package docker
 
 import (
-	"reflect"
 	"strconv"
 	"testing"
 
 	"github.com/containous/traefik/types"
 	docker "github.com/docker/engine-api/types"
 	"github.com/docker/go-connections/nat"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDockerGetServiceProtocol(t *testing.T) {
@@ -41,9 +41,7 @@ func TestDockerGetServiceProtocol(t *testing.T) {
 			t.Parallel()
 			dockerData := parseContainer(e.container)
 			actual := provider.getServiceProtocol(dockerData, "myservice")
-			if actual != e.expected {
-				t.Fatalf("expected %q, got %q", e.expected, actual)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -79,9 +77,7 @@ func TestDockerGetServiceWeight(t *testing.T) {
 			t.Parallel()
 			dockerData := parseContainer(e.container)
 			actual := provider.getServiceWeight(dockerData, "myservice")
-			if actual != e.expected {
-				t.Fatalf("expected %q, got %q", e.expected, actual)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -117,9 +113,7 @@ func TestDockerGetServicePort(t *testing.T) {
 			t.Parallel()
 			dockerData := parseContainer(e.container)
 			actual := provider.getServicePort(dockerData, "myservice")
-			if actual != e.expected {
-				t.Fatalf("expected %q, got %q", e.expected, actual)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -155,9 +149,7 @@ func TestDockerGetServiceFrontendRule(t *testing.T) {
 			t.Parallel()
 			dockerData := parseContainer(e.container)
 			actual := provider.getServiceFrontendRule(dockerData, "myservice")
-			if actual != e.expected {
-				t.Fatalf("expected %q, got %q", e.expected, actual)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -193,9 +185,7 @@ func TestDockerGetServiceBackend(t *testing.T) {
 			t.Parallel()
 			dockerData := parseContainer(e.container)
 			actual := provider.getServiceBackend(dockerData, "myservice")
-			if actual != e.expected {
-				t.Fatalf("expected %q, got %q", e.expected, actual)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -231,9 +221,7 @@ func TestDockerGetServicePriority(t *testing.T) {
 			t.Parallel()
 			dockerData := parseContainer(e.container)
 			actual := provider.getServicePriority(dockerData, "myservice")
-			if actual != e.expected {
-				t.Fatalf("expected %q, got %q", e.expected, actual)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -269,9 +257,7 @@ func TestDockerGetServicePassHostHeader(t *testing.T) {
 			t.Parallel()
 			dockerData := parseContainer(e.container)
 			actual := provider.getServicePassHostHeader(dockerData, "myservice")
-			if actual != e.expected {
-				t.Fatalf("expected %q, got %q", e.expected, actual)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -307,9 +293,7 @@ func TestDockerGetServiceEntryPoints(t *testing.T) {
 			t.Parallel()
 			dockerData := parseContainer(e.container)
 			actual := provider.getServiceEntryPoints(dockerData, "myservice")
-			if !reflect.DeepEqual(actual, e.expected) {
-				t.Fatalf("expected %q, got %q for container %q", e.expected, actual, dockerData.Name)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -457,13 +441,8 @@ func TestDockerLoadDockerServiceConfig(t *testing.T) {
 			}
 
 			actualConfig := provider.loadDockerConfig(dockerDataList)
-			// Compare backends
-			if !reflect.DeepEqual(actualConfig.Backends, c.expectedBackends) {
-				t.Fatalf("expected %#v, got %#v", c.expectedBackends, actualConfig.Backends)
-			}
-			if !reflect.DeepEqual(actualConfig.Frontends, c.expectedFrontends) {
-				t.Fatalf("expected %#v, got %#v", c.expectedFrontends, actualConfig.Frontends)
-			}
+			assert.Equal(t, c.expectedBackends, actualConfig.Backends)
+			assert.Equal(t, c.expectedFrontends, actualConfig.Frontends)
 		})
 	}
 }

--- a/provider/docker/swarm_test.go
+++ b/provider/docker/swarm_test.go
@@ -12,6 +12,7 @@ import (
 	docker "github.com/docker/engine-api/types"
 	dockertypes "github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/swarm"
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 )
 
@@ -70,9 +71,7 @@ func TestSwarmGetFrontendName(t *testing.T) {
 			t.Parallel()
 			dockerData := parseService(e.service, e.networks)
 			actual := provider.getFrontendName(dockerData)
-			if actual != e.expected {
-				t.Errorf("expected %q, got %q", e.expected, actual)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -120,9 +119,7 @@ func TestSwarmGetFrontendRule(t *testing.T) {
 			t.Parallel()
 			dockerData := parseService(e.service, e.networks)
 			actual := provider.getFrontendRule(dockerData)
-			if actual != e.expected {
-				t.Errorf("expected %q, got %q", e.expected, actual)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -162,9 +159,7 @@ func TestSwarmGetBackend(t *testing.T) {
 			t.Parallel()
 			dockerData := parseService(e.service, e.networks)
 			actual := provider.getBackend(dockerData)
-			if actual != e.expected {
-				t.Errorf("expected %q, got %q", e.expected, actual)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -225,9 +220,7 @@ func TestSwarmGetIPAddress(t *testing.T) {
 			t.Parallel()
 			dockerData := parseService(e.service, e.networks)
 			actual := provider.getIPAddress(dockerData)
-			if actual != e.expected {
-				t.Errorf("expected %q, got %q", e.expected, actual)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -260,9 +253,7 @@ func TestSwarmGetPort(t *testing.T) {
 			t.Parallel()
 			dockerData := parseService(e.service, e.networks)
 			actual := provider.getPort(dockerData)
-			if actual != e.expected {
-				t.Errorf("expected %q, got %q", e.expected, actual)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -297,9 +288,7 @@ func TestSwarmGetWeight(t *testing.T) {
 			t.Parallel()
 			dockerData := parseService(e.service, e.networks)
 			actual := provider.getWeight(dockerData)
-			if actual != e.expected {
-				t.Errorf("expected %q, got %q", e.expected, actual)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -335,9 +324,7 @@ func TestSwarmGetDomain(t *testing.T) {
 			t.Parallel()
 			dockerData := parseService(e.service, e.networks)
 			actual := provider.getDomain(dockerData)
-			if actual != e.expected {
-				t.Errorf("expected %q, got %q", e.expected, actual)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -372,9 +359,7 @@ func TestSwarmGetProtocol(t *testing.T) {
 			t.Parallel()
 			dockerData := parseService(e.service, e.networks)
 			actual := provider.getProtocol(dockerData)
-			if actual != e.expected {
-				t.Errorf("expected %q, got %q", e.expected, actual)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -409,9 +394,7 @@ func TestSwarmGetPassHostHeader(t *testing.T) {
 			t.Parallel()
 			dockerData := parseService(e.service, e.networks)
 			actual := provider.getPassHostHeader(dockerData)
-			if actual != e.expected {
-				t.Errorf("expected %q, got %q", e.expected, actual)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -498,14 +481,12 @@ func TestSwarmGetLabels(t *testing.T) {
 			t.Parallel()
 			dockerData := parseService(e.service, e.networks)
 			labels, err := getLabels(dockerData, []string{"foo", "bar"})
-			if !reflect.DeepEqual(labels, e.expectedLabels) {
-				t.Errorf("expect %v, got %v", e.expectedLabels, labels)
-			}
 			if e.expectedError != "" {
 				if err == nil || !strings.Contains(err.Error(), e.expectedError) {
 					t.Errorf("expected an error with %q, got %v", e.expectedError, err)
 				}
 			}
+			assert.Equal(t, e.expectedLabels, labels)
 		})
 	}
 }
@@ -605,9 +586,7 @@ func TestSwarmTraefikFilter(t *testing.T) {
 			dockerData := parseService(e.service, e.networks)
 			provider.ExposedByDefault = e.exposedByDefault
 			actual := provider.containerFilter(dockerData)
-			if actual != e.expected {
-				t.Errorf("expected %v for %+v, got %+v", e.expected, e, actual)
-			}
+			assert.Equal(t, e.expected, actual)
 		})
 	}
 }
@@ -751,13 +730,8 @@ func TestSwarmLoadDockerConfig(t *testing.T) {
 			}
 
 			actualConfig := provider.loadDockerConfig(dockerDataList)
-			// Compare backends
-			if !reflect.DeepEqual(actualConfig.Backends, c.expectedBackends) {
-				t.Errorf("expected %#v, got %#v", c.expectedBackends, actualConfig.Backends)
-			}
-			if !reflect.DeepEqual(actualConfig.Frontends, c.expectedFrontends) {
-				t.Errorf("expected %#v, got %#v", c.expectedFrontends, actualConfig.Frontends)
-			}
+			assert.Equal(t, c.expectedBackends, actualConfig.Backends)
+			assert.Equal(t, c.expectedFrontends, actualConfig.Frontends)
 		})
 	}
 }


### PR DESCRIPTION
It displays diff with `go-spew` which is way better than our current failure output.

<del>It also removes t.Parallel as without it tests run in 0.018s.. and `t.Parallel` really freaks me out</del>

I intend to follow-up for each and every tests (starting with providers). For providers I'll also do the builders for each .

Signed-off-by: Vincent Demeester <vincent@sbr.pm>