### PR TITLE
Sanitize cookie names.

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -659,6 +659,13 @@ func TestServerResponseEmptyBackend(t *testing.T) {
 	}
 }
 
+func TestGetCookieName(t *testing.T) {
+	want := "_TRAEFIK_BACKEND__my_BACKEND-v1.0~rc1"
+	if got := getCookieName("/my/BACKEND-v1.0~rc1"); got != want {
+		t.Errorf("got sticky cookie name %q, want %q", got, want)
+	}
+}
+
 func buildDynamicConfig(dynamicConfigBuilders ...func(*types.Configuration)) *types.Configuration {
 	config := &types.Configuration{
 		Frontends: make(map[string]*types.Frontend),


### PR DESCRIPTION
According to [RFC 2616](https://www.ietf.org/rfc/rfc2616.txt) section 2.2 and [this StackOverflow response](https://stackoverflow.com/a/1969339), only a certain subset of characters is permitted in cookie names. Specifically, slashes contained may cause the cookie to not get set by certain browsers.

This change makes sure that the backend name embedded in the cookie name is sanitized accordingly.