### PR TITLE
compress: preserve status code

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,4 +1,4 @@
-hash: c7f74f8b5eac556a531d2cb3bae212e32785c1128d416c75fabedc31d27f0e03
+hash: b056b388f961ddc3509b19b4546d8dfc70fd50ebd1ca47f2fd2de67bf49ba01e
 updated: 2017-08-12T14:15:06.346751095+02:00
 imports:
 - name: cloud.google.com/go
@@ -377,7 +377,7 @@ imports:
   repo: https://github.com/ijc25/Gotty.git
   vcs: git
 - name: github.com/NYTimes/gziphandler
-  version: 316adfc72ed3b0157975917adf62ba2dc31842ce
+  version: 824b33f2a7457025697878c865c323f801118043
   repo: https://github.com/containous/gziphandler.git
   vcs: git
 - name: github.com/ogier/pflag

--- a/glide.yaml
+++ b/glide.yaml
@@ -81,6 +81,7 @@ import:
 - package: github.com/NYTimes/gziphandler
   repo: https://github.com/containous/gziphandler.git
   vcs: git
+  version: ^v1002.0.0
 - package: github.com/docker/leadership
 - package: github.com/satori/go.uuid
   version: ^1.1.0

--- a/middlewares/compress.go
+++ b/middlewares/compress.go
@@ -17,7 +17,10 @@ func (c *Compress) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.
 }
 
 func gzipHandler(h http.Handler) http.Handler {
-	wrapper, err := gziphandler.NewGzipHandler(gzip.DefaultCompression, gziphandler.DefaultMinSize, &gziphandler.GzipResponseWriterWrapper{})
+	wrapper, err := gziphandler.GzipHandlerWithOpts(
+		&gziphandler.GzipResponseWriterWrapper{},
+		gziphandler.CompressionLevel(gzip.DefaultCompression),
+		gziphandler.MinSize(gziphandler.DefaultMinSize))
 	if err != nil {
 		log.Error(err)
 	}

--- a/vendor/github.com/NYTimes/gziphandler/wrapper.go
+++ b/vendor/github.com/NYTimes/gziphandler/wrapper.go
@@ -23,6 +23,7 @@ type GzipWriter interface {
 	SetResponseWriter(http.ResponseWriter)
 	setIndex(int)
 	setMinSize(int)
+	setContentTypes([]string)
 }
 
 func (w *GzipResponseWriter) SetResponseWriter(rw http.ResponseWriter) {
@@ -37,6 +38,10 @@ func (w *GzipResponseWriter) setMinSize(minSize int) {
 	w.minSize = minSize
 }
 
+func (w *GzipResponseWriter) setContentTypes(contentTypes []string) {
+	w.contentTypes = contentTypes
+}
+
 // --------
 
 type GzipResponseWriterWrapper struct {
@@ -45,6 +50,9 @@ type GzipResponseWriterWrapper struct {
 
 func (g *GzipResponseWriterWrapper) Write(b []byte) (int, error) {
 	if g.gw == nil && isEncoded(g.Header()) {
+		if g.code != 0 {
+			g.ResponseWriter.WriteHeader(g.code)
+		}
 		return g.ResponseWriter.Write(b)
 	}
 	return g.GzipResponseWriter.Write(b)


### PR DESCRIPTION
### Description

before the fixes: when compress is enable and the content is already compress, the status code is not preserved.

Fixes #1937