### PR TITLE
Add basic auth to kubernetes provider

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -1186,6 +1186,22 @@ Additionally, an annotation can be used on Kubernetes services to set the [circu
 
 - `traefik.backend.circuitbreaker: <expression>`: set the circuit breaker expression for the backend (Default: nil).
 
+### Authentication
+
+Is possible to add additional authentication annotations in the Ingress rule.
+The source of the authentication is a secret that contains usernames and passwords inside the the key auth.
+
+- `ingress.kubernetes.io/auth-type`: `basic`
+- `ingress.kubernetes.io/auth-secret`: contains the usernames and passwords with access to the paths defined in the Ingress Rule.
+
+The secret must be created in the same namespace as the Ingress rule.
+
+Limitations:
+
+- Basic authentication only.
+- Realm not configurable; only `traefik` default.
+- Secret must contain only single file.
+
 ## Consul backend
 
 Træfik can be configured to use Consul as a backend configuration:
@@ -1718,7 +1734,6 @@ RefreshSeconds = 15
 ```
 
 Items in the `dynamodb` table must have three attributes: 
-
 
 - `id` : string
     - The id is the primary key.

--- a/docs/user-guide/kubernetes.md
+++ b/docs/user-guide/kubernetes.md
@@ -505,19 +505,22 @@ You should now be able to visit the websites in your browser.
 * [cheeses.local/wensleydale](http://cheeses.local/wensleydale/)
 
 ## Disable passing the Host header
-By default Træfik will pass the incoming Host header on to the upstream resource. There
-are times however where you may not want this to be the case. For example if your service
-is of the ExternalName type.
+
+By default Træfik will pass the incoming Host header on to the upstream resource.
+There are times however where you may not want this to be the case.
+For example if your service is of the ExternalName type.
 
 ### Disable entirely
+
 Add the following to your toml config:
 ```toml
 disablePassHostHeaders = true
 ```
 
 ### Disable per ingress
-To disable passing the Host header per ingress resource set the "traefik.frontend.passHostHeader"
-annotation on your ingress to "false".
+
+To disable passing the Host header per ingress resource set the `traefik.frontend.passHostHeader`
+annotation on your ingress to `false`.
 
 Here is an example ingress definition:
 ```yaml
@@ -557,16 +560,15 @@ If you were to visit example.com/static the request would then be passed onto
 static.otherdomain.com/static and static.otherdomain.com would receive the
 request with the Host header being static.otherdomain.com.
 
-Note: The per ingress annotation overides whatever the global value is set to. So you
-could set `disablePassHostHeaders` to true in your toml file and then enable passing
+Note: The per ingress annotation overides whatever the global value is set to.
+So you could set `disablePassHostHeaders` to `true` in your toml file and then enable passing 
 the host header per ingress if you wanted.
 
 ## Excluding an ingress from Træfik
 
-You can control which ingress Træfik cares about by using the `kubernetes.io/ingress.class`
-annotation. By default if the annotation is not set at all Træfik will include the
-ingress. If the annotation is set to anything other than traefik or a blank string
-Træfik will ignore it.
+You can control which ingress Træfik cares about by using the `kubernetes.io/ingress.class` annotation.
+By default if the annotation is not set at all Træfik will include the ingress.
+If the annotation is set to anything other than traefik or a blank string Træfik will ignore it.
 
 
 ![](http://i.giphy.com/ujUdrdpX7Ok5W.gif)

--- a/templates/kubernetes.tmpl
+++ b/templates/kubernetes.tmpl
@@ -20,6 +20,9 @@
   backend = "{{$frontend.Backend}}"
   priority = {{$frontend.Priority}}
   passHostHeader = {{$frontend.PassHostHeader}}
+  basicAuth = [{{range $frontend.BasicAuth}}
+      "{{.}}",
+  {{end}}]
     {{range $routeName, $route := $frontend.Routes}}
     [frontends."{{$frontendName}}".routes."{{$routeName}}"]
     rule = "{{$route.Rule}}"


### PR DESCRIPTION
This will add the kubernetes provider for basic authentication. Thanks to @SantoDE for #1147.

## Some constraints: 
* Basic authentication only
* Realm not configurable; only `traefik`default
* Secret is in same namespace as ingress rule
* Secret must contain only single file (*)

(*) otherwise we can have some conventions here like key name (pattern)

## Example
Based on https://docs.traefik.io/user-guide/kubernetes/
* Encode credentials
`htpasswd -c ./auth jane`
* Deploy a secret to k8s
`kubectl --namespace=kube-system create secret generic mysecret --from-file auth`
* Deploy ingress
```yaml
apiVersion: v1
kind: Service
metadata:
  name: traefik-web-ui
  namespace: kube-system
spec:
  selector:
    k8s-app: traefik-ingress-lb
  ports:
  - port: 80
    targetPort: 8080
---
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: traefik-web-ui
  namespace: kube-system
  annotations:
    ingress.kubernetes.io/auth-type: "basic"
    ingress.kubernetes.io/auth-secret: "mysecret"
spec:
  rules:
  - host: traefik-ui.local
    http:
      paths:
      - backend:
          serviceName: traefik-web-ui
          servicePort: 80
```
Note the two annotations to enable basic auth and link the secret