### PR TITLE
retry only on real network errors

### DIFF
--- a/middlewares/prometheus_test.go
+++ b/middlewares/prometheus_test.go
@@ -151,7 +151,7 @@ func TestPrometheusRegisterMetricsMultipleTimes(t *testing.T) {
 func setupTestHTTPHandler() http.Handler {
 	serveMux := http.NewServeMux()
 	serveMux.Handle("/metrics", promhttp.Handler())
-	serveMux.Handle("/ok", &networkFailingHTTPHandler{failAtCalls: []int{1}})
+	serveMux.Handle("/ok", &networkFailingHTTPHandler{failAtCalls: []int{1}, netErrorRecorder: &DefaultNetErrorRecorder{}})
 
 	metrics, _ := newPrometheusMetrics()
 

--- a/server/errorhandler.go
+++ b/server/errorhandler.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"io"
+	"net"
+	"net/http"
+
+	"github.com/containous/traefik/middlewares"
+)
+
+// RecordingErrorHandler is an error handler, implementing the vulcand/oxy
+// error handler interface, which is recording network errors by using the netErrorRecorder.
+// In addition it sets a proper HTTP status code and body, depending on the type of error occurred.
+type RecordingErrorHandler struct {
+	netErrorRecorder middlewares.NetErrorRecorder
+}
+
+// NewRecordingErrorHandler creates and returns a new instance of RecordingErrorHandler.
+func NewRecordingErrorHandler(recorder middlewares.NetErrorRecorder) *RecordingErrorHandler {
+	return &RecordingErrorHandler{recorder}
+}
+
+func (eh *RecordingErrorHandler) ServeHTTP(w http.ResponseWriter, req *http.Request, err error) {
+	statusCode := http.StatusInternalServerError
+
+	if e, ok := err.(net.Error); ok {
+		eh.netErrorRecorder.Record(req.Context())
+		if e.Timeout() {
+			statusCode = http.StatusGatewayTimeout
+		} else {
+			statusCode = http.StatusBadGateway
+		}
+	} else if err == io.EOF {
+		eh.netErrorRecorder.Record(req.Context())
+		statusCode = http.StatusBadGateway
+	}
+
+	w.WriteHeader(statusCode)
+	w.Write([]byte(http.StatusText(statusCode)))
+}

--- a/server/errorhandler_test.go
+++ b/server/errorhandler_test.go
@@ -1,0 +1,88 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type timeoutError struct{}
+
+func (e *timeoutError) Error() string   { return "i/o timeout" }
+func (e *timeoutError) Timeout() bool   { return true }
+func (e *timeoutError) Temporary() bool { return true }
+
+func TestServeHTTP(t *testing.T) {
+	tests := []struct {
+		name               string
+		err                error
+		wantHTTPStatus     int
+		wantNetErrRecorded bool
+	}{
+		{
+			name:               "net.Error",
+			err:                net.UnknownNetworkError("any network error"),
+			wantHTTPStatus:     http.StatusBadGateway,
+			wantNetErrRecorded: true,
+		},
+		{
+			name:               "net.Error with Timeout",
+			err:                &timeoutError{},
+			wantHTTPStatus:     http.StatusGatewayTimeout,
+			wantNetErrRecorded: true,
+		},
+		{
+			name:               "io.EOF",
+			err:                io.EOF,
+			wantHTTPStatus:     http.StatusBadGateway,
+			wantNetErrRecorded: true,
+		},
+		{
+			name:               "custom error",
+			err:                errors.New("any error"),
+			wantHTTPStatus:     http.StatusInternalServerError,
+			wantNetErrRecorded: false,
+		},
+		{
+			name:               "nil error",
+			err:                nil,
+			wantHTTPStatus:     http.StatusInternalServerError,
+			wantNetErrRecorded: false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			recorder := httptest.NewRecorder()
+
+			errorRecorder := &netErrorRecorder{}
+			req := httptest.NewRequest(http.MethodGet, "http://localhost:3000/any", nil)
+
+			recordingErrorHandler := NewRecordingErrorHandler(errorRecorder)
+			recordingErrorHandler.ServeHTTP(recorder, req, test.err)
+
+			if recorder.Code != test.wantHTTPStatus {
+				t.Errorf("got HTTP status code %v, wanted %v", recorder.Code, test.wantHTTPStatus)
+			}
+			if errorRecorder.netErrorWasRecorded != test.wantNetErrRecorded {
+				t.Errorf("net error recording wrong, got %v wanted %v", errorRecorder.netErrorWasRecorded, test.wantNetErrRecorded)
+			}
+		})
+	}
+}
+
+type netErrorRecorder struct {
+	netErrorWasRecorded bool
+}
+
+func (recorder *netErrorRecorder) Record(ctx context.Context) {
+	recorder.netErrorWasRecorded = true
+}


### PR DESCRIPTION
Now retries only happen when actual network errors occur and not only
anymore based on the HTTP status code. This is because the backend could
also send this status codes as their normal interface and in that case
we don't want to retry.

This PR should solve the issue [1104](https://github.com/containous/traefik/issues/1104)