### PR TITLE
Modify ETCD tests to remove docker-etcd fork

### DIFF
--- a/integration/etcd_test.go
+++ b/integration/etcd_test.go
@@ -25,8 +25,8 @@ const (
 	ipWhoami03 string = "172.10.1.5"
 	ipWhoami04 string = "172.10.1.6"
 
-	traefikEtcdUrl    string = "http://127.0.0.1:8000/"
-	traefikWebEtcdUrl string = "http://127.0.0.1:8081/"
+	traefikEtcdURL    string = "http://127.0.0.1:8000/"
+	traefikWebEtcdURL string = "http://127.0.0.1:8081/"
 
 	serviceEtcdName string = "etcd"
 )
@@ -84,7 +84,7 @@ func (s *EtcdSuite) TestSimpleConfiguration(c *check.C) {
 
 	// TODO validate : run on 80
 	// Expected a 404 as we did not configure anything
-	err = try.GetRequest(traefikEtcdUrl, 1000*time.Millisecond, try.StatusCodeIs(http.StatusNotFound))
+	err = try.GetRequest(traefikEtcdURL, 1000*time.Millisecond, try.StatusCodeIs(http.StatusNotFound))
 	c.Assert(err, checker.IsNil)
 }
 
@@ -149,11 +149,11 @@ func (s *EtcdSuite) TestNominalConfiguration(c *check.C) {
 	c.Assert(err, checker.IsNil)
 
 	// wait for traefik
-	err = try.GetRequest(traefikWebEtcdUrl+"api/providers", 60*time.Second, try.BodyContains("Path:/test"))
+	err = try.GetRequest(traefikWebEtcdURL+"api/providers", 60*time.Second, try.BodyContains("Path:/test"))
 	c.Assert(err, checker.IsNil)
 
 	client := &http.Client{}
-	req, err := http.NewRequest(http.MethodGet, traefikEtcdUrl, nil)
+	req, err := http.NewRequest(http.MethodGet, traefikEtcdURL, nil)
 	c.Assert(err, checker.IsNil)
 	req.Host = "test.localhost"
 	response, err := client.Do(req)
@@ -168,7 +168,7 @@ func (s *EtcdSuite) TestNominalConfiguration(c *check.C) {
 		c.Fail()
 	}
 
-	req, err = http.NewRequest(http.MethodGet, traefikEtcdUrl+"test", nil)
+	req, err = http.NewRequest(http.MethodGet, traefikEtcdURL+"test", nil)
 	c.Assert(err, checker.IsNil)
 	response, err = client.Do(req)
 
@@ -182,14 +182,14 @@ func (s *EtcdSuite) TestNominalConfiguration(c *check.C) {
 		c.Fail()
 	}
 
-	req, err = http.NewRequest(http.MethodGet, traefikEtcdUrl+"test2", nil)
+	req, err = http.NewRequest(http.MethodGet, traefikEtcdURL+"test2", nil)
 	c.Assert(err, checker.IsNil)
 	req.Host = "test2.localhost"
 	resp, err := client.Do(req)
 	c.Assert(err, checker.IsNil)
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusNotFound)
 
-	resp, err = http.Get(traefikEtcdUrl)
+	resp, err = http.Get(traefikEtcdURL)
 	c.Assert(err, checker.IsNil)
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusNotFound)
 }

--- a/integration/fixtures/etcd/simple.toml
+++ b/integration/fixtures/etcd/simple.toml
@@ -8,7 +8,7 @@ logLevel = "DEBUG"
 
 
 [etcd]
-  endpoint = "{{.EtcdHost}}:2379"
+  endpoint = "172.10.1.2:2379"
   prefix = "/traefik"
   watch = true
 

--- a/integration/resources/compose/etcd.yml
+++ b/integration/resources/compose/etcd.yml
@@ -1,14 +1,62 @@
-etcd:
-  image: containous/docker-etcd
+version: '2'
 
-whoami1:
-  image: emilevauge/whoami
+services:
 
-whoami2:
-  image: emilevauge/whoami
+  etcd:
+    image: quay.io/coreos/etcd:v3.0.10
+    command: /usr/local/bin/etcd -data-dir=/data -listen-peer-urls="http://172.10.1.2:7001,http://172.10.1.2:2380" -listen-client-urls="http://172.10.1.2:4001,http://172.10.1.2:2379" -advertise-client-urls="http://172.10.1.2:4001"
+    expose:
+      - 2380
+      - 2379
+      - 4001
+      - 7001
+    networks:
+      net:
+        ipv4_address: 172.10.1.2
 
-whoami3:
-  image: emilevauge/whoami
+  whoami1:
+    image: emilevauge/whoami
+    # depends_on option activate because libcompose (used by libkermit) does not support fix IP yet...
+    # Remove it ASAP
+    depends_on:
+      - etcd
+    networks:
+      net:
+        ipv4_address: 172.10.1.3
 
-whoami4:
-  image: emilevauge/whoami
+  whoami2:
+    image: emilevauge/whoami
+    # depends_on option activate because libcompose (used by libkermit) does not support fix IP yet...
+    # Remove it ASAP
+    depends_on:
+      - whoami1
+    networks:
+      net:
+        ipv4_address: 172.10.1.4
+
+  whoami3:
+    image: emilevauge/whoami
+    # depends_on option activate because libcompose (used by libkermit) does not support fix IP yet...
+    # Remove it ASAP
+    depends_on:
+      - whoami2
+    networks:
+      net:
+        ipv4_address: 172.10.1.5
+
+  whoami4:
+    image: emilevauge/whoami
+    # depends_on option activate because libcompose (used by libkermit) does not support fix IP yet...
+    # Remove it ASAP
+    depends_on:
+      - whoami3
+    networks:
+      net:
+        ipv4_address: 172.10.1.6
+
+networks:
+  net:
+    driver: bridge
+    ipam:
+     config:
+       - subnet: 172.10.1.0/28


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### Description

<!--
Briefly describe the pull request in a few paragraphs.
-->

The Repository [docker-tecd](https://github.com/containous/docker-etcd) has been created to override the ETCD starting script in the way to know the container IP address before to really start ETCD.
Træfik tests needed its because they didn't support docker-compose api v2.

Since libkermit and libcompose dependencies have been upgraded, it's possible to define networks in a better way (not quite perfect yet but better).

This PR modify the ETCD test by defining the network IP ranges and force the containers starting order in the way to use the ETCD official image.