### PR TITLE
Use Host IP address if PrimaryIP is empty

### DIFF
--- a/provider/rancher/rancher.go
+++ b/provider/rancher/rancher.go
@@ -231,6 +231,14 @@ func getenv(key, fallback string) string {
 	return value
 }
 
+func getHostIpAddress(endpoints []interface{}) string{
+	
+	if len(endpoints) == 0 {
+		return ""
+	}
+	return endpoints[0].(map[string]interface{})["ipAddress"].(string)
+}
+
 // Provide allows the rancher provider to provide configurations to traefik
 // using the given configuration channel.
 func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *safe.Pool, constraints types.Constraints) error {
@@ -398,7 +406,13 @@ func parseRancherData(environments []*rancher.Environment, services []*rancher.S
 
 			for _, container := range containers {
 				if container.Labels["io.rancher.stack_service.name"] == rancherData.Name && containerFilter(container) {
-					rancherData.Containers = append(rancherData.Containers, container.PrimaryIpAddress)
+					
+					// If no IP address is provided use the host IP address
+					if container.PrimaryIpAddress == "" {
+						rancherData.Containers = append(rancherData.Containers, getHostIpAddress(service.PublicEndpoints))
+					} else {
+						rancherData.Containers = append(rancherData.Containers, container.PrimaryIpAddress)
+					}
 				}
 			}
 			rancherDataList = append(rancherDataList, rancherData)

--- a/vendor/github.com/rancher/go-rancher/client/generated_secondary_launch_config.go
+++ b/vendor/github.com/rancher/go-rancher/client/generated_secondary_launch_config.go
@@ -115,6 +115,8 @@ type SecondaryLaunchConfig struct {
 
 	Privileged bool `json:"privileged,omitempty" yaml:"privileged,omitempty"`
 
+	PublicEndpoints map[string]interface{} `json:"publicEndpoints,omitempty" yaml:"public_endpoints,omitempty"`
+
 	PublishAllPorts bool `json:"publishAllPorts,omitempty" yaml:"publish_all_ports,omitempty"`
 
 	ReadOnly bool `json:"readOnly,omitempty" yaml:"read_only,omitempty"`


### PR DESCRIPTION
### Description

When host network is selected on rancher container, traefik returns as primary IP address "". This results in proxying to http://:PORT. With this PR if the IP address is empty, the returned IP address is host's address where the container is running.

Follow up description: https://github.com/containous/traefik/issues/1498

This is a quick-fix and should be made differently in future. Probably it should start by detecting what network was chosen on a container and based on that return the proper IP address.