### PR TITLE
Only enable redirection if a frontend has no backends

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -598,7 +598,7 @@ func (server *Server) loadConfig(configurations configs, globalConfiguration Glo
 				}
 
 				entryPoint := globalConfiguration.EntryPoints[entryPointName]
-				if entryPoint.Redirect != nil {
+				if entryPoint.Redirect != nil && configuration.Backends[frontend.Backend] == nil {
 					if redirectHandlers[entryPointName] != nil {
 						newServerRoute.route.Handler(redirectHandlers[entryPointName])
 					} else if handler, err := server.loadEntryPointConfig(entryPointName, entryPoint); err != nil {


### PR DESCRIPTION
This change allows you to selectively redirect front ends. To support
setups such as #1456 and #987

With this in place, I have a marathon template that only sets the
backend on frontends that have a label that requests redirect to https.