### PR TITLE
Document ways to partition Ingresses in the k8s guide.

### DIFF
--- a/docs/user-guide/kubernetes.md
+++ b/docs/user-guide/kubernetes.md
@@ -686,13 +686,23 @@ If you were to visit `example.com/static` the request would then be passed onto 
     So you could set `disablePassHostHeaders` to `true` in your toml file and then enable passing
     the host header per ingress if you wanted.
 
-## Excluding an ingress from Træfik
+## Partitioning the Ingress object space
 
-You can control which ingress Træfik cares about by using the `kubernetes.io/ingress.class` annotation.
+By default, Træfik processes every Ingress objects it observes. At times, however, it may be desirable to ignore certain objects. The following sub-sections describe common use cases and how they can be handled with Træfik.
 
-By default if the annotation is not set at all Træfik will include the ingress.
-If the annotation is set to anything other than traefik or a blank string Træfik will ignore it.
+### Between Træfik and other Ingress controller implementations
 
+Sometimes Træfik runs along other Ingress controller implementations. One such example is when both Træfik and a cloud provider Ingress controller are active.
+
+The `kubernetes.io/ingress.class` annotation can be attached to any Ingress object in order to control whether Træfik should handle it.
+
+If the annotation is missing, contains an empty value, or the value `traefik`, then the Træfik controller will take responsibility and process the associated Ingress object. If the annotation contains any other value (usually the name of a different Ingress controller), Træfik will ignore the object.
+
+### Between multiple Træfik Deployments
+
+Sometimes multiple Træfik Deployments are supposed to run concurrently. For instance, it is conceivable to have one Deployment deal with internal and another one with external traffic.
+
+For such cases, it is advisable to classify Ingress objects through a label and configure the `labelSelector` option per each Træfik Deployment accordingly. To stick with the internal/external example above, all Ingress objects meant for internal traffic could receive a `traffic-type: internal` label while objects designated for external traffic receive a `traffic-type: external` label. The label selectors on the Træfik Deployments would then be `traffic-type=internal` and `traffic-type=external`, respectively.
 
 ## Production advice
 


### PR DESCRIPTION
Judging from support questions, many users seem to be unclear about the options they have to restrict Traefik to certain types of Ingresses. This Kubernetes guide extension is meant to shine some light on the matter.