### PR TITLE
Fix the healthcheck integration test

### DIFF
--- a/integration/fixtures/healthcheck/simple.toml
+++ b/integration/fixtures/healthcheck/simple.toml
@@ -13,7 +13,7 @@ logLevel = "DEBUG"
 [backends]
   [backends.backend1]
     [backends.backend1.healthcheck]
-    url = "/health"
+    path = "/health"
     interval = "1s"
     [backends.backend1.servers.server1]
     url = "http://{{.Server1}}:80"

--- a/integration/healthcheck_test.go
+++ b/integration/healthcheck_test.go
@@ -16,16 +16,16 @@ import (
 	checker "github.com/vdemeester/shakers"
 )
 
-// HealchCheck test suites (using libcompose)
-type HealchCheckSuite struct{ BaseSuite }
+// HealthCheck test suites (using libcompose)
+type HealthCheckSuite struct{ BaseSuite }
 
-func (s *HealchCheckSuite) SetUpSuite(c *check.C) {
+func (s *HealthCheckSuite) SetUpSuite(c *check.C) {
 	s.createComposeProject(c, "healthcheck")
 	s.composeProject.Start(c)
 
 }
 
-func (s *HealchCheckSuite) TestSimpleConfiguration(c *check.C) {
+func (s *HealthCheckSuite) TestSimpleConfiguration(c *check.C) {
 
 	whoami1Host := s.composeProject.Container(c, "whoami1").NetworkSettings.IPAddress
 	whoami2Host := s.composeProject.Container(c, "whoami2").NetworkSettings.IPAddress

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -37,7 +37,7 @@ func init() {
 	check.Suite(&EurekaSuite{})
 	check.Suite(&AcmeSuite{})
 	check.Suite(&DynamoDBSuite{})
-	check.Suite(&HealchCheckSuite{})
+	check.Suite(&HealthCheckSuite{})
 }
 
 var traefikBinary = "../dist/traefik"

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -37,6 +37,7 @@ func init() {
 	check.Suite(&EurekaSuite{})
 	check.Suite(&AcmeSuite{})
 	check.Suite(&DynamoDBSuite{})
+	check.Suite(&HealchCheckSuite{})
 }
 
 var traefikBinary = "../dist/traefik"


### PR DESCRIPTION
This PR https://github.com/containous/traefik/pull/1285 renamed the URL member of types.HealthCheck to "Path", but it didn't update the integration test.

I also added the Healthcheck test to the integration suite.