### PR TITLE
traefik controller access to secrets

### DIFF
--- a/examples/k8s/traefik-rbac.yaml
+++ b/examples/k8s/traefik-rbac.yaml
@@ -10,6 +10,7 @@ rules:
       - pods
       - services
       - endpoints
+      - secrets
     verbs:
       - get
       - list


### PR DESCRIPTION
The traefik controller shall have access to secrets for the k8s basic authentication (#1488) to work
