### PR TITLE
Exported getSubDomain function from Marathon provider

### DIFF
--- a/provider/marathon/marathon.go
+++ b/provider/marathon/marathon.go
@@ -145,6 +145,7 @@ func (p *Provider) loadMarathonConfig() *types.Configuration {
 		"getPort":                     p.getPort,
 		"getWeight":                   p.getWeight,
 		"getDomain":                   p.getDomain,
+		"getSubDomain":                p.getSubDomain,
 		"getProtocol":                 p.getProtocol,
 		"getPassHostHeader":           p.getPassHostHeader,
 		"getPriority":                 p.getPriority,


### PR DESCRIPTION
When creating custom template for Marathon provider, it really helps to have a `getSubDomain` function be available to use in custom templates.  Otherwise the logic to compute the sub-domain directly inside the template gets very messy, and reusing the same logic as the provider would help with consistency.