### PR TITLE
Moved namespace to correct place

### DIFF
--- a/examples/k8s/traefik-deployment.yaml
+++ b/examples/k8s/traefik-deployment.yaml
@@ -36,6 +36,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: traefik-ingress-service
+  namespace: kube-system
 spec:
   selector:
     k8s-app: traefik-ingress-lb
@@ -46,5 +47,4 @@ spec:
     - protocol: TCP
       port: 8080
       name: admin
-  namespace: kube-system
   type: NodePort

--- a/examples/k8s/traefik-ds.yaml
+++ b/examples/k8s/traefik-ds.yaml
@@ -42,6 +42,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: traefik-ingress-service
+  namespace: kube-system
 spec:
   selector:
     k8s-app: traefik-ingress-lb
@@ -52,5 +53,4 @@ spec:
     - protocol: TCP
       port: 8080
       name: admin
-  namespace: kube-system
   type: NodePort


### PR DESCRIPTION
### Description

Moves the `namespace` key to the correct location in the k8s examples. Currently, these fail with a `found invalid field namespace for v1.ServiceSpec` validation error.