### PR TITLE
Fix replace path rule

### DIFF
--- a/middlewares/replace_path.go
+++ b/middlewares/replace_path.go
@@ -16,5 +16,6 @@ const ReplacedPathHeader = "X-Replaced-Path"
 func (s *ReplacePath) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r.Header.Add(ReplacedPathHeader, r.URL.Path)
 	r.URL.Path = s.Path
+	r.RequestURI = r.URL.RequestURI()
 	s.Handler.ServeHTTP(w, r)
 }


### PR DESCRIPTION
### Description

Fixes #1775. 

The path replace middleware wasn't setting the `http.Request.RequestURI` which is used by `oxy.forward` to compose the outgoing URL and from the point of view of the backend the path was never replaced.

Other middlewares, like `addPrefix` and `stripPrefix`, do the same thing.