### PR TITLE
Create dummy main() function in generate.go.

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -3,3 +3,5 @@
 //go:generate go-bindata -pkg autogen -o autogen/gen.go ./static/... ./templates/...
 
 package main
+
+func main() {}


### PR DESCRIPTION
Required to guarantee that `go test ./...` does not fail with

```
runtime.main_main·f: relocation target main.main not defined
runtime.main_main·f: undefined: "main.main"
```