### PR TITLE
fix flakiness in log rotation test

### DIFF
--- a/integration/log_rotation_test.go
+++ b/integration/log_rotation_test.go
@@ -122,9 +122,8 @@ func (s *LogRotationSuite) TestTraefikLogRotation(c *check.C) {
 
 func logAccessLogFile(c *check.C, fileName string) {
 	output, err := ioutil.ReadFile(fileName)
-	c.Assert(err, checker.IsNil, check.Commentf("error opening access log file %s: %s", fileName, err))
-	c.Logf("Contents of file %s", fileName)
-	c.Log(string(output))
+	c.Assert(err, checker.IsNil)
+	c.Logf("Contents of file %s\n%s", fileName, string(output))
 }
 
 func verifyEmptyErrorLog(c *check.C, name string) {

--- a/integration/log_rotation_test.go
+++ b/integration/log_rotation_test.go
@@ -57,10 +57,19 @@ func (s *LogRotationSuite) TestAccessLogRotation(c *check.C) {
 	c.Assert(err, checker.IsNil)
 
 	// Verify access.log.rotated output as expected
+	logAccessLogFile(c, traefikTestAccessLogFile+".rotated")
 	lineCount := verifyLogLines(c, traefikTestAccessLogFile+".rotated", 0, true)
 	c.Assert(lineCount, checker.GreaterOrEqualThan, 1)
 
+	// make sure that the access log file is at least created before we do assertions on it
+	err = try.Do(3*time.Second, func() error {
+		_, err := os.Stat(traefikTestAccessLogFile)
+		return err
+	})
+	c.Assert(err, checker.IsNil, check.Commentf("access log file was not created in time"))
+
 	// Verify access.log output as expected
+	logAccessLogFile(c, traefikTestAccessLogFile)
 	lineCount = verifyLogLines(c, traefikTestAccessLogFile, lineCount, true)
 	c.Assert(lineCount, checker.Equals, 3)
 
@@ -111,6 +120,13 @@ func (s *LogRotationSuite) TestTraefikLogRotation(c *check.C) {
 	c.Assert(lineCount, checker.GreaterOrEqualThan, 7)
 }
 
+func logAccessLogFile(c *check.C, fileName string) {
+	output, err := ioutil.ReadFile(fileName)
+	c.Assert(err, checker.IsNil, check.Commentf("error opening access log file %s: %s", fileName, err))
+	c.Logf("Contents of file %s", fileName)
+	c.Log(string(output))
+}
+
 func verifyEmptyErrorLog(c *check.C, name string) {
 	err := try.Do(5*time.Second, func() error {
 		traefikLog, e2 := ioutil.ReadFile(name)
@@ -130,7 +146,6 @@ func verifyLogLines(c *check.C, fileName string, countInit int, accessLog bool) 
 	count := countInit
 	for rotatedLog.Scan() {
 		line := rotatedLog.Text()
-		c.Log(line)
 		if accessLog {
 			if len(line) > 0 {
 				CheckAccessLogFormat(c, line, count)

--- a/integration/log_rotation_test.go
+++ b/integration/log_rotation_test.go
@@ -62,7 +62,7 @@ func (s *LogRotationSuite) TestAccessLogRotation(c *check.C) {
 	c.Assert(lineCount, checker.GreaterOrEqualThan, 1)
 
 	// make sure that the access log file is at least created before we do assertions on it
-	err = try.Do(3*time.Second, func() error {
+	err = try.Do(1*time.Second, func() error {
 		_, err := os.Stat(traefikTestAccessLogFile)
 		return err
 	})


### PR DESCRIPTION
This PR fixes https://github.com/containous/traefik/issues/2203 by waiting up to 3 seconds until the new log file is created after the signal was sent to Traefik to rotate the log files. Also, it improves logging of the log file output in case something is not correct to ease the detection of potential other problems that were hidden before.