### PR TITLE
Enable loss less rotation of log files

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -227,8 +227,10 @@ func RotateFile() error {
 		return nil
 	}
 
-	if err := CloseFile(); err != nil {
-		return fmt.Errorf("error closing log file: %s", err)
+	if logFile != nil {
+		defer func(f *os.File) {
+			f.Close()
+		}(logFile)
 	}
 
 	if err := OpenFile(logFilePath); err != nil {

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -1,0 +1,79 @@
+package log
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLogRotation(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "traefik_")
+	if err != nil {
+		t.Fatalf("Error setting up temporary directory: %s", err)
+	}
+
+	fileName := tempDir + "traefik.log"
+	if err := OpenFile(fileName); err != nil {
+		t.Fatalf("Error opening temporary file %s: %s", fileName, err)
+	}
+	defer CloseFile()
+
+	rotatedFileName := fileName + ".rotated"
+
+	iterations := 20
+	halfDone := make(chan bool)
+	writeDone := make(chan bool)
+	go func() {
+		for i := 0; i < iterations; i++ {
+			Println("Test log line")
+			if i == iterations/2 {
+				halfDone <- true
+			}
+		}
+		writeDone <- true
+	}()
+
+	<-halfDone
+	err = os.Rename(fileName, rotatedFileName)
+	if err != nil {
+		t.Fatalf("Error renaming file: %s", err)
+	}
+
+	err = RotateFile()
+	if err != nil {
+		t.Fatalf("Error rotating file: %s", err)
+	}
+
+	select {
+	case <-writeDone:
+		gotLineCount := lineCount(t, fileName) + lineCount(t, rotatedFileName)
+		if iterations != gotLineCount {
+			t.Errorf("Wanted %d written log lines, got %d", iterations, gotLineCount)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("test timed out")
+	}
+
+	close(halfDone)
+	close(writeDone)
+}
+
+func lineCount(t *testing.T, fileName string) int {
+	t.Helper()
+	fileContents, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		t.Fatalf("Error reading from file %s: %s", fileName, err)
+	}
+
+	count := 0
+	for _, line := range strings.Split(string(fileContents), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		count++
+	}
+
+	return count
+}

--- a/server/server_signals.go
+++ b/server/server_signals.go
@@ -27,7 +27,7 @@ func (server *Server) listenSignals() {
 			}
 
 			if err := log.RotateFile(); err != nil {
-				log.Errorf("Error rotating error log: %s", err)
+				log.Errorf("Error rotating traefik log: %s", err)
 			}
 		default:
 			log.Infof("I have to go... %+v", sig)


### PR DESCRIPTION
There is the chance that Traefik looses log lines for requests during rotation of the log file. This is at the moment true for the traefik log file as well as the access log files. I added two unit tests to prove this. This was also responsible for one flaky behaviour in the integration test [here](https://semaphoreci.com/containous/traefik/branches/pull-request-2054/builds/2).

For the traefik logs this is accomplished by opening the new log file before closing the previous one. The traefik logs use the global `logrus` instance and it is already protected by a mutex on rotation. For the access logs such a mutex also had to be introduced.

I think there is some potential in refactoring and aligning the two logging implementations in order to avoid duplicate code when it comes to the file handling and the logrus configuration. I will do this in a follow-up PR.


