### PR TITLE
prefere yarnpkg over yarn

### DIFF
--- a/webui/readme.md
+++ b/webui/readme.md
@@ -21,6 +21,9 @@ make generate-webui  # Generate static contents in `traefik/static/` folder.
 
 - prerequisite: [Node 4+](https://nodejs.org) [yarn](https://yarnpkg.com/)
 
+  Note: In case of conflict with the Apache Hadoop Yarn Command Line Interface, use the `yarnpkg`
+  alias.
+
 - Go to the directory `webui`
 
 - To install dependencies, execute the following commands:


### PR DESCRIPTION
to avoid conflict with Hadoop Yarn cli.

I don’t know the best practice, but i do
have Apache Yarn installed on my machine, so
I get this conflict. Of course this conflict does
not arised when building within the docker.

see https://github.com/yarnpkg/yarn/issues/2337
Signed-off-by: Gaetan Semet <gaetan@xeberon.net>