### PR TITLE
Mark Marathon and Kubernetes as constraint-supporting.

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -126,6 +126,8 @@ Supported backends:
 - Etcd
 - Consul Catalog
 - Rancher
+- Marathon
+- Kubernetes (using a provider-specific mechanism based on label selectors)
 
 Supported filters:
 


### PR DESCRIPTION
Discovered along #1958.

@containous/traefik PTAL.