### PR TITLE
Remove pod from RBAC rules.

### DIFF
--- a/docs/user-guide/kubernetes.md
+++ b/docs/user-guide/kubernetes.md
@@ -32,7 +32,6 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - pods
       - services
       - endpoints
       - secrets

--- a/examples/k8s/traefik-rbac.yaml
+++ b/examples/k8s/traefik-rbac.yaml
@@ -7,7 +7,6 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - pods
       - services
       - endpoints
       - secrets


### PR DESCRIPTION
The client implementation does not require access to Pods.