### PR TITLE
Server-Sent Events are broken when enabling the retry option

### DIFF
--- a/middlewares/retry.go
+++ b/middlewares/retry.go
@@ -42,6 +42,12 @@ func (retry *Retry) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		recorder := NewRecorder()
 		recorder.responseWriter = rw
 		retry.next.ServeHTTP(recorder, r)
+
+		// In case of a stream, data has already been sent if code 200
+		if recorder.stream {
+			break
+		}
+
 		if !isNetworkError(recorder.Code) || attempts >= retry.attempts {
 			utils.CopyHeaders(rw.Header(), recorder.Header())
 			rw.WriteHeader(recorder.Code)
@@ -66,6 +72,7 @@ type ResponseRecorder struct {
 
 	responseWriter http.ResponseWriter
 	err            error
+	stream    bool
 }
 
 // NewRecorder returns an initialized ResponseRecorder.
@@ -74,6 +81,7 @@ func NewRecorder() *ResponseRecorder {
 		HeaderMap: make(http.Header),
 		Body:      new(bytes.Buffer),
 		Code:      200,
+		stream:    false,
 	}
 }
 
@@ -114,6 +122,10 @@ func (rw *ResponseRecorder) CloseNotify() <-chan bool {
 
 // Flush sends any buffered data to the client.
 func (rw *ResponseRecorder) Flush() {
+	if !rw.stream && !isNetworkError(rw.Code) {
+		rw.stream = true
+		utils.CopyHeaders(rw.responseWriter.Header(), rw.Header())
+	}
 	_, err := rw.responseWriter.Write(rw.Body.Bytes())
 	if err != nil {
 		log.Errorf("Error writing response in ResponseRecorder: %s", err)

--- a/middlewares/retry.go
+++ b/middlewares/retry.go
@@ -72,7 +72,7 @@ type ResponseRecorder struct {
 
 	responseWriter http.ResponseWriter
 	err            error
-	stream    bool
+	stream         bool
 }
 
 // NewRecorder returns an initialized ResponseRecorder.


### PR DESCRIPTION
When backends streams http content and traefik is configured with retry middleware,
flush is called on response recorder of retry middleware.
Unfortunately, http headers are not copied from original response.

### Description

In retry middleware, add a boolean called stream on `ResponseRecorder`.
This boolean will be `true` when handling an http stream.

When `Flush` is called and stream is `false`, this means we didn't `copyHeaders` from original response yet.
Copy headers and set stream to true.

N.B. : stream vocable is also used in`fwd.go`.
```golang
	stream := f.streamResponse
	if !stream {
		contentType, err := utils.GetHeaderMediaType(response.Header, ContentType)
		if err == nil {
			stream = contentType == "text/event-stream"
		}
	}
```
### Reproduction of issue

Using docker-compose below

```json
{
    "version": "3",
    "services": {
        "dashing": {
            "image": "johnzan/dashing",
            "expose": ["3030"],
            "labels": {
                "traefik.enable": "true",
                "traefik.backend": "dashing",
                "traefik.frontend.rule": "PathPrefixStrip:/dashing",
                "traefik.port": "3030"
            }
        }

   }
}
```

Before patch
```
$ docker-compose up -d
$ curl -v http://localhost:8081/dashing/events
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 8081 (#0)
> GET /dashing/events HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.47.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Vary: Accept-Encoding
< Date: Mon, 17 Jul 2017 14:05:28 GMT
< Content-Type: text/plain; charset=utf-8
< Transfer-Encoding: chunked
< 
```
With patch, headers are copied
```
$ docker-compose up -d
$ curl -v http://localhost:8081/dashing/events
> GET /dashing/events HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.47.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Content-Type: text/event-stream;charset=utf-8
< Server: thin 1.6.1 codename Death Proof
< Vary: Accept-Encoding
< X-Accel-Buffering: no
< X-Content-Type-Options: nosniff
< Date: Mon, 17 Jul 2017 14:04:34 GMT
< Transfer-Encoding: chunked
< 
data: {"points":[{"x":620,"y":27},{"x":621,"y":22},{"x":622,"y":16},{"x":623,"y":29},{"x":624,"y":18},{"x":625,"y":41},{"x":626,"y":37},{"x":627,"y":26},{"x":628,"y":27},{"x":629,"y":15}],"id":"convergence","updatedAt":1500300270}
```

Fixes #1862