### PR TITLE
make the cookie name unique to the backend being served

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -641,7 +641,7 @@ func (server *Server) loadConfig(configurations configs, globalConfiguration Glo
 					}
 
 					stickysession := configuration.Backends[frontend.Backend].LoadBalancer.Sticky
-					cookiename := "_TRAEFIK_BACKEND"
+					cookiename := "_TRAEFIK_BACKEND_" + frontend.Backend
 					var sticky *roundrobin.StickySession
 
 					if stickysession {


### PR DESCRIPTION
### Description

Set cookie name so that it is unique to the backend.

Addresses issue #1574.

See PR #1712 for additional discussion.
