### PR TITLE
add status code to request duration metric

### DIFF
--- a/middlewares/metrics.go
+++ b/middlewares/metrics.go
@@ -42,9 +42,12 @@ func (m *MetricsWrapper) ServeHTTP(rw http.ResponseWriter, r *http.Request, next
 	start := time.Now()
 	prw := &responseRecorder{rw, http.StatusOK}
 	next(prw, r)
-	labels := []string{"code", strconv.Itoa(prw.statusCode), "method", r.Method}
-	m.Impl.getReqsCounter().With(labels...).Add(1)
-	m.Impl.getReqDurationHistogram().Observe(float64(time.Since(start).Seconds()))
+
+	reqLabels := []string{"code", strconv.Itoa(prw.statusCode), "method", r.Method}
+	m.Impl.getReqsCounter().With(reqLabels...).Add(1)
+
+	reqDurationLabels := []string{"code", strconv.Itoa(prw.statusCode)}
+	m.Impl.getReqDurationHistogram().With(reqDurationLabels...).Observe(float64(time.Since(start).Seconds()))
 }
 
 // MetricsRetryListener is an implementation of the RetryListener interface to

--- a/middlewares/prometheus.go
+++ b/middlewares/prometheus.go
@@ -17,7 +17,7 @@ const (
 
 // Prometheus is an Implementation for Metrics that exposes the following Prometheus metrics:
 // - number of requests partitioned by status code and method
-// - request durations
+// - request durations partitioned by status code
 // - amount of retries happened
 type Prometheus struct {
 	reqsCounter          metrics.Counter
@@ -73,7 +73,7 @@ func NewPrometheus(name string, config *types.Prometheus) (*Prometheus, []stdpro
 			ConstLabels: stdprometheus.Labels{"service": name},
 			Buckets:     buckets,
 		},
-		[]string{},
+		[]string{"code"},
 	)
 	hv, err = registerHistogramVec(hv)
 	if err != nil {

--- a/middlewares/prometheus_test.go
+++ b/middlewares/prometheus_test.go
@@ -75,6 +75,7 @@ func TestPrometheus(t *testing.T) {
 			name: reqDurationName,
 			labels: map[string]string{
 				"service": "test",
+				"code":    "200",
 			},
 			assert: func(family *dto.MetricFamily) {
 				sc := family.Metric[0].Histogram.GetSampleCount()


### PR DESCRIPTION
Its best practice to monitor request durations partitioned by the status code of the response.  4xx/5xx usually have a different response time then succeeding requests. In case of 4xx they are most of the time very fast and depending on the type of server error, 5xx are also either very fast or very slow. Having no differentiation of those would distort calculations on the request durations, e.g. when you want to calculate an average.

Adding the label to the metric is not breaking existing Prometheus queries and is therefore backwards compatible.