### PR TITLE
Add configurable timeouts and curate default timeout settings

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -1,12 +1,9 @@
 package main
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	fmtlog "log"
-	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -29,7 +26,6 @@ import (
 	"github.com/coreos/go-systemd/daemon"
 	"github.com/docker/libkv/store"
 	"github.com/satori/go.uuid"
-	"golang.org/x/net/http2"
 )
 
 func main() {
@@ -177,28 +173,6 @@ func run(traefikConfiguration *server.TraefikConfiguration) {
 
 	// load global configuration
 	globalConfiguration := traefikConfiguration.GlobalConfiguration
-
-	http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost = globalConfiguration.MaxIdleConnsPerHost
-	if globalConfiguration.InsecureSkipVerify {
-		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	}
-
-	if len(globalConfiguration.RootCAs) > 0 {
-		roots := x509.NewCertPool()
-		for _, cert := range globalConfiguration.RootCAs {
-			certContent, err := cert.Read()
-			if err != nil {
-				log.Error("Error while read RootCAs", err)
-				continue
-			}
-			roots.AppendCertsFromPEM(certContent)
-		}
-
-		tr := http.DefaultTransport.(*http.Transport)
-		tr.TLSClientConfig = &tls.Config{RootCAs: roots}
-
-		http2.ConfigureTransport(tr)
-	}
 
 	if globalConfiguration.File != nil && len(globalConfiguration.File.Filename) == 0 {
 		// no filename, setting to global config file

--- a/docs/toml.md
+++ b/docs/toml.md
@@ -68,7 +68,12 @@
 #
 # ProvidersThrottleDuration = "2s"
 
-# IdleTimeout: maximum amount of time an idle (keep-alive) connection will remain idle before closing itself.
+# IdleTimeout
+# 
+# Deprecated - see [respondingTimeouts] section. In the case both settings are configured, the deprecated option will
+# be overwritten.
+#
+# IdleTimeout is the maximum amount of time an idle (keep-alive) connection will remain idle before closing itself.
 # This is set to enforce closing of stale client connections.
 # Can be provided in a format supported by [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration) or as raw
 # values (digits). If no units are provided, the value is parsed assuming seconds.
@@ -328,6 +333,76 @@ To write JSON format logs, specify `json` as the format:
 # Default: "30s"
 #
 # interval = "30s"
+```
+
+## Responding timeouts
+```
+# respondingTimeouts are timeouts for incoming requests to the Traefik instance.
+#
+# Optional
+# 
+[respondingTimeouts]
+
+# readTimeout is the maximum duration for reading the entire request, including the body.
+# If zero, no timeout exists.
+# Can be provided in a format supported by [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration) or as raw
+# values (digits). If no units are provided, the value is parsed assuming seconds.
+# 
+# Optional
+# Default: "0s"
+# 
+# readTimeout = "5s"
+
+# writeTimeout is the maximum duration before timing out writes of the response. It covers the time from the end of 
+# the request header read to the end of the response write.
+# If zero, no timeout exists.
+# Can be provided in a format supported by [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration) or as raw
+# values (digits). If no units are provided, the value is parsed assuming seconds.
+#
+# Optional
+# Default: "0s"
+# 
+# writeTimeout = "5s"
+
+# idleTimeout is the maximum duration an idle (keep-alive) connection will remain idle before closing itself.
+# If zero, no timeout exists.
+# Can be provided in a format supported by [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration) or as raw
+# values (digits). If no units are provided, the value is parsed assuming seconds.
+#
+# Optional
+# Default: "180s"
+#
+# idleTimeout = "360s"
+
+```
+
+## Forwarding timeouts
+```
+# forwardingTimeouts are timeouts for requests forwarded to the backend servers.
+#
+# Optional
+# 
+[forwardingTimeouts]
+
+# dialTimeout is the amount of time to wait until a connection to a backend server can be established. 
+# If zero, no timeout exists.
+# Can be provided in a format supported by [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration) or as raw
+# values (digits). If no units are provided, the value is parsed assuming seconds.
+# 
+# Optional
+# Default: "30s"
+# 
+# dialTimeout = "30s"
+
+# responseHeaderTimeout is the amount of time to wait for a server's response headers after fully writing the request (including its body, if any). 
+# If zero, no timeout exists.
+# Can be provided in a format supported by [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration) or as raw
+# values (digits). If no units are provided, the value is parsed assuming seconds.
+#
+# Optional
+# Default: "0s"
+# 
+# responseHeaderTimeout = "0s"
 ```
 
 ## ACME (Let's Encrypt) configuration

--- a/integration/fixtures/timeout/forwarding_timeouts.toml
+++ b/integration/fixtures/timeout/forwarding_timeouts.toml
@@ -1,0 +1,38 @@
+logLevel = "DEBUG"
+defaultEntryPoints = ["http"]
+
+[entryPoints]
+  [entryPoints.http]
+  address = ":8000"
+
+[accessLog]
+format = "json"
+
+[web]
+address = ":8080"
+
+[forwardingTimeouts]
+dialTimeout = "300ms"
+responseHeaderTimeout = "300ms"
+
+[file]
+
+[backends]
+  [backends.backend1]
+    [backends.backend1.servers.server1]
+    # Non-routable IP address that should always deliver a dial timeout.
+    # See: https://stackoverflow.com/questions/100841/artificially-create-a-connection-timeout-error#answer-904609
+    url = "http://10.255.255.1"
+  [backends.backend2]
+    [backends.backend2.servers.server2]
+    url = "http://{{.TimeoutEndpoint}}:9000"
+
+[frontends]
+  [frontends.frontend1]
+  backend = "backend1"
+    [frontends.frontend1.routes.test_1]
+    rule = "Path:/dialTimeout"
+  [frontends.frontend2]
+  backend = "backend2"
+    [frontends.frontend2.routes.test_2]
+    rule = "Path:/responseHeaderTimeout"

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -25,6 +25,7 @@ func init() {
 	check.Suite(&SimpleSuite{})
 	check.Suite(&AccessLogSuite{})
 	check.Suite(&HTTPSSuite{})
+	check.Suite(&TimeoutSuite{})
 	check.Suite(&FileSuite{})
 	check.Suite(&HealthCheckSuite{})
 	check.Suite(&DockerSuite{})

--- a/integration/resources/compose/timeout.yml
+++ b/integration/resources/compose/timeout.yml
@@ -1,0 +1,7 @@
+timeoutEndpoint:
+  image: yaman/timeout
+  environment:
+    - PROTO=http
+    - PORT=9000
+  ports:
+    - "9000:9000"

--- a/integration/timeout_test.go
+++ b/integration/timeout_test.go
@@ -1,0 +1,44 @@
+package integration
+
+import (
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/containous/traefik/integration/try"
+	"github.com/go-check/check"
+	checker "github.com/vdemeester/shakers"
+)
+
+type TimeoutSuite struct{ BaseSuite }
+
+func (s *TimeoutSuite) SetUpSuite(c *check.C) {
+	s.createComposeProject(c, "timeout")
+	s.composeProject.Start(c)
+}
+
+func (s *TimeoutSuite) TestForwardingTimeouts(c *check.C) {
+	httpTimeoutEndpoint := s.composeProject.Container(c, "timeoutEndpoint").NetworkSettings.IPAddress
+	file := s.adaptFile(c, "fixtures/timeout/forwarding_timeouts.toml", struct {
+		TimeoutEndpoint string
+	}{httpTimeoutEndpoint})
+	defer os.Remove(file)
+
+	cmd, _ := s.cmdTraefik(withConfigFile(file))
+	err := cmd.Start()
+	c.Assert(err, checker.IsNil)
+	defer cmd.Process.Kill()
+
+	err = try.GetRequest("http://127.0.0.1:8080/api/providers", 60*time.Second, try.BodyContains("Path:/dialTimeout"))
+	c.Assert(err, checker.IsNil)
+
+	// This simulates a DialTimeout when connecting to the backend server.
+	response, err := http.Get("http://127.0.0.1:8000/dialTimeout")
+	c.Assert(err, checker.IsNil)
+	c.Assert(response.StatusCode, checker.Equals, http.StatusGatewayTimeout)
+
+	// This simulates a ResponseHeaderTimeout.
+	response, err = http.Get("http://127.0.0.1:8000/responseHeaderTimeout?sleep=1000")
+	c.Assert(err, checker.IsNil)
+	c.Assert(response.StatusCode, checker.Equals, http.StatusGatewayTimeout)
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -36,6 +36,86 @@ func (lb *testLoadBalancer) Servers() []*url.URL {
 	return []*url.URL{}
 }
 
+func TestPrepareServerTimeouts(t *testing.T) {
+	tests := []struct {
+		desc             string
+		globalConfig     GlobalConfiguration
+		wantIdleTimeout  time.Duration
+		wantReadTimeout  time.Duration
+		wantWriteTimeout time.Duration
+	}{
+		{
+			desc: "full configuration",
+			globalConfig: GlobalConfiguration{
+				RespondingTimeouts: &RespondingTimeouts{
+					IdleTimeout:  flaeg.Duration(10 * time.Second),
+					ReadTimeout:  flaeg.Duration(12 * time.Second),
+					WriteTimeout: flaeg.Duration(14 * time.Second),
+				},
+			},
+			wantIdleTimeout:  time.Duration(10 * time.Second),
+			wantReadTimeout:  time.Duration(12 * time.Second),
+			wantWriteTimeout: time.Duration(14 * time.Second),
+		},
+		{
+			desc:             "using defaults",
+			globalConfig:     GlobalConfiguration{},
+			wantIdleTimeout:  time.Duration(180 * time.Second),
+			wantReadTimeout:  time.Duration(0 * time.Second),
+			wantWriteTimeout: time.Duration(0 * time.Second),
+		},
+		{
+			desc: "deprecated IdleTimeout configured",
+			globalConfig: GlobalConfiguration{
+				IdleTimeout: flaeg.Duration(45 * time.Second),
+			},
+			wantIdleTimeout:  time.Duration(45 * time.Second),
+			wantReadTimeout:  time.Duration(0 * time.Second),
+			wantWriteTimeout: time.Duration(0 * time.Second),
+		},
+		{
+			desc: "deprecated and new IdleTimeout configured",
+			globalConfig: GlobalConfiguration{
+				IdleTimeout: flaeg.Duration(45 * time.Second),
+				RespondingTimeouts: &RespondingTimeouts{
+					IdleTimeout: flaeg.Duration(80 * time.Second),
+				},
+			},
+			wantIdleTimeout:  time.Duration(80 * time.Second),
+			wantReadTimeout:  time.Duration(0 * time.Second),
+			wantWriteTimeout: time.Duration(0 * time.Second),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			entryPointName := "http"
+			entryPoint := &EntryPoint{Address: "localhost:8080"}
+			router := middlewares.NewHandlerSwitcher(mux.NewRouter())
+
+			srv := NewServer(test.globalConfig)
+			httpServer, err := srv.prepareServer(entryPointName, entryPoint, router)
+			if err != nil {
+				t.Fatalf("Unexpected error when preparing srv: %s", err)
+			}
+
+			if httpServer.IdleTimeout != test.wantIdleTimeout {
+				t.Errorf("Got %s as IdleTimeout, want %s", httpServer.IdleTimeout, test.wantIdleTimeout)
+			}
+			if httpServer.ReadTimeout != test.wantReadTimeout {
+				t.Errorf("Got %s as ReadTimeout, want %s", httpServer.ReadTimeout, test.wantReadTimeout)
+			}
+			if httpServer.WriteTimeout != test.wantWriteTimeout {
+				t.Errorf("Got %s as WriteTimeout, want %s", httpServer.WriteTimeout, test.wantWriteTimeout)
+			}
+		})
+	}
+}
+
 func TestServerMultipleFrontendRules(t *testing.T) {
 	cases := []struct {
 		expression  string

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -366,6 +366,58 @@
 #
 # interval = "30s"
 
+# Timeout settings for the http servers Traefik starts
+#
+# Optional
+#
+# [respondingTimeouts]
+
+# ReadTimeout is the maximum duration for reading the entire request, including the body.
+# If zero, no timeout exists.
+#
+# Optional
+# Default: "0s"
+#
+# readTimeout = "5s"
+
+# WriteTimeout is the maximum duration before timing out writes of the response.
+# If zero, no timeout exists.
+#
+# Optional
+# Default: "0s"
+#
+# writeTimeout = "5s"
+
+# IdleTimeout is the maximum amount duration an idle (keep-alive) connection will remain idle before closing itself.
+# Defaults to 180 seconds.
+# If zero, no timeout exists.
+#
+# Optional
+# Default: "180s"
+#
+# idleTimeout = "360s"
+
+# Timeout settings for requests forwarded to the Backend Servers
+#
+# Optional
+#
+# [forwardingTimeouts]
+
+# The amount of time to wait until a connection to a Backend Server can be established.
+# If zero, no timeout exists.
+#
+# Optional
+# Default: "30s"
+#
+# dialTimeout = "30s"
+
+# The amount of time to wait for a server's response headers after fully writing the request (including its body, if any). If zero, no timeout exists
+#
+# Optional
+# Default: "0s"
+#
+# responseHeaderTimeout = "0s"
+
 ################################################################
 # Web configuration backend
 ################################################################


### PR DESCRIPTION
This PR adds some configurable timeouts to Traefik. Namely it introduces:

- ForwardingTimeouts -> Timeouts for forwarding requests to the Backend Server's. In specific
  - DialTimeout
  - ResponseHeaderTimeout
- RespondingTimeouts -> Timeouts for the `http.Server` instances that Traefik opens. 
  - ReadTimeout
  - WriteTimeout
  - Move of IdleTimeout into this configuration section with proper deprecation for uniformity.

The motivation for this PR are the suboptimal default settings of go itself and it is important to make the load balancer robust against bad behaving clients / backends in a microservice environment.

In order to introduce this configuration options I had to first clean up the global modification of the `http.DefaultTransport`. I think a global modification of it is in general considered a bad practice and leads to unintended side-effects. To do this I added a `createHTTPTransport` method in the server that will produce a `http.Transport` with a very similar configuration as the 'http.DefaultTransport'. Apart of the removal form global modification this has another big benefit, given TLS is configured we create a new `http.Transport` for that and before this PR this Transport did not have any timeouts configured at all, not even those from the `http.DefaultTransport`.

I know that this PR is largish and timeouts in general are really difficult to test. Let me know when I can support reviewers in any way, usually I am also hanging around in the Traefik slack channel. I tried to split the commits logically so that at least those should give some guideline of the introduced changes and hopefully make reviewing easier.

For background information: There are very good articles regarding timeouts in golang. Here some links:
- https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/
- https://medium.com/@nate510/don-t-use-go-s-default-http-client-4804cb19f779