### PR TITLE
Check for explicitly defined Marathon port first.

### DIFF
--- a/testhelpers/helpers.go
+++ b/testhelpers/helpers.go
@@ -1,0 +1,6 @@
+package testhelpers
+
+// Intp returns a pointer to the given integer value.
+func Intp(i int) *int {
+	return &i
+}


### PR DESCRIPTION
Check for explicitly defined Marathon port first.
    
Previously, we did the check too late resulting in the `traefik.port` label not being effective.
    
The change comes with additional refactorings in production and tests.

Original issue at #261.
Complements PR at #1394.
Discovered along #1390.