### PR TITLE
Update docs for dnsimple env vars.

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -374,7 +374,7 @@ entryPoint = "https"
 # and provide environment variables with access keys to enable setting it:
 #  - cloudflare: CLOUDFLARE_EMAIL, CLOUDFLARE_API_KEY
 #  - digitalocean: DO_AUTH_TOKEN
-#  - dnsimple: DNSIMPLE_EMAIL, DNSIMPLE_API_KEY
+#  - dnsimple: DNSIMPLE_EMAIL, DNSIMPLE_OAUTH_TOKEN
 #  - dnsmadeeasy: DNSMADEEASY_API_KEY, DNSMADEEASY_API_SECRET
 #  - exoscale: EXOSCALE_API_KEY, EXOSCALE_API_SECRET
 #  - gandi: GANDI_API_KEY

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -154,7 +154,7 @@
 # and provide environment variables with access keys to enable setting it:
 #  - cloudflare: CLOUDFLARE_EMAIL, CLOUDFLARE_API_KEY
 #  - digitalocean: DO_AUTH_TOKEN
-#  - dnsimple: DNSIMPLE_EMAIL, DNSIMPLE_API_KEY
+#  - dnsimple: DNSIMPLE_EMAIL, DNSIMPLE_OAUTH_TOKEN
 #  - dnsmadeeasy: DNSMADEEASY_API_KEY, DNSMADEEASY_API_SECRET
 #  - exoscale: EXOSCALE_API_KEY, EXOSCALE_API_SECRET
 #  - gandi: GANDI_API_KEY


### PR DESCRIPTION
### Description
Yesterday I followed the docs (https://docs.traefik.io/toml/#acme-lets-encrypt-configuration) to set traefik with dnsimple as dns provider in order to get Let's Encrypt certs with txt dns challenge.

Thing is traefik says I need to set some env vars for the container to use and setup dnsimple (`DNSIMPLE_EMAIL` and `DNSIMPLE_API_KEY`  in this case), I set them but wasn't able to use dnsimple (the container exited), found out in the logs it exited because of something related to an OAuth key that wasn't found ('cause it was not set), after searching for the library traefik use for this (https://github.com/xenolf/lego/blob/master/providers/dns/dnsimple/dnsimple.go#L25) I figured out I needed to set a different env var instead of `DNSIMPLE_API_KEY` (`DNSIMPLE_OAUTH_TOKEN`) so i did, now it's working without problems.

So i opened this PR in order to update the docs.

PS. Sorry, bad commit description, it's midnight here and i'm kinda sleepy.