### PR TITLE
[Kubernetes] Ignore missing pass host header annotation. [v1.3 - CHERRY-PICK]

### DIFF
--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -156,14 +156,16 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 
 				PassHostHeader := p.getPassHostHeader()
 
-				passHostHeaderAnnotation := i.Annotations["traefik.frontend.passHostHeader"]
-				switch passHostHeaderAnnotation {
-				case "true":
-					PassHostHeader = true
-				case "false":
+				passHostHeaderAnnotation, ok := i.Annotations["traefik.frontend.passHostHeader"]
+				switch {
+				case !ok:
+					// No op.
+				case passHostHeaderAnnotation == "false":
 					PassHostHeader = false
+				case passHostHeaderAnnotation == "true":
+					PassHostHeader = true
 				default:
-					log.Warnf("Unknown value of %s for traefik.frontend.passHostHeader, falling back to %s", passHostHeaderAnnotation, PassHostHeader)
+					log.Warnf("Unknown value '%s' for traefik.frontend.passHostHeader, falling back to %s", passHostHeaderAnnotation, PassHostHeader)
 				}
 				if realm := i.Annotations["ingress.kubernetes.io/auth-realm"]; realm != "" && realm != traefikDefaultRealm {
 					return nil, errors.New("no realm customization supported")


### PR DESCRIPTION
We are starting to see reports of people using 1.3-rc1 and complaining/wondering about the problem reported in #1548. Hence, I think we should include the fix in the 1.3 branch as well.