### PR TITLE
Removing double wording from documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ Run it and forget it!
 
 - [It's fast](https://docs.traefik.io/benchmarks)
 - No dependency hell, single binary made with go
-- [Tiny](https://microbadger.com/images/traefik) [official](https://hub.docker.com/r/_/traefik/) official docker image
+- [Tiny](https://microbadger.com/images/traefik) [official](https://hub.docker.com/r/_/traefik/) docker image
 - Rest API
 - Hot-reloading of configuration. No need to restart the process
 - Circuit breakers, retry


### PR DESCRIPTION
### Description

This PR is removing a double wording which appears in the list of features. The same typo is also present on the official web page (https://traefik.io/).