### PR TITLE
rebuild webui when building docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_deploy:
       docker version;
       pip install --user -r requirements.txt;
       make -j${N_MAKE_JOBS} crossbinary-parallel;
-      make image;
+      make image-dirty;
       mkdocs build --clean;
       tar cfz dist/traefik-${VERSION}.src.tar.gz --exclude-vcs --exclude dist .;
     fi

--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,14 @@ build-no-cache: dist
 shell: build ## start a shell inside the build env
 	$(DOCKER_RUN_TRAEFIK) /bin/bash
 
-image: binary ## build a docker traefik image
+image-dirty: binary ## build a docker traefik image
 	docker build -t $(TRAEFIK_IMAGE) .
+
+image: clear-static binary ## clean up static directory and build a docker traefik image
+	docker build -t $(TRAEFIK_IMAGE) .
+
+clear-static:
+	rm -rf static
 
 dist:
 	mkdir dist


### PR DESCRIPTION
I think its a good idea to always rebuild the web-ui when building a docker image via `make image`. Otherwise there is the risk that an image is built and used which has not the latest ui version. WDYT?

Side note: I recognised that the `make run-dev` command does not work as expected. The `main` package is now in the `server` directory. Do you think its still in use and should be cleaned up or is it obsolete?