### PR TITLE
Update CONTRIBUTING.md.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,7 +12,7 @@ You need to run the `binary` target. This will create binaries for Linux platfor
 $ make binary
 docker build -t "traefik-dev:no-more-godep-ever" -f build.Dockerfile .
 Sending build context to Docker daemon 295.3 MB
-Step 0 : FROM golang:1.7
+Step 0 : FROM golang:1.8
  ---> 8c6473912976
 Step 1 : RUN go get github.com/Masterminds/glide
 [...]
@@ -30,7 +30,7 @@ traefik*
 
 ###### Setting up your `go` environment
 
-- You need `go` v1.7+
+- You need `go` v1.8+
 - It is recommended you clone Træfik into a directory like `~/go/src/github.com/containous/traefik` (This is the official golang workspace hierarchy, and will allow dependencies to resolve properly)
 - This will allow your `GOPATH` and `PATH` variable to be set to `~/go` via:
 ```bash
@@ -64,11 +64,7 @@ $ ( cd integration && ../script/glide.sh get github.com/baz/quuz )
 # generate (Only required to integrate other components such as web dashboard)
 $ go generate
 # Standard go build
-$ go build
-# Using gox to build multiple platform
-$ gox "linux darwin" "386 amd64 arm" \
-    -output="dist/traefik_{{.OS}}-{{.Arch}}" \
-    ./cmd/traefik
+$ go build ./cmd/traefik
 # run other commands like tests
 ```
 


### PR DESCRIPTION
- Go 1.8 is the current minimum requirement.
- The main binary moved to `cmd/traefik`.
- Remove obsolete gox example.