### PR TITLE
Reuse backend-LBs over entrypoints

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -663,7 +663,7 @@ func (server *Server) loadConfig(configurations configs, globalConfiguration Glo
 						}
 					}
 				}
-				if backends[entryPointName+frontend.Backend] == nil {
+				if backends[frontend.Backend] == nil {
 					log.Debugf("Creating backend %s", frontend.Backend)
 
 					var (
@@ -857,14 +857,14 @@ func (server *Server) loadConfig(configurations configs, globalConfiguration Glo
 					} else {
 						negroni.UseHandler(lb)
 					}
-					backends[entryPointName+frontend.Backend] = negroni
+					backends[frontend.Backend] = negroni
 				} else {
 					log.Debugf("Reusing backend %s", frontend.Backend)
 				}
 				if frontend.Priority > 0 {
 					newServerRoute.route.Priority(frontend.Priority)
 				}
-				server.wireFrontendBackend(newServerRoute, backends[entryPointName+frontend.Backend])
+				server.wireFrontendBackend(newServerRoute, backends[frontend.Backend])
 
 				err := newServerRoute.route.GetError()
 				if err != nil {


### PR DESCRIPTION
### Description

Fixes: #1866
Conflicts: #1868

This approach reuses backend-LBs for multiple entrypoints. If e.g. there
are the entrypoints `http` and `https`, both use the same lb-instance.
So because of a healthcheck one server is removed from the backend, it
is removed from both entrypoints.

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

<!--
Briefly describe the pull request in a few paragraphs.
-->