### PR TITLE
Fix capitalization of PathPrefixStrip in kubernetes doc

### DIFF
--- a/docs/user-guide/kubernetes.md
+++ b/docs/user-guide/kubernetes.md
@@ -471,7 +471,7 @@ metadata:
   name: cheeses
   annotations:
     kubernetes.io/ingress.class: traefik
-    traefik.frontend.rule.type: pathprefixstrip
+    traefik.frontend.rule.type: PathPrefixStrip
 spec:
   rules:
   - host: cheeses.local

--- a/examples/k8s/cheeses-ingress.yaml
+++ b/examples/k8s/cheeses-ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: cheeses
   annotations:
-    traefik.frontend.rule.type: pathprefixstrip
+    traefik.frontend.rule.type: PathPrefixStrip
 spec:
   rules:
   - host: cheeses.local


### PR DESCRIPTION
### Description

This changes the doc and example from pathprefixstrip to PathPrefixStrip.

With v1.3 pathprefixstrip does not work, with the following error:
```
time="2017-06-01T11:46:32Z" level=error msg="Error creating route for frontend cheeses.minikube/wensleydale: Error parsing rule: Error parsing rule: 'pathprefixstrip:/wensleydale'. Unknown function: 'pathprefixstrip'" 
time="2017-06-01T11:46:32Z" level=error msg="Skipping frontend cheeses.minikube/wensleydale..." 
```
