### PR TITLE
Minor Health UI fixes

### DIFF
--- a/webui/src/app/sections/health/health.controller.js
+++ b/webui/src/app/sections/health/health.controller.js
@@ -32,9 +32,9 @@ function HealthController($scope, $interval, $log, Health) {
       valueFormat: function (d) {
         return d3.format('d')(d);
       },
-      transitionDuration: 50,
       yAxis: {
-        axisLabelDistance: 30
+        axisLabelDistance: 30,
+        tickFormat: d3.format('d')
       }
     },
     "title": {
@@ -95,7 +95,6 @@ function HealthController($scope, $interval, $log, Health) {
         bottom: 40,
         left: 55
       },
-      transitionDuration: 50,
       x: function (d) {
         return d.x;
       },
@@ -112,7 +111,10 @@ function HealthController($scope, $interval, $log, Health) {
         tickFormat: function (d) {
           return d3.format(',.1f')(d);
         }
-      }
+      },
+      forceY: [0., 1.], // This prevents the chart from showing -1 on Oy when all the input data points
+                        // have y = 0. It won't disable the automatic adjustment of the max value.
+      duration: 0 // Bug: Markers will not be drawn if you set this to some other value...
     },
     "title": {
       "enable": true,


### PR DESCRIPTION
- format the Oy axis ticks as integers on the Total Status Code Count chart
- prevent the Average Response Time chart from showing negative values on the Oy axis
- remove the deprecated `transitionDuration` field
- set the transition duration to 0 on the Average Response Time chart to avoid triggering an NVD3 marker placement bug

Here is some background on `transitionDuration`: https://stackoverflow.com/questions/30455485/transitionduration-function-does-not-exist-in-nvd3-js

These are some issues that I noticed while developing #1650 and I thought you guys might want to have them fixed. Please note that I'm not much of a web developer, so I hope I got them right :)