### PR TITLE
Added a check to ensure clientTLS configuration contains either a cert or a key

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -157,24 +157,26 @@ func (clientTLS *ClientTLS) CreateTLSConfig() (*tls.Config, error) {
 	cert := tls.Certificate{}
 	_, errKeyIsFile := os.Stat(clientTLS.Key)
 
-	if _, errCertIsFile := os.Stat(clientTLS.Cert); errCertIsFile == nil {
-		if errKeyIsFile == nil {
-			cert, err = tls.LoadX509KeyPair(clientTLS.Cert, clientTLS.Key)
-			if err != nil {
-				return nil, fmt.Errorf("Failed to load TLS keypair: %v", err)
+	if len(clientTLS.Cert) > 0 && len(clientTLS.Key) > 0 {
+		if _, errCertIsFile := os.Stat(clientTLS.Cert); errCertIsFile == nil {
+			if errKeyIsFile == nil {
+				cert, err = tls.LoadX509KeyPair(clientTLS.Cert, clientTLS.Key)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to load TLS keypair: %v", err)
+				}
+			} else {
+				return nil, fmt.Errorf("tls cert is a file, but tls key is not")
 			}
 		} else {
-			return nil, fmt.Errorf("tls cert is a file, but tls key is not")
-		}
-	} else {
-		if errKeyIsFile != nil {
-			cert, err = tls.X509KeyPair([]byte(clientTLS.Cert), []byte(clientTLS.Key))
-			if err != nil {
-				return nil, fmt.Errorf("Failed to load TLS keypair: %v", err)
+			if errKeyIsFile != nil {
+				cert, err = tls.X509KeyPair([]byte(clientTLS.Cert), []byte(clientTLS.Key))
+				if err != nil {
+					return nil, fmt.Errorf("Failed to load TLS keypair: %v", err)
 
+				}
+			} else {
+				return nil, fmt.Errorf("tls key is a file, but tls cert is not")
 			}
-		} else {
-			return nil, fmt.Errorf("tls key is a file, but tls cert is not")
 		}
 	}
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -157,6 +157,10 @@ func (clientTLS *ClientTLS) CreateTLSConfig() (*tls.Config, error) {
 	cert := tls.Certificate{}
 	_, errKeyIsFile := os.Stat(clientTLS.Key)
 
+	if !clientTLS.InsecureSkipVerify && (len(clientTLS.Cert) == 0 || len(clientTLS.Key) == 0) {
+		return nil, fmt.Errorf("TLS Certificate or Key file must be set when TLS configuration is created")
+	}
+
 	if len(clientTLS.Cert) > 0 && len(clientTLS.Key) > 0 {
 		if _, errCertIsFile := os.Stat(clientTLS.Cert); errCertIsFile == nil {
 			if errKeyIsFile == nil {

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -215,6 +215,22 @@ func TestInsecureSkipVerifyClientTLS(t *testing.T) {
 	}
 }
 
+func TestInsecureSkipVerifyFalseClientTLS(t *testing.T) {
+	provider := &myProvider{
+		BaseProvider{
+			Filename: "",
+		},
+		&ClientTLS{
+			InsecureSkipVerify: false,
+		},
+	}
+	_, err := provider.TLS.CreateTLSConfig()
+	if err == nil {
+		t.Fatal("CreateTLSConfig should error if consumer does not set a TLS cert or key configuration and not chooses InsecureSkipVerify to be true")
+	}
+	t.Log(err)
+}
+
 func TestMatchingConstraints(t *testing.T) {
 	cases := []struct {
 		constraints types.Constraints

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -197,6 +197,24 @@ func TestNilClientTLS(t *testing.T) {
 	}
 }
 
+func TestInsecureSkipVerifyClientTLS(t *testing.T) {
+	provider := &myProvider{
+		BaseProvider{
+			Filename: "",
+		},
+		&ClientTLS{
+			InsecureSkipVerify: true,
+		},
+	}
+	config, err := provider.TLS.CreateTLSConfig()
+	if err != nil {
+		t.Fatal("CreateTLSConfig should assume that consumer does not want a TLS configuration if input is nil")
+	}
+	if !config.InsecureSkipVerify {
+		t.Fatal("CreateTLSConfig should support setting only InsecureSkipVerify property")
+	}
+}
+
 func TestMatchingConstraints(t *testing.T) {
 	cases := []struct {
 		constraints types.Constraints


### PR DESCRIPTION
### Description

Added a check to ensure `clientTLS` configuration contains either a cert or a key
If any of the `ClientTLS` only sets `InsecureSkipVerify` property to `true`, the `CreateTLSConfig()` method fails, because it expects a `Cert` or a `Key` property to always be present.