### PR TITLE
remove confusing go-marathon log message

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 4e2a6a4fe84b2843ff946fe56deae17f8c7666e2e6567d8a75f4b0bdd7cb0280
-updated: 2017-06-29T16:47:14.848940186+02:00
+updated: 2017-06-30T11:03:09.025639582+02:00
 imports:
 - name: cloud.google.com/go
   version: 2e6a95edb1071d750f6d7db777bf66cd2997af6c
@@ -172,7 +172,7 @@ imports:
   - store/etcd
   - store/zookeeper
 - name: github.com/donovanhide/eventsource
-  version: 441a03aa37b3329bbb79f43de81914ea18724718
+  version: b8f31a59085e69dd2678cf51840db2ac625cb741
 - name: github.com/eapache/channels
   version: 47238d5aae8c0fefd518ef2bee46290909cf8263
 - name: github.com/eapache/queue


### PR DESCRIPTION
Log message produced by go-marathon was:

`time="2017-06-28T09:08:19Z" level=debug msg="listenToSSE(): failed to
handle event: failed to decode the event type, content: , error: EOF"`

The fix for this was done in the upstream project of go-marathon donovanhide/eventsource.

Background is that Marathon periodically sends a `\n` over the SSE subscription, in order to keep the connection alive. This was parsed as empty event by the eventsource and published. go-marathon in turn was not able to do something with this empty event was producing the log message above. By getting rid of publishing empty events in the downstream library, we also get rid of this log message.