### PR TITLE
Document custom error page restrictions.

### DIFF
--- a/docs/configuration/commons.md
+++ b/docs/configuration/commons.md
@@ -242,6 +242,9 @@ Instead, the query parameter can also be set to some generic error page like so:
 Now the `500s.html` error page is returned for the configured code range.
 The configured status code ranges are inclusive; that is, in the above example, the `500s.html` page will be returned for status codes `500` through, and including, `599`.
 
+Custom error pages are easiest to implement using the file provider.
+For dynamic providers, the corresponding template file needs to be customized accordingly and referenced in the Traefik configuration.
+
 
 ## Retry Configuration
 


### PR DESCRIPTION
@containous/traefik PTAL.

In particular, someone with sufficient expertise please acknowledge that custom error pages can really be used with the key/value stores we support.

Refs #2035.