### PR TITLE
Project-wide Editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,7 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.go]
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
Move on top of project to hit all directories.
Go files seems to prefer tab indentation over 2-space indent.