### PR TITLE
Update documentation in kubernetes setup

### DIFF
--- a/examples/k8s/cheese-ingress.yaml
+++ b/examples/k8s/cheese-ingress.yaml
@@ -2,6 +2,8 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: cheese
+  annotations:
+    kubernetes.io/ingress.class: traefik
 spec:
   rules:
   - host: stilton.minikube

--- a/examples/k8s/cheeses-ingress.yaml
+++ b/examples/k8s/cheeses-ingress.yaml
@@ -3,6 +3,7 @@ kind: Ingress
 metadata:
   name: cheeses
   annotations:
+    kubernetes.io/ingress.class: traefik
     traefik.frontend.rule.type: PathPrefixStrip
 spec:
   rules:


### PR DESCRIPTION
### Description

This PR updates the docs to use a daemonset for deployments, and adds missing annotations to the kubernetes example files.