### PR TITLE
Send traefik logs to stdout

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -18,6 +18,7 @@ var (
 
 func init() {
 	logger = logrus.StandardLogger().WithFields(logrus.Fields{})
+	logrus.SetOutput(os.Stdout)
 }
 
 // Context sets the Context of the logger


### PR DESCRIPTION
The default setting in `logrus` is to send the logs to stderr. The documentation states already that the output should be sent to stdout.