### PR TITLE
Added ability to override frontend priority for k8s ingress router

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -1242,6 +1242,7 @@ Træfik can be configured to use Kubernetes Ingress as a backend configuration:
 Annotations can be used on containers to override default behaviour for the whole Ingress resource:
 
 - `traefik.frontend.rule.type: PathPrefixStrip`: override the default frontend rule type (Default: `PathPrefix`).
+- `traefik.frontend.priority: 3`: override the default frontend rule priority (Default: `len(Path)`).
 
 Annotations can be used on the Kubernetes service to override default behaviour:
 

--- a/docs/user-guide/kubernetes.md
+++ b/docs/user-guide/kubernetes.md
@@ -613,7 +613,7 @@ This can be done by adding annotation ```traefik.frontend.priority```, i.e.:
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: cheeses
+  name: wildcard-cheeses
   annotations:
     traefik.frontend.priority: 1
 spec:
@@ -621,14 +621,14 @@ spec:
   - host: *.minikube
     http:
       paths:
-      - path: /stilton
+      - path: /
         backend:
           serviceName: stilton
           servicePort: http
 
 kind: Ingress
 metadata:
-  name: cheeses
+  name: specific-cheeses
   annotations:
     traefik.frontend.priority: 2
 spec:
@@ -636,7 +636,7 @@ spec:
   - host: specific.minikube
     http:
       paths:
-      - path: /stilton
+      - path: /
         backend:
           serviceName: stilton
           servicePort: http

--- a/docs/user-guide/kubernetes.md
+++ b/docs/user-guide/kubernetes.md
@@ -604,6 +604,45 @@ You should now be able to visit the websites in your browser.
 * [cheeses.minikube/cheddar](http://cheeses.minikube/cheddar/)
 * [cheeses.minikube/wensleydale](http://cheeses.minikube/wensleydale/)
 
+## Specifying priority for routing
+
+Sometimes you need to specify priority for ingress route, especially when handling wildcard routes.
+This can be done by adding annotation ```traefik.frontend.priority```, i.e.:
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: cheeses
+  annotations:
+    traefik.frontend.priority: 1
+spec:
+  rules:
+  - host: *.minikube
+    http:
+      paths:
+      - path: /stilton
+        backend:
+          serviceName: stilton
+          servicePort: http
+
+kind: Ingress
+metadata:
+  name: cheeses
+  annotations:
+    traefik.frontend.priority: 2
+spec:
+  rules:
+  - host: specific.minikube
+    http:
+      paths:
+      - path: /stilton
+        backend:
+          serviceName: stilton
+          servicePort: http
+```
+
+
 ## Forwarding to ExternalNames
 
 When specifying an [ExternalName](https://kubernetes.io/docs/concepts/services-networking/service/#services-without-selectors),

--- a/docs/user-guide/kubernetes.md
+++ b/docs/user-guide/kubernetes.md
@@ -607,7 +607,7 @@ You should now be able to visit the websites in your browser.
 ## Specifying priority for routing
 
 Sometimes you need to specify priority for ingress route, especially when handling wildcard routes.
-This can be done by adding annotation ```traefik.frontend.priority```, i.e.:
+This can be done by adding annotation `traefik.frontend.priority`, i.e.:
 
 ```yaml
 apiVersion: extensions/v1beta1

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -335,7 +335,7 @@ func (p *Provider) getPriority(path v1beta1.HTTPIngressPath, i *v1beta1.Ingress)
 		if err == nil {
 			priority = priorityParsed
 		} else{
-			log.Errorf("Error in ingress: failed to parse 'traefik.frontend.priority' value '%s'.", priorityRaw)
+			log.Errorf("Error in ingress: failed to parse '%q' value '%q'.", types.LabelFrontendPriority, priorityRaw)
 		}
 	}
 

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -334,12 +334,12 @@ func (p *Provider) getPriority(path v1beta1.HTTPIngressPath, i *v1beta1.Ingress)
 
 		if err == nil {
 			priority = priorityParsed
-		} else{
+		} else {
 			log.Errorf("Error in ingress: failed to parse '%q' value '%q'.", types.LabelFrontendPriority, priorityRaw)
 		}
 	}
 
-	return priority;
+	return priority
 }
 
 func handleBasicAuthConfig(i *v1beta1.Ingress, k8sClient Client) ([]string, error) {

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -335,7 +335,7 @@ func (p *Provider) getPriority(path v1beta1.HTTPIngressPath, i *v1beta1.Ingress)
 		if err == nil {
 			priority = priorityParsed
 		} else {
-			log.Errorf("Error in ingress: failed to parse '%q' value '%q'.", types.LabelFrontendPriority, priorityRaw)
+			log.Errorf("Error in ingress: failed to parse %q value %q.", types.LabelFrontendPriority, priorityRaw)
 		}
 	}
 

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -186,6 +186,17 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 				witelistSourceRangeAnnotation := i.Annotations[annotationKubernetesWhitelistSourceRange]
 				whitelistSourceRange := provider.SplitAndTrimString(witelistSourceRangeAnnotation)
 
+				priority := len(pa.Path)
+
+				priorityString, ok := i.Annotations[types.LabelFrontendPriority]
+				if ok {
+					priorityParsed, err := strconv.Atoi(priorityString)
+
+					if err == nil {
+						priority = priorityParsed;
+					}
+				}
+
 				if _, exists := templateObjects.Frontends[r.Host+pa.Path]; !exists {
 					basicAuthCreds, err := handleBasicAuthConfig(i, k8sClient)
 					if err != nil {
@@ -196,7 +207,7 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 						Backend:              r.Host + pa.Path,
 						PassHostHeader:       PassHostHeader,
 						Routes:               make(map[string]types.Route),
-						Priority:             len(pa.Path),
+						Priority:             priority,
 						BasicAuth:            basicAuthCreds,
 						WhitelistSourceRange: whitelistSourceRange,
 					}

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -1877,12 +1877,7 @@ func TestPriorityHeaderValue(t *testing.T) {
 		},
 	}
 
-	actualJSON, _ := json.Marshal(actual)
-	expectedJSON, _ := json.Marshal(expected)
-
-	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("expected %+v, got %+v", string(expectedJSON), string(actualJSON))
-	}
+	assert.Equal(t, expected, actual)
 }
 
 func TestInvalidPassHostHeaderValue(t *testing.T) {

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -1778,6 +1778,113 @@ func TestIngressAnnotations(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestPriorityHeaderValue(t *testing.T) {
+	ingresses := []*v1beta1.Ingress{
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace: "testing",
+				Annotations: map[string]string{
+					types.LabelFrontendPriority: "1337",
+				},
+			},
+			Spec: v1beta1.IngressSpec{
+				Rules: []v1beta1.IngressRule{
+					{
+						Host: "foo",
+						IngressRuleValue: v1beta1.IngressRuleValue{
+							HTTP: &v1beta1.HTTPIngressRuleValue{
+								Paths: []v1beta1.HTTPIngressPath{
+									{
+										Path: "/bar",
+										Backend: v1beta1.IngressBackend{
+											ServiceName: "service1",
+											ServicePort: intstr.FromInt(80),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	services := []*v1.Service{
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "service1",
+				UID:       "1",
+				Namespace: "testing",
+			},
+			Spec: v1.ServiceSpec{
+				ClusterIP:    "10.0.0.1",
+				Type:         "ExternalName",
+				ExternalName: "example.com",
+				Ports: []v1.ServicePort{
+					{
+						Name: "http",
+						Port: 80,
+					},
+				},
+			},
+		},
+	}
+
+	endpoints := []*v1.Endpoints{}
+	watchChan := make(chan interface{})
+	client := clientMock{
+		ingresses: ingresses,
+		services:  services,
+		endpoints: endpoints,
+		watchChan: watchChan,
+	}
+	provider := Provider{}
+	actual, err := provider.loadIngresses(client)
+	if err != nil {
+		t.Fatalf("error %+v", err)
+	}
+
+	expected := &types.Configuration{
+		Backends: map[string]*types.Backend{
+			"foo/bar": {
+				Servers: map[string]types.Server{
+					"http://example.com": {
+						URL:    "http://example.com",
+						Weight: 1,
+					},
+				},
+				CircuitBreaker: nil,
+				LoadBalancer: &types.LoadBalancer{
+					Sticky: false,
+					Method: "wrr",
+				},
+			},
+		},
+		Frontends: map[string]*types.Frontend{
+			"foo/bar": {
+				Backend:        "foo/bar",
+				PassHostHeader: true,
+				Priority:       1337,
+				Routes: map[string]types.Route{
+					"/bar": {
+						Rule: "PathPrefix:/bar",
+					},
+					"foo": {
+						Rule: "Host:foo",
+					},
+				},
+			},
+		},
+	}
+
+	actualJSON, _ := json.Marshal(actual)
+	expectedJSON, _ := json.Marshal(expected)
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("expected %+v, got %+v", string(expectedJSON), string(actualJSON))
+	}
+}
+
 func TestInvalidPassHostHeaderValue(t *testing.T) {
 	ingresses := []*v1beta1.Ingress{
 		{


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### Description

Added ability to specify ```traefik.frontend.priority``` priority from kubernetes ingress annotation.
This is useful when you have following case:

Ingress A:
Host: *.mydomain

Ingress B:
Host: specific.mydomain