### PR TITLE
Use single API call to fetch Marathon resources.

### DIFF
--- a/templates/marathon.tmpl
+++ b/templates/marathon.tmpl
@@ -1,35 +1,38 @@
 {{$apps := .Applications}}
-[backends]{{range .Tasks}}
-    [backends."backend{{getBackend . $apps}}".servers."server-{{.ID | replace "." "-"}}"]
-    url = "{{getProtocol . $apps}}://{{getBackendServer . $apps}}:{{getPort . $apps}}"
-    weight = {{getWeight . $apps}}
+
+{{range $app := $apps}}
+{{range $app.Tasks}}
+    [backends."backend{{getBackend $app}}".servers."server-{{.ID | replace "." "-"}}"]
+    url = "{{getProtocol $app}}://{{getBackendServer . $app}}:{{getPort . $app}}"
+    weight = {{getWeight $app}}
+{{end}}
 {{end}}
 
-{{range .Applications}}
+{{range $apps}}
 {{ if hasMaxConnLabels . }}
-      [backends."backend{{getFrontendBackend . }}".maxconn]
+      [backends."backend{{getBackend . }}".maxconn]
         amount = {{getMaxConnAmount . }}
         extractorfunc = "{{getMaxConnExtractorFunc . }}"
 {{end}}
 {{ if hasLoadBalancerLabels . }}
-      [backends."backend{{getFrontendBackend . }}".loadbalancer]
+      [backends."backend{{getBackend . }}".loadbalancer]
         method = "{{getLoadBalancerMethod . }}"
         sticky = {{getSticky .}}
 {{end}}
 {{ if hasCircuitBreakerLabels . }}
-      [backends."backend{{getFrontendBackend . }}".circuitbreaker]
+      [backends."backend{{getBackend . }}".circuitbreaker]
         expression = "{{getCircuitBreakerExpression . }}"
 {{end}}
 {{ if hasHealthCheckLabels . }}
-      [backends."backend{{getFrontendBackend . }}".healthcheck]
+      [backends."backend{{getBackend . }}".healthcheck]
         path = "{{getHealthCheckPath . }}"
         interval = "{{getHealthCheckInterval . }}"
 {{end}}
 {{end}}
 
-[frontends]{{range .Applications}}
+[frontends]{{range $apps}}
   [frontends."frontend{{.ID | replace "/" "-"}}"]
-  backend = "backend{{getFrontendBackend .}}"
+  backend = "backend{{getBackend .}}"
   passHostHeader = {{getPassHostHeader .}}
   priority = {{getPriority .}}
   entryPoints = [{{range getEntryPoints .}}


### PR DESCRIPTION
Change Marathon provider to make just one API call instead of two per configuration update by means of specifying embedded resources, which enable retrieving multiple response types from the API at once. Apart from the obvious savings in API calls, we primarily gain a consistent view on both applications and tasks that allows us to drop a lot of correlation logic.  Additionally, it will serve as the basis for the introduction of [readiness checks](https://github.com/containous/traefik/issues/1559) which require application/task consistency for correct leverage on the proxy end.

Additional changes:

marathon.go:
- Filter on tasks now embedded inside the applications.
- Reduce/simplify signature on multiple template functions as we do not need to check for proper application/task correlation anymore.
- Remove getFrontendBackend in favor of just getBackend.
- Move filtering on enabled/exposed applications from `taskFilter` to `applicationFilter`. (The task filter just reached out to the applications anyway, so it never made sense to locate it with the
  tasks where the filter was called once for every task even though the result would never change.)
- Remove duplicate constraints filter in tasks, where it neither made sense to keep as it operates on the application level only.
- Add context to rendering error.

marathon_test.go:
- Simplify and reduce numerous tests.
- Convert tests with high number of cases into parallelized sub-tests.
- Improve readability/structure for several tests.
- Add missing test for enabled/exposed applications.
- Simplify the mocked Marathon server.

marathon.tmpl:
- Update application/task iteration.
- Replace `getFrontendBackend` by `getBackend`.

Fixes #1846