### PR TITLE
Assign filtered tasks to apps contained in slice.

### DIFF
--- a/provider/marathon/marathon.go
+++ b/provider/marathon/marathon.go
@@ -175,8 +175,8 @@ func (p *Provider) loadMarathonConfig() *types.Configuration {
 	}
 
 	filteredApps := fun.Filter(p.applicationFilter, applications.Apps).([]marathon.Application)
-	for _, app := range filteredApps {
-		app.Tasks = fun.Filter(func(task *marathon.Task) bool {
+	for i, app := range filteredApps {
+		filteredApps[i].Tasks = fun.Filter(func(task *marathon.Task) bool {
 			return p.taskFilter(*task, app)
 		}, app.Tasks).([]*marathon.Task)
 	}

--- a/provider/marathon/marathon_test.go
+++ b/provider/marathon/marathon_test.go
@@ -91,6 +91,31 @@ func TestMarathonLoadConfigNonAPIErrors(t *testing.T) {
 			},
 		},
 		{
+			desc: "filtered task",
+			application: marathon.Application{
+				Ports:  []int{80},
+				Labels: &map[string]string{},
+			},
+			task: marathon.Task{
+				Ports: []int{80},
+				State: "TASK_STAGING",
+			},
+			expectedFrontends: map[string]*types.Frontend{
+				"frontend-app": {
+					Backend:        "backend-app",
+					PassHostHeader: true,
+					BasicAuth:      []string{},
+					EntryPoints:    []string{},
+					Routes: map[string]types.Route{
+						"route-host-app": {
+							Rule: "Host:app.docker.localhost",
+						},
+					},
+				},
+			},
+			expectedBackends: nil,
+		},
+		{
 			desc: "load balancer / circuit breaker labels",
 			application: marathon.Application{
 
@@ -328,6 +353,9 @@ func TestMarathonLoadConfigNonAPIErrors(t *testing.T) {
 			t.Parallel()
 			c.application.ID = "/app"
 			c.task.ID = "task"
+			if c.task.State == "" {
+				c.task.State = "TASK_RUNNING"
+			}
 			c.application.Tasks = []*marathon.Task{&c.task}
 			fakeClient := newFakeClient(false,
 				marathon.Applications{Apps: []marathon.Application{c.application}})


### PR DESCRIPTION
We previously assigned them to a copy of each application, which effectively disabled all filtering.

Fixes a bug introduced along commit 779eeba.

Ignore the nasty test struct please; in #1871, the fix will look much nicer. :-)

@containous/traefik PTAL.
