### PR TITLE
doc: add notes on server urls with path

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -381,7 +381,10 @@ To use a different port for the healthcheck:
 
 ### Servers
 
-Servers are simply defined using a `URL`. You can also apply a custom `weight` to each server (this will be used by load-balancing).
+Servers are simply defined using a `url`. You can also apply a custom `weight` to each server (this will be used by load-balancing).
+
+!!! note
+    Paths in `url` are ignored. Use `Modifier` to specify paths instead.
 
 Here is an example of backends and servers definition:
 


### PR DESCRIPTION
### Description

Currently paths in server `url` is silently ignored, and it makes confusion (see #561 for example). Update the doc to address the limitation.