### PR TITLE
[k8s] Ignore Ingresses with empty Endpoint subsets.

### DIFF
--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -1913,6 +1913,21 @@ func TestMissingResources(t *testing.T) {
 						},
 					},
 				},
+				{
+					Host: "missing_endpoint_subsets",
+					IngressRuleValue: v1beta1.IngressRuleValue{
+						HTTP: &v1beta1.HTTPIngressRuleValue{
+							Paths: []v1beta1.HTTPIngressPath{
+								{
+									Backend: v1beta1.IngressBackend{
+										ServiceName: "missing_endpoint_subsets_service",
+										ServicePort: intstr.FromInt(80),
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	}}
@@ -1947,6 +1962,21 @@ func TestMissingResources(t *testing.T) {
 				},
 			},
 		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "missing_endpoint_subsets_service",
+				UID:       "4",
+				Namespace: "testing",
+			},
+			Spec: v1.ServiceSpec{
+				ClusterIP: "10.0.0.4",
+				Ports: []v1.ServicePort{
+					{
+						Port: 80,
+					},
+				},
+			},
+		},
 	}
 	endpoints := []*v1.Endpoints{
 		{
@@ -1969,6 +1999,14 @@ func TestMissingResources(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "missing_endpoint_subsets_service",
+				UID:       "4",
+				Namespace: "testing",
+			},
+			Subsets: []v1.EndpointSubset{},
 		},
 	}
 
@@ -2016,6 +2054,14 @@ func TestMissingResources(t *testing.T) {
 					Sticky: false,
 				},
 			},
+			"missing_endpoint_subsets": {
+				Servers:        map[string]types.Server{},
+				CircuitBreaker: nil,
+				LoadBalancer: &types.LoadBalancer{
+					Method: "wrr",
+					Sticky: false,
+				},
+			},
 		},
 		Frontends: map[string]*types.Frontend{
 			"fully_working": {
@@ -2033,6 +2079,15 @@ func TestMissingResources(t *testing.T) {
 				Routes: map[string]types.Route{
 					"missing_endpoints": {
 						Rule: "Host:missing_endpoints",
+					},
+				},
+			},
+			"missing_endpoint_subsets": {
+				Backend:        "missing_endpoint_subsets",
+				PassHostHeader: true,
+				Routes: map[string]types.Route{
+					"missing_endpoint_subsets": {
+						Rule: "Host:missing_endpoint_subsets",
 					},
 				},
 			},

--- a/templates/kubernetes.tmpl
+++ b/templates/kubernetes.tmpl
@@ -1,4 +1,5 @@
 [backends]{{range $backendName, $backend := .Backends}}
+    [backends."{{$backendName}}"]
     {{if $backend.CircuitBreaker}}
     [backends."{{$backendName}}".circuitbreaker]
       expression = "{{$backend.CircuitBreaker.Expression}}"


### PR DESCRIPTION
We previously fell back to using ClusterIPs. However, the approach can lead to all kinds of problems since Ingresses rely on being able to talk to Endpoints directly. For instance, it can break stickiness and retries.

I believe the issue should still go into 1.3 since the implications can be quite severe and users won't have much of a chance to spot the misconfigurations easily.

Fixes #1462.