### PR TITLE
[vendor] use abronan/libkv instead of docker/libkv;

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -35,7 +35,7 @@ import:
   - tlsconfig
 - package: github.com/docker/go-units
   version: 9e638d38cf6977a37a8ea0078f3ee75a7cdb2dd1
-- package: github.com/docker/libkv
+- package: github.com/abronan/libkv
   subpackages:
   - store
   - store/boltdb


### PR DESCRIPTION
docker/libkv is dead and abronan/libkv is the repository where development is happening.
this solves #1975 and therefore hopefully #926 once the etcdv2 fix is merged.
this also adds support for redis and etcdv3 storage backends.