### PR TITLE
examples/k8s: fix ui ingress port out of sync with deployment

### DIFF
--- a/examples/k8s/ui.yaml
+++ b/examples/k8s/ui.yaml
@@ -10,7 +10,7 @@ spec:
   ports:
   - name: web
     port: 80
-    targetPort: 8081
+    targetPort: 8080
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### Description

When deploying traefik on my local kubernetes cluster, I saw that the UI didn't display correctly. I narrowed it down to the ingress port mismatch with the traefik deployment.