### PR TITLE
Fix proxy protocol over TLS

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -618,12 +618,7 @@ func (server *Server) createTLSConfig(entryPointName string, tlsOption *configur
 
 func (server *Server) startServer(serverEntryPoint *serverEntryPoint, globalConfiguration configuration.GlobalConfiguration) {
 	log.Infof("Starting server on %s", serverEntryPoint.httpServer.Addr)
-	var err error
-	if serverEntryPoint.httpServer.TLSConfig != nil {
-		err = serverEntryPoint.httpServer.ServeTLS(serverEntryPoint.listener, "", "")
-	} else {
-		err = serverEntryPoint.httpServer.Serve(serverEntryPoint.listener)
-	}
+	err := serverEntryPoint.httpServer.Serve(serverEntryPoint.listener)
 	if err != nil {
 		log.Error("Error creating server: ", err)
 	}
@@ -650,6 +645,10 @@ func (server *Server) prepareServer(entryPointName string, entryPoint *configura
 	if err != nil {
 		log.Error("Error opening listener ", err)
 		return nil, nil, err
+	}
+
+	if tlsConfig != nil {
+		listener = tls.NewListener(listener, tlsConfig)
 	}
 
 	if entryPoint.ProxyProtocol {


### PR DESCRIPTION
On AWS ELB the proxy protocol header is inside the TLS stream so we
need to deal with TLS first, then read the proxy procol header.

This does break oxy setting X-Forwarded-Proto correctly.
This is because this depends on reading req.TLS, that is
only set up correctly by net.http server based on a type
assertion on the connection. https://golang.org/src/net/http/server.go#L1706

I am not sure about the best way forward here, I am guessing
patching oxy here https://github.com/containous/oxy/blob/master/forward/rewrite.go#L29
is the best option...