### PR TITLE
Add support for Query String filtering

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -109,6 +109,7 @@ Following is the list of existing matcher rules along with examples:
 - `PathPrefix: /products/, /articles/{category}/{id:[0-9]+}`: Match request prefix path. It accepts a sequence of literal and regular expression prefix paths.
 - `PathPrefixStrip: /products/`: Match request prefix path and strip off the path prefix prior to forwarding the request to the backend. It accepts a sequence of literal prefix paths. Starting with Traefik 1.3, the stripped prefix path will be available in the `X-Forwarded-Prefix` header.
 - `PathPrefixStripRegex: /articles/{category}/{id:[0-9]+}`: Match request prefix path and strip off the path prefix prior to forwarding the request to the backend. It accepts a sequence of literal and regular expression prefix paths. Starting with Traefik 1.3, the stripped prefix path will be available in the `X-Forwarded-Prefix` header.
+- `Query: foo=bar, bar=baz`: Match Query String parameters. It accepts a sequence of key=value pairs.
 
 In order to use regular expressions with Host and Path matchers, you must declare an arbitrarily named variable followed by the colon-separated regular expression, all enclosed in curly braces. Any pattern supported by [Go's regexp package](https://golang.org/pkg/regexp/) may be used. Example: `/posts/{id:[0-9]+}`.
 

--- a/server/rules.go
+++ b/server/rules.go
@@ -131,6 +131,15 @@ func (r *Rules) headersRegexp(headers ...string) *mux.Route {
 	return r.route.route.HeadersRegexp(headers...)
 }
 
+func (r *Rules) query(query ...string) *mux.Route {
+	var queries []string
+	for _, elem := range query {
+		queries = append(queries, strings.Split(elem, "=")...)
+	}
+
+	return r.route.route.Queries(queries...)
+}
+
 func (r *Rules) parseRules(expression string, onRule func(functionName string, function interface{}, arguments []string) error) error {
 	functions := map[string]interface{}{
 		"Host":                 r.host,
@@ -146,6 +155,7 @@ func (r *Rules) parseRules(expression string, onRule func(functionName string, f
 		"HeadersRegexp":        r.headersRegexp,
 		"AddPrefix":            r.addPrefix,
 		"ReplacePath":          r.replacePath,
+		"Query":                r.query,
 	}
 
 	if len(expression) == 0 {


### PR DESCRIPTION
As title says

Usage:

```
Query: foo=bar, bar=baz
```