### PR TITLE
New oxy with gorilla for websocket with integration tests

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,4 +1,4 @@
-hash: df3bba260c0e5c3183741ab4aca2ae551a5c6d9ba11f4e05b90554a9ffad96ad
+hash: bfc5801ed56be5f703a0924d8832dcccc42bf02f9e2b035ef77eab62c0cb4884
 updated: 2017-06-29T16:47:14.848940186+02:00
 imports:
 - name: cloud.google.com/go
@@ -411,7 +411,7 @@ imports:
 - name: github.com/vdemeester/docker-events
   version: be74d4929ec1ad118df54349fda4b0cba60f849b
 - name: github.com/vulcand/oxy
-  version: 7da864c1d53bd58165435bb78bbf8c01f01c8f4a
+  version: 49f1894c20d972f5c73ff44b859f87deb83f0076
   repo: https://github.com/containous/oxy.git
   vcs: git
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,7 +8,7 @@ import:
 - package: github.com/cenk/backoff
 - package: github.com/containous/flaeg
 - package: github.com/vulcand/oxy
-  version: 7da864c1d53bd58165435bb78bbf8c01f01c8f4a
+  version: 49f1894c20d972f5c73ff44b859f87deb83f0076
   repo: https://github.com/containous/oxy.git
   vcs: git
   subpackages:

--- a/integration/fixtures/websocket/config.toml
+++ b/integration/fixtures/websocket/config.toml
@@ -1,0 +1,24 @@
+defaultEntryPoints = ["http"]
+
+logLevel = "DEBUG"
+
+[entryPoints]
+  [entryPoints.http]
+  address = ":8000"
+
+
+[web]
+  address = ":8080"
+
+[file]
+
+[backends]
+  [backends.backend1]
+    [backends.backend1.servers.server1]
+    url = "{{ .WebsocketServer }}"
+
+[frontends]
+  [frontends.frontend1]
+  backend = "backend1"
+    [frontends.frontend1.routes.test_1]
+    rule = "Path:/ws"

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/containous/traefik/integration/utils"
 	"github.com/go-check/check"
 
+	"bytes"
+
 	compose "github.com/libkermit/compose/check"
 	checker "github.com/vdemeester/shakers"
 )
@@ -38,6 +40,7 @@ func init() {
 	check.Suite(&EurekaSuite{})
 	check.Suite(&AcmeSuite{})
 	check.Suite(&DynamoDBSuite{})
+	check.Suite(&WebsocketSuite{})
 }
 
 var traefikBinary = "../dist/traefik"
@@ -69,6 +72,18 @@ func (s *BaseSuite) createComposeProject(c *check.C, name string) {
 	}
 
 	s.composeProject = compose.CreateProject(c, projectName, composeFile)
+}
+
+func withConfigFile(file string) string {
+	return "--configFile=" + file
+}
+
+func (s *BaseSuite) cmdTraefik(args ...string) (*exec.Cmd, *bytes.Buffer) {
+	cmd := exec.Command(traefikBinary, args...)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	return cmd, &out
 }
 
 func (s *BaseSuite) traefikCmd(c *check.C, args ...string) (*exec.Cmd, string) {

--- a/integration/websocket_test.go
+++ b/integration/websocket_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/go-check/check"
+
+	"errors"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/containous/traefik/integration/utils"
+	"github.com/gorilla/websocket"
+	checker "github.com/vdemeester/shakers"
+)
+
+// WebsocketSuite
+type WebsocketSuite struct{ BaseSuite }
+
+func (suite *WebsocketSuite) TestBase(c *check.C) {
+	var upgrader = websocket.Upgrader{} // use default options
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		for {
+			mt, message, err := c.ReadMessage()
+			if err != nil {
+				break
+			}
+			err = c.WriteMessage(mt, message)
+			if err != nil {
+				break
+			}
+		}
+	}))
+
+	file := suite.adaptFile(c, "fixtures/websocket/config.toml", struct {
+		WebsocketServer string
+	}{
+		WebsocketServer: srv.URL,
+	})
+
+	defer os.Remove(file)
+	cmd, _ := suite.cmdTraefik(withConfigFile(file), "--debug")
+
+	err := cmd.Start()
+
+	c.Assert(err, check.IsNil)
+	defer cmd.Process.Kill()
+
+	// wait for traefik
+	err = utils.TryRequest("http://127.0.0.1:8080/api/providers", 60*time.Second, func(res *http.Response) error {
+		body, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return err
+		}
+		if !strings.Contains(string(body), "127.0.0.1") {
+			return errors.New("Incorrect traefik config")
+		}
+		return nil
+	})
+	c.Assert(err, checker.IsNil)
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws://127.0.0.1:8000/ws", nil)
+
+	c.Assert(err, checker.IsNil)
+	conn.WriteMessage(websocket.TextMessage, []byte("OK"))
+
+	_, msg, err := conn.ReadMessage()
+	c.Assert(err, checker.IsNil)
+
+	c.Assert(string(msg), checker.Equals, "OK")
+
+}

--- a/vendor/github.com/vulcand/oxy/forward/headers.go
+++ b/vendor/github.com/vulcand/oxy/forward/headers.go
@@ -1,20 +1,25 @@
 package forward
 
 const (
-	XForwardedProto    = "X-Forwarded-Proto"
-	XForwardedFor      = "X-Forwarded-For"
-	XForwardedHost     = "X-Forwarded-Host"
-	XForwardedServer   = "X-Forwarded-Server"
-	Connection         = "Connection"
-	KeepAlive          = "Keep-Alive"
-	ProxyAuthenticate  = "Proxy-Authenticate"
-	ProxyAuthorization = "Proxy-Authorization"
-	Te                 = "Te" // canonicalized version of "TE"
-	Trailers           = "Trailers"
-	TransferEncoding   = "Transfer-Encoding"
-	Upgrade            = "Upgrade"
-	ContentLength      = "Content-Length"
-	ContentType        = "Content-Type"
+	XForwardedProto        = "X-Forwarded-Proto"
+	XForwardedFor          = "X-Forwarded-For"
+	XForwardedHost         = "X-Forwarded-Host"
+	XForwardedServer       = "X-Forwarded-Server"
+	Connection             = "Connection"
+	KeepAlive              = "Keep-Alive"
+	ProxyAuthenticate      = "Proxy-Authenticate"
+	ProxyAuthorization     = "Proxy-Authorization"
+	Te                     = "Te" // canonicalized version of "TE"
+	Trailers               = "Trailers"
+	TransferEncoding       = "Transfer-Encoding"
+	Upgrade                = "Upgrade"
+	ContentLength          = "Content-Length"
+	ContentType            = "Content-Type"
+	SecWebsocketKey        = "Sec-Websocket-Key"
+	SecWebsocketVersion    = "Sec-Websocket-Version"
+	SecWebsocketExtensions = "Sec-Websocket-Extensions"
+	SecWebsocketProtocol   = "Sec-Websocket-Protocol"
+	SecWebsocketAccept     = "Sec-Websocket-Accept"
 )
 
 // Hop-by-hop headers. These are removed when sent to the backend.
@@ -29,4 +34,20 @@ var HopHeaders = []string{
 	Trailers,
 	TransferEncoding,
 	Upgrade,
+}
+
+var WebsocketDialHeaders = []string{
+	Upgrade,
+	Connection,
+	SecWebsocketKey,
+	SecWebsocketVersion,
+	SecWebsocketExtensions,
+	SecWebsocketProtocol,
+	SecWebsocketAccept,
+}
+
+var WebsocketUpgradeHeaders = []string{
+	Upgrade,
+	Connection,
+	SecWebsocketAccept,
 }


### PR DESCRIPTION
 - Use the new websocket implementation in oxy, based on gorilla/websocket
 - Add integration tests for verify websocket



fixes #1858 

In order to reproduce the issue:
```bash
docker run -d --name="home-assistant" \
    --restart=always \
    -v $PWD/config:/config \
    -v /etc/localtime:/etc/localtime:ro \
    -p 8123:8123 \
    --label traefik.port=8123 \
    --label traefik.frontend.rule="Host:127.0.0.1" \
    homeassistant/home-assistant
```
```
./traefik --docker=true
```

Then just try to view the homepage (http://127.0.0.1)
