### PR TITLE
fix rancher api environment get

### DIFF
--- a/provider/rancher/api.go
+++ b/provider/rancher/api.go
@@ -125,14 +125,14 @@ func (p *Provider) apiProvide(configurationChan chan<- types.ConfigMessage, pool
 	return nil
 }
 
-func listRancherEnvironments(client *rancher.RancherClient) []*rancher.Project {
+func listRancherEnvironments(client *rancher.RancherClient) []*rancher.Environment {
 
-	// Rancher Environment in frontend UI is actually project in API
+	// Rancher Environment in frontend UI is actually a stack
 	// https://forums.rancher.com/t/api-key-for-all-environments/279/9
 
-	var environmentList = []*rancher.Project{}
+	var environmentList = []*rancher.Environment{}
 
-	environments, err := client.Project.List(nil)
+	environments, err := client.Environment.List(nil)
 
 	if err != nil {
 		log.Errorf("Cannot get Rancher Environments %+v", err)
@@ -193,12 +193,13 @@ func listRancherContainer(client *rancher.RancherClient) []*rancher.Container {
 	return containerList
 }
 
-func parseAPISourcedRancherData(environments []*rancher.Project, services []*rancher.Service, containers []*rancher.Container) []rancherData {
+func parseAPISourcedRancherData(environments []*rancher.Environment, services []*rancher.Service, containers []*rancher.Container) []rancherData {
 	var rancherDataList []rancherData
 
 	for _, environment := range environments {
 
 		for _, service := range services {
+
 			if service.EnvironmentId != environment.Id {
 				continue
 			}


### PR DESCRIPTION
### Description

This one fixes #1999 and makes it possible that traefik can get the current configuration out of rancher again :)

Test Image (Based on 1.4-rc1) : https://hub.docker.com/r/santode/traefik:experimental