### PR TITLE
Undo the Secrets controller sync wait.

### DIFF
--- a/provider/kubernetes/client.go
+++ b/provider/kubernetes/client.go
@@ -263,7 +263,7 @@ func (c *clientImpl) WatchAll(labelSelector string, stopCh <-chan struct{}) (<-c
 // fireEvent checks if all controllers have synced before firing
 // Used after startup or a reconnect
 func (c *clientImpl) fireEvent(event interface{}, eventCh chan interface{}) {
-	if !c.ingController.HasSynced() || !c.svcController.HasSynced() || !c.epController.HasSynced() || !c.secController.HasSynced() {
+	if !c.ingController.HasSynced() || !c.svcController.HasSynced() || !c.epController.HasSynced() {
 		return
 	}
 	eventHandlerFunc(eventCh, event)


### PR DESCRIPTION
When Secrets permissions have not been granted (which is likely to be the case for users not needing the basic auth feature), the watch on the Secrets API will never yield a response, thereby causing the controller to never sync successfully, and in turn causing the check for all controller synchronizations to fail consistently. Thus, no event will ever be handled.

Fixes #1826 
Reverts a part of #1798
Verified that #1794 continues to be fixed

Reviewers and @containous/traefik: PTAL.