### PR TITLE
Put Host into a header for Forward Auth

### DIFF
--- a/auth/forward.go
+++ b/auth/forward.go
@@ -33,9 +33,10 @@ func Forward(forward *types.Forward, w http.ResponseWriter, r *http.Request, nex
 	}
 	forwardReq.Header = r.Header
 
-	if forward.ForwardHostname != nil {
-		forwardReq.Header.Add(forward.ForwardHostname.HeaderName, r.Host)
+	if forward.HostHeader == "" {
+		forward.HostHeader = "X-Forwarded-Host"
 	}
+	forwardReq.Header.Add(forward.HostHeader, r.Host)
 
 	forwardResponse, forwardErr := httpClient.Do(forwardReq)
 	if forwardErr != nil {

--- a/auth/forward.go
+++ b/auth/forward.go
@@ -33,6 +33,10 @@ func Forward(forward *types.Forward, w http.ResponseWriter, r *http.Request, nex
 	}
 	forwardReq.Header = r.Header
 
+	if forward.ForwardHostname != nil {
+		forwardReq.Header.Add(forward.ForwardHostname.HeaderName, r.Host)
+	}
+
 	forwardResponse, forwardErr := httpClient.Do(forwardReq)
 	if forwardErr != nil {
 		log.Debugf("Error calling %s. Cause: %s", forward.Address, forwardErr)

--- a/docs/configuration/entrypoints.md
+++ b/docs/configuration/entrypoints.md
@@ -118,35 +118,26 @@ Otherwise, the response from the auth server is returned.
 
 ```toml
 [entryPoints]
-  [entryPoints.http]
-  # ...
-  # To enable forward auth on an entrypoint
-  [entryPoints.http.auth.forward]
-  address = "http://authserver.com/auth"
-```
-
-```toml
-[entryPoints]
   [entrypoints.http]
     # ...
-    # To enable forward auth on an entrypoint (HTTPS)
+    # To enable forward auth on an entrypoint
     [entrypoints.http.auth.forward]
     address = "https://authserver.com/auth"
+    
+    # Enable forward auth TLS connection.
+    #
+    # Optional
+    #
     [entrypoints.http.auth.forward.tls]
     cert = "authserver.crt"
     key = "authserver.key"
-```
-
-# Origin Host
-
-The origin host is forwarded by default in `X-Forwarded-Host` header.
-To override default header name.
-
-```toml
-[entryPoints]
-  [entrypoints.http]
-    address = "https://authserver.com/auth"
-    hostheader = "Traefik-Host"
+    
+    #  Pass the request Host via a configurable header value.
+    #
+    # Optional
+    # Default: "X-Forwarded-Host"
+    #
+    hostHeader = "X-Forwarded-Host"
 ```
 
 ## Specify Minimum TLS Version

--- a/docs/configuration/entrypoints.md
+++ b/docs/configuration/entrypoints.md
@@ -137,6 +137,17 @@ Otherwise, the response from the auth server is returned.
     key = "authserver.key"
 ```
 
+# Origin Host
+
+The origin host is forwarded by default in `X-Forwarded-Host` header.
+To override default header name.
+
+```toml
+[entryPoints]
+  [entrypoints.http]
+    address = "https://authserver.com/auth"
+    hostheader = "Traefik-Host"
+```
 
 ## Specify Minimum TLS Version
 

--- a/types/types.go
+++ b/types/types.go
@@ -325,8 +325,14 @@ type Digest struct {
 
 // Forward authentication
 type Forward struct {
-	Address string     `description:"Authentication server address"`
-	TLS     *ClientTLS `description:"Enable TLS support"`
+	Address         string           `description:"Authentication server address"`
+	TLS             *ClientTLS       `description:"Enable TLS support"`
+	ForwardHostname *ForwardHostname `description:"Enable forward hostname request "`
+}
+
+// ForwardHostname option of Forward authentication
+type ForwardHostname struct {
+	HeaderName string `description:"Header name"`
 }
 
 // CanonicalDomain returns a lower case domain with trim space

--- a/types/types.go
+++ b/types/types.go
@@ -325,14 +325,9 @@ type Digest struct {
 
 // Forward authentication
 type Forward struct {
-	Address         string           `description:"Authentication server address"`
-	TLS             *ClientTLS       `description:"Enable TLS support"`
-	ForwardHostname *ForwardHostname `description:"Enable forward hostname request "`
-}
-
-// ForwardHostname option of Forward authentication
-type ForwardHostname struct {
-	HeaderName string `description:"Header name"`
+	Address    string     `description:"Authentication server address"`
+	TLS        *ClientTLS `description:"Enable TLS support"`
+	HostHeader string     `description:"Header name to put the forwarded host"`
 }
 
 // CanonicalDomain returns a lower case domain with trim space


### PR DESCRIPTION
Hi all,

I just added possibility of forward the origin host to the as

Config example 

```toml
[entryPoints.http.auth.forward]
address = "http://authtest/"
hostheader = "x-origin-host"
```

It's follow the design  
> Additional Headers
> The AS might be interested in some of the original request informations such as:
> Original Host - The target host address, eg api.example.com

> All this information should be optional. The user must be allowed to define each header name. 


Related to #2105