### PR TITLE
Re-exclude /dist/traefik from .dockerignore.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 dist/
+!dist/traefik
 site/


### PR DESCRIPTION
The master build is [currently broken](https://travis-ci.org/containous/traefik/jobs/225606534). Turns out we can't remove the .dockerfile exclusion for `/dist/traefik` since it's needed to build the Docker image.

This PR reverts that decision taken in #1470.