### PR TITLE
Fix docs about default namespaces.

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -1332,7 +1332,7 @@ Træfik can be configured to use Kubernetes Ingress as a backend configuration:
 # Array of namespaces to watch.
 #
 # Optional
-# Default: ["default"].
+# Default: all namespaces (empty array).
 #
 # namespaces = ["default", "production"]
 

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -861,7 +861,7 @@
 # Array of namespaces to watch.
 #
 # Optional
-# Default: ["default"].
+# Default: all namespaces (empty array).
 #
 # namespaces = ["default"]
 


### PR DESCRIPTION
It's not the `default` namespace that's watched if nothing is specified, but _all namespaces_.

Proof: Our [Namespaces type](https://github.com/containous/traefik/blob/60a35c8abae23ffbd58810d2ec2790d49e98bd72/provider/kubernetes/namespace.go#L9) is a string slice which we use in the [Kubernetes provider](https://github.com/containous/traefik/blob/60a35c8abae23ffbd58810d2ec2790d49e98bd72/provider/kubernetes/kubernetes.go#L50), and we [accept all Ingresses if the slice is empty](https://github.com/containous/traefik/blob/60a35c8abae23ffbd58810d2ec2790d49e98bd72/provider/kubernetes/client.go#L283-L285).

An alternative approach to fixing this would be to really make the `default` namespace the default. I don't think that's a good solution though because we probably want users to be able to watch all namespaces if they like to without complete enumeration. In fact, I ran across the doc/code divergence when somebody on Slack asked if it was possible to watch all namespaces, which I was about to deny until I digged into the code.

@containous/kubernetes PTAL.