### PR TITLE
[Bug fix] Default access logs to stdout

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -88,9 +88,7 @@ func NewServer(globalConfiguration GlobalConfiguration) *Server {
 		server.leadership = cluster.NewLeadership(server.routinesPool.Ctx(), globalConfiguration.Cluster)
 	}
 
-	if globalConfiguration.AccessLogsFile != "" {
-		globalConfiguration.AccessLog = &types.AccessLog{FilePath: globalConfiguration.AccessLogsFile, Format: accesslog.CommonFormat}
-	}
+	normalizeAccessLogConfig(&globalConfiguration)
 
 	if globalConfiguration.AccessLog != nil {
 		var err error
@@ -100,6 +98,15 @@ func NewServer(globalConfiguration GlobalConfiguration) *Server {
 		}
 	}
 	return server
+}
+
+func normalizeAccessLogConfig(globalConfiguration *GlobalConfiguration) {
+	if globalConfiguration.AccessLogsFile != "" {
+		log.Warnf("The config key 'accessLogFile' is deprecated. Please use 'accessLog' instead.")
+		globalConfiguration.AccessLog = &types.AccessLog{FilePath: globalConfiguration.AccessLogsFile, Format: accesslog.CommonFormat}
+	} else if globalConfiguration.AccessLog == nil {
+		globalConfiguration.AccessLog = &types.AccessLog{FilePath: "", Format: accesslog.CommonFormat}
+	}
 }
 
 // Start starts the server.


### PR DESCRIPTION
### Description

This PR fixes the bug where neither `accessLogsFile` nor `accessLog` was configured, traefik does not use the standard output as output stream for access logs as [described in the sample config](https://github.com/containous/traefik/blob/master/traefik.sample.toml#L231).

A minimal example to reproduce this issue:

`traefik -c config.yaml` where config.yaml is as below:

```yaml
debug = true
[entryPoints]
  [entryPoints.http]
  address = ":8080"
```

Output:
```
INFO[2017-06-15T00:29:57-04:00] Traefik version 2ddae2e856379f7ce2fb9b6509712e1ad523deeb built on 2017-06-15_04:28:43AM                                                                                           
INFO[2017-06-15T00:29:57-04:00] Using TOML configuration file /home/kevin/.gopath/src/github.com/containous/traefik/dist/config.yaml                                                                              
DEBU[2017-06-15T00:29:57-04:00] Global configuration loaded {"GraceTimeOut":10000000000,"Debug":true,"CheckNewVersion":true,"AccessLogsFile":"","AccessLog":null,"TraefikLogsFile":"","LogLevel":"DEBUG","EntryPoints":{"http":{"Network":"","Address":":8080","TLS":null,"Redirect":null,"Auth":null,"Compress":false}},"Cluster":null,"Constraints":[],"ACME":null,"DefaultEntryPoints":[],"ProvidersThrottleDuration":2000000000,
"MaxIdleConnsPerHost":200,"IdleTimeout":180000000000,"InsecureSkipVerify":false,"Retry":null,"HealthCheck":{"Interval":30000000000},"Docker":null,"File":null,"Web":null,"Marathon":null,"Consul":null,"ConsulCata
log":null,"Etcd":null,"Zookeeper":null,"Boltdb":null,"Kubernetes":null,"Mesos":null,"Eureka":null,"ECS":null,"Rancher":null,"DynamoDB":null}                                                                      
INFO[2017-06-15T00:29:57-04:00] Preparing server http &{Network: Address::8080 TLS:<nil> Redirect:<nil> Auth:<nil> Compress:false}                                                                                
INFO[2017-06-15T00:29:57-04:00] Starting server on :8080
```

Make a curl request (`curl localhost:8080`) and observe that nothing got written to stdout.

This is because when `AccessLogsFile == ""` and `AccessLog == nil`, line `server/server.go:95-101` are skipped so `server.accessLoggerMiddleware` is never set.

This PR fixes the issue and added a warning when the deprecated config key `accessLogsFile` is still being used.