### PR TITLE
Add secrets resource to in-line RBAC spec.

### DIFF
--- a/docs/user-guide/kubernetes.md
+++ b/docs/user-guide/kubernetes.md
@@ -35,6 +35,7 @@ rules:
       - pods
       - services
       - endpoints
+      - secrets
     verbs:
       - get
       - list


### PR DESCRIPTION
Previously only existed in the Github-hosted example file.

Fixes an oversight from #1707.