### PR TITLE
Fix IAM policy sid.

### DIFF
--- a/docs/configuration/backends/ecs.md
+++ b/docs/configuration/backends/ecs.md
@@ -103,7 +103,7 @@ Træfik needs the following policy to read ECS information:
     "Version": "2012-10-17",
     "Statement": [
         {
-            "Sid": "Traefik ECS read access",
+            "Sid": "TraefikECSReadAccess",
             "Effect": "Allow",
             "Action": [
                 "ecs:ListClusters",


### PR DESCRIPTION
### Description
The required IAM policy uses spaces in the `Sid` field, but this is not allowed by IAM. As a result, attempting to create this policy results in a validation error. The fix is simply to remove the spaces from the `Sid`.