### PR TITLE
Updating make run-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ dist:
 
 run-dev:
 	go generate
-	go build
+	go build ./cmd/traefik
 	./traefik
 
 generate-webui: build-webui


### PR DESCRIPTION
### Description

This updates the build instructions in the Makefile to match what is in the documentation.  https://github.com/containous/traefik/blob/master/CONTRIBUTING.md#build-træfik 

In the current state when running `make run-dev` you get back a cryptic error 
```
runtime.main_main·f: relocation target main.main not defined
runtime.main_main·f: undefined: "main.main"
make: *** [run-dev] Error 2 
``` 
 and this fixes that error.
