### PR TITLE
Use correct type when watching for k8s secrets

### DIFF
--- a/provider/kubernetes/client.go
+++ b/provider/kubernetes/client.go
@@ -221,7 +221,7 @@ func (c *clientImpl) WatchSecrets(watchCh chan<- interface{}, stopCh <-chan stru
 
 	c.secStore, c.secController = cache.NewInformer(
 		source,
-		&v1.Endpoints{},
+		&v1.Secret{},
 		resyncPeriod,
 		newResourceEventHandlerFuncs(watchCh))
 	go c.secController.Run(stopCh)


### PR DESCRIPTION
This was likely just a copy-paste issue, the bug should be benign because the secret is cast to the correct type later, but the additional logging is a major annoyance, and is happening even if basic auth is not in use with Kubernetes.

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### Description

<!--
Briefly describe the pull request in a few paragraphs.
-->