### PR TITLE
Fix race on closing event channel.

### DIFF
--- a/provider/kubernetes/client.go
+++ b/provider/kubernetes/client.go
@@ -263,7 +263,7 @@ func (c *clientImpl) WatchAll(labelSelector string, stopCh <-chan struct{}) (<-c
 // fireEvent checks if all controllers have synced before firing
 // Used after startup or a reconnect
 func (c *clientImpl) fireEvent(event interface{}, eventCh chan interface{}) {
-	if !c.ingController.HasSynced() || !c.svcController.HasSynced() || !c.epController.HasSynced() {
+	if !c.ingController.HasSynced() || !c.svcController.HasSynced() || !c.epController.HasSynced() || !c.secController.HasSynced() {
 		return
 	}
 	eventHandlerFunc(eventCh, event)

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -171,7 +171,8 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 				if _, exists := templateObjects.Frontends[r.Host+pa.Path]; !exists {
 					basicAuthCreds, err := handleBasicAuthConfig(i, k8sClient)
 					if err != nil {
-						return nil, err
+						log.Errorf("Failed to retrieve basic auth configuration for ingress %s/%s: %s", i.ObjectMeta.Namespace, i.ObjectMeta.Name, err)
+						continue
 					}
 					templateObjects.Frontends[r.Host+pa.Path] = &types.Frontend{
 						Backend:        r.Host + pa.Path,


### PR DESCRIPTION
- Wait for secret controller to finish synchronizing.
- Improve basic auth handling.
- Continue Ingress processing on auth retrieval failure.

The last point is noteworthy: We previously returned an error when we couldn't retrieve basic auth credentials, blocking following Ingresses from being processed. Since retrieving the auth credentials is highly dependent on an external component (the Kubernetes Secret object), we should opt for dropping such failing Ingresses but move forward with the remaining ones.

Fixes #1794.

@dtomcej @errm @emilevauge @ldez and others: PTAL.