### PR TITLE
Allow to bypass https redirection per frontend

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -920,6 +920,7 @@ Labels can be used on containers to override default behaviour:
 - `traefik.frontend.auth.basic=test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/,test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0`: Sets basic authentication for that frontend with the usernames and passwords test:test and test2:test2, respectively
 - `traefik.frontend.whitelistSourceRange: "1.2.3.0/24, fe80::/16"`: List of IP-Ranges which are allowed to access. An unset or empty list allows all Source-IPs to access. If one of the Net-Specifications are invalid, the whole list is invalid and allows all Source-IPs to access.
 - `traefik.docker.network`: Set the docker network to use for connections to this container. If a container is linked to several networks, be sure to set the proper network name (you can check with docker inspect <container_id>) otherwise it will randomly pick one (depending on how docker is returning them). For instance when deploying docker `stack` from compose files, the compose defined networks will be prefixed with the `stack` name.
+- `traefik.http.redirect=false`: When used with endpoints setup in HTTP + HTTPS configuration, set this flag to false to prevent https redirection for a given frontend.
 
 If several ports need to be exposed from a container, the services labels can be used
 - `traefik.<service-name>.port=443`: create a service binding with frontend/backend using this port. Overrides `traefik.port`.

--- a/provider/docker/docker.go
+++ b/provider/docker/docker.go
@@ -261,6 +261,7 @@ func (p *Provider) loadDockerConfig(containersInspected []dockerData) *types.Con
 		"getProtocol":                 p.getProtocol,
 		"getPassHostHeader":           p.getPassHostHeader,
 		"getPriority":                 p.getPriority,
+		"getHTTPRedirect":             p.getHTTPRedirect,
 		"getEntryPoints":              p.getEntryPoints,
 		"getBasicAuth":                p.getBasicAuth,
 		"getFrontendRule":             p.getFrontendRule,
@@ -283,6 +284,7 @@ func (p *Provider) loadDockerConfig(containersInspected []dockerData) *types.Con
 		"getServiceFrontendRule":      p.getServiceFrontendRule,
 		"getServicePassHostHeader":    p.getServicePassHostHeader,
 		"getServicePriority":          p.getServicePriority,
+		"getServiceHTTPRedirect":      p.getServiceHTTPRedirect,
 		"getServiceBackend":           p.getServiceBackend,
 		"getWhitelistSourceRange":     p.getWhitelistSourceRange,
 	}
@@ -415,6 +417,15 @@ func (p *Provider) getServicePriority(container dockerData, serviceName string) 
 		return value
 	}
 	return p.getPriority(container)
+
+}
+
+// Extract http redirect (allow to disable per-frontend https redirection) from labels for a given service and a given docker container
+func (p *Provider) getServiceHTTPRedirect(container dockerData, serviceName string) string {
+	if value, ok := getContainerServiceLabel(container, serviceName, types.LabelHTTPRedirect); ok {
+		return value
+	}
+	return p.getHTTPRedirect(container)
 
 }
 
@@ -690,6 +701,13 @@ func (p *Provider) getPriority(container dockerData) string {
 		return priority
 	}
 	return "0"
+}
+
+func (p *Provider) getHTTPRedirect(container dockerData) string {
+	if redirect, err := getLabel(container, types.LabelHTTPRedirect); err == nil {
+		return redirect
+	}
+	return "true"
 }
 
 func (p *Provider) getEntryPoints(container dockerData) []string {

--- a/provider/docker/docker_test.go
+++ b/provider/docker/docker_test.go
@@ -885,6 +885,7 @@ func TestDockerLoadDockerConfig(t *testing.T) {
 			expectedFrontends: map[string]*types.Frontend{
 				"frontend-Host-test-docker-localhost": {
 					Backend:        "backend-test",
+					HTTPRedirect:   true,
 					PassHostHeader: true,
 					EntryPoints:    []string{},
 					BasicAuth:      []string{},
@@ -935,6 +936,7 @@ func TestDockerLoadDockerConfig(t *testing.T) {
 			expectedFrontends: map[string]*types.Frontend{
 				"frontend-Host-test1-docker-localhost": {
 					Backend:        "backend-foobar",
+					HTTPRedirect:   true,
 					PassHostHeader: true,
 					EntryPoints:    []string{"http", "https"},
 					BasicAuth:      []string{"test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/", "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"},
@@ -946,6 +948,7 @@ func TestDockerLoadDockerConfig(t *testing.T) {
 				},
 				"frontend-Host-test2-docker-localhost": {
 					Backend:        "backend-foobar",
+					HTTPRedirect:   true,
 					PassHostHeader: true,
 					EntryPoints:    []string{},
 					BasicAuth:      []string{},
@@ -993,6 +996,7 @@ func TestDockerLoadDockerConfig(t *testing.T) {
 			expectedFrontends: map[string]*types.Frontend{
 				"frontend-Host-test1-docker-localhost": {
 					Backend:        "backend-foobar",
+					HTTPRedirect:   true,
 					PassHostHeader: true,
 					EntryPoints:    []string{"http", "https"},
 					BasicAuth:      []string{},
@@ -1047,6 +1051,37 @@ func TestDockerLoadDockerConfig(t *testing.T) {
 			}
 			if !reflect.DeepEqual(actualConfig.Frontends, c.expectedFrontends) {
 				t.Errorf("expected %#v, got %#v", c.expectedFrontends, actualConfig.Frontends)
+			}
+		})
+	}
+}
+
+func TestDockerGetHTTPRedirect(t *testing.T) {
+	containers := []struct {
+		container docker.ContainerJSON
+		expected  string
+	}{
+		{
+			container: containerJSON(),
+			expected:  "true",
+		},
+		{
+			container: containerJSON(labels(map[string]string{
+				types.LabelHTTPRedirect: "false",
+			})),
+			expected: "false",
+		},
+	}
+
+	for containerID, e := range containers {
+		e := e
+		t.Run(strconv.Itoa(containerID), func(t *testing.T) {
+			t.Parallel()
+			dockerData := parseContainer(e.container)
+			provider := &Provider{}
+			actual := provider.getHTTPRedirect(dockerData)
+			if actual != e.expected {
+				t.Errorf("expected %q, got %q", e.expected, actual)
 			}
 		})
 	}

--- a/provider/docker/service_test.go
+++ b/provider/docker/service_test.go
@@ -343,6 +343,7 @@ func TestDockerLoadDockerServiceConfig(t *testing.T) {
 			expectedFrontends: map[string]*types.Frontend{
 				"frontend-foo-service": {
 					Backend:        "backend-foo-service",
+					HTTPRedirect:   true,
 					PassHostHeader: true,
 					EntryPoints:    []string{"http", "https"},
 					BasicAuth:      []string{"test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/", "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"},
@@ -401,6 +402,7 @@ func TestDockerLoadDockerServiceConfig(t *testing.T) {
 			expectedFrontends: map[string]*types.Frontend{
 				"frontend-foobar": {
 					Backend:        "backend-foobar",
+					HTTPRedirect:   true,
 					PassHostHeader: false,
 					Priority:       5000,
 					EntryPoints:    []string{"http", "https", "ws"},
@@ -413,6 +415,7 @@ func TestDockerLoadDockerServiceConfig(t *testing.T) {
 				},
 				"frontend-test2-anotherservice": {
 					Backend:        "backend-test2-anotherservice",
+					HTTPRedirect:   true,
 					PassHostHeader: true,
 					EntryPoints:    []string{},
 					BasicAuth:      []string{},

--- a/provider/docker/swarm_test.go
+++ b/provider/docker/swarm_test.go
@@ -662,6 +662,7 @@ func TestSwarmLoadDockerConfig(t *testing.T) {
 			expectedFrontends: map[string]*types.Frontend{
 				"frontend-Host-test-docker-localhost": {
 					Backend:        "backend-test",
+					HTTPRedirect:   true,
 					PassHostHeader: true,
 					EntryPoints:    []string{},
 					BasicAuth:      []string{},
@@ -716,6 +717,7 @@ func TestSwarmLoadDockerConfig(t *testing.T) {
 			expectedFrontends: map[string]*types.Frontend{
 				"frontend-Host-test1-docker-localhost": {
 					Backend:        "backend-foobar",
+					HTTPRedirect:   true,
 					PassHostHeader: true,
 					EntryPoints:    []string{"http", "https"},
 					BasicAuth:      []string{"test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/", "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"},
@@ -727,6 +729,7 @@ func TestSwarmLoadDockerConfig(t *testing.T) {
 				},
 				"frontend-Host-test2-docker-localhost": {
 					Backend:        "backend-foobar",
+					HTTPRedirect:   true,
 					PassHostHeader: true,
 					EntryPoints:    []string{},
 					BasicAuth:      []string{},

--- a/server/server.go
+++ b/server/server.go
@@ -645,7 +645,8 @@ func (server *Server) loadConfig(configurations configs, globalConfiguration Glo
 
 				entryPoint := globalConfiguration.EntryPoints[entryPointName]
 				negroni := negroni.New()
-				if entryPoint.Redirect != nil {
+
+				if entryPoint.Redirect != nil && frontend.HTTPRedirect == true {
 					if redirectHandlers[entryPointName] != nil {
 						negroni.Use(redirectHandlers[entryPointName])
 					} else if handler, err := server.loadEntryPointConfig(entryPointName, entryPoint); err != nil {

--- a/templates/docker.tmpl
+++ b/templates/docker.tmpl
@@ -52,6 +52,7 @@
   entryPoints = [{{range getServiceEntryPoints $container $serviceName}}
     "{{.}}",
   {{end}}]
+  httpRedirect = {{getServiceHTTPRedirect $container $serviceName}}
   basicAuth = [{{range getServiceBasicAuth $container $serviceName}}
     "{{.}}",
   {{end}}]
@@ -71,6 +72,7 @@
   entryPoints = [{{range getEntryPoints $container}}
     "{{.}}",
   {{end}}]
+  httpRedirect = {{getHTTPRedirect $container}}
   basicAuth = [{{range getBasicAuth $container}}
     "{{.}}",
   {{end}}]

--- a/types/common_label.go
+++ b/types/common_label.go
@@ -31,6 +31,8 @@ const (
 	LabelTraefikFrontendValue = "traefik.frontend.value"
 	// LabelTraefikFrontendWhitelistSourceRange Traefik label
 	LabelTraefikFrontendWhitelistSourceRange = "traefik.frontend.whitelistSourceRange"
+	// LabelHTTPRedirect Traefik label
+	LabelHTTPRedirect = "traefik.http.redirect"
 	// LabelBackend Traefik label
 	LabelBackend = "traefik.backend"
 	// LabelBackendID Traefik label

--- a/types/types.go
+++ b/types/types.go
@@ -116,6 +116,7 @@ func (h Headers) HasSecureHeadersDefined() bool {
 // Frontend holds frontend configuration.
 type Frontend struct {
 	EntryPoints          []string             `json:"entryPoints,omitempty"`
+	HTTPRedirect         bool                 `json:"httpRedirect,omitempty"`
 	Backend              string               `json:"backend,omitempty"`
 	Routes               map[string]Route     `json:"routes,omitempty"`
 	PassHostHeader       bool                 `json:"passHostHeader,omitempty"`


### PR DESCRIPTION
# Description

This is an attempt to implement #541.
The goal is to allow a container to bypass http -> https redirection using a label `traefik.http.redirect`.
This is my first PR on this project (and in golang), let me know if I've made mistakes :wink: 
Dunno if I have to implement this new label for each provider or if you'd rather prefer to split the work in multiples PR's.

- [x] Fix test
- [x] Add test
- [x] Update doc
- [ ] Implement for every provider ?

## Example Usage
```
➜ docker run -it --rm --name whoami emilevauge/whoami                                      
Starting up on port 80

➜ curl -I --insecure http://whoami.localhost 
HTTP/1.1 302 Found
Location: https://whoami.localhost:443/
Date: Tue, 11 Jul 2017 14:41:29 GMT
Content-Length: 5
Content-Type: text/plain; charset=utf-8

➜ curl -I --insecure https://whoami.localhost
HTTP/1.1 200 OK
Content-Length: 256
Content-Type: text/plain; charset=utf-8
Date: Tue, 11 Jul 2017 14:41:45 GMT
```

```
➜ docker run -it --rm --name whoami --label "traefik.http.redirect=false" emilevauge/whoami                                                               
Starting up on port 80

➜ curl -I --insecure http://whoami.localhost 
HTTP/1.1 200 OK
Content-Length: 255
Content-Type: text/plain; charset=utf-8
Date: Tue, 11 Jul 2017 14:42:09 GMT

➜ curl -I --insecure https://whoami.localhost
HTTP/1.1 200 OK
Content-Length: 256
Content-Type: text/plain; charset=utf-8
Date: Tue, 11 Jul 2017 14:42:20 GMT
```

Assuming endpoint configuration is :

```toml
defaultEntryPoints = ["http", "https"]
[entryPoints]
  [entryPoints.http]
  address = ":80"
    [entryPoints.http.redirect]
    entryPoint = "https"
  [entryPoints.https]
  address = ":443"
    [entryPoints.https.tls]
      [[entryPoints.https.tls.certificates]]
      CertFile = "www.crt"
      KeyFile = "www.key"
```