### PR TITLE
Tell glog to log everything into STDERR.

### DIFF
--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"flag"
 	"fmt"
 	"os"
 	"reflect"
@@ -62,6 +63,12 @@ func (p *Provider) newK8sClient() (Client, error) {
 // Provide allows the k8s provider to provide configurations to traefik
 // using the given configuration channel.
 func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *safe.Pool, constraints types.Constraints) error {
+	// Tell glog (used by client-go) to log into STDERR. Otherwise, we risk
+	// certain kinds of API errors getting logged into a directory not
+	// available in a `FROM scratch` Docker container, causing glog to abort
+	// hard with an exit code > 0.
+	flag.Set("logtostderr", "true")
+
 	k8sClient, err := p.newK8sClient()
 	if err != nil {
 		return err


### PR DESCRIPTION
Logging errors into a file inside a minimalistic container might not be possible, and glog bails out with an exit code > 0 if it fails.

Fixes #1785