### PR TITLE
Fix deprecated IdleTimeout config

### DIFF
--- a/cmd/traefik/configuration.go
+++ b/cmd/traefik/configuration.go
@@ -159,6 +159,11 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 		FilePath: "",
 	}
 
+	// default HealthCheckConfig
+	healthCheck := configuration.HealthCheckConfig{
+		Interval: flaeg.Duration(configuration.DefaultHealthCheckInterval),
+	}
+
 	// default RespondingTimeouts
 	respondingTimeouts := configuration.RespondingTimeouts{
 		IdleTimeout: flaeg.Duration(configuration.DefaultIdleTimeout),
@@ -186,7 +191,7 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 		Eureka:             &defaultEureka,
 		DynamoDB:           &defaultDynamoDB,
 		Retry:              &configuration.Retry{},
-		HealthCheck:        &configuration.HealthCheckConfig{},
+		HealthCheck:        &healthCheck,
 		AccessLog:          &defaultAccessLog,
 		RespondingTimeouts: &respondingTimeouts,
 		ForwardingTimeouts: &forwardingTimeouts,

--- a/cmd/traefik/configuration.go
+++ b/cmd/traefik/configuration.go
@@ -159,25 +159,31 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 		FilePath: "",
 	}
 
+	// default RespondingTimeouts
+	respondingTimeouts := configuration.RespondingTimeouts{
+		IdleTimeout: flaeg.Duration(configuration.DefaultIdleTimeout),
+	}
+
 	defaultConfiguration := configuration.GlobalConfiguration{
-		Docker:        &defaultDocker,
-		File:          &defaultFile,
-		Web:           &defaultWeb,
-		Marathon:      &defaultMarathon,
-		Consul:        &defaultConsul,
-		ConsulCatalog: &defaultConsulCatalog,
-		Etcd:          &defaultEtcd,
-		Zookeeper:     &defaultZookeeper,
-		Boltdb:        &defaultBoltDb,
-		Kubernetes:    &defaultKubernetes,
-		Mesos:         &defaultMesos,
-		ECS:           &defaultECS,
-		Rancher:       &defaultRancher,
-		Eureka:        &defaultEureka,
-		DynamoDB:      &defaultDynamoDB,
-		Retry:         &configuration.Retry{},
-		HealthCheck:   &configuration.HealthCheckConfig{},
-		AccessLog:     &defaultAccessLog,
+		Docker:             &defaultDocker,
+		File:               &defaultFile,
+		Web:                &defaultWeb,
+		Marathon:           &defaultMarathon,
+		Consul:             &defaultConsul,
+		ConsulCatalog:      &defaultConsulCatalog,
+		Etcd:               &defaultEtcd,
+		Zookeeper:          &defaultZookeeper,
+		Boltdb:             &defaultBoltDb,
+		Kubernetes:         &defaultKubernetes,
+		Mesos:              &defaultMesos,
+		ECS:                &defaultECS,
+		Rancher:            &defaultRancher,
+		Eureka:             &defaultEureka,
+		DynamoDB:           &defaultDynamoDB,
+		Retry:              &configuration.Retry{},
+		HealthCheck:        &configuration.HealthCheckConfig{},
+		AccessLog:          &defaultAccessLog,
+		RespondingTimeouts: &respondingTimeouts,
 	}
 
 	return &TraefikConfiguration{
@@ -201,9 +207,6 @@ func NewTraefikConfiguration() *TraefikConfiguration {
 			IdleTimeout:               flaeg.Duration(0),
 			HealthCheck: &configuration.HealthCheckConfig{
 				Interval: flaeg.Duration(configuration.DefaultHealthCheckInterval),
-			},
-			RespondingTimeouts: &configuration.RespondingTimeouts{
-				IdleTimeout: flaeg.Duration(configuration.DefaultIdleTimeout),
 			},
 			ForwardingTimeouts: &configuration.ForwardingTimeouts{
 				DialTimeout: flaeg.Duration(configuration.DefaultDialTimeout),

--- a/cmd/traefik/configuration.go
+++ b/cmd/traefik/configuration.go
@@ -164,6 +164,11 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 		IdleTimeout: flaeg.Duration(configuration.DefaultIdleTimeout),
 	}
 
+	// default ForwardingTimeouts
+	forwardingTimeouts := configuration.ForwardingTimeouts{
+		DialTimeout: flaeg.Duration(configuration.DefaultDialTimeout),
+	}
+
 	defaultConfiguration := configuration.GlobalConfiguration{
 		Docker:             &defaultDocker,
 		File:               &defaultFile,
@@ -184,6 +189,7 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 		HealthCheck:        &configuration.HealthCheckConfig{},
 		AccessLog:          &defaultAccessLog,
 		RespondingTimeouts: &respondingTimeouts,
+		ForwardingTimeouts: &forwardingTimeouts,
 	}
 
 	return &TraefikConfiguration{
@@ -207,9 +213,6 @@ func NewTraefikConfiguration() *TraefikConfiguration {
 			IdleTimeout:               flaeg.Duration(0),
 			HealthCheck: &configuration.HealthCheckConfig{
 				Interval: flaeg.Duration(configuration.DefaultHealthCheckInterval),
-			},
-			ForwardingTimeouts: &configuration.ForwardingTimeouts{
-				DialTimeout: flaeg.Duration(configuration.DefaultDialTimeout),
 			},
 			CheckNewVersion: true,
 		},

--- a/server/server.go
+++ b/server/server.go
@@ -675,14 +675,13 @@ func buildServerTimeouts(globalConfig configuration.GlobalConfiguration) (readTi
 		writeTimeout = time.Duration(globalConfig.RespondingTimeouts.WriteTimeout)
 	}
 
-	// When RespondingTimeouts.IdleTimout is configured, always use that setting
-	if globalConfig.RespondingTimeouts != nil {
-		idleTimeout = time.Duration(globalConfig.RespondingTimeouts.IdleTimeout)
-	} else if globalConfig.IdleTimeout != 0 {
-		// Backwards compatibility for deprecated IdleTimeout
+	// Prefer legacy idle timeout parameter for backwards compatibility reasons
+	if globalConfig.IdleTimeout > 0 {
 		idleTimeout = time.Duration(globalConfig.IdleTimeout)
+		log.Warn("top-level idle timeout configuration has been deprecated -- please use responding timeouts")
+	} else if globalConfig.RespondingTimeouts != nil {
+		idleTimeout = time.Duration(globalConfig.RespondingTimeouts.IdleTimeout)
 	} else {
-		// Default value if neither the deprecated IdleTimeout nor the new RespondingTimeouts.IdleTimout are configured
 		idleTimeout = time.Duration(configuration.DefaultIdleTimeout)
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -127,7 +127,7 @@ func NewServer(globalConfiguration configuration.GlobalConfiguration) *Server {
 // behaviour and backwards compatibility issues.
 func createHTTPTransport(globalConfiguration configuration.GlobalConfiguration) *http.Transport {
 	dialer := &net.Dialer{
-		Timeout:   30 * time.Second,
+		Timeout:   configuration.DefaultDialTimeout,
 		KeepAlive: 30 * time.Second,
 		DualStack: true,
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -83,7 +83,7 @@ func TestPrepareServerTimeouts(t *testing.T) {
 					IdleTimeout: flaeg.Duration(80 * time.Second),
 				},
 			},
-			wantIdleTimeout:  time.Duration(80 * time.Second),
+			wantIdleTimeout:  time.Duration(45 * time.Second),
 			wantReadTimeout:  time.Duration(0 * time.Second),
 			wantWriteTimeout: time.Duration(0 * time.Second),
 		},


### PR DESCRIPTION
This PR fixes loading of the deprecated top-level option `IdleTimeout`. Also, it changes the semantics so that the deprecated option is now preferred and a warning is logged when it is used.

_All the different configuration constellations I also verified via the matching CLI parameters as well._

I tried the following configs and they deliver now the expected results:

```toml
# default config, nothing specified
```
-> default timeout of 30 seconds is used

```toml
# only deprecated option specified
idleTimeout="42s"
```
-> deprecated option of 42 seconds is used

```toml
# deprecated option with RespondingTimeouts "activated"
idleTimeout="42s"
[respondingTimeouts]
```
-> deprecated option of 42 seconds is used

```toml
# deprecated option and new option specified
idleTimeout="42s"
[respondingTimeouts]
  idleTimeout="23s"
```
-> deprecated option of 42 seconds is used

```toml
# deprecated option *other* new option specified
idleTimeout="42s"
[respondingTimeouts]
  readTimeout="23s"
```
-> deprecated option of 42 seconds is used

```toml
# only new option specified
[respondingTimeouts]
  idleTimeout="23s"
```
-> new option of 23 seconds is used

While working on this PR I realized that also the health check has "problems" with its default interval, given it is configured in the following way (imho no one would do such a thing, but still...). As this was at related code places as my change I decided to include it in this PR:

```toml
[healthcheck]

[backends]
  [backends.backend1]
    [backends.backend1.healthCheck]
    path="/health"
    [backends.backend1.servers.server1]
    url = "http://localhost:8081"
```
-> interval is initialised with 0 and will lead to `Error in Go routine: non-positive interval for NewTicker`