### PR TITLE
enable prefix matching within slash boundaries

### DIFF
--- a/middlewares/stripPrefix.go
+++ b/middlewares/stripPrefix.go
@@ -16,17 +16,9 @@ type StripPrefix struct {
 
 func (s *StripPrefix) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	for _, prefix := range s.Prefixes {
-		origPrefix := strings.TrimSpace(prefix)
-		if origPrefix == r.URL.Path {
-			r.URL.Path = "/"
-			s.serveRequest(w, r, origPrefix)
-			return
-		}
-
-		prefix = strings.TrimSuffix(origPrefix, "/") + "/"
 		if p := strings.TrimPrefix(r.URL.Path, prefix); len(p) < len(r.URL.Path) {
 			r.URL.Path = "/" + strings.TrimPrefix(p, "/")
-			s.serveRequest(w, r, origPrefix)
+			s.serveRequest(w, r, strings.TrimSpace(prefix))
 			return
 		}
 	}

--- a/middlewares/stripPrefix_test.go
+++ b/middlewares/stripPrefix_test.go
@@ -86,6 +86,14 @@ func TestStripPrefix(t *testing.T) {
 			expectedPath:       "/",
 			expectedHeader:     "/stat",
 		},
+		{
+			desc:               "prefix matching within slash boundaries",
+			prefixes:           []string{"/stat"},
+			path:               "/status",
+			expectedStatusCode: http.StatusOK,
+			expectedPath:       "/us",
+			expectedHeader:     "/stat",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This PR enables stripping prefixes not only on slash boundaries but also inside of them. The actual mux routing was always capable of routing within the slash boundaries, only the prefix wasn't stripped properly.

Consider we have a fronted rule like `PathPrefixStrip:/stat` and we are calling Traefik with a Path like `/status`. This would route the request to the frontend/it's connected backends but the path wouldn't be stripped. With the fix provided in this PR it will properly strip and forward a path like `/us`.

While fixing this problem I realized that the `stripPrefix` middleware could actually be simplified while keeping all tests working properly.

As there was no bug-report by any other Traefik users I am unsure whether we still want to bring this into the 1.4 release. Let me know if I should switch PR to master instead.