### PR TITLE
added modifications for parsing out && and || on front end rule

### DIFF
--- a/provider/consul/consul_catalog.go
+++ b/provider/consul/consul_catalog.go
@@ -251,7 +251,7 @@ func (p *CatalogProvider) getBackend(node *api.ServiceEntry) string {
 
 func (p *CatalogProvider) getFrontendRule(service serviceUpdate) string {
 	customFrontendRule := p.getAttribute("frontend.rule", service.Attributes, "")
-	if customFrontendRule == "" || customFrontendRule == nil {
+	if customFrontendRule == "" {
 		customFrontendRule = p.FrontEndRule
 	} else {
 		customFrontendRule = translateRuleSeparators(customFrontendRule)

--- a/provider/consul/consul_catalog.go
+++ b/provider/consul/consul_catalog.go
@@ -251,8 +251,10 @@ func (p *CatalogProvider) getBackend(node *api.ServiceEntry) string {
 
 func (p *CatalogProvider) getFrontendRule(service serviceUpdate) string {
 	customFrontendRule := p.getAttribute("frontend.rule", service.Attributes, "")
-	if customFrontendRule == "" {
+	if customFrontendRule == "" || customFrontendRule == nil {
 		customFrontendRule = p.FrontEndRule
+	} else {
+		customFrontendRule = translateRuleSeparators ( customFrontendRule )
 	}
 
 	t := p.frontEndRuleTemplate
@@ -281,6 +283,18 @@ func (p *CatalogProvider) getFrontendRule(service serviceUpdate) string {
 
 	return buffer.String()
 }
+
+func translateRuleSeparators(customRule string) string {
+	rule := replaceAll ( customRule, "||", ",")
+	rule = replaceAll ( customRule, "&&", ";")
+	return rule
+}
+
+func replaceAll(source string, what string, with string) string {
+	return strings.Replace( source, what, with, -1 )
+}
+
+
 
 func (p *CatalogProvider) getBackendAddress(node *api.ServiceEntry) string {
 	if node.Service.Address != "" {

--- a/provider/consul/consul_catalog.go
+++ b/provider/consul/consul_catalog.go
@@ -254,7 +254,7 @@ func (p *CatalogProvider) getFrontendRule(service serviceUpdate) string {
 	if customFrontendRule == "" || customFrontendRule == nil {
 		customFrontendRule = p.FrontEndRule
 	} else {
-		customFrontendRule = translateRuleSeparators ( customFrontendRule )
+		customFrontendRule = translateRuleSeparators(customFrontendRule)
 	}
 
 	t := p.frontEndRuleTemplate
@@ -285,16 +285,14 @@ func (p *CatalogProvider) getFrontendRule(service serviceUpdate) string {
 }
 
 func translateRuleSeparators(customRule string) string {
-	rule := replaceAll ( customRule, "||", ",")
-	rule = replaceAll ( customRule, "&&", ";")
+	rule := replaceAll(customRule, "||", ",")
+	rule = replaceAll(customRule, "&&", ";")
 	return rule
 }
 
 func replaceAll(source string, what string, with string) string {
-	return strings.Replace( source, what, with, -1 )
+	return strings.Replace(source, what, with, -1)
 }
-
-
 
 func (p *CatalogProvider) getBackendAddress(node *api.ServiceEntry) string {
 	if node.Service.Address != "" {


### PR DESCRIPTION
The changes to have this implemented for the Consul Catalog are here.

Fixes #1280