### PR TITLE
add json format support for traefik logs

### DIFF
--- a/cmd/traefik/configuration.go
+++ b/cmd/traefik/configuration.go
@@ -153,6 +153,12 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 	var defaultEureka eureka.Provider
 	defaultEureka.Delay = "30s"
 
+	// default TraefikLog
+	defaultTraefikLog := types.TraefikLog{
+		Format:   "common",
+		FilePath: "",
+	}
+
 	// default AccessLog
 	defaultAccessLog := types.AccessLog{
 		Format:   accesslog.CommonFormat,
@@ -177,6 +183,7 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 		DynamoDB:      &defaultDynamoDB,
 		Retry:         &configuration.Retry{},
 		HealthCheck:   &configuration.HealthCheckConfig{},
+		TraefikLog:    &defaultTraefikLog,
 		AccessLog:     &defaultAccessLog,
 	}
 

--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -267,6 +267,9 @@ func run(globalConfiguration *configuration.GlobalConfiguration) {
 	log.SetLevel(level)
 
 	logFile := globalConfiguration.TraefikLogsFile
+	if len(logFile) > 0 {
+		log.Warn("top-level traefiklogsfile has been deprecated -- please use traefiklog.filepath")
+	}
 	if globalConfiguration.TraefikLog != nil && len(globalConfiguration.TraefikLog.FilePath) > 0 {
 		logFile = globalConfiguration.TraefikLog.FilePath
 	}

--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -266,18 +266,22 @@ func run(globalConfiguration *configuration.GlobalConfiguration) {
 	}
 	log.SetLevel(level)
 
-	var formatter logrus.Formatter
-	if globalConfiguration.TraefikLog != nil && globalConfiguration.TraefikLog.Format == "json" {
-		formatter = &logrus.JSONFormatter{}
-	} else {
-		formatter = &logrus.TextFormatter{DisableColors: true, FullTimestamp: true, DisableSorting: true}
-	}
-	log.SetFormatter(formatter)
-
 	logFile := globalConfiguration.TraefikLogsFile
 	if globalConfiguration.TraefikLog != nil && len(globalConfiguration.TraefikLog.FilePath) > 0 {
 		logFile = globalConfiguration.TraefikLog.FilePath
 	}
+
+	var formatter logrus.Formatter
+	if globalConfiguration.TraefikLog != nil && globalConfiguration.TraefikLog.Format == "json" {
+		formatter = &logrus.JSONFormatter{}
+	} else {
+		disableColors := false
+		if len(logFile) > 0 {
+			disableColors = true
+		}
+		formatter = &logrus.TextFormatter{DisableColors: disableColors, FullTimestamp: true, DisableSorting: true}
+	}
+	log.SetFormatter(formatter)
 
 	if len(logFile) > 0 {
 		dir := filepath.Dir(logFile)
@@ -297,6 +301,7 @@ func run(globalConfiguration *configuration.GlobalConfiguration) {
 			log.Error("Error opening file", err)
 		}
 	}
+
 	jsonConf, _ := json.Marshal(globalConfiguration)
 	log.Infof("Traefik version %s built on %s", version.Version, version.BuildDate)
 

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -47,7 +47,8 @@ type GlobalConfiguration struct {
 	CheckNewVersion           bool                    `description:"Periodically check if a new version has been released"`
 	AccessLogsFile            string                  `description:"(Deprecated) Access logs file"` // Deprecated
 	AccessLog                 *types.AccessLog        `description:"Access log settings"`
-	TraefikLogsFile           string                  `description:"Traefik logs file. Stdout is used when omitted or empty"`
+	TraefikLogsFile           string                  `description:"(Deprecated) Traefik logs file. Stdout is used when omitted or empty"` // Deprecated
+	TraefikLog                *types.TraefikLog       `description:"Traefik log settings"`
 	LogLevel                  string                  `short:"l" description:"Log level"`
 	EntryPoints               EntryPoints             `description:"Entrypoints definition using format: --entryPoints='Name:http Address::8000 Redirect.EntryPoint:https' --entryPoints='Name:https Address::4442 TLS:tests/traefik.crt,tests/traefik.key;prod/traefik.crt,prod/traefik.key'"`
 	Cluster                   *types.Cluster          `description:"Enable clustering"`

--- a/docs/configuration/commons.md
+++ b/docs/configuration/commons.md
@@ -152,6 +152,10 @@ constraints = ["tag==api", "tag!=v*-beta"]
 ```toml
 # Traefik logs file
 # If not defined, logs to stdout
+#
+# DEPRECATED - see [traefikLog] lower down
+# Optional
+#
 traefikLogsFile = "log/traefik.log"
 
 # Log level
@@ -163,6 +167,23 @@ traefikLogsFile = "log/traefik.log"
 # Messages at and above the selected level will be logged.
 #
 logLevel = "ERROR"
+```
+
+## Traefik Logs
+
+By default the Traefik log is written to stdout in text format.
+
+To write the logs into a logfile specify the `filePath`.
+```toml
+[traefikLog]
+  filePath = "/path/to/traefik.log"
+```
+
+To write JSON format logs, specify `json` as the format:
+```toml
+[traefikLog]
+  filePath = "/path/to/traefik.log"
+  format   = "json"
 ```
 
 ### Access Logs

--- a/docs/configuration/commons.md
+++ b/docs/configuration/commons.md
@@ -154,6 +154,7 @@ constraints = ["tag==api", "tag!=v*-beta"]
 # If not defined, logs to stdout
 #
 # DEPRECATED - see [traefikLog] lower down
+# In case both traefikLogsFile and traefikLog.filePath are specified, the latter will take precedence.
 # Optional
 #
 traefikLogsFile = "log/traefik.log"

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -9,13 +9,6 @@
 #
 # debug = true
 
-# Traefik logs file
-# If not defined, logs to stdout
-#
-# Optional
-#
-# traefikLogsFile = "log/traefik.log"
-
 # Log level
 #
 # Optional
@@ -38,6 +31,28 @@
 [entryPoints]
     [entryPoints.http]
     address = ":80"
+
+# Traefik logs
+# Enabled by default and log to stdout
+#
+# Optional
+#
+# [traefikLog]
+
+# Sets the filepath for the traefik log. If not specified, stdout will be used.
+# Intermediate directories are created if necessary.
+#
+# Optional
+# Default: os.Stdout
+#
+# filePath = "log/traefik.log"
+
+# Format is either "json" or "common".
+#
+# Optional
+# Default: "common"
+#
+# format = "common"
 
 # Enable access logs
 # By default it will write to stdout and produce logs in the textual

--- a/types/types.go
+++ b/types/types.go
@@ -412,6 +412,12 @@ func (b *Buckets) SetValue(val interface{}) {
 	*b = Buckets(val.(Buckets))
 }
 
+// TraefikLog holds the configuration settings for the traefik logger.
+type TraefikLog struct {
+	FilePath string `json:"file,omitempty" description:"Traefik log file path. Stdout is used when omitted or empty"`
+	Format   string `json:"format,omitempty" description:"Traefik log format: json | common"`
+}
+
 // AccessLog holds the configuration settings for the access logger (middlewares/accesslog).
 type AccessLog struct {
 	FilePath string `json:"file,omitempty" description:"Access log file path. Stdout is used when omitted or empty"`


### PR DESCRIPTION
This PR adds the possibility to use JSON format for the traefik logs. 

Also it aligns the configuration to the accessLogs and deprecates the `traefikLogsFile` option.

Sample log line:
```json
{"level":"info","msg":"Traefik version dev built on I don't remember exactly","time":"2017-09-05T02:34:52+02:00"}
```

This fixes https://github.com/containous/traefik/issues/780.