### PR TITLE
Add basic auth to kubernetes provider

### DIFF
--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -283,6 +283,7 @@ func TestLoadIngresses(t *testing.T) {
 		Frontends: map[string]*types.Frontend{
 			"foo/bar": {
 				Backend:        "foo/bar",
+				BasicAuth:      []string{},
 				PassHostHeader: true,
 				Priority:       len("/bar"),
 				Routes: map[string]types.Route{
@@ -296,6 +297,7 @@ func TestLoadIngresses(t *testing.T) {
 			},
 			"foo/namedthing": {
 				Backend:        "foo/namedthing",
+				BasicAuth:      []string{},
 				PassHostHeader: true,
 				Priority:       len("/namedthing"),
 				Routes: map[string]types.Route{
@@ -309,6 +311,7 @@ func TestLoadIngresses(t *testing.T) {
 			},
 			"bar": {
 				Backend:        "bar",
+				BasicAuth:      []string{},
 				PassHostHeader: true,
 				Routes: map[string]types.Route{
 					"bar": {
@@ -413,7 +416,8 @@ func TestRuleType(t *testing.T) {
 			actual := actualConfig.Frontends
 			expected := map[string]*types.Frontend{
 				"host/path": {
-					Backend:  "host/path",
+					Backend: "host/path",
+					BasicAuth: []string{},
 					Priority: len("/path"),
 					Routes: map[string]types.Route{
 						"/path": {
@@ -504,7 +508,100 @@ func TestGetPassHostHeader(t *testing.T) {
 		},
 		Frontends: map[string]*types.Frontend{
 			"foo/bar": {
-				Backend:  "foo/bar",
+				Backend: "foo/bar",
+				BasicAuth: []string{},
+				Priority: len("/bar"),
+				Routes: map[string]types.Route{
+					"/bar": {
+						Rule: "PathPrefix:/bar",
+					},
+					"foo": {
+						Rule: "Host:foo",
+					},
+				},
+			},
+		},
+	}
+	actualJSON, _ := json.Marshal(actual)
+	expectedJSON, _ := json.Marshal(expected)
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("expected %+v, got %+v", string(expectedJSON), string(actualJSON))
+	}
+}
+
+func TestBasicAuth(t *testing.T) {
+	ingresses := []*v1beta1.Ingress{{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: "awesome",
+			Annotations: map[string]string{"traefik.frontend.auth.basic": "test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/,test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"},
+		},
+		Spec: v1beta1.IngressSpec{
+			Rules: []v1beta1.IngressRule{
+				{
+					Host: "foo",
+					IngressRuleValue: v1beta1.IngressRuleValue{
+						HTTP: &v1beta1.HTTPIngressRuleValue{
+							Paths: []v1beta1.HTTPIngressPath{
+								{
+									Path: "/bar",
+									Backend: v1beta1.IngressBackend{
+										ServiceName: "service1",
+										ServicePort: intstr.FromInt(801),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}}
+	services := []*v1.Service{
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "service1",
+				Namespace: "awesome",
+				UID:       "1",
+			},
+			Spec: v1.ServiceSpec{
+				ClusterIP: "10.0.0.1",
+				Ports: []v1.ServicePort{
+					{
+						Name: "http",
+						Port: 801,
+					},
+				},
+			},
+		},
+	}
+	watchChan := make(chan interface{})
+	client := clientMock{
+		ingresses: ingresses,
+		services:  services,
+		watchChan: watchChan,
+	}
+	provider := Provider{DisablePassHostHeaders: true}
+	actual, err := provider.loadIngresses(client)
+	if err != nil {
+		t.Fatalf("error %+v", err)
+	}
+
+	expected := &types.Configuration{
+		Backends: map[string]*types.Backend{
+			"foo/bar": {
+				Servers:        map[string]types.Server{},
+				CircuitBreaker: nil,
+				LoadBalancer: &types.LoadBalancer{
+					Sticky: false,
+					Method: "wrr",
+				},
+			},
+		},
+		Frontends: map[string]*types.Frontend{
+			"foo/bar": {
+				Backend: "foo/bar",
+				BasicAuth: []string{"test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/", "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"},
 				Priority: len("/bar"),
 				Routes: map[string]types.Route{
 					"/bar": {
@@ -612,6 +709,7 @@ func TestOnlyReferencesServicesFromOwnNamespace(t *testing.T) {
 		Frontends: map[string]*types.Frontend{
 			"foo": {
 				Backend:        "foo",
+				BasicAuth:      []string{},
 				PassHostHeader: true,
 				Routes: map[string]types.Route{
 					"foo": {
@@ -804,6 +902,7 @@ func TestLoadNamespacedIngresses(t *testing.T) {
 		Frontends: map[string]*types.Frontend{
 			"foo/bar": {
 				Backend:        "foo/bar",
+				BasicAuth:      []string{},
 				PassHostHeader: true,
 				Priority:       len("/bar"),
 				Routes: map[string]types.Route{
@@ -817,6 +916,7 @@ func TestLoadNamespacedIngresses(t *testing.T) {
 			},
 			"bar": {
 				Backend:        "bar",
+				BasicAuth:      []string{},
 				PassHostHeader: true,
 				Routes: map[string]types.Route{
 					"bar": {
@@ -1042,6 +1142,7 @@ func TestLoadMultipleNamespacedIngresses(t *testing.T) {
 		Frontends: map[string]*types.Frontend{
 			"foo/bar": {
 				Backend:        "foo/bar",
+				BasicAuth:      []string{},
 				PassHostHeader: true,
 				Priority:       len("/bar"),
 				Routes: map[string]types.Route{
@@ -1055,6 +1156,7 @@ func TestLoadMultipleNamespacedIngresses(t *testing.T) {
 			},
 			"bar": {
 				Backend:        "bar",
+				BasicAuth:      []string{},
 				PassHostHeader: true,
 				Routes: map[string]types.Route{
 					"bar": {
@@ -1064,6 +1166,7 @@ func TestLoadMultipleNamespacedIngresses(t *testing.T) {
 			},
 			"awesome/quix": {
 				Backend:        "awesome/quix",
+				BasicAuth:      []string{},
 				PassHostHeader: true,
 				Priority:       len("/quix"),
 				Routes: map[string]types.Route{
@@ -1153,7 +1256,8 @@ func TestHostlessIngress(t *testing.T) {
 		},
 		Frontends: map[string]*types.Frontend{
 			"/bar": {
-				Backend:  "/bar",
+				Backend: "/bar",
+				BasicAuth: []string{},
 				Priority: len("/bar"),
 				Routes: map[string]types.Route{
 					"/bar": {
@@ -1377,6 +1481,7 @@ func TestServiceAnnotations(t *testing.T) {
 		Frontends: map[string]*types.Frontend{
 			"foo/bar": {
 				Backend:        "foo/bar",
+				BasicAuth:      []string{},
 				PassHostHeader: true,
 				Priority:       len("/bar"),
 				Routes: map[string]types.Route{
@@ -1390,6 +1495,7 @@ func TestServiceAnnotations(t *testing.T) {
 			},
 			"bar": {
 				Backend:        "bar",
+				BasicAuth:      []string{},
 				PassHostHeader: true,
 				Routes: map[string]types.Route{
 					"bar": {
@@ -1562,6 +1668,7 @@ func TestIngressAnnotations(t *testing.T) {
 		Frontends: map[string]*types.Frontend{
 			"foo/bar": {
 				Backend:        "foo/bar",
+				BasicAuth:      []string{},
 				PassHostHeader: false,
 				Priority:       len("/bar"),
 				Routes: map[string]types.Route{
@@ -1575,6 +1682,7 @@ func TestIngressAnnotations(t *testing.T) {
 			},
 			"other/stuff": {
 				Backend:        "other/stuff",
+				BasicAuth:      []string{},
 				PassHostHeader: true,
 				Priority:       len("/stuff"),
 				Routes: map[string]types.Route{
@@ -1682,6 +1790,7 @@ func TestInvalidPassHostHeaderValue(t *testing.T) {
 		Frontends: map[string]*types.Frontend{
 			"foo/bar": {
 				Backend:        "foo/bar",
+				BasicAuth:      []string{},
 				PassHostHeader: true,
 				Priority:       len("/bar"),
 				Routes: map[string]types.Route{
@@ -2006,6 +2115,7 @@ func TestMissingResources(t *testing.T) {
 		Frontends: map[string]*types.Frontend{
 			"fully_working": {
 				Backend:        "fully_working",
+				BasicAuth:      []string{},
 				PassHostHeader: true,
 				Routes: map[string]types.Route{
 					"fully_working": {
@@ -2015,6 +2125,7 @@ func TestMissingResources(t *testing.T) {
 			},
 			"missing_endpoints": {
 				Backend:        "missing_endpoints",
+				BasicAuth:      []string{},
 				PassHostHeader: true,
 				Routes: map[string]types.Route{
 					"missing_endpoints": {

--- a/templates/kubernetes.tmpl
+++ b/templates/kubernetes.tmpl
@@ -18,6 +18,9 @@
 [frontends]{{range $frontendName, $frontend := .Frontends}}
   [frontends."{{$frontendName}}"]
   backend = "{{$frontend.Backend}}"
+  basicAuth = [{{range $frontend.BasicAuth}}
+    "{{.}}",
+  {{end}}]
   priority = {{$frontend.Priority}}
   passHostHeader = {{$frontend.PassHostHeader}}
     {{range $routeName, $route := $frontend.Routes}}


### PR DESCRIPTION
### Description

Partially fixes #1465.
Implements frontend basic auth for kubernetes provider.