### PR TITLE
grep to-be-pulled-images directly to avoid newline issue.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ fmt:
 	gofmt -s -l -w $(SRCS)
 
 pull-images:
-	cat ./integration/resources/compose/*.yml | grep -E '^\s+image:' | awk '{print $$2}' | sort | uniq  | xargs -P 6 -n 1 docker pull
+	grep --no-filename -E '^\s+image:' ./integration/resources/compose/*.yml | awk '{print $$2}' | sort | uniq  | xargs -n 1 docker pull
 
 help: ## this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)


### PR DESCRIPTION
The previous implementation of the `pull-images` is susceptible to a hideous formatting bug: If one of the docker-compose files is missing its newline, the cat-grep pipe would merge the grepped image name with the first line of the subsequent YAML file.

For instance, we had the following file with a single whoami image missing a newline:

```yaml
whoami:
  image: emilevauge/whoami
```

The next compose file in order would be `timeout.yml` and start like this:

```yaml
timeoutEndpoint:
  image: yaman/timeout
```

As a result, `make pull-images` would try to pull the image

```
emilevauge/whoamitimeoutEndpoint
```

and fail silently (which is another problem by the way).

Adding the missing newline fixes the problem but doesn't offer protection against this general problem in the future. Luckily, dropping the cat and having grep operate on the files directly prevents the issue while also saving us one unnecessary pipe. (Note that we tell grep to
omit filenames from the result so that filtering out the second column with awk always works regardless of the filename.)