### PR TITLE
Enable loadbalancer.sticky for ECS

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -1777,6 +1777,8 @@ Labels can be used on task containers to override default behaviour:
 - `traefik.protocol=https`: override the default `http` protocol
 - `traefik.weight=10`: assign this weight to the container
 - `traefik.enable=false`: disable this container in Træfik
+- `traefik.backend.loadbalancer.method=drr`: override the default `wrr` load balancer algorithm
+- `traefik.backend.loadbalancer.sticky=true`: enable backend sticky sessions
 - `traefik.frontend.rule=Host:test.traefik.io`: override the default frontend rule (Default: `Host:{containerName}.{domain}`).
 - `traefik.frontend.passHostHeader=true`: forward client `Host` header to the backend.
 - `traefik.frontend.priority=10`: override default frontend priority

--- a/provider/ecs/ecs.go
+++ b/provider/ecs/ecs.go
@@ -457,6 +457,20 @@ func (p *Provider) getFrontendRule(i ecsInstance) string {
 	return "Host:" + strings.ToLower(strings.Replace(i.Name, "_", "-", -1)) + "." + p.Domain
 }
 
+func (p *Provider) getLabelLoadBalancerSticky(i ecsInstance) string {
+	if label := i.label(types.LabelBackendLoadbalancerSticky); label != "" {
+		return label
+	}
+	return "false"
+}
+
+func (p *Provider) getLabelLoadBalancerMethod(i ecsInstance) string {
+	if label := i.label(types.LabelBackendLoadbalancerMethod); label != "" {
+		return label
+	}
+	return "wrr"
+}
+
 // Provider expects no more than 100 parameters be passed to a DescribeTask call; thus, pack
 // each string into an array capped at 100 elements
 func (p *Provider) chunkedTaskArns(tasks []*string) [][]*string {

--- a/provider/ecs/ecs.go
+++ b/provider/ecs/ecs.go
@@ -195,11 +195,11 @@ func (p *Provider) loadECSConfig(ctx context.Context, client *awsClient) (*types
 
 	services := make(map[string][]ecsInstance)
 
-	for _, i := range instances {
-		if serviceInstances, ok := services[i.Name]; ok {
-			services[i.Name] = append(serviceInstances, i)
+	for _, instance := range instances {
+		if serviceInstances, ok := services[instance.Name]; ok {
+			services[instance.Name] = append(serviceInstances, instance)
 		} else {
-			services[i.Name] = []ecsInstance{i}
+			services[instance.Name] = []ecsInstance{instance}
 		}
 	}
 
@@ -470,8 +470,9 @@ func (p *Provider) getFrontendRule(i ecsInstance) string {
 }
 
 func (p *Provider) getLoadBalancerSticky(instances []ecsInstance) string {
-	for instances != nil && len(instances) > 0 {
-		if label := instances[0].label(types.LabelBackendLoadbalancerSticky); label != "" {
+	for len(instances) > 0 {
+		label := instances[0].label(types.LabelBackendLoadbalancerSticky)
+		if label != "" {
 			return label
 		}
 	}
@@ -479,8 +480,9 @@ func (p *Provider) getLoadBalancerSticky(instances []ecsInstance) string {
 }
 
 func (p *Provider) getLoadBalancerMethod(instances []ecsInstance) string {
-	for instances != nil && len(instances) > 0 {
-		if label := instances[0].label(types.LabelBackendLoadbalancerMethod); label != "" {
+	for len(instances) > 0 {
+		label := instances[0].label(types.LabelBackendLoadbalancerMethod)
+		if label != "" {
 			return label
 		}
 	}

--- a/provider/ecs/ecs.go
+++ b/provider/ecs/ecs.go
@@ -470,7 +470,7 @@ func (p *Provider) getFrontendRule(i ecsInstance) string {
 }
 
 func (p *Provider) getLoadBalancerSticky(instances []ecsInstance) string {
-	for len(instances) > 0 {
+	if len(instances) > 0 {
 		label := instances[0].label(types.LabelBackendLoadbalancerSticky)
 		if label != "" {
 			return label
@@ -480,7 +480,7 @@ func (p *Provider) getLoadBalancerSticky(instances []ecsInstance) string {
 }
 
 func (p *Provider) getLoadBalancerMethod(instances []ecsInstance) string {
-	for len(instances) > 0 {
+	if len(instances) > 0 {
 		label := instances[0].label(types.LabelBackendLoadbalancerMethod)
 		if label != "" {
 			return label

--- a/provider/ecs/ecs.go
+++ b/provider/ecs/ecs.go
@@ -180,10 +180,10 @@ func wrapAws(ctx context.Context, req *request.Request) error {
 
 func (p *Provider) loadECSConfig(ctx context.Context, client *awsClient) (*types.Configuration, error) {
 	var ecsFuncMap = template.FuncMap{
-		"filterFrontends":    p.filterFrontends,
-		"getFrontendRule":    p.getFrontendRule,
-		"LoadBalancerSticky": p.LoadBalancerSticky,
-		"LoadBalancerMethod": p.LoadBalancerMethod,
+		"filterFrontends":       p.filterFrontends,
+		"getFrontendRule":       p.getFrontendRule,
+		"getLoadBalancerSticky": p.getLoadBalancerSticky,
+		"getLoadBalancerMethod": p.getLoadBalancerMethod,
 	}
 
 	instances, err := p.listInstances(ctx, client)
@@ -469,7 +469,7 @@ func (p *Provider) getFrontendRule(i ecsInstance) string {
 	return "Host:" + strings.ToLower(strings.Replace(i.Name, "_", "-", -1)) + "." + p.Domain
 }
 
-func (p *Provider) LoadBalancerSticky(instances []ecsInstance) string {
+func (p *Provider) getLoadBalancerSticky(instances []ecsInstance) string {
 	for instances != nil && len(instances) > 0 {
 		if label := instances[0].label(types.LabelBackendLoadbalancerSticky); label != "" {
 			return label
@@ -478,7 +478,7 @@ func (p *Provider) LoadBalancerSticky(instances []ecsInstance) string {
 	return "false"
 }
 
-func (p *Provider) LoadBalancerMethod(instances []ecsInstance) string {
+func (p *Provider) getLoadBalancerMethod(instances []ecsInstance) string {
 	for instances != nil && len(instances) > 0 {
 		if label := instances[0].label(types.LabelBackendLoadbalancerMethod); label != "" {
 			return label

--- a/templates/ecs.tmpl
+++ b/templates/ecs.tmpl
@@ -1,25 +1,25 @@
 [backends]{{range $serviceName, $instances := .Services}}
-    [backends.backend-{{ $serviceName }}.loadbalancer]
-        sticky = {{ LoadBalancerSticky $instances}}
-        method = "{{ LoadBalancerMethod $instances}}"
+  [backends.backend-{{ $serviceName }}.loadbalancer]
+    sticky = {{ LoadBalancerSticky $instances}}
+    method = "{{ LoadBalancerMethod $instances}}"
 
-    {{range $index, $i := $instances}}
-        [backends.backend-{{ $i.Name }}.servers.server-{{ $i.Name }}{{ $i.ID }}]
-            url = "{{ $i.Protocol }}://{{ $i.Host }}:{{ $i.Port }}"
-            weight = {{ $i.Weight }}
-    {{end}}
+  {{range $index, $i := $instances}}
+    [backends.backend-{{ $i.Name }}.servers.server-{{ $i.Name }}{{ $i.ID }}]
+      url = "{{ $i.Protocol }}://{{ $i.Host }}:{{ $i.Port }}"
+      weight = {{ $i.Weight }}
+  {{end}}
 {{end}}
 
 [frontends]{{range $serviceName, $instances := .Services}}
-    {{range filterFrontends $instances}}
-        [frontends.frontend-{{ $serviceName }}]
-            backend = "backend-{{ $serviceName }}"
-            passHostHeader = {{ .PassHostHeader }}
-            priority = {{ .Priority }}
-            entryPoints = [{{range  .EntryPoints }}
-                "{{.}}",
-            {{end}}]
-        [frontends.frontend-{{ $serviceName }}.routes.route-frontend-{{ $serviceName }}]
-        rule = "{{getFrontendRule .}}"
-    {{end}}
+  {{range filterFrontends $instances}}
+    [frontends.frontend-{{ $serviceName }}]
+      backend = "backend-{{ $serviceName }}"
+      passHostHeader = {{ .PassHostHeader }}
+      priority = {{ .Priority }}
+      entryPoints = [{{range  .EntryPoints }}
+      "{{.}}",
+    {{end}}]
+    [frontends.frontend-{{ $serviceName }}.routes.route-frontend-{{ $serviceName }}]
+      rule = "{{getFrontendRule .}}"
+  {{end}}
 {{end}}

--- a/templates/ecs.tmpl
+++ b/templates/ecs.tmpl
@@ -1,20 +1,25 @@
-[backends]{{range .Instances}}
-    [backends.backend-{{ .Name }}.servers.server-{{ .Name }}{{ .ID }}]
-    url = "{{ .Protocol }}://{{ .Host }}:{{ .Port }}"
-    weight = {{ .Weight }}
-    [backends.backend-{{ .Name }}.servers.server-{{ .Name }}{{ .ID }}.loadbalancer]
-        sticky = {{getLabelLoadBalancerSticky .}}
-        method = "{{getLabelLoadBalancerMethod .}}"
+[backends]{{range $serviceName, $instances := .Services}}
+    [backends.backend-{{ $serviceName }}.loadbalancer]
+        sticky = {{ LoadBalancerSticky $instances}}
+        method = "{{ LoadBalancerMethod $instances}}"
+
+    {{range $index, $i := $instances}}
+        [backends.backend-{{ $i.Name }}.servers.server-{{ $i.Name }}{{ $i.ID }}]
+            url = "{{ $i.Protocol }}://{{ $i.Host }}:{{ $i.Port }}"
+            weight = {{ $i.Weight }}
+    {{end}}
 {{end}}
 
-[frontends]{{range filterFrontends .Instances}}
-  [frontends.frontend-{{ .Name }}]
-  backend = "backend-{{ .Name }}"
-  passHostHeader = {{ .PassHostHeader }}
-  priority = {{ .Priority }}
-  entryPoints = [{{range  .EntryPoints }}
-    "{{.}}",
-  {{end}}]
-    [frontends.frontend-{{ .Name }}.routes.route-frontend-{{ .Name }}]
-    rule = "{{getFrontendRule .}}"
+[frontends]{{range $serviceName, $instances := .Services}}
+    {{range filterFrontends $instances}}
+        [frontends.frontend-{{ $serviceName }}]
+            backend = "backend-{{ $serviceName }}"
+            passHostHeader = {{ .PassHostHeader }}
+            priority = {{ .Priority }}
+            entryPoints = [{{range  .EntryPoints }}
+                "{{.}}",
+            {{end}}]
+        [frontends.frontend-{{ $serviceName }}.routes.route-frontend-{{ $serviceName }}]
+        rule = "{{getFrontendRule .}}"
+    {{end}}
 {{end}}

--- a/templates/ecs.tmpl
+++ b/templates/ecs.tmpl
@@ -1,7 +1,7 @@
 [backends]{{range $serviceName, $instances := .Services}}
   [backends.backend-{{ $serviceName }}.loadbalancer]
-    sticky = {{ LoadBalancerSticky $instances}}
-    method = "{{ LoadBalancerMethod $instances}}"
+    sticky = {{ getLoadBalancerSticky $instances}}
+    method = "{{ getLoadBalancerMethod $instances}}"
 
   {{range $index, $i := $instances}}
     [backends.backend-{{ $i.Name }}.servers.server-{{ $i.Name }}{{ $i.ID }}]

--- a/templates/ecs.tmpl
+++ b/templates/ecs.tmpl
@@ -2,6 +2,9 @@
     [backends.backend-{{ .Name }}.servers.server-{{ .Name }}{{ .ID }}]
     url = "{{ .Protocol }}://{{ .Host }}:{{ .Port }}"
     weight = {{ .Weight }}
+    [backends.backend-{{ .Name }}.servers.server-{{ .Name }}{{ .ID }}.loadbalancer]
+        sticky = {{getLabelLoadBalancerSticky .}}
+        method = "{{getLabelLoadBalancerMethod .}}"
 {{end}}
 
 [frontends]{{range filterFrontends .Instances}}


### PR DESCRIPTION
### Description

The goal of this PR is to add support of sticky session for ECS.
Low balancer configuration will be always present with default values:
`traefik.backend.loadbalancer.method=wrr`
`traefik.backend.loadbalancer.sticky=false`

To override these values you just to add labels 

Fixes #1522