### PR TITLE
Allow configuration of SSLRedirect and SSLProxyHeaders from ingress annotations

### DIFF
--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -327,18 +327,16 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 	return &templateObjects, nil
 }
 
+// getSSLProxyHeaders
 func (p *Provider) getSSLProxyHeaders(str string) map[string]string {
+	parts := append(p.DefaultSSLProxyHeaders, strings.Split(str, ",")...)
 	headers := map[string]string{}
-	kvs := append(p.DefaultSSLProxyHeaders, strings.Split(str, ",")...)
-	for _, kvp := range kvs {
-		kv := strings.SplitN(kvp, "=", 2)
-		if kv[0] == "" {
+	for _, part := range parts {
+		key, val := splitKeyValue(part)
+		if key == "" {
 			continue
 		}
-		headers[kv[0]] = ""
-		if len(kv) == 2 {
-			headers[kv[0]] = kv[1]
-		}
+		headers[key] = val
 	}
 
 	if len(headers) == 0 {

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -204,19 +204,20 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 						Priority:             priority,
 						BasicAuth:            basicAuthCreds,
 						WhitelistSourceRange: whitelistSourceRange,
+						Headers:              types.Headers{},
 					}
-				}
 
-				sslRedirectAnnotation, ok := i.Annotations[annotationKubernetesSSLRedirect]
-				switch {
-				case !ok:
-					// No op.
-				case sslRedirectAnnotation == "false":
-					templateObjects.Frontends[r.Host+pa.Path].Headers.SSLRedirect = false
-				case sslRedirectAnnotation == "true":
-					templateObjects.Frontends[r.Host+pa.Path].Headers.SSLRedirect = true
-				default:
-					log.Warnf("Unknown value '%s' for %s", sslRedirectAnnotation, annotationKubernetesSSLRedirect)
+					sslRedirectAnnotation, ok := i.Annotations[annotationKubernetesSSLRedirect]
+					switch {
+					case !ok:
+						// No op.
+					case sslRedirectAnnotation == "false":
+						templateObjects.Frontends[r.Host+pa.Path].Headers.SSLRedirect = false
+					case sslRedirectAnnotation == "true":
+						templateObjects.Frontends[r.Host+pa.Path].Headers.SSLRedirect = true
+					default:
+						log.Warnf("Unknown value '%s' for %s", sslRedirectAnnotation, annotationKubernetesSSLRedirect)
+					}
 				}
 
 				if len(r.Host) > 0 {

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -35,7 +35,7 @@ const (
 	annotationKubernetesRewriteTarget        = "ingress.kubernetes.io/rewrite-target"
 	annotationKubernetesWhitelistSourceRange = "ingress.kubernetes.io/whitelist-source-range"
 	annotationKubernetesSSLRedirect          = "ingress.kubernetes.io/force-ssl-redirect"
-	annotationKubernetesSSLProxyHeaders      = "ingress.kubernetes.io/ssl-proxy-headers"
+	annotationKubernetesSSLProxyHeaders      = types.LabelPrefix + "ingress.kubernetes.io/ssl-proxy-headers"
 )
 
 const traefikDefaultRealm = "traefik"

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -47,8 +47,8 @@ type Provider struct {
 	Token                  string     `description:"Kubernetes bearer token (not needed for in-cluster client)"`
 	CertAuthFilePath       string     `description:"Kubernetes certificate authority file path (not needed for in-cluster client)"`
 	DisablePassHostHeaders bool       `description:"Kubernetes disable PassHost Headers"`
-	DefaultSSLRedirect     bool       `description:"Kubernetes default ssl redierect mode"`
-	DefaultSSLProxyHeaders []string   `description:"Kubernetes default ssl proxy headers"`
+	DefaultSSLRedirect     bool       `description:"Kubernetes default SSLRedirect mode"`
+	DefaultSSLProxyHeaders []string   `description:"Kubernetes default SSLProxyHeaders (format: key=val)"`
 	Namespaces             Namespaces `description:"Kubernetes namespaces"`
 	LabelSelector          string     `description:"Kubernetes api label selector to use"`
 	lastConfiguration      safe.Safe

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -327,7 +327,8 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 	return &templateObjects, nil
 }
 
-// getSSLProxyHeaders
+// getSSLProxyHeaders merging provider defaults and
+// provided 'Key=Val' comma delimited string
 func (p *Provider) getSSLProxyHeaders(str string) map[string]string {
 	parts := append(p.DefaultSSLProxyHeaders, strings.Split(str, ",")...)
 	headers := map[string]string{}

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -327,8 +327,8 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 	return &templateObjects, nil
 }
 
-// getSSLProxyHeaders merging provider defaults and
-// provided 'Key=Val' comma delimited string
+// getSSLProxyHeaders from provider defaults merging headers parsed from str.
+// Expects str format to be a 'Key=Val' comma delimited string.
 func (p *Provider) getSSLProxyHeaders(str string) map[string]string {
 	parts := append(p.DefaultSSLProxyHeaders, strings.Split(str, ",")...)
 	headers := map[string]string{}

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -2403,7 +2403,7 @@ func TestSSLRedirectInTemplate(t *testing.T) {
 				Namespace: "testing",
 				Annotations: map[string]string{
 					annotationKubernetesSSLRedirect:     "true",
-					annotationKubernetesSSLProxyHeaders: "X-Forward-Proto=https",
+					annotationKubernetesSSLProxyHeaders: "X-Forwarded-Proto=https",
 				},
 			},
 			Spec: v1beta1.IngressSpec{
@@ -2464,14 +2464,12 @@ func TestSSLRedirectInTemplate(t *testing.T) {
 	}
 
 	actual = provider.loadConfig(*actual)
-	got := actual.Frontends["ssl/redirect"].Headers.SSLRedirect
-	if !got {
-		t.Fatalf("expected SSLRedirect to be true got: %+v", got)
-	}
+	assert.Equal(t, true,
+		actual.Frontends["ssl/redirect"].Headers.SSLRedirect)
 
-	if got := actual.Frontends["ssl/redirect"].Headers.SSLProxyHeaders; !reflect.DeepEqual(got, map[string]string{"X-Forward-Proto": "https"}) {
-		t.Fatalf("expected 'X-Forward-Proto' to be 'https' got: %+v", got)
-	}
+	assert.Equal(t,
+		map[string]string{"X-Forwarded-Proto": "https"},
+		actual.Frontends["ssl/redirect"].Headers.SSLProxyHeaders)
 }
 
 type clientMock struct {

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -1714,7 +1714,6 @@ func TestIngressAnnotations(t *testing.T) {
 			},
 			"ssl/redirect": {
 				Backend:        "ssl/redirect",
-				Priority:       len("/redirect"),
 				PassHostHeader: true,
 				Headers: types.Headers{
 					SSLRedirect: true,
@@ -2403,7 +2402,8 @@ func TestSSLRedirectInTemplate(t *testing.T) {
 			ObjectMeta: v1.ObjectMeta{
 				Namespace: "testing",
 				Annotations: map[string]string{
-					"ingress.kubernetes.io/ssl-redirect": "true",
+					annotationKubernetesSSLRedirect:     "true",
+					annotationKubernetesSSLProxyHeaders: "X-Forward-Proto=https",
 				},
 			},
 			Spec: v1beta1.IngressSpec{
@@ -2467,6 +2467,10 @@ func TestSSLRedirectInTemplate(t *testing.T) {
 	got := actual.Frontends["ssl/redirect"].Headers.SSLRedirect
 	if !got {
 		t.Fatalf("expected SSLRedirect to be true got: %+v", got)
+	}
+
+	if got := actual.Frontends["ssl/redirect"].Headers.SSLProxyHeaders; !reflect.DeepEqual(got, map[string]string{"X-Forward-Proto": "https"}) {
+		t.Fatalf("expected 'X-Forward-Proto' to be 'https' got: %+v", got)
 	}
 }
 

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -2427,6 +2427,34 @@ func TestSSLRedirectInTemplate(t *testing.T) {
 				},
 			},
 		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace: "testing",
+				Annotations: map[string]string{
+					annotationKubernetesSSLProxyHeaders: "X-Forwarded-Proto=https,X-Test=test",
+				},
+			},
+			Spec: v1beta1.IngressSpec{
+				Rules: []v1beta1.IngressRule{
+					{
+						Host: "multiple",
+						IngressRuleValue: v1beta1.IngressRuleValue{
+							HTTP: &v1beta1.HTTPIngressRuleValue{
+								Paths: []v1beta1.HTTPIngressPath{
+									{
+										Path: "/headers",
+										Backend: v1beta1.IngressBackend{
+											ServiceName: "service1",
+											ServicePort: intstr.FromInt(80),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	services := []*v1.Service{
 		{
@@ -2470,6 +2498,96 @@ func TestSSLRedirectInTemplate(t *testing.T) {
 	assert.Equal(t,
 		map[string]string{"X-Forwarded-Proto": "https"},
 		actual.Frontends["ssl/redirect"].Headers.SSLProxyHeaders)
+
+	assert.Equal(t,
+		map[string]string{
+			"X-Forwarded-Proto": "https",
+			"X-Test":            "test",
+		},
+		actual.Frontends["multiple/headers"].Headers.SSLProxyHeaders,
+		"Parses multiple headers from annotation")
+}
+
+func TestProviderDefaultSSLConfig(t *testing.T) {
+	ingresses := []*v1beta1.Ingress{
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Annotations: map[string]string{
+					annotationKubernetesSSLProxyHeaders: "X-Forwarded-Proto=https",
+				},
+			},
+			Spec: v1beta1.IngressSpec{
+				Rules: []v1beta1.IngressRule{
+					{
+						Host: "default",
+						IngressRuleValue: v1beta1.IngressRuleValue{
+							HTTP: &v1beta1.HTTPIngressRuleValue{
+								Paths: []v1beta1.HTTPIngressPath{
+									{
+										Path: "/headers",
+										Backend: v1beta1.IngressBackend{
+											ServiceName: "service1",
+											ServicePort: intstr.FromInt(80),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	services := []*v1.Service{
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "service1",
+				UID:  "1",
+			},
+			Spec: v1.ServiceSpec{
+				ClusterIP: "10.0.0.1",
+				Type:      "ClusterIP",
+				Ports: []v1.ServicePort{
+					{
+						Name: "http",
+						Port: 80,
+					},
+				},
+			},
+		},
+	}
+
+	endpoints := []*v1.Endpoints{}
+	watchChan := make(chan interface{})
+	client := clientMock{
+		ingresses: ingresses,
+		services:  services,
+		endpoints: endpoints,
+		watchChan: watchChan,
+	}
+	provider := Provider{
+		DefaultSSLRedirect: true,
+		DefaultSSLProxyHeaders: []string{
+			"X-Test=test",
+		},
+	}
+	actual, err := provider.loadIngresses(client)
+	if err != nil {
+		t.Fatalf("error %+v", err)
+	}
+
+	actual = provider.loadConfig(*actual)
+
+	assert.Equal(t,
+		true,
+		actual.Frontends["default/headers"].Headers.SSLRedirect)
+
+	assert.Equal(t,
+		map[string]string{
+			"X-Forwarded-Proto": "https",
+			"X-Test":            "test",
+		},
+		actual.Frontends["default/headers"].Headers.SSLProxyHeaders)
 }
 
 type clientMock struct {

--- a/provider/kubernetes/util.go
+++ b/provider/kubernetes/util.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/client-go/pkg/util/intstr"
 )
 
-// splitKeyValue on first '=' returning a seperate key, value pair
+// splitKeyValue on first '=' returning a separate key, value pair
 func splitKeyValue(str string) (key, val string) {
 	parts := strings.SplitN(str, "=", 2)
 	key = parts[0]

--- a/provider/kubernetes/util.go
+++ b/provider/kubernetes/util.go
@@ -1,0 +1,60 @@
+package kubernetes
+
+import (
+	"github.com/containous/traefik/types"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	"k8s.io/client-go/pkg/util/intstr"
+)
+
+func getRuleForPath(pa v1beta1.HTTPIngressPath, i *v1beta1.Ingress) string {
+	if len(pa.Path) == 0 {
+		return ""
+	}
+
+	ruleType := i.Annotations[types.LabelFrontendRuleType]
+	if ruleType == "" {
+		ruleType = ruleTypePathPrefix
+	}
+
+	rule := ruleType + ":" + pa.Path
+
+	if rewriteTarget := i.Annotations[annotationKubernetesRewriteTarget]; rewriteTarget != "" {
+		rule = ruleTypeReplacePath + ":" + rewriteTarget
+	}
+
+	return rule
+}
+
+func endpointPortNumber(servicePort v1.ServicePort, endpointPorts []v1.EndpointPort) int {
+	if len(endpointPorts) > 0 {
+		//name is optional if there is only one port
+		port := endpointPorts[0]
+		for _, endpointPort := range endpointPorts {
+			if servicePort.Name == endpointPort.Name {
+				port = endpointPort
+			}
+		}
+		return int(port.Port)
+	}
+	return int(servicePort.Port)
+}
+
+func equalPorts(servicePort v1.ServicePort, ingressPort intstr.IntOrString) bool {
+	if int(servicePort.Port) == ingressPort.IntValue() {
+		return true
+	}
+	if servicePort.Name != "" && servicePort.Name == ingressPort.String() {
+		return true
+	}
+	return false
+}
+
+func shouldProcessIngress(ingressClass string) bool {
+	switch ingressClass {
+	case "", "traefik":
+		return true
+	default:
+		return false
+	}
+}

--- a/provider/kubernetes/util.go
+++ b/provider/kubernetes/util.go
@@ -1,11 +1,22 @@
 package kubernetes
 
 import (
+	"strings"
+
 	"github.com/containous/traefik/types"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/pkg/util/intstr"
 )
+
+func splitKeyValue(str string) (key, val string) {
+	parts := strings.SplitN(str, "=", 2)
+	key = parts[0]
+	if len(parts) == 2 {
+		val = parts[1]
+	}
+	return
+}
 
 func getRuleForPath(pa v1beta1.HTTPIngressPath, i *v1beta1.Ingress) string {
 	if len(pa.Path) == 0 {

--- a/provider/kubernetes/util.go
+++ b/provider/kubernetes/util.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/client-go/pkg/util/intstr"
 )
 
+// splitKeyValue on first '=' returning a seperate key, value pair
 func splitKeyValue(str string) (key, val string) {
 	parts := strings.SplitN(str, "=", 2)
 	key = parts[0]

--- a/templates/kubernetes.tmpl
+++ b/templates/kubernetes.tmpl
@@ -21,6 +21,8 @@
   backend = "{{$frontend.Backend}}"
   priority = {{$frontend.Priority}}
   passHostHeader = {{$frontend.PassHostHeader}}
+    [frontends."{{$frontendName}}".headers]
+    sslRedirect = {{$frontend.Headers.SSLRedirect}}
   basicAuth = [{{range $frontend.BasicAuth}}
       "{{.}}",
   {{end}}]

--- a/templates/kubernetes.tmpl
+++ b/templates/kubernetes.tmpl
@@ -21,14 +21,17 @@
   backend = "{{$frontend.Backend}}"
   priority = {{$frontend.Priority}}
   passHostHeader = {{$frontend.PassHostHeader}}
-    [frontends."{{$frontendName}}".headers]
-    sslRedirect = {{$frontend.Headers.SSLRedirect}}
   basicAuth = [{{range $frontend.BasicAuth}}
       "{{.}}",
   {{end}}]
   whitelistSourceRange = [{{range $frontend.WhitelistSourceRange}}
     "{{.}}",
   {{end}}]
+    [frontends."{{$frontendName}}".headers]
+    sslRedirect = {{$frontend.Headers.SSLRedirect}}
+    [frontends."{{$frontendName}}".headers.sslProxyHeaders]{{range $key, $val := $frontend.Headers.SSLProxyHeaders}}
+      {{$key}} = "{{$val}}"
+    {{end}}
     {{range $routeName, $route := $frontend.Routes}}
     [frontends."{{$frontendName}}".routes."{{$routeName}}"]
     rule = "{{$route.Rule}}"


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### Description

Provides the ability to set kubernetes provider defaults for SSLRedirect and SSLProxyHeaders with per frontend overrides via annotations on ingress resources. 

Follows k8s ingress annotation convention for SSLRedirect and adds a namespaced SSLProxyHeaders annotation.


<!--
Briefly describe the pull request in a few paragraphs.
-->