### PR TITLE
add configuration option for not found http status code

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -55,6 +55,13 @@
 #
 # logLevel = "ERROR"
 
+# HTTP response code to send when no route to backend exists.
+#
+# Optional
+# Default: 404
+#
+# noRouteResponseCode = 404
+
 # Backends throttle duration: minimum duration in seconds between 2 events from providers
 # before applying a new configuration. It avoids unnecessary reloads if multiples events
 # are sent in a short amount of time.

--- a/server/adapters.go
+++ b/server/adapters.go
@@ -1,8 +1,6 @@
 package server
 
 import (
-	"net/http"
-
 	"github.com/containous/traefik/log"
 )
 
@@ -23,9 +21,4 @@ func (oxylogger *OxyLogger) Warningf(format string, args ...interface{}) {
 // Errorf logs specified string as Warningf level in logrus.
 func (oxylogger *OxyLogger) Errorf(format string, args ...interface{}) {
 	log.Warningf(format, args...)
-}
-
-func notFoundHandler(w http.ResponseWriter, r *http.Request) {
-	http.NotFound(w, r)
-	//templatesRenderer.HTML(w, http.StatusNotFound, "notFound", nil)
 }

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"regexp"
 	"strings"
@@ -45,6 +46,7 @@ type GlobalConfiguration struct {
 	AccessLogsFile            string                  `description:"Access logs file"`
 	TraefikLogsFile           string                  `description:"Traefik logs file"`
 	LogLevel                  string                  `short:"l" description:"Log level"`
+	NoRouteResponseCode       int                     `description:"HTTP response code to send when no route to backend exists"`
 	EntryPoints               EntryPoints             `description:"Entrypoints definition using format: --entryPoints='Name:http Address::8000 Redirect.EntryPoint:https' --entryPoints='Name:https Address::4442 TLS:tests/traefik.crt,tests/traefik.key;prod/traefik.crt,prod/traefik.key'"`
 	Cluster                   *types.Cluster          `description:"Enable clustering"`
 	Constraints               types.Constraints       `description:"Filter services by constraint, matching with service tags"`
@@ -491,6 +493,7 @@ func NewTraefikConfiguration() *TraefikConfiguration {
 			AccessLogsFile:            "",
 			TraefikLogsFile:           "",
 			LogLevel:                  "ERROR",
+			NoRouteResponseCode:       http.StatusNotFound,
 			EntryPoints:               map[string]*EntryPoint{},
 			Constraints:               types.Constraints{},
 			DefaultEntryPoints:        []string{},

--- a/server/server.go
+++ b/server/server.go
@@ -541,7 +541,7 @@ func (server *Server) prepareServer(entryPointName string, router *middlewares.H
 func (server *Server) buildEntryPoints(globalConfiguration GlobalConfiguration) map[string]*serverEntryPoint {
 	serverEntryPoints := make(map[string]*serverEntryPoint)
 	for entryPointName := range globalConfiguration.EntryPoints {
-		router := server.buildDefaultHTTPRouter(globalConfiguration)
+		router := server.buildDefaultHTTPRouter(globalConfiguration.NoRouteResponseCode)
 		serverEntryPoints[entryPointName] = &serverEntryPoint{
 			httpRouter: middlewares.NewHandlerSwitcher(router),
 		}
@@ -842,9 +842,9 @@ func (server *Server) loadEntryPointConfig(entryPointName string, entryPoint *En
 	return rewrite, nil
 }
 
-func (server *Server) buildDefaultHTTPRouter(globalConfiguration GlobalConfiguration) *mux.Router {
+func (server *Server) buildDefaultHTTPRouter(noRouteResponseCode int) *mux.Router {
 	router := mux.NewRouter()
-	router.NotFoundHandler = newNotFounderHandler(globalConfiguration.NoRouteResponseCode)
+	router.NotFoundHandler = newNotFounderHandler(noRouteResponseCode)
 	router.StrictSlash(true)
 	router.SkipClean(true)
 	return router

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -163,28 +163,34 @@ func TestServerParseHealthCheckOptions(t *testing.T) {
 
 func TestNewNotFounderHandler(t *testing.T) {
 	tests := []struct {
-		name           string
-		globalConfig   GlobalConfiguration
-		wantStatusCode int
-		wantBody       string
+		name                string
+		noRouteResponseCode int
+		wantStatusCode      int
+		wantBody            string
 	}{
 		{
-			name:           "default",
-			globalConfig:   GlobalConfiguration{},
-			wantStatusCode: http.StatusNotFound,
-			wantBody:       "Not Found",
+			name:                "default",
+			noRouteResponseCode: 0,
+			wantStatusCode:      http.StatusNotFound,
+			wantBody:            "Not Found",
 		},
 		{
-			name:           "not found",
-			globalConfig:   GlobalConfiguration{NoRouteResponseCode: http.StatusNotFound},
-			wantStatusCode: http.StatusNotFound,
-			wantBody:       "Not Found",
+			name:                "not found",
+			noRouteResponseCode: http.StatusNotFound,
+			wantStatusCode:      http.StatusNotFound,
+			wantBody:            "Not Found",
 		},
 		{
-			name:           "bad gateway",
-			globalConfig:   GlobalConfiguration{NoRouteResponseCode: http.StatusBadGateway},
-			wantStatusCode: http.StatusBadGateway,
-			wantBody:       "Bad Gateway",
+			name:                "bad gateway",
+			noRouteResponseCode: http.StatusBadGateway,
+			wantStatusCode:      http.StatusBadGateway,
+			wantBody:            "Bad Gateway",
+		},
+		{
+			name:                "invalid status code",
+			noRouteResponseCode: 1000,
+			wantStatusCode:      http.StatusNotFound,
+			wantBody:            "Not Found",
 		},
 	}
 
@@ -194,9 +200,9 @@ func TestNewNotFounderHandler(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			notFoundHandler := newNotFounderHandler(test.globalConfig)
+			notFoundHandler := newNotFounderHandler(test.noRouteResponseCode)
 			recorder := httptest.NewRecorder()
-			req := httptest.NewRequest("GET", "http://localhost/notknown", nil)
+			req := httptest.NewRequest(http.MethodGet, "http://localhost/notknown", nil)
 
 			notFoundHandler.ServeHTTP(recorder, req)
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -173,12 +173,12 @@ func TestBuildDefaultHTTPRouterSetupNotFoundHandler(t *testing.T) {
 			wantNotFoundStatusCode: http.StatusNotFound,
 		},
 		{
-			name:                   "sane config",
+			name:                   "valid response code",
 			globalConfig:           GlobalConfiguration{NoRouteResponseCode: http.StatusBadGateway},
 			wantNotFoundStatusCode: http.StatusBadGateway,
 		},
 		{
-			name:                   "invalid config",
+			name:                   "invalid response code",
 			globalConfig:           GlobalConfiguration{NoRouteResponseCode: 1000},
 			wantNotFoundStatusCode: http.StatusNotFound,
 		},

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -46,6 +46,13 @@
 #
 # logLevel = "ERROR"
 
+# HTTP response code to send when no route to backend exists
+#
+# Optional
+# Default: 404
+#
+# noRouteResponseCode = 404
+
 # Backends throttle duration: minimum duration in seconds between 2 events from providers
 # before applying a new configuration. It avoids unnecessary reloads if multiples events
 # are sent in a short amount of time.

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -46,7 +46,7 @@
 #
 # logLevel = "ERROR"
 
-# HTTP response code to send when no route to backend exists
+# HTTP response code to send when no route to backend exists.
 #
 # Optional
 # Default: 404


### PR DESCRIPTION
This PR adds the ability to configure the HTTP status code that should be sent, given for an incoming request, no backend can be found. Without adding any configuration, it will behave as before, sending 404 responses and therefore keeps the compatibility for the Traefik users.

This PR should solve the issue [1077](https://github.com/containous/traefik/issues/1077).