### PR TITLE
Quote priority values in annotation examples.

### DIFF
--- a/docs/configuration/backends/kubernetes.md
+++ b/docs/configuration/backends/kubernetes.md
@@ -86,7 +86,7 @@ Annotations can be used on containers to override default behaviour for the whol
 
 - `traefik.frontend.rule.type: PathPrefixStrip`  
     Override the default frontend rule type. Default: `PathPrefix`.
-- `traefik.frontend.priority: 3`  
+- `traefik.frontend.priority: "3"`
     Override the default frontend rule priority.
 
 Annotations can be used on the Kubernetes service to override default behaviour:

--- a/docs/user-guide/kubernetes.md
+++ b/docs/user-guide/kubernetes.md
@@ -590,7 +590,7 @@ kind: Ingress
 metadata:
   name: wildcard-cheeses
   annotations:
-    traefik.frontend.priority: 1
+    traefik.frontend.priority: "1"
 spec:
   rules:
   - host: *.minikube
@@ -605,7 +605,7 @@ kind: Ingress
 metadata:
   name: specific-cheeses
   annotations:
-    traefik.frontend.priority: 2
+    traefik.frontend.priority: "2"
 spec:
   rules:
   - host: specific.minikube
@@ -617,6 +617,7 @@ spec:
           servicePort: http
 ```
 
+Note that priority values must be quoted to avoid them being interpreted as numbers (which are illegal for annotations).
 
 ## Forwarding to ExternalNames
 


### PR DESCRIPTION
Otherwise, they'd be interpreted as numbers and rejected/dropped by the API server since annotations must always be strings.

Refs #2225.