### PR TITLE
[CI] Enhance cross-binary builds and parallelism

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
     - REPO: $TRAVIS_REPO_SLUG
     - VERSION: $TRAVIS_TAG
     - CODENAME: raclette
+    - N_MAKE_JOBS: 2
 
 matrix:
   fast_finish: true
@@ -26,11 +27,13 @@ install:
   - make pull-images
 before_script:
   - make validate
-script: make test-unit && travis_retry make test-integration
+script:
+  - make test-unit && travis_retry make test-integration
+  - make -j${N_MAKE_JOBS} crossbinary-default-parallel
 after_failure:
   - docker ps
 before_deploy:
-  - make crossbinary
+  - make -j${N_MAKE_JOBS} crossbinary-others-parallel
   - make image
   - mkdocs build --clean
   - tar cfz dist/traefik-${VERSION}.src.tar.gz --exclude-vcs --exclude dist .

--- a/Makefile
+++ b/Makefile
@@ -41,14 +41,21 @@ crossbinary: generate-webui build ## cross build the non-linux binaries
 
 crossbinary-parallel:
 	$(MAKE) generate-webui
-	$(MAKE) build
-	$(MAKE) crossbinary-default crossbinary-others
+	$(MAKE) build crossbinary-default crossbinary-others
 
 crossbinary-default: generate-webui build
 	$(DOCKER_RUN_TRAEFIK_NOTTY) ./script/make.sh generate crossbinary-default
 
+crossbinary-default-parallel:
+	$(MAKE) generate-webui
+	$(MAKE) build crossbinary-default
+
 crossbinary-others: generate-webui build
 	$(DOCKER_RUN_TRAEFIK_NOTTY) ./script/make.sh generate crossbinary-others
+
+crossbinary-others-parallel:
+	$(MAKE) generate-webui
+	$(MAKE) build crossbinary-others
 
 test: build ## run the unit and integration tests
 	$(DOCKER_RUN_TRAEFIK) ./script/make.sh generate test-unit binary test-integration

--- a/script/crossbinary
+++ b/script/crossbinary
@@ -18,6 +18,10 @@ if [ -z "$DATE" ]; then
     DATE=$(date -u '+%Y-%m-%d_%I:%M:%S%p')
 fi
 
+GIT_REPO_URL='github.com/containous/traefik/version'
+GO_BUILD_CMD="go build -ldflags"
+GO_BUILD_OPT="-s -w -X ${GIT_REPO_URL}.Version=$VERSION -X ${GIT_REPO_URL}.Codename=$CODENAME -X ${GIT_REPO_URL}.BuildDate=$DATE"
+
 # Get rid of existing binaries
 rm -f dist/traefik_*
 
@@ -27,7 +31,7 @@ OS_ARCH_ARG=(386 amd64)
 for OS in ${OS_PLATFORM_ARG[@]}; do
   for ARCH in ${OS_ARCH_ARG[@]}; do
     echo "Building binary for $OS/$ARCH..."
-    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/containous/traefik/version.Version=$VERSION -X github.com/containous/traefik/version.Codename=$CODENAME -X github.com/containous/traefik/version.BuildDate=$DATE" -o "dist/traefik_$OS-$ARCH" ./cmd/traefik/
+    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 $GO_BUILD_CMD "$GO_BUILD_OPT" -o "dist/traefik_$OS-$ARCH" ./cmd/traefik/
   done
 done
 
@@ -38,6 +42,6 @@ OS_ARCH_ARG=(arm arm64)
 for OS in ${OS_PLATFORM_ARG[@]}; do
   for ARCH in ${OS_ARCH_ARG[@]}; do
     echo "Building binary for $OS/$ARCH..."
-    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/containous/traefik/version.Version=$VERSION -X github.com/containous/traefik/version.Codename=$CODENAME -X github.com/containous/traefik/version.BuildDate=$DATE" -o "dist/traefik_$OS-$ARCH" ./cmd/traefik/
+    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 $GO_BUILD_CMD "$GO_BUILD_OPT" -o "dist/traefik_$OS-$ARCH" ./cmd/traefik/
   done
 done

--- a/script/crossbinary-default
+++ b/script/crossbinary-default
@@ -18,13 +18,17 @@ if [ -z "$DATE" ]; then
     DATE=$(date -u '+%Y-%m-%d_%I:%M:%S%p')
 fi
 
+GIT_REPO_URL='github.com/containous/traefik/version'
+GO_BUILD_CMD="go build -ldflags"
+GO_BUILD_OPT="-s -w -X ${GIT_REPO_URL}.Version=$VERSION -X ${GIT_REPO_URL}.Codename=$CODENAME -X ${GIT_REPO_URL}.BuildDate=$DATE"
+
 # Build 386 amd64 binaries
 OS_PLATFORM_ARG=(linux windows darwin)
 OS_ARCH_ARG=(amd64)
 for OS in ${OS_PLATFORM_ARG[@]}; do
   for ARCH in ${OS_ARCH_ARG[@]}; do
     echo "Building binary for $OS/$ARCH..."
-    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/containous/traefik/version.Version=$VERSION -X github.com/containous/traefik/version.Codename=$CODENAME -X github.com/containous/traefik/version.BuildDate=$DATE" -o "dist/traefik_$OS-$ARCH" ./cmd/traefik/
+    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 $GO_BUILD_CMD "$GO_BUILD_OPT" -o "dist/traefik_$OS-$ARCH" ./cmd/traefik/
   done
 done
 
@@ -35,6 +39,6 @@ OS_ARCH_ARG=(arm64)
 for OS in ${OS_PLATFORM_ARG[@]}; do
   for ARCH in ${OS_ARCH_ARG[@]}; do
     echo "Building binary for $OS/$ARCH..."
-    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/containous/traefik/version.Version=$VERSION -X github.com/containous/traefik/version.Codename=$CODENAME -X github.com/containous/traefik/version.BuildDate=$DATE" -o "dist/traefik_$OS-$ARCH" ./cmd/traefik/
+    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 $GO_BUILD_CMD "$GO_BUILD_OPT" -o "dist/traefik_$OS-$ARCH" ./cmd/traefik/
   done
 done

--- a/script/crossbinary-others
+++ b/script/crossbinary-others
@@ -18,13 +18,17 @@ if [ -z "$DATE" ]; then
     DATE=$(date -u '+%Y-%m-%d_%I:%M:%S%p')
 fi
 
+GIT_REPO_URL='github.com/containous/traefik/version'
+GO_BUILD_CMD="go build -ldflags"
+GO_BUILD_OPT="-s -w -X ${GIT_REPO_URL}.Version=$VERSION -X ${GIT_REPO_URL}.Codename=$CODENAME -X ${GIT_REPO_URL}.BuildDate=$DATE"
+
 # Build arm binaries
 OS_PLATFORM_ARG=(linux windows darwin)
 OS_ARCH_ARG=(386)
 for OS in ${OS_PLATFORM_ARG[@]}; do
   for ARCH in ${OS_ARCH_ARG[@]}; do
     echo "Building binary for $OS/$ARCH..."
-    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/containous/traefik/version.Version=$VERSION -X github.com/containous/traefik/version.Codename=$CODENAME -X github.com/containous/traefik/version.BuildDate=$DATE" -o "dist/traefik_$OS-$ARCH" ./cmd/traefik/
+    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 $GO_BUILD_CMD "$GO_BUILD_OPT" -o "dist/traefik_$OS-$ARCH" ./cmd/traefik/
   done
 done
 
@@ -36,7 +40,7 @@ for OS in ${OS_PLATFORM_ARG[@]}; do
     # Get rid of existing binaries
     rm -f dist/traefik_$OS-$ARCH
     echo "Building binary for $OS/$ARCH..."
-    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/containous/traefik/version.Version=$VERSION -X github.com/containous/traefik/version.Codename=$CODENAME -X github.com/containous/traefik/version.BuildDate=$DATE" -o "dist/traefik_$OS-$ARCH" ./cmd/traefik/
+    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 $GO_BUILD_CMD "$GO_BUILD_OPT" -o "dist/traefik_$OS-$ARCH" ./cmd/traefik/
   done
 done
 
@@ -46,6 +50,6 @@ OS_ARCH_ARG=(arm)
 for OS in ${OS_PLATFORM_ARG[@]}; do
   for ARCH in ${OS_ARCH_ARG[@]}; do
     echo "Building binary for $OS/$ARCH..."
-    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/containous/traefik/version.Version=$VERSION -X github.com/containous/traefik/version.Codename=$CODENAME -X github.com/containous/traefik/version.BuildDate=$DATE" -o "dist/traefik_$OS-$ARCH" ./cmd/traefik/
+    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 $GO_BUILD_CMD "$GO_BUILD_OPT" -o "dist/traefik_$OS-$ARCH" ./cmd/traefik/
   done
 done


### PR DESCRIPTION
With this PR the make target cross binary is executed before the travis deploy step, so for each PR.
I have also added the parallelization of the same target and a new variable "GO_BUILD_CMD" for the scripts.