### PR TITLE
Makefile target to enable parallel jobs

### DIFF
--- a/script/crossbinary-default
+++ b/script/crossbinary-default
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+if ! test -e autogen/gen.go; then
+	echo >&2 'error: generate must be run before crossbinary'
+	false
+fi
+
+if [ -z "$VERSION" ]; then
+    VERSION=$(git rev-parse HEAD)
+fi
+
+if [ -z "$CODENAME" ]; then
+    CODENAME=cheddar
+fi
+
+if [ -z "$DATE" ]; then
+    DATE=$(date -u '+%Y-%m-%d_%I:%M:%S%p')
+fi
+
+# Build 386 amd64 binaries
+OS_PLATFORM_ARG=(linux windows darwin)
+OS_ARCH_ARG=(amd64)
+for OS in ${OS_PLATFORM_ARG[@]}; do
+  for ARCH in ${OS_ARCH_ARG[@]}; do
+    echo "Building binary for $OS/$ARCH..."
+    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/containous/traefik/version.Version=$VERSION -X github.com/containous/traefik/version.Codename=$CODENAME -X github.com/containous/traefik/version.BuildDate=$DATE" -o "dist/traefik_$OS-$ARCH" ./cmd/traefik/
+  done
+done
+
+
+# Build arm64 binaries
+OS_PLATFORM_ARG=(linux)
+OS_ARCH_ARG=(arm64)
+for OS in ${OS_PLATFORM_ARG[@]}; do
+  for ARCH in ${OS_ARCH_ARG[@]}; do
+    echo "Building binary for $OS/$ARCH..."
+    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/containous/traefik/version.Version=$VERSION -X github.com/containous/traefik/version.Codename=$CODENAME -X github.com/containous/traefik/version.BuildDate=$DATE" -o "dist/traefik_$OS-$ARCH" ./cmd/traefik/
+  done
+done

--- a/script/crossbinary-others
+++ b/script/crossbinary-others
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e
+
+if ! test -e autogen/gen.go; then
+	echo >&2 'error: generate must be run before crossbinary'
+	false
+fi
+
+if [ -z "$VERSION" ]; then
+    VERSION=$(git rev-parse HEAD)
+fi
+
+if [ -z "$CODENAME" ]; then
+    CODENAME=cheddar
+fi
+
+if [ -z "$DATE" ]; then
+    DATE=$(date -u '+%Y-%m-%d_%I:%M:%S%p')
+fi
+
+# Build arm binaries
+OS_PLATFORM_ARG=(linux windows darwin)
+OS_ARCH_ARG=(386)
+for OS in ${OS_PLATFORM_ARG[@]}; do
+  for ARCH in ${OS_ARCH_ARG[@]}; do
+    echo "Building binary for $OS/$ARCH..."
+    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/containous/traefik/version.Version=$VERSION -X github.com/containous/traefik/version.Codename=$CODENAME -X github.com/containous/traefik/version.BuildDate=$DATE" -o "dist/traefik_$OS-$ARCH" ./cmd/traefik/
+  done
+done
+
+# Build Bsd binaries
+OS_PLATFORM_ARG=(freebsd openbsd)
+OS_ARCH_ARG=(386 amd64)
+for OS in ${OS_PLATFORM_ARG[@]}; do
+  for ARCH in ${OS_ARCH_ARG[@]}; do
+    # Get rid of existing binaries
+    rm -f dist/traefik_$OS-$ARCH
+    echo "Building binary for $OS/$ARCH..."
+    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/containous/traefik/version.Version=$VERSION -X github.com/containous/traefik/version.Codename=$CODENAME -X github.com/containous/traefik/version.BuildDate=$DATE" -o "dist/traefik_$OS-$ARCH" ./cmd/traefik/
+  done
+done
+
+# Build arm binaries
+OS_PLATFORM_ARG=(linux)
+OS_ARCH_ARG=(arm)
+for OS in ${OS_PLATFORM_ARG[@]}; do
+  for ARCH in ${OS_ARCH_ARG[@]}; do
+    echo "Building binary for $OS/$ARCH..."
+    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/containous/traefik/version.Version=$VERSION -X github.com/containous/traefik/version.Codename=$CODENAME -X github.com/containous/traefik/version.BuildDate=$DATE" -o "dist/traefik_$OS-$ARCH" ./cmd/traefik/
+  done
+done


### PR DESCRIPTION
With this PR i have divided the original ./script/crossbinary file in 2 files.

- crossbinary-default
It contains windows and linux

- crossbinary-others
it contains darwin, freebsd and openbsd

Makefile has been modified using the same schema adding new targets to enable parallelism at make level.
The main goal was to reduce the make crossbinary exec time and to separate win/linux platforms  with minimum impact on actual test suite.
see https://github.com/containous/traefik/issues/1266

with parallel execution (make -j2 crossbinary-parallel) we reduce the exec time of ~10%

tested with 
make crossbinary
semaphoreci : <https://semaphoreci.com/atbore/traefik/branches/crossbinary-parallel/builds/4> 

