### PR TITLE
Add annotation to allow use of service ClusterIP

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -1250,6 +1250,13 @@ As known from nginx when used as Kubernetes Ingress Controller, a List of IP-Ran
 
 An unset or empty list allows all Source-IPs to access. If one of the Net-Specifications are invalid, the whole list is invalid and allows all Source-IPs to access.
 
+- `ingress.kubernetes.io/service-upstream: "true"`
+
+Use the service's clusterIP as the backend rather than resolve the pod IPs via the endpoints API and use them as individual backends. 
+As this results in only a single backend, some features are lost:
+ - Prevents sticky session
+ - Specific load balancer algorithms
+ - Retries will not work (`proxy_next_upstream` directive will have no effect)
 
 ### Authentication
 


### PR DESCRIPTION
Equivalent to https://github.com/kubernetes/ingress/pull/981

Added support for `ingress.kubernetes.io/service-upstream` Kubernetes ingress annotation that causes traefik to use ClusterIP as backend rather than endpoints API. ~~Primary motivation is this allows for zero-downtime deployments as Kubernetes services respect readiness checks, which is lost when using the endpoints API directly.~~

From the doc update I wrote:

> ~Use the service's clusterIP as the backend rather than resolve the pod IPs via the endpoints API and use them as individual backends. This will prevent sticky sessions from working and any specific loadbalancer algorithm as there will be only one backend for the service registered in traefik. The advantage is Kubernetes readiness checks will apply and rolling deployments to services can be graceful.~

> Use the service's clusterIP as the backend rather than resolve the pod IPs via the endpoints API and use them as individual backends. As this results in only a single backend, some features are lost:
>  - Prevents sticky session
>  - Specific load balancer algorithms
>  - Retries will not work (proxy_next_upstream directive will have no effect)