### PR TITLE
Use test builder.

### DIFF
--- a/provider/marathon/builder_test.go
+++ b/provider/marathon/builder_test.go
@@ -1,0 +1,131 @@
+package marathon
+
+import "github.com/gambol99/go-marathon"
+
+// Functions related to building applications.
+
+func createApplication(ops ...func(*marathon.Application)) marathon.Application {
+	app := marathon.Application{}
+	app.EmptyLabels()
+
+	for _, op := range ops {
+		op(&app)
+	}
+
+	return app
+}
+
+func appID(name string) func(*marathon.Application) {
+	return func(app *marathon.Application) {
+		app.Name(name)
+	}
+}
+
+func appPorts(ports ...int) func(*marathon.Application) {
+	return func(app *marathon.Application) {
+		app.Ports = append(app.Ports, ports...)
+	}
+}
+
+func label(key, value string) func(*marathon.Application) {
+	return func(app *marathon.Application) {
+		app.AddLabel(key, value)
+	}
+}
+
+func healthChecks(checks ...*marathon.HealthCheck) func(*marathon.Application) {
+	return func(app *marathon.Application) {
+		for _, check := range checks {
+			app.AddHealthCheck(*check)
+		}
+	}
+}
+
+func portDefinition(port int) func(*marathon.Application) {
+	return func(app *marathon.Application) {
+		app.AddPortDefinition(marathon.PortDefinition{
+			Port: &port,
+		})
+	}
+}
+
+func ipAddrPerTask(port int) func(*marathon.Application) {
+	return func(app *marathon.Application) {
+		p := marathon.Port{
+			Number: port,
+			Name:   "port",
+		}
+		disc := marathon.Discovery{}
+		disc.AddPort(p)
+		ipAddr := marathon.IPAddressPerTask{}
+		ipAddr.SetDiscovery(disc)
+		app.SetIPAddressPerTask(ipAddr)
+	}
+}
+
+// Functions related to building tasks.
+
+func createTask(ops ...func(*marathon.Task)) marathon.Task {
+	t := marathon.Task{
+		// The vast majority of tests expect the task state to be TASK_RUNNING.
+		State: string(taskStateRunning),
+	}
+
+	for _, op := range ops {
+		op(&t)
+	}
+
+	return t
+}
+
+func createLocalhostTask(ops ...func(*marathon.Task)) marathon.Task {
+	t := createTask(
+		host("localhost"),
+		ipAddresses("127.0.0.1"),
+	)
+
+	for _, op := range ops {
+		op(&t)
+	}
+
+	return t
+}
+
+func taskPorts(ports ...int) func(*marathon.Task) {
+	return func(t *marathon.Task) {
+		t.Ports = append(t.Ports, ports...)
+	}
+}
+
+func host(h string) func(*marathon.Task) {
+	return func(t *marathon.Task) {
+		t.Host = h
+	}
+}
+
+func ipAddresses(addresses ...string) func(*marathon.Task) {
+	return func(t *marathon.Task) {
+		for _, addr := range addresses {
+			t.IPAddresses = append(t.IPAddresses, &marathon.IPAddress{
+				IPAddress: addr,
+				Protocol:  "tcp",
+			})
+		}
+	}
+}
+
+func state(s TaskState) func(*marathon.Task) {
+	return func(t *marathon.Task) {
+		t.State = string(s)
+	}
+}
+
+func healthCheckResultLiveness(alive ...bool) func(*marathon.Task) {
+	return func(t *marathon.Task) {
+		for _, a := range alive {
+			t.HealthCheckResults = append(t.HealthCheckResults, &marathon.HealthCheckResult{
+				Alive: a,
+			})
+		}
+	}
+}

--- a/provider/marathon/marathon.go
+++ b/provider/marathon/marathon.go
@@ -26,7 +26,14 @@ import (
 
 const (
 	traceMaxScanTokenSize = 1024 * 1024
-	taskStateRunning      = "TASK_RUNNING"
+)
+
+// TaskState denotes the Mesos state a task can have.
+type TaskState string
+
+const (
+	taskStateRunning TaskState = "TASK_RUNNING"
+	taskStateStaging TaskState = "TASK_STAGING"
 )
 
 var _ provider.Provider = (*Provider)(nil)
@@ -222,7 +229,7 @@ func (p *Provider) applicationFilter(app marathon.Application) bool {
 }
 
 func (p *Provider) taskFilter(task marathon.Task, application marathon.Application) bool {
-	if task.State != taskStateRunning {
+	if task.State != string(taskStateRunning) {
 		return false
 	}
 
@@ -252,15 +259,6 @@ func (p *Provider) taskFilter(task marathon.Task, application marathon.Applicati
 	}
 
 	return true
-}
-
-func getApplication(task marathon.Task, apps []marathon.Application) (marathon.Application, error) {
-	for _, application := range apps {
-		if application.ID == task.AppID {
-			return application, nil
-		}
-	}
-	return marathon.Application{}, errors.New("Application not found: " + task.AppID)
 }
 
 func isApplicationEnabled(application marathon.Application, exposedByDefault bool) bool {

--- a/testhelpers/helpers.go
+++ b/testhelpers/helpers.go
@@ -12,6 +12,11 @@ func Intp(i int) *int {
 	return &i
 }
 
+// Stringp returns a pointer to the given string value.
+func Stringp(s string) *string {
+	return &s
+}
+
 // MustNewRequest creates a new http get request or panics if it can't
 func MustNewRequest(method, urlStr string, body io.Reader) *http.Request {
 	request, err := http.NewRequest(method, urlStr, body)


### PR DESCRIPTION
This change introduces the builder pattern to the Marathon unit tests in order to simplify and reduce the amount of testing boilerplate.

Additional changes:

- Add missing unit tests.
- Make all tests look consistent.
- Use dedicated type for task states for increased type safety.
- Remove obsoleted `getApplication` function.

Note: I pushed the branch to the containous repo because I intend to submit another PR based onto this one.

@containous/marathon @containous/traefik PTAL.