### PR TITLE
Allow custom value for kubernetes.io/ingress.class annotation

### DIFF
--- a/cmd/traefik/anonymize/anonymize_config_test.go
+++ b/cmd/traefik/anonymize/anonymize_config_test.go
@@ -384,6 +384,7 @@ func TestDo_globalConfiguration(t *testing.T) {
 		DisablePassHostHeaders: true,
 		Namespaces:             kubernetes.Namespaces{"k8s Namespaces 1", "k8s Namespaces 2", "k8s Namespaces 3"},
 		LabelSelector:          "k8s LabelSelector",
+		IngressClass:           "traefik",
 	}
 	config.Mesos = &mesos.Provider{
 		BaseProvider: provider.BaseProvider{

--- a/cmd/traefik/anonymize/anonymize_config_test.go
+++ b/cmd/traefik/anonymize/anonymize_config_test.go
@@ -384,7 +384,7 @@ func TestDo_globalConfiguration(t *testing.T) {
 		DisablePassHostHeaders: true,
 		Namespaces:             kubernetes.Namespaces{"k8s Namespaces 1", "k8s Namespaces 2", "k8s Namespaces 3"},
 		LabelSelector:          "k8s LabelSelector",
-		IngressClass:           "traefik",
+		IngressClass:           "",
 	}
 	config.Mesos = &mesos.Provider{
 		BaseProvider: provider.BaseProvider{

--- a/cmd/traefik/anonymize/anonymize_config_test.go
+++ b/cmd/traefik/anonymize/anonymize_config_test.go
@@ -384,7 +384,6 @@ func TestDo_globalConfiguration(t *testing.T) {
 		DisablePassHostHeaders: true,
 		Namespaces:             kubernetes.Namespaces{"k8s Namespaces 1", "k8s Namespaces 2", "k8s Namespaces 3"},
 		LabelSelector:          "k8s LabelSelector",
-		IngressClass:           "",
 	}
 	config.Mesos = &mesos.Provider{
 		BaseProvider: provider.BaseProvider{

--- a/cmd/traefik/configuration.go
+++ b/cmd/traefik/configuration.go
@@ -132,7 +132,7 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 	defaultKubernetes.Watch = true
 	defaultKubernetes.Endpoint = ""
 	defaultKubernetes.LabelSelector = ""
-	defaultKubernetes.IngressClass = "traefik"
+	defaultKubernetes.IngressClass = ""
 	defaultKubernetes.Constraints = types.Constraints{}
 
 	// default Mesos

--- a/cmd/traefik/configuration.go
+++ b/cmd/traefik/configuration.go
@@ -132,6 +132,7 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 	defaultKubernetes.Watch = true
 	defaultKubernetes.Endpoint = ""
 	defaultKubernetes.LabelSelector = ""
+	defaultKubernetes.IngressClass = "traefik"
 	defaultKubernetes.Constraints = types.Constraints{}
 
 	// default Mesos

--- a/cmd/traefik/configuration.go
+++ b/cmd/traefik/configuration.go
@@ -130,9 +130,6 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 	//default Kubernetes
 	var defaultKubernetes kubernetes.Provider
 	defaultKubernetes.Watch = true
-	defaultKubernetes.Endpoint = ""
-	defaultKubernetes.LabelSelector = ""
-	defaultKubernetes.IngressClass = ""
 	defaultKubernetes.Constraints = types.Constraints{}
 
 	// default Mesos

--- a/docs/configuration/backends/kubernetes.md
+++ b/docs/configuration/backends/kubernetes.md
@@ -50,6 +50,15 @@ See also [Kubernetes user guide](/user-guide/kubernetes).
 #
 # labelselector = "A and not B"
 
+# Value of `kubernetes.io/ingress.class` annotation that identify Ingress objects to be processed.
+# Note that Ingress objects with an empty or nonexistent `kubernetes.io/ingress.class` value
+# will also be processed.
+#
+# Optional
+# Default: traefik (process all Ingresses)
+#
+# ingressClass = "custom-proxy"
+
 # Disable PassHost Headers.
 #
 # Optional

--- a/docs/configuration/backends/kubernetes.md
+++ b/docs/configuration/backends/kubernetes.md
@@ -51,14 +51,15 @@ See also [Kubernetes user guide](/user-guide/kubernetes).
 # labelselector = "A and not B"
 
 # Value of `kubernetes.io/ingress.class` annotation that identifies Ingress objects to be processed.
-# Note that Ingress objects with an empty or nonexistent `kubernetes.io/ingress.class` value
-# will also be processed.
-# Note that if `kubernetes.io/ingress.class` annotation  is not empty, only annotations with the prefix `traefik` will be processed.
+# If the parameter is non-empty, only Ingresses containing an annotation with the same value are processed.
+# Otherwise, Ingresses missing the annotation, having an empty value, or the value `traefik` are processed.
+#
+# Note : `ingressClass` option must begin with the "traefik" prefix.
 #
 # Optional
-# Default: empty (process all Ingresses)
+# Default: empty
 #
-# ingressClass = "traefik-custom-proxy"
+# ingressClass = "traefik-internal"
 
 # Disable PassHost Headers.
 #

--- a/docs/configuration/backends/kubernetes.md
+++ b/docs/configuration/backends/kubernetes.md
@@ -50,7 +50,7 @@ See also [Kubernetes user guide](/user-guide/kubernetes).
 #
 # labelselector = "A and not B"
 
-# Value of `kubernetes.io/ingress.class` annotation that identify Ingress objects to be processed.
+# Value of `kubernetes.io/ingress.class` annotation that identifies Ingress objects to be processed.
 # Note that Ingress objects with an empty or nonexistent `kubernetes.io/ingress.class` value
 # will also be processed.
 #

--- a/docs/configuration/backends/kubernetes.md
+++ b/docs/configuration/backends/kubernetes.md
@@ -53,7 +53,7 @@ See also [Kubernetes user guide](/user-guide/kubernetes).
 # Value of `kubernetes.io/ingress.class` annotation that identifies Ingress objects to be processed.
 # Note that Ingress objects with an empty or nonexistent `kubernetes.io/ingress.class` value
 # will also be processed.
-# Note that only annotations with the prefix `traefik` will be processed.
+# Note that if `kubernetes.io/ingress.class` annotation  is not empty, only annotations with the prefix `traefik` will be processed.
 #
 # Optional
 # Default: empty (process all Ingresses)

--- a/docs/configuration/backends/kubernetes.md
+++ b/docs/configuration/backends/kubernetes.md
@@ -53,11 +53,12 @@ See also [Kubernetes user guide](/user-guide/kubernetes).
 # Value of `kubernetes.io/ingress.class` annotation that identifies Ingress objects to be processed.
 # Note that Ingress objects with an empty or nonexistent `kubernetes.io/ingress.class` value
 # will also be processed.
+# Note that only annotations with the prefix `traefik` will be processed.
 #
 # Optional
-# Default: traefik (process all Ingresses)
+# Default: empty (process all Ingresses)
 #
-# ingressClass = "custom-proxy"
+# ingressClass = "traefik-custom-proxy"
 
 # Disable PassHost Headers.
 #

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -79,7 +79,7 @@ func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *s
 
 	// We require that IngressClasses start with `traefik` to reduce chances of
 	// conflict with other Ingress Providers
-	if !strings.HasPrefix(p.IngressClass, "traefik") {
+	if len(p.IngressClass) > 0 && !strings.HasPrefix(p.IngressClass, "traefik") {
 		return fmt.Errorf("kubernetes.io/ingress.class must start with traefik, instead found %s", p.IngressClass)
 	}
 

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -137,8 +137,13 @@ func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *s
 }
 
 func (p *Provider) shouldProcessIngress(ingressClass string) bool {
+	ingressClassRequired := "traefik"
+	if p.IngressClass != "" {
+		ingressClassRequired = p.IngressClass
+	}
+
 	switch ingressClass {
-	case "", p.IngressClass:
+	case "", ingressClassRequired:
 		return true
 	default:
 		return false

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -30,11 +30,8 @@ import (
 var _ provider.Provider = (*Provider)(nil)
 
 const (
-	ruleTypePathPrefix  = "PathPrefix"
-	ruleTypeReplacePath = "ReplacePath"
-)
-
-const (
+	ruleTypePathPrefix         = "PathPrefix"
+	ruleTypeReplacePath        = "ReplacePath"
 	traefikDefaultRealm        = "traefik"
 	traefikDefaultIngressClass = "traefik"
 )

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -142,10 +142,6 @@ func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *s
 	return nil
 }
 
-func (p *Provider) shouldProcessIngress(ingressClass string) bool {
-	return ingressClass == "" || ingressClass == p.IngressClass
-}
-
 func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error) {
 	ingresses := k8sClient.GetIngresses()
 
@@ -460,6 +456,10 @@ func equalPorts(servicePort v1.ServicePort, ingressPort intstr.IntOrString) bool
 		return true
 	}
 	return false
+}
+
+func (p *Provider) shouldProcessIngress(ingressClass string) bool {
+	return ingressClass == "" || ingressClass == p.IngressClass
 }
 
 func getFrontendRedirect(i *v1beta1.Ingress) *types.Redirect {

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -137,12 +137,7 @@ func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *s
 }
 
 func (p *Provider) shouldProcessIngress(ingressClass string) bool {
-	ingressClassRequired := "traefik"
-	if p.IngressClass != "" {
-		ingressClassRequired = p.IngressClass
-	}
-
-	return ingressClass == "" || ingressClass == ingressClassRequired
+	return ingressClass == "" || ingressClass == p.IngressClass
 }
 
 func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error) {

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -77,6 +77,12 @@ func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *s
 		return err
 	}
 
+	// We require that IngressClasses start with `traefik` to reduce chances of
+	// conflict with other Ingress Providers
+	if !strings.HasPrefix(p.IngressClass, "traefik") {
+		return fmt.Errorf("kubernetes.io/ingress.class must start with traefik, instead found %s", p.IngressClass)
+	}
+
 	k8sClient, err := p.newK8sClient()
 	if err != nil {
 		return err

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -142,12 +142,7 @@ func (p *Provider) shouldProcessIngress(ingressClass string) bool {
 		ingressClassRequired = p.IngressClass
 	}
 
-	switch ingressClass {
-	case "", ingressClassRequired:
-		return true
-	default:
-		return false
-	}
+	return ingressClass == "" || ingressClass == ingressClassRequired
 }
 
 func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error) {

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -616,7 +616,7 @@ func TestIngressAnnotations(t *testing.T) {
 		buildIngress(
 			iNamespace("testing"),
 			iAnnotation(annotationKubernetesPreserveHost, "true"),
-			iAnnotation(annotationKubernetesIngressClass, traefikDefaulAnnotationValue),
+			iAnnotation(annotationKubernetesIngressClass, traefikDefaultAnnotationValue),
 			iRules(
 				iRule(
 					iHost("other"),
@@ -626,7 +626,7 @@ func TestIngressAnnotations(t *testing.T) {
 		buildIngress(
 			iNamespace("testing"),
 			iAnnotation(annotationKubernetesPassTLSCert, "true"),
-			iAnnotation(annotationKubernetesIngressClass, traefikDefaulAnnotationValue),
+			iAnnotation(annotationKubernetesIngressClass, traefikDefaultAnnotationValue),
 			iRules(
 				iRule(
 					iHost("other"),
@@ -636,7 +636,7 @@ func TestIngressAnnotations(t *testing.T) {
 		buildIngress(
 			iNamespace("testing"),
 			iAnnotation(annotationKubernetesFrontendEntryPoints, "http,https"),
-			iAnnotation(annotationKubernetesIngressClass, traefikDefaulAnnotationValue),
+			iAnnotation(annotationKubernetesIngressClass, traefikDefaultAnnotationValue),
 			iRules(
 				iRule(
 					iHost("other"),
@@ -655,7 +655,7 @@ func TestIngressAnnotations(t *testing.T) {
 		),
 		buildIngress(
 			iNamespace("testing"),
-			iAnnotation(annotationKubernetesIngressClass, "somethingOtherThanTraefik"),
+			iAnnotation(annotationKubernetesIngressClass, traefikDefaultAnnotationValue+"-other"),
 			iRules(
 				iRule(
 					iHost("herp"),
@@ -664,7 +664,6 @@ func TestIngressAnnotations(t *testing.T) {
 		),
 		buildIngress(
 			iNamespace("testing"),
-			iAnnotation(annotationKubernetesIngressClass, traefikDefaulAnnotationValue),
 			iAnnotation(annotationKubernetesWhitelistSourceRange, "1.1.1.1/24, 1234:abcd::42/32"),
 			iRules(
 				iRule(
@@ -692,7 +691,6 @@ func TestIngressAnnotations(t *testing.T) {
 		),
 		buildIngress(
 			iNamespace("testing"),
-			iAnnotation(annotationKubernetesIngressClass, traefikDefaulAnnotationValue),
 			iAnnotation(annotationKubernetesRedirectEntryPoint, "https"),
 			iRules(
 				iRule(
@@ -806,7 +804,7 @@ rateset:
 		secrets:   secrets,
 		watchChan: watchChan,
 	}
-	provider := Provider{IngressClass: traefikDefaulAnnotationValue}
+	provider := Provider{}
 
 	actual, err := provider.loadIngresses(client)
 	require.NoError(t, err, "error loading ingresses")
@@ -992,6 +990,31 @@ rateset:
 				routes(
 					route("/customheaders", "PathPrefix:/customheaders"),
 					route("custom-headers", "Host:custom-headers")),
+			),
+		),
+	)
+
+	assert.Equal(t, expected, actual)
+
+	provider = Provider{IngressClass: traefikDefaultAnnotationValue + "-other"}
+
+	actual, err = provider.loadIngresses(client)
+	require.NoError(t, err, "error reloading ingresses")
+
+	expected = buildConfiguration(
+		backends(
+			backend("herp/derp",
+				servers(),
+				lbMethod("wrr"),
+			),
+		),
+		frontends(
+			frontend("herp/derp",
+				headers(),
+				passHostHeader(),
+				routes(
+					route("/derp", "PathPrefix:/derp"),
+					route("herp", "Host:herp")),
 			),
 		),
 	)

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -1146,11 +1146,16 @@ func TestIngressClassAnnotation(t *testing.T) {
 		},
 	}
 
-	for _, testCase := range testCases {
-		actual, err := testCase.provider.loadIngresses(client)
-		require.NoError(t, err, "error loading ingresses")
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 
-		assert.Equal(t, testCase.expected, actual)
+			actual, err := test.provider.loadIngresses(client)
+			require.NoError(t, err, "error loading ingresses")
+
+			assert.Equal(t, test.expected, actual)
+		})
 	}
 }
 

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -806,7 +806,7 @@ rateset:
 		secrets:   secrets,
 		watchChan: watchChan,
 	}
-	provider := Provider{}
+	provider := Provider{IngressClass: "traefik"}
 
 	actual, err := provider.loadIngresses(client)
 	require.NoError(t, err, "error loading ingresses")

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -616,7 +616,7 @@ func TestIngressAnnotations(t *testing.T) {
 		buildIngress(
 			iNamespace("testing"),
 			iAnnotation(annotationKubernetesPreserveHost, "true"),
-			iAnnotation(annotationKubernetesIngressClass, "traefik"),
+			iAnnotation(annotationKubernetesIngressClass, traefikDefaulAnnotationValue),
 			iRules(
 				iRule(
 					iHost("other"),
@@ -626,7 +626,7 @@ func TestIngressAnnotations(t *testing.T) {
 		buildIngress(
 			iNamespace("testing"),
 			iAnnotation(annotationKubernetesPassTLSCert, "true"),
-			iAnnotation(annotationKubernetesIngressClass, "traefik"),
+			iAnnotation(annotationKubernetesIngressClass, traefikDefaulAnnotationValue),
 			iRules(
 				iRule(
 					iHost("other"),
@@ -636,7 +636,7 @@ func TestIngressAnnotations(t *testing.T) {
 		buildIngress(
 			iNamespace("testing"),
 			iAnnotation(annotationKubernetesFrontendEntryPoints, "http,https"),
-			iAnnotation(annotationKubernetesIngressClass, "traefik"),
+			iAnnotation(annotationKubernetesIngressClass, traefikDefaulAnnotationValue),
 			iRules(
 				iRule(
 					iHost("other"),
@@ -664,7 +664,7 @@ func TestIngressAnnotations(t *testing.T) {
 		),
 		buildIngress(
 			iNamespace("testing"),
-			iAnnotation(annotationKubernetesIngressClass, "traefik"),
+			iAnnotation(annotationKubernetesIngressClass, traefikDefaulAnnotationValue),
 			iAnnotation(annotationKubernetesWhitelistSourceRange, "1.1.1.1/24, 1234:abcd::42/32"),
 			iRules(
 				iRule(
@@ -692,7 +692,7 @@ func TestIngressAnnotations(t *testing.T) {
 		),
 		buildIngress(
 			iNamespace("testing"),
-			iAnnotation(annotationKubernetesIngressClass, "traefik"),
+			iAnnotation(annotationKubernetesIngressClass, traefikDefaulAnnotationValue),
 			iAnnotation(annotationKubernetesRedirectEntryPoint, "https"),
 			iRules(
 				iRule(
@@ -806,7 +806,7 @@ rateset:
 		secrets:   secrets,
 		watchChan: watchChan,
 	}
-	provider := Provider{IngressClass: "traefik"}
+	provider := Provider{IngressClass: traefikDefaulAnnotationValue}
 
 	actual, err := provider.loadIngresses(client)
 	require.NoError(t, err, "error loading ingresses")


### PR DESCRIPTION
### Description

Allow configuring the values of the `kubernetes.io/ingress.class` annotation
on ingress objects that traefik will process. This is useful when you have
multiple traefik servers in one kubernetes cluster, and you want tight control
over which Ingresses are processed by which servers.

Fixes #2221
