### PR TITLE
Update dockerignore to ignore dist and sites

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
-/dist/
-!/dist/traefik
-/site/
+dist/
+site/


### PR DESCRIPTION
As of now, it does nothing (`/dist/` doesn't filter the dist folder) and sending anything from `dist` doesn't make sense as it's mounted anyway (that's why removing `!/dist/traefik`).

To see why it's important : `make cross-binary && make validate`… look at the size of the build context sent on the 2nd command (without this PR >600M, with this PR ~60M).

> Removing the traefik binary from whitelist as the integration script
compiles the binary before running, so we don't need to send it via
the build context.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>