### PR TITLE
Move Docker test provider instantiation into t.Run body.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - make pull-images
 before_script:
   - make validate
-script: travis_retry make test-unit && travis_retry make test-integration
+script: make test-unit && travis_retry make test-integration
 after_failure:
   - docker ps
 before_deploy:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ TRAEFIK_ENVS := \
 	-e TESTFLAGS \
 	-e VERBOSE \
 	-e VERSION \
-	-e CODENAME
+	-e CODENAME \
+	-e TESTDIRS
 
 SRCS = $(shell git ls-files '*.go' | grep -v '^vendor/' | grep -v '^integration/vendor/')
 

--- a/provider/docker/docker_test.go
+++ b/provider/docker/docker_test.go
@@ -12,10 +12,6 @@ import (
 )
 
 func TestDockerGetFrontendName(t *testing.T) {
-	provider := &Provider{
-		Domain: "docker.localhost",
-	}
-
 	containers := []struct {
 		container docker.ContainerJSON
 		expected  string
@@ -62,6 +58,9 @@ func TestDockerGetFrontendName(t *testing.T) {
 		t.Run(strconv.Itoa(containerID), func(t *testing.T) {
 			t.Parallel()
 			dockerData := parseContainer(e.container)
+			provider := &Provider{
+				Domain: "docker.localhost",
+			}
 			actual := provider.getFrontendName(dockerData)
 			if actual != e.expected {
 				t.Errorf("expected %q, got %q", e.expected, actual)
@@ -71,10 +70,6 @@ func TestDockerGetFrontendName(t *testing.T) {
 }
 
 func TestDockerGetFrontendRule(t *testing.T) {
-	provider := &Provider{
-		Domain: "docker.localhost",
-	}
-
 	containers := []struct {
 		container docker.ContainerJSON
 		expected  string
@@ -112,6 +107,9 @@ func TestDockerGetFrontendRule(t *testing.T) {
 		t.Run(strconv.Itoa(containerID), func(t *testing.T) {
 			t.Parallel()
 			dockerData := parseContainer(e.container)
+			provider := &Provider{
+				Domain: "docker.localhost",
+			}
 			actual := provider.getFrontendRule(dockerData)
 			if actual != e.expected {
 				t.Errorf("expected %q, got %q", e.expected, actual)
@@ -121,8 +119,6 @@ func TestDockerGetFrontendRule(t *testing.T) {
 }
 
 func TestDockerGetBackend(t *testing.T) {
-	provider := &Provider{}
-
 	containers := []struct {
 		container docker.ContainerJSON
 		expected  string
@@ -155,6 +151,7 @@ func TestDockerGetBackend(t *testing.T) {
 		t.Run(strconv.Itoa(containerID), func(t *testing.T) {
 			t.Parallel()
 			dockerData := parseContainer(e.container)
+			provider := &Provider{}
 			actual := provider.getBackend(dockerData)
 			if actual != e.expected {
 				t.Errorf("expected %q, got %q", e.expected, actual)
@@ -164,8 +161,6 @@ func TestDockerGetBackend(t *testing.T) {
 }
 
 func TestDockerGetIPAddress(t *testing.T) {
-	provider := &Provider{}
-
 	containers := []struct {
 		container docker.ContainerJSON
 		expected  string
@@ -208,6 +203,7 @@ func TestDockerGetIPAddress(t *testing.T) {
 		t.Run(strconv.Itoa(containerID), func(t *testing.T) {
 			t.Parallel()
 			dockerData := parseContainer(e.container)
+			provider := &Provider{}
 			actual := provider.getIPAddress(dockerData)
 			if actual != e.expected {
 				t.Errorf("expected %q, got %q", e.expected, actual)
@@ -217,8 +213,6 @@ func TestDockerGetIPAddress(t *testing.T) {
 }
 
 func TestDockerGetPort(t *testing.T) {
-	provider := &Provider{}
-
 	containers := []struct {
 		container docker.ContainerJSON
 		expected  string
@@ -271,6 +265,7 @@ func TestDockerGetPort(t *testing.T) {
 		t.Run(strconv.Itoa(containerID), func(t *testing.T) {
 			t.Parallel()
 			dockerData := parseContainer(e.container)
+			provider := &Provider{}
 			actual := provider.getPort(dockerData)
 			if actual != e.expected {
 				t.Errorf("expected %q, got %q", e.expected, actual)
@@ -280,8 +275,6 @@ func TestDockerGetPort(t *testing.T) {
 }
 
 func TestDockerGetWeight(t *testing.T) {
-	provider := &Provider{}
-
 	containers := []struct {
 		container docker.ContainerJSON
 		expected  string
@@ -303,6 +296,7 @@ func TestDockerGetWeight(t *testing.T) {
 		t.Run(strconv.Itoa(containerID), func(t *testing.T) {
 			t.Parallel()
 			dockerData := parseContainer(e.container)
+			provider := &Provider{}
 			actual := provider.getWeight(dockerData)
 			if actual != e.expected {
 				t.Errorf("expected %q, got %q", e.expected, actual)
@@ -312,10 +306,6 @@ func TestDockerGetWeight(t *testing.T) {
 }
 
 func TestDockerGetDomain(t *testing.T) {
-	provider := &Provider{
-		Domain: "docker.localhost",
-	}
-
 	containers := []struct {
 		container docker.ContainerJSON
 		expected  string
@@ -337,6 +327,9 @@ func TestDockerGetDomain(t *testing.T) {
 		t.Run(strconv.Itoa(containerID), func(t *testing.T) {
 			t.Parallel()
 			dockerData := parseContainer(e.container)
+			provider := &Provider{
+				Domain: "docker.localhost",
+			}
 			actual := provider.getDomain(dockerData)
 			if actual != e.expected {
 				t.Errorf("expected %q, got %q", e.expected, actual)
@@ -346,8 +339,6 @@ func TestDockerGetDomain(t *testing.T) {
 }
 
 func TestDockerGetProtocol(t *testing.T) {
-	provider := &Provider{}
-
 	containers := []struct {
 		container docker.ContainerJSON
 		expected  string
@@ -369,6 +360,7 @@ func TestDockerGetProtocol(t *testing.T) {
 		t.Run(strconv.Itoa(containerID), func(t *testing.T) {
 			t.Parallel()
 			dockerData := parseContainer(e.container)
+			provider := &Provider{}
 			actual := provider.getProtocol(dockerData)
 			if actual != e.expected {
 				t.Errorf("expected %q, got %q", e.expected, actual)
@@ -378,7 +370,6 @@ func TestDockerGetProtocol(t *testing.T) {
 }
 
 func TestDockerGetPassHostHeader(t *testing.T) {
-	provider := &Provider{}
 	containers := []struct {
 		container docker.ContainerJSON
 		expected  string
@@ -400,6 +391,7 @@ func TestDockerGetPassHostHeader(t *testing.T) {
 		t.Run(strconv.Itoa(containerID), func(t *testing.T) {
 			t.Parallel()
 			dockerData := parseContainer(e.container)
+			provider := &Provider{}
 			actual := provider.getPassHostHeader(dockerData)
 			if actual != e.expected {
 				t.Errorf("expected %q, got %q", e.expected, actual)
@@ -496,7 +488,6 @@ func TestDockerGetLabels(t *testing.T) {
 }
 
 func TestDockerTraefikFilter(t *testing.T) {
-	provider := Provider{}
 	containers := []struct {
 		container        docker.ContainerJSON
 		exposedByDefault bool
@@ -626,6 +617,7 @@ func TestDockerTraefikFilter(t *testing.T) {
 		e := e
 		t.Run(strconv.Itoa(containerID), func(t *testing.T) {
 			t.Parallel()
+			provider := Provider{}
 			provider.ExposedByDefault = e.exposedByDefault
 			dockerData := parseContainer(e.container)
 			actual := provider.containerFilter(dockerData)
@@ -801,11 +793,6 @@ func TestDockerLoadDockerConfig(t *testing.T) {
 		},
 	}
 
-	provider := &Provider{
-		Domain:           "docker.localhost",
-		ExposedByDefault: true,
-	}
-
 	for caseID, c := range cases {
 		c := c
 		t.Run(strconv.Itoa(caseID), func(t *testing.T) {
@@ -816,6 +803,10 @@ func TestDockerLoadDockerConfig(t *testing.T) {
 				dockerDataList = append(dockerDataList, dockerData)
 			}
 
+			provider := &Provider{
+				Domain:           "docker.localhost",
+				ExposedByDefault: true,
+			}
 			actualConfig := provider.loadDockerConfig(dockerDataList)
 			// Compare backends
 			if !reflect.DeepEqual(actualConfig.Backends, c.expectedBackends) {

--- a/provider/docker/swarm_test.go
+++ b/provider/docker/swarm_test.go
@@ -16,11 +16,6 @@ import (
 )
 
 func TestSwarmGetFrontendName(t *testing.T) {
-	provider := &Provider{
-		Domain:    "docker.localhost",
-		SwarmMode: true,
-	}
-
 	services := []struct {
 		service  swarm.Service
 		expected string
@@ -69,6 +64,10 @@ func TestSwarmGetFrontendName(t *testing.T) {
 		t.Run(strconv.Itoa(serviceID), func(t *testing.T) {
 			t.Parallel()
 			dockerData := parseService(e.service, e.networks)
+			provider := &Provider{
+				Domain:    "docker.localhost",
+				SwarmMode: true,
+			}
 			actual := provider.getFrontendName(dockerData)
 			if actual != e.expected {
 				t.Errorf("expected %q, got %q", e.expected, actual)
@@ -78,11 +77,6 @@ func TestSwarmGetFrontendName(t *testing.T) {
 }
 
 func TestSwarmGetFrontendRule(t *testing.T) {
-	provider := &Provider{
-		Domain:    "docker.localhost",
-		SwarmMode: true,
-	}
-
 	services := []struct {
 		service  swarm.Service
 		expected string
@@ -119,6 +113,10 @@ func TestSwarmGetFrontendRule(t *testing.T) {
 		t.Run(strconv.Itoa(serviceID), func(t *testing.T) {
 			t.Parallel()
 			dockerData := parseService(e.service, e.networks)
+			provider := &Provider{
+				Domain:    "docker.localhost",
+				SwarmMode: true,
+			}
 			actual := provider.getFrontendRule(dockerData)
 			if actual != e.expected {
 				t.Errorf("expected %q, got %q", e.expected, actual)
@@ -128,10 +126,6 @@ func TestSwarmGetFrontendRule(t *testing.T) {
 }
 
 func TestSwarmGetBackend(t *testing.T) {
-	provider := &Provider{
-		SwarmMode: true,
-	}
-
 	services := []struct {
 		service  swarm.Service
 		expected string
@@ -161,6 +155,9 @@ func TestSwarmGetBackend(t *testing.T) {
 		t.Run(strconv.Itoa(serviceID), func(t *testing.T) {
 			t.Parallel()
 			dockerData := parseService(e.service, e.networks)
+			provider := &Provider{
+				SwarmMode: true,
+			}
 			actual := provider.getBackend(dockerData)
 			if actual != e.expected {
 				t.Errorf("expected %q, got %q", e.expected, actual)
@@ -170,10 +167,6 @@ func TestSwarmGetBackend(t *testing.T) {
 }
 
 func TestSwarmGetIPAddress(t *testing.T) {
-	provider := &Provider{
-		SwarmMode: true,
-	}
-
 	services := []struct {
 		service  swarm.Service
 		expected string
@@ -224,6 +217,9 @@ func TestSwarmGetIPAddress(t *testing.T) {
 		t.Run(strconv.Itoa(serviceID), func(t *testing.T) {
 			t.Parallel()
 			dockerData := parseService(e.service, e.networks)
+			provider := &Provider{
+				SwarmMode: true,
+			}
 			actual := provider.getIPAddress(dockerData)
 			if actual != e.expected {
 				t.Errorf("expected %q, got %q", e.expected, actual)
@@ -233,10 +229,6 @@ func TestSwarmGetIPAddress(t *testing.T) {
 }
 
 func TestSwarmGetPort(t *testing.T) {
-	provider := &Provider{
-		SwarmMode: true,
-	}
-
 	services := []struct {
 		service  swarm.Service
 		expected string
@@ -259,6 +251,9 @@ func TestSwarmGetPort(t *testing.T) {
 		t.Run(strconv.Itoa(serviceID), func(t *testing.T) {
 			t.Parallel()
 			dockerData := parseService(e.service, e.networks)
+			provider := &Provider{
+				SwarmMode: true,
+			}
 			actual := provider.getPort(dockerData)
 			if actual != e.expected {
 				t.Errorf("expected %q, got %q", e.expected, actual)
@@ -268,10 +263,6 @@ func TestSwarmGetPort(t *testing.T) {
 }
 
 func TestSwarmGetWeight(t *testing.T) {
-	provider := &Provider{
-		SwarmMode: true,
-	}
-
 	services := []struct {
 		service  swarm.Service
 		expected string
@@ -296,6 +287,9 @@ func TestSwarmGetWeight(t *testing.T) {
 		t.Run(strconv.Itoa(serviceID), func(t *testing.T) {
 			t.Parallel()
 			dockerData := parseService(e.service, e.networks)
+			provider := &Provider{
+				SwarmMode: true,
+			}
 			actual := provider.getWeight(dockerData)
 			if actual != e.expected {
 				t.Errorf("expected %q, got %q", e.expected, actual)
@@ -305,11 +299,6 @@ func TestSwarmGetWeight(t *testing.T) {
 }
 
 func TestSwarmGetDomain(t *testing.T) {
-	provider := &Provider{
-		Domain:    "docker.localhost",
-		SwarmMode: true,
-	}
-
 	services := []struct {
 		service  swarm.Service
 		expected string
@@ -334,6 +323,10 @@ func TestSwarmGetDomain(t *testing.T) {
 		t.Run(strconv.Itoa(serviceID), func(t *testing.T) {
 			t.Parallel()
 			dockerData := parseService(e.service, e.networks)
+			provider := &Provider{
+				Domain:    "docker.localhost",
+				SwarmMode: true,
+			}
 			actual := provider.getDomain(dockerData)
 			if actual != e.expected {
 				t.Errorf("expected %q, got %q", e.expected, actual)
@@ -343,10 +336,6 @@ func TestSwarmGetDomain(t *testing.T) {
 }
 
 func TestSwarmGetProtocol(t *testing.T) {
-	provider := &Provider{
-		SwarmMode: true,
-	}
-
 	services := []struct {
 		service  swarm.Service
 		expected string
@@ -371,6 +360,9 @@ func TestSwarmGetProtocol(t *testing.T) {
 		t.Run(strconv.Itoa(serviceID), func(t *testing.T) {
 			t.Parallel()
 			dockerData := parseService(e.service, e.networks)
+			provider := &Provider{
+				SwarmMode: true,
+			}
 			actual := provider.getProtocol(dockerData)
 			if actual != e.expected {
 				t.Errorf("expected %q, got %q", e.expected, actual)
@@ -380,10 +372,6 @@ func TestSwarmGetProtocol(t *testing.T) {
 }
 
 func TestSwarmGetPassHostHeader(t *testing.T) {
-	provider := &Provider{
-		SwarmMode: true,
-	}
-
 	services := []struct {
 		service  swarm.Service
 		expected string
@@ -408,6 +396,9 @@ func TestSwarmGetPassHostHeader(t *testing.T) {
 		t.Run(strconv.Itoa(serviceID), func(t *testing.T) {
 			t.Parallel()
 			dockerData := parseService(e.service, e.networks)
+			provider := &Provider{
+				SwarmMode: true,
+			}
 			actual := provider.getPassHostHeader(dockerData)
 			if actual != e.expected {
 				t.Errorf("expected %q, got %q", e.expected, actual)
@@ -511,9 +502,6 @@ func TestSwarmGetLabels(t *testing.T) {
 }
 
 func TestSwarmTraefikFilter(t *testing.T) {
-	provider := &Provider{
-		SwarmMode: true,
-	}
 	services := []struct {
 		service          swarm.Service
 		exposedByDefault bool
@@ -603,6 +591,9 @@ func TestSwarmTraefikFilter(t *testing.T) {
 		t.Run(strconv.Itoa(serviceID), func(t *testing.T) {
 			t.Parallel()
 			dockerData := parseService(e.service, e.networks)
+			provider := &Provider{
+				SwarmMode: true,
+			}
 			provider.ExposedByDefault = e.exposedByDefault
 			actual := provider.containerFilter(dockerData)
 			if actual != e.expected {
@@ -738,12 +729,6 @@ func TestSwarmLoadDockerConfig(t *testing.T) {
 		},
 	}
 
-	provider := &Provider{
-		Domain:           "docker.localhost",
-		ExposedByDefault: true,
-		SwarmMode:        true,
-	}
-
 	for caseID, c := range cases {
 		c := c
 		t.Run(strconv.Itoa(caseID), func(t *testing.T) {
@@ -754,6 +739,11 @@ func TestSwarmLoadDockerConfig(t *testing.T) {
 				dockerDataList = append(dockerDataList, dockerData)
 			}
 
+			provider := &Provider{
+				Domain:           "docker.localhost",
+				ExposedByDefault: true,
+				SwarmMode:        true,
+			}
 			actualConfig := provider.loadDockerConfig(dockerDataList)
 			// Compare backends
 			if !reflect.DeepEqual(actualConfig.Backends, c.expectedBackends) {


### PR DESCRIPTION
Piggyback change to pass `TESTDIRS` env var through to the Docker build container to run the `test-unit` Makefile target on limited packages/files.

Fixes #1443.