### PR TITLE
Stickiness cookie name

### DIFF
--- a/provider/consul/consul_catalog.go
+++ b/provider/consul/consul_catalog.go
@@ -394,15 +394,16 @@ func (p *CatalogProvider) getBasicAuth(tags []string) []string {
 }
 
 func (p *CatalogProvider) hasStickinessLabel(tags []string) bool {
-	stickiness := p.getTag(types.LabelBackendLoadbalancerStickiness, tags, "")
+	stickinessTag := p.getTag(types.LabelBackendLoadbalancerStickiness, tags, "")
 
-	sticky := p.getTag(types.LabelBackendLoadbalancerSticky, tags, "")
-	if len(sticky) != 0 {
+	stickyTag := p.getTag(types.LabelBackendLoadbalancerSticky, tags, "")
+	if len(stickyTag) > 0 {
 		log.Warn("Deprecated configuration found: %s. Please use %s.", types.LabelBackendLoadbalancerSticky, types.LabelBackendLoadbalancerStickiness)
 	}
 
-	return (len(stickiness) != 0 && strings.EqualFold(strings.TrimSpace(stickiness), "true")) ||
-		(len(sticky) != 0 && strings.EqualFold(strings.TrimSpace(sticky), "true"))
+	stickiness := len(stickinessTag) > 0 && strings.EqualFold(strings.TrimSpace(stickinessTag), "true")
+	sticky := len(stickyTag) > 0 && strings.EqualFold(strings.TrimSpace(stickyTag), "true")
+	return stickiness || sticky
 }
 
 func (p *CatalogProvider) getStickinessCookieName(tags []string) string {

--- a/provider/docker/docker.go
+++ b/provider/docker/docker.go
@@ -275,7 +275,8 @@ func (p *Provider) loadDockerConfig(containersInspected []dockerData) *types.Con
 		"hasMaxConnLabels":            p.hasMaxConnLabels,
 		"getMaxConnAmount":            p.getMaxConnAmount,
 		"getMaxConnExtractorFunc":     p.getMaxConnExtractorFunc,
-		"getSticky":                   p.getSticky,
+		"getStickinessCookieName":     p.getStickinessCookieName,
+		"hasStickinessLabel":          p.hasStickinessLabel,
 		"getIsBackendLBSwarm":         p.getIsBackendLBSwarm,
 		"hasServices":                 p.hasServices,
 		"getServiceNames":             p.getServiceNames,
@@ -328,10 +329,8 @@ func (p *Provider) loadDockerConfig(containersInspected []dockerData) *types.Con
 }
 
 func (p *Provider) hasCircuitBreakerLabel(container dockerData) bool {
-	if _, err := getLabel(container, types.LabelBackendCircuitbreakerExpression); err != nil {
-		return false
-	}
-	return true
+	_, err := getLabel(container, types.LabelBackendCircuitbreakerExpression)
+	return err == nil
 }
 
 // Regexp used to extract the name of the service and the name of the property for this service
@@ -645,11 +644,22 @@ func (p *Provider) getWeight(container dockerData) string {
 	return "0"
 }
 
-func (p *Provider) getSticky(container dockerData) string {
-	if label, err := getLabel(container, types.LabelBackendLoadbalancerSticky); err == nil {
+func (p *Provider) hasStickinessLabel(container dockerData) bool {
+	_, errStickiness := getLabel(container, types.LabelBackendLoadbalancerStickiness)
+
+	label, errSticky := getLabel(container, types.LabelBackendLoadbalancerSticky)
+	if len(label) != 0 {
+		log.Warn("Deprecated configuration found: %s. Please use %s.", types.LabelBackendLoadbalancerSticky, types.LabelBackendLoadbalancerStickiness)
+	}
+
+	return errStickiness == nil || (errSticky == nil && strings.EqualFold(strings.TrimSpace(label), "true"))
+}
+
+func (p *Provider) getStickinessCookieName(container dockerData) string {
+	if label, err := getLabel(container, types.LabelBackendLoadbalancerStickinessCookieName); err == nil {
 		return label
 	}
-	return "false"
+	return ""
 }
 
 func (p *Provider) getIsBackendLBSwarm(container dockerData) string {

--- a/provider/docker/docker.go
+++ b/provider/docker/docker.go
@@ -648,7 +648,7 @@ func (p *Provider) hasStickinessLabel(container dockerData) bool {
 	_, errStickiness := getLabel(container, types.LabelBackendLoadbalancerStickiness)
 
 	label, errSticky := getLabel(container, types.LabelBackendLoadbalancerSticky)
-	if len(label) != 0 {
+	if len(label) > 0 {
 		log.Warn("Deprecated configuration found: %s. Please use %s.", types.LabelBackendLoadbalancerSticky, types.LabelBackendLoadbalancerStickiness)
 	}
 

--- a/provider/dynamodb/dynamodb.go
+++ b/provider/dynamodb/dynamodb.go
@@ -162,12 +162,12 @@ func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *s
 		})
 
 		operation := func() error {
-			aws, err := p.createClient()
+			awsClient, err := p.createClient()
 			if err != nil {
 				return handleCanceled(ctx, err)
 			}
 
-			configuration, err := p.loadDynamoConfig(aws)
+			configuration, err := p.loadDynamoConfig(awsClient)
 			if err != nil {
 				return handleCanceled(ctx, err)
 			}
@@ -184,7 +184,7 @@ func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *s
 					log.Debug("Watching Provider...")
 					select {
 					case <-reload.C:
-						configuration, err := p.loadDynamoConfig(aws)
+						configuration, err := p.loadDynamoConfig(awsClient)
 						if err != nil {
 							return handleCanceled(ctx, err)
 						}

--- a/provider/ecs/ecs.go
+++ b/provider/ecs/ecs.go
@@ -480,22 +480,21 @@ func (p *Provider) getBasicAuth(i ecsInstance) []string {
 
 func getFirstInstanceLabel(instances []ecsInstance, labelName string) string {
 	if len(instances) > 0 {
-		label := instances[0].label(labelName)
-		return label
+		return instances[0].label(labelName)
 	}
 	return ""
 }
 
 func (p *Provider) hasStickinessLabel(instances []ecsInstance) bool {
-	stickiness := getFirstInstanceLabel(instances, types.LabelBackendLoadbalancerStickiness)
+	stickinessLabel := getFirstInstanceLabel(instances, types.LabelBackendLoadbalancerStickiness)
 
-	sticky := getFirstInstanceLabel(instances, types.LabelBackendLoadbalancerSticky)
-	if len(sticky) != 0 {
+	stickyLabel := getFirstInstanceLabel(instances, types.LabelBackendLoadbalancerSticky)
+	if len(stickyLabel) > 0 {
 		log.Warn("Deprecated configuration found: %s. Please use %s.", types.LabelBackendLoadbalancerSticky, types.LabelBackendLoadbalancerStickiness)
 	}
-
-	return (len(stickiness) != 0 && strings.EqualFold(strings.TrimSpace(stickiness), "true")) ||
-		(len(sticky) != 0 && strings.EqualFold(strings.TrimSpace(sticky), "true"))
+	stickiness := len(stickinessLabel) > 0 && strings.EqualFold(strings.TrimSpace(stickinessLabel), "true")
+	sticky := len(stickyLabel) > 0 && strings.EqualFold(strings.TrimSpace(stickyLabel), "true")
+	return stickiness || sticky
 }
 
 func (p *Provider) getStickinessCookieName(instances []ecsInstance) string {

--- a/provider/ecs/ecs.go
+++ b/provider/ecs/ecs.go
@@ -122,12 +122,12 @@ func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *s
 		})
 
 		operation := func() error {
-			aws, err := p.createClient()
+			awsClient, err := p.createClient()
 			if err != nil {
 				return err
 			}
 
-			configuration, err := p.loadECSConfig(ctx, aws)
+			configuration, err := p.loadECSConfig(ctx, awsClient)
 			if err != nil {
 				return handleCanceled(ctx, err)
 			}
@@ -143,7 +143,7 @@ func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *s
 				for {
 					select {
 					case <-reload.C:
-						configuration, err := p.loadECSConfig(ctx, aws)
+						configuration, err := p.loadECSConfig(ctx, awsClient)
 						if err != nil {
 							return handleCanceled(ctx, err)
 						}
@@ -180,11 +180,12 @@ func wrapAws(ctx context.Context, req *request.Request) error {
 
 func (p *Provider) loadECSConfig(ctx context.Context, client *awsClient) (*types.Configuration, error) {
 	var ecsFuncMap = template.FuncMap{
-		"filterFrontends":       p.filterFrontends,
-		"getFrontendRule":       p.getFrontendRule,
-		"getBasicAuth":          p.getBasicAuth,
-		"getLoadBalancerSticky": p.getLoadBalancerSticky,
-		"getLoadBalancerMethod": p.getLoadBalancerMethod,
+		"filterFrontends":         p.filterFrontends,
+		"getFrontendRule":         p.getFrontendRule,
+		"getBasicAuth":            p.getBasicAuth,
+		"getLoadBalancerMethod":   p.getLoadBalancerMethod,
+		"hasStickinessLabel":      p.hasStickinessLabel,
+		"getStickinessCookieName": p.getStickinessCookieName,
 	}
 
 	instances, err := p.listInstances(ctx, client)
@@ -477,14 +478,28 @@ func (p *Provider) getBasicAuth(i ecsInstance) []string {
 	return []string{}
 }
 
-func (p *Provider) getLoadBalancerSticky(instances []ecsInstance) string {
+func getFirstInstanceLabel(instances []ecsInstance, labelName string) string {
 	if len(instances) > 0 {
-		label := instances[0].label(types.LabelBackendLoadbalancerSticky)
-		if label != "" {
-			return label
-		}
+		label := instances[0].label(labelName)
+		return label
 	}
-	return "false"
+	return ""
+}
+
+func (p *Provider) hasStickinessLabel(instances []ecsInstance) bool {
+	stickiness := getFirstInstanceLabel(instances, types.LabelBackendLoadbalancerStickiness)
+
+	sticky := getFirstInstanceLabel(instances, types.LabelBackendLoadbalancerSticky)
+	if len(sticky) != 0 {
+		log.Warn("Deprecated configuration found: %s. Please use %s.", types.LabelBackendLoadbalancerSticky, types.LabelBackendLoadbalancerStickiness)
+	}
+
+	return (len(stickiness) != 0 && strings.EqualFold(strings.TrimSpace(stickiness), "true")) ||
+		(len(sticky) != 0 && strings.EqualFold(strings.TrimSpace(sticky), "true"))
+}
+
+func (p *Provider) getStickinessCookieName(instances []ecsInstance) string {
+	return getFirstInstanceLabel(instances, types.LabelBackendLoadbalancerStickinessCookieName)
 }
 
 func (p *Provider) getLoadBalancerMethod(instances []ecsInstance) string {

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -18,6 +18,7 @@ import (
 	"github.com/containous/traefik/log"
 	"github.com/containous/traefik/provider"
 	"github.com/containous/traefik/safe"
+	"github.com/containous/traefik/server/cookie"
 	"github.com/containous/traefik/types"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
@@ -160,7 +161,6 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 					templateObjects.Backends[r.Host+pa.Path] = &types.Backend{
 						Servers: make(map[string]types.Server),
 						LoadBalancer: &types.LoadBalancer{
-							Sticky: false,
 							Method: "wrr",
 						},
 					}
@@ -247,8 +247,14 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 					templateObjects.Backends[r.Host+pa.Path].LoadBalancer.Method = "drr"
 				}
 
-				if service.Annotations[types.LabelBackendLoadbalancerSticky] == "true" {
-					templateObjects.Backends[r.Host+pa.Path].LoadBalancer.Sticky = true
+				if len(service.Annotations[types.LabelBackendLoadbalancerSticky]) != 0 {
+					log.Warn("Deprecated configuration found: %s. Please use %s.", types.LabelBackendLoadbalancerSticky, types.LabelBackendLoadbalancerStickiness)
+				}
+
+				if service.Annotations[types.LabelBackendLoadbalancerSticky] == "true" || service.Annotations[types.LabelBackendLoadbalancerStickiness] == "true" {
+					templateObjects.Backends[r.Host+pa.Path].LoadBalancer.Stickiness = &types.Stickiness{
+						CookieName: cookie.GenerateName(r.Host + pa.Path),
+					}
 				}
 
 				protocol := "http"

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -247,7 +247,7 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 					templateObjects.Backends[r.Host+pa.Path].LoadBalancer.Method = "drr"
 				}
 
-				if len(service.Annotations[types.LabelBackendLoadbalancerSticky]) != 0 {
+				if len(service.Annotations[types.LabelBackendLoadbalancerSticky]) > 0 {
 					log.Warn("Deprecated configuration found: %s. Please use %s.", types.LabelBackendLoadbalancerSticky, types.LabelBackendLoadbalancerStickiness)
 				}
 

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -243,7 +243,6 @@ func TestLoadIngresses(t *testing.T) {
 				},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -256,7 +255,6 @@ func TestLoadIngresses(t *testing.T) {
 				},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -273,7 +271,6 @@ func TestLoadIngresses(t *testing.T) {
 				},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -489,7 +486,6 @@ func TestGetPassHostHeader(t *testing.T) {
 				Servers:        map[string]types.Server{},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -591,7 +587,6 @@ func TestOnlyReferencesServicesFromOwnNamespace(t *testing.T) {
 				Servers:        map[string]types.Server{},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -771,7 +766,6 @@ func TestLoadNamespacedIngresses(t *testing.T) {
 				Servers:        map[string]types.Server{},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -779,7 +773,6 @@ func TestLoadNamespacedIngresses(t *testing.T) {
 				Servers:        map[string]types.Server{},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -996,7 +989,6 @@ func TestLoadMultipleNamespacedIngresses(t *testing.T) {
 				Servers:        map[string]types.Server{},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -1004,7 +996,6 @@ func TestLoadMultipleNamespacedIngresses(t *testing.T) {
 				Servers:        map[string]types.Server{},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -1012,7 +1003,6 @@ func TestLoadMultipleNamespacedIngresses(t *testing.T) {
 				Servers:        map[string]types.Server{},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -1118,7 +1108,6 @@ func TestHostlessIngress(t *testing.T) {
 				Servers:        map[string]types.Server{},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -1320,7 +1309,6 @@ func TestServiceAnnotations(t *testing.T) {
 				},
 				LoadBalancer: &types.LoadBalancer{
 					Method: "drr",
-					Sticky: false,
 				},
 			},
 			"bar": {
@@ -1337,7 +1325,9 @@ func TestServiceAnnotations(t *testing.T) {
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
 					Method: "wrr",
-					Sticky: true,
+					Stickiness: &types.Stickiness{
+						CookieName: "_4155f",
+					},
 				},
 			},
 		},
@@ -1601,7 +1591,6 @@ func TestIngressAnnotations(t *testing.T) {
 				},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -1614,7 +1603,6 @@ func TestIngressAnnotations(t *testing.T) {
 				},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -1627,7 +1615,6 @@ func TestIngressAnnotations(t *testing.T) {
 				},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -1640,7 +1627,6 @@ func TestIngressAnnotations(t *testing.T) {
 				},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -1653,7 +1639,6 @@ func TestIngressAnnotations(t *testing.T) {
 				},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -1807,7 +1792,6 @@ func TestPriorityHeaderValue(t *testing.T) {
 				},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -1909,7 +1893,6 @@ func TestInvalidPassHostHeaderValue(t *testing.T) {
 				},
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
-					Sticky: false,
 					Method: "wrr",
 				},
 			},
@@ -2192,14 +2175,12 @@ func TestMissingResources(t *testing.T) {
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
 					Method: "wrr",
-					Sticky: false,
 				},
 			},
 			"missing_service": {
 				Servers: map[string]types.Server{},
 				LoadBalancer: &types.LoadBalancer{
 					Method: "wrr",
-					Sticky: false,
 				},
 			},
 			"missing_endpoints": {
@@ -2207,7 +2188,6 @@ func TestMissingResources(t *testing.T) {
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
 					Method: "wrr",
-					Sticky: false,
 				},
 			},
 			"missing_endpoint_subsets": {
@@ -2215,7 +2195,6 @@ func TestMissingResources(t *testing.T) {
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
 					Method: "wrr",
-					Sticky: false,
 				},
 			},
 		},

--- a/provider/kv/kv.go
+++ b/provider/kv/kv.go
@@ -139,11 +139,13 @@ func (p *Provider) loadConfig() *types.Configuration {
 	}
 
 	var KvFuncMap = template.FuncMap{
-		"List":        p.list,
-		"ListServers": p.listServers,
-		"Get":         p.get,
-		"SplitGet":    p.splitGet,
-		"Last":        p.last,
+		"List":                    p.list,
+		"ListServers":             p.listServers,
+		"Get":                     p.get,
+		"SplitGet":                p.splitGet,
+		"Last":                    p.last,
+		"hasStickinessLabel":      p.hasStickinessLabel,
+		"getStickinessCookieName": p.getStickinessCookieName,
 	}
 
 	configuration, err := p.GetConfiguration("templates/kv.tmpl", KvFuncMap, templateObjects)
@@ -238,4 +240,18 @@ func (p *Provider) checkConstraints(keys ...string) bool {
 		return false
 	}
 	return true
+}
+
+func (p *Provider) hasStickinessLabel(rootPath string) bool {
+	stickiness, err := p.kvclient.Exists(rootPath + "/loadbalancer/stickiness")
+	if err != nil {
+		log.Debugf("Error occurs when check stickiness: %v", err)
+	}
+	sticky := p.get("false", rootPath, "/loadbalancer", "/sticky")
+
+	return stickiness || (len(sticky) != 0 && strings.EqualFold(strings.TrimSpace(sticky), "true"))
+}
+
+func (p *Provider) getStickinessCookieName(rootPath string) string {
+	return p.get("", rootPath, "/loadbalancer", "/stickiness", "/cookiename")
 }

--- a/provider/marathon/marathon.go
+++ b/provider/marathon/marathon.go
@@ -433,7 +433,7 @@ func (p *Provider) hasStickinessLabel(application marathon.Application) bool {
 	_, okStickiness := p.getAppLabel(application, types.LabelBackendLoadbalancerStickiness)
 
 	label, okSticky := p.getAppLabel(application, types.LabelBackendLoadbalancerSticky)
-	if len(label) != 0 {
+	if len(label) > 0 {
 		log.Warn("Deprecated configuration found: %s. Please use %s.", types.LabelBackendLoadbalancerSticky, types.LabelBackendLoadbalancerStickiness)
 	}
 

--- a/provider/marathon/marathon.go
+++ b/provider/marathon/marathon.go
@@ -188,7 +188,8 @@ func (p *Provider) loadMarathonConfig() *types.Configuration {
 		"getMaxConnAmount":            p.getMaxConnAmount,
 		"getLoadBalancerMethod":       p.getLoadBalancerMethod,
 		"getCircuitBreakerExpression": p.getCircuitBreakerExpression,
-		"getSticky":                   p.getSticky,
+		"getStickinessCookieName":     p.getStickinessCookieName,
+		"hasStickinessLabel":          p.hasStickinessLabel,
 		"hasHealthCheckLabels":        p.hasHealthCheckLabels,
 		"getHealthCheckPath":          p.getHealthCheckPath,
 		"getHealthCheckInterval":      p.getHealthCheckInterval,
@@ -428,11 +429,22 @@ func (p *Provider) getProtocol(application marathon.Application, serviceName str
 	return "http"
 }
 
-func (p *Provider) getSticky(application marathon.Application) string {
-	if sticky, ok := p.getAppLabel(application, types.LabelBackendLoadbalancerSticky); ok {
-		return sticky
+func (p *Provider) hasStickinessLabel(application marathon.Application) bool {
+	_, okStickiness := p.getAppLabel(application, types.LabelBackendLoadbalancerStickiness)
+
+	label, okSticky := p.getAppLabel(application, types.LabelBackendLoadbalancerSticky)
+	if len(label) != 0 {
+		log.Warn("Deprecated configuration found: %s. Please use %s.", types.LabelBackendLoadbalancerSticky, types.LabelBackendLoadbalancerStickiness)
 	}
-	return "false"
+
+	return okStickiness || (okSticky && strings.EqualFold(strings.TrimSpace(label), "true"))
+}
+
+func (p *Provider) getStickinessCookieName(application marathon.Application) string {
+	if label, ok := p.getAppLabel(application, types.LabelBackendLoadbalancerStickinessCookieName); ok {
+		return label
+	}
+	return ""
 }
 
 func (p *Provider) getPassHostHeader(application marathon.Application, serviceName string) string {

--- a/provider/marathon/marathon_test.go
+++ b/provider/marathon/marathon_test.go
@@ -855,21 +855,36 @@ func TestMarathonGetProtocol(t *testing.T) {
 	}
 }
 
-func TestMarathonGetSticky(t *testing.T) {
+func TestMarathonHasStickinessLabel(t *testing.T) {
 	cases := []struct {
 		desc        string
 		application marathon.Application
-		expected    string
+		expected    bool
 	}{
 		{
 			desc:        "label missing",
 			application: application(),
-			expected:    "false",
+			expected:    false,
 		},
 		{
-			desc:        "label existing",
+			desc:        "label existing and value equals true (deprecated)",
 			application: application(label(types.LabelBackendLoadbalancerSticky, "true")),
-			expected:    "true",
+			expected:    true,
+		},
+		{
+			desc:        "label existing and value equals false (deprecated)",
+			application: application(label(types.LabelBackendLoadbalancerSticky, "false")),
+			expected:    false,
+		},
+		{
+			desc:        "label existing and value equals true",
+			application: application(label(types.LabelBackendLoadbalancerStickiness, "true")),
+			expected:    true,
+		},
+		{
+			desc:        "label existing and value equals false ",
+			application: application(label(types.LabelBackendLoadbalancerStickiness, "true")),
+			expected:    true,
 		},
 	}
 
@@ -878,7 +893,7 @@ func TestMarathonGetSticky(t *testing.T) {
 		t.Run(c.desc, func(t *testing.T) {
 			t.Parallel()
 			provider := &Provider{}
-			actual := provider.getSticky(c.application)
+			actual := provider.hasStickinessLabel(c.application)
 			if actual != c.expected {
 				t.Errorf("actual %q, expected %q", actual, c.expected)
 			}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -34,7 +34,7 @@ type BaseProvider struct {
 // MatchConstraints must match with EVERY single contraint
 // returns first constraint that do not match or nil
 func (p *BaseProvider) MatchConstraints(tags []string) (bool, *types.Constraint) {
-	// if there is no tags and no contraints, filtering is disabled
+	// if there is no tags and no constraints, filtering is disabled
 	if len(tags) == 0 && len(p.Constraints) == 0 {
 		return true, nil
 	}

--- a/provider/rancher/rancher.go
+++ b/provider/rancher/rancher.go
@@ -116,7 +116,7 @@ func (p *Provider) hasStickinessLabel(service rancherData) bool {
 	_, errStickiness := getServiceLabel(service, types.LabelBackendLoadbalancerStickiness)
 
 	label, errSticky := getServiceLabel(service, types.LabelBackendLoadbalancerSticky)
-	if len(label) != 0 {
+	if len(label) > 0 {
 		log.Warn("Deprecated configuration found: %s. Please use %s.", types.LabelBackendLoadbalancerSticky, types.LabelBackendLoadbalancerStickiness)
 	}
 

--- a/provider/rancher/rancher.go
+++ b/provider/rancher/rancher.go
@@ -112,11 +112,22 @@ func (p *Provider) getCircuitBreakerExpression(service rancherData) string {
 	return "NetworkErrorRatio() > 1"
 }
 
-func (p *Provider) getSticky(service rancherData) string {
-	if _, err := getServiceLabel(service, types.LabelBackendLoadbalancerSticky); err == nil {
-		return "true"
+func (p *Provider) hasStickinessLabel(service rancherData) bool {
+	_, errStickiness := getServiceLabel(service, types.LabelBackendLoadbalancerStickiness)
+
+	label, errSticky := getServiceLabel(service, types.LabelBackendLoadbalancerSticky)
+	if len(label) != 0 {
+		log.Warn("Deprecated configuration found: %s. Please use %s.", types.LabelBackendLoadbalancerSticky, types.LabelBackendLoadbalancerStickiness)
 	}
-	return "false"
+
+	return errStickiness == nil || (errSticky == nil && strings.EqualFold(strings.TrimSpace(label), "true"))
+}
+
+func (p *Provider) getStickinessCookieName(service rancherData, backendName string) string {
+	if label, err := getServiceLabel(service, types.LabelBackendLoadbalancerStickinessCookieName); err == nil {
+		return label
+	}
+	return ""
 }
 
 func (p *Provider) getBackend(service rancherData) string {
@@ -222,7 +233,8 @@ func (p *Provider) loadRancherConfig(services []rancherData) *types.Configuratio
 		"hasMaxConnLabels":            p.hasMaxConnLabels,
 		"getMaxConnAmount":            p.getMaxConnAmount,
 		"getMaxConnExtractorFunc":     p.getMaxConnExtractorFunc,
-		"getSticky":                   p.getSticky,
+		"hasStickinessLabel":          p.hasStickinessLabel,
+		"getStickinessCookieName":     p.getStickinessCookieName,
 	}
 
 	// filter services

--- a/server/cookie/cookie.go
+++ b/server/cookie/cookie.go
@@ -1,0 +1,57 @@
+package cookie
+
+import (
+	"crypto/sha1"
+	"fmt"
+	"strings"
+
+	"github.com/containous/traefik/log"
+)
+
+const cookieNameLength = 6
+
+// GetName of a cookie
+func GetName(cookieName string, backendName string) string {
+	if len(cookieName) != 0 {
+		return sanitizeName(cookieName)
+	}
+
+	return GenerateName(backendName)
+}
+
+// GenerateName Generate a hashed name
+func GenerateName(backendName string) string {
+	data := []byte("_TRAEFIK_BACKEND_" + backendName)
+
+	hash := sha1.New()
+	_, err := hash.Write(data)
+	if err != nil {
+		// Impossible case
+		log.Errorf("Fail to create cookie name: %v", err)
+	}
+
+	return fmt.Sprintf("_%x", hash.Sum(nil))[:cookieNameLength]
+}
+
+// sanitizeName According to [RFC 2616](https://www.ietf.org/rfc/rfc2616.txt) section 2.2
+func sanitizeName(backend string) string {
+	sanitizer := func(r rune) rune {
+		switch r {
+		case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '`', '|', '~':
+			return r
+		}
+
+		switch {
+		case 'a' <= r && r <= 'z':
+			fallthrough
+		case 'A' <= r && r <= 'Z':
+			fallthrough
+		case '0' <= r && r <= '9':
+			return r
+		default:
+			return '_'
+		}
+	}
+
+	return strings.Map(sanitizer, backend)
+}

--- a/server/cookie/cookie_test.go
+++ b/server/cookie/cookie_test.go
@@ -1,0 +1,83 @@
+package cookie
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetName(t *testing.T) {
+	testCases := []struct {
+		desc               string
+		cookieName         string
+		backendName        string
+		expectedCookieName string
+	}{
+		{
+			desc:               "with backend name, without cookie name",
+			cookieName:         "",
+			backendName:        "/my/BACKEND-v1.0~rc1",
+			expectedCookieName: "_5f7bc",
+		},
+		{
+			desc:               "without backend name, with cookie name",
+			cookieName:         "/my/BACKEND-v1.0~rc1",
+			backendName:        "",
+			expectedCookieName: "_my_BACKEND-v1.0~rc1",
+		},
+		{
+			desc:               "with backend name, with cookie name",
+			cookieName:         "containous",
+			backendName:        "treafik",
+			expectedCookieName: "containous",
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			cookieName := GetName(test.cookieName, test.backendName)
+
+			assert.Equal(t, test.expectedCookieName, cookieName)
+		})
+	}
+}
+
+func Test_sanitizeName(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		srcName      string
+		expectedName string
+	}{
+		{
+			desc:         "with /",
+			srcName:      "/my/BACKEND-v1.0~rc1",
+			expectedName: "_my_BACKEND-v1.0~rc1",
+		},
+		{
+			desc:         "some chars",
+			srcName:      "!#$%&'()*+-./:<=>?@[]^_`{|}~",
+			expectedName: "!#$%&'__*+-._________^_`_|_~",
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			cookieName := sanitizeName(test.srcName)
+
+			assert.Equal(t, test.expectedName, cookieName, "Cookie name")
+		})
+	}
+}
+
+func TestGenerateName(t *testing.T) {
+	cookieName := GenerateName("containous")
+
+	assert.Len(t, "_8a7bc", 6)
+	assert.Equal(t, "_8a7bc", cookieName)
+}

--- a/templates/consul_catalog.tmpl
+++ b/templates/consul_catalog.tmpl
@@ -17,8 +17,12 @@
   {{end}}
 
   [backends."backend-{{$service}}".loadbalancer]
-    sticky = {{getAttribute "backend.loadbalancer.sticky" .Attributes "false"}}
     method = "{{getAttribute "backend.loadbalancer" .Attributes "wrr"}}"
+    sticky = {{getAttribute "backend.loadbalancer.sticky" .Attributes "false"}}
+    {{if hasStickinessLabel .Attributes}}
+    [Backends."backend-{{$service}}".LoadBalancer.Stickiness]
+      cookieName = {{getStickinessCookieName .Attributes}}
+    {{end}}
 
   {{if hasMaxconnAttributes .Attributes}}
   [backends."backend-{{$service}}".maxconn]

--- a/templates/docker.tmpl
+++ b/templates/docker.tmpl
@@ -8,7 +8,10 @@
     {{if hasLoadBalancerLabel $backend}}
     [backends.backend-{{$backendName}}.loadbalancer]
       method = "{{getLoadBalancerMethod $backend}}"
-      sticky = {{getSticky $backend}}
+      {{if hasStickinessLabel $backend}}
+      [Backends."{{$backendName}}".LoadBalancer.Stickiness]
+        cookieName = {{getStickinessCookieName $backend}}
+      {{end}}
     {{end}}
 
     {{if hasMaxConnLabels $backend}}

--- a/templates/ecs.tmpl
+++ b/templates/ecs.tmpl
@@ -1,7 +1,10 @@
 [backends]{{range $serviceName, $instances := .Services}}
   [backends.backend-{{ $serviceName }}.loadbalancer]
-    sticky = {{ getLoadBalancerSticky $instances}}
     method = "{{ getLoadBalancerMethod $instances}}"
+    {{if hasStickinessLabel $instances}} 
+    [Backends.backend-{{ $serviceName }}.LoadBalancer.Stickiness]
+      cookieName = {{getStickinessCookieName $instances}}
+    {{end}}
 
   {{range $index, $i := $instances}}
     [backends.backend-{{ $i.Name }}.servers.server-{{ $i.Name }}{{ $i.ID }}]

--- a/templates/kubernetes.tmpl
+++ b/templates/kubernetes.tmpl
@@ -6,8 +6,9 @@
     {{end}}
     [backends."{{$backendName}}".loadbalancer]
       method = "{{$backend.LoadBalancer.Method}}"
-      {{if $backend.LoadBalancer.Sticky}}
-          sticky = true
+      {{if $backend.LoadBalancer.Stickiness}}
+      [Backends."{{$backendName}}".LoadBalancer.Stickiness]
+        cookieName = {{$backend.LoadBalancer.Stickiness.CookieName}}
       {{end}}
     {{range $serverName, $server := $backend.Servers}}
     [backends."{{$backendName}}".servers."{{$serverName}}"]

--- a/templates/kv.tmpl
+++ b/templates/kv.tmpl
@@ -3,25 +3,29 @@
 
 [backends]{{range $backends}}
 {{$backend := .}}
+{{$backendName := Last $backend}}
 {{$servers := ListServers $backend }}
 
 {{$circuitBreaker := Get "" . "/circuitbreaker/" "expression"}}
 {{with $circuitBreaker}}
-[backends."{{Last $backend}}".circuitBreaker]
+[backends."{{$backendName}}".circuitBreaker]
     expression = "{{$circuitBreaker}}"
 {{end}}
 
 {{$loadBalancer := Get "" . "/loadbalancer/" "method"}}
-{{$sticky := Get "false" . "/loadbalancer/" "sticky"}}
 {{with $loadBalancer}}
-[backends."{{Last $backend}}".loadBalancer]
+[backends."{{$backendName}}".loadBalancer]
     method = "{{$loadBalancer}}"
-    sticky = {{$sticky}}
+    sticky = {{ Get "false" . "/loadbalancer/" "sticky" }}
+    {{if hasStickinessLabel $backend}}
+    [Backends."{{$backendName}}".LoadBalancer.Stickiness]
+      cookieName = {{getStickinessCookieName $backend}}
+    {{end}}
 {{end}}
 
 {{$healthCheck := Get "" . "/healthcheck/" "path"}}
 {{with $healthCheck}}
-[backends."{{Last $backend}}".healthCheck]
+[backends."{{$backendName}}".healthCheck]
     path = "{{$healthCheck}}"
     interval = "{{ Get "30s" $backend "/healthcheck/" "interval" }}"
 {{end}}
@@ -30,14 +34,14 @@
 {{$maxConnExtractorFunc := Get "" . "/maxconn/" "extractorfunc"}}
 {{with $maxConnAmt}}
 {{with $maxConnExtractorFunc}}
-[backends."{{Last $backend}}".maxConn]
+[backends."{{$backendName}}".maxConn]
     amount = {{$maxConnAmt}}
     extractorFunc = "{{$maxConnExtractorFunc}}"
 {{end}}
 {{end}}
 
 {{range $servers}}
-[backends."{{Last $backend}}".servers."{{Last .}}"]
+[backends."{{$backendName}}".servers."{{Last .}}"]
     url = "{{Get "" . "/url"}}"
     weight = {{Get "0"  . "/weight"}}
 {{end}}

--- a/templates/marathon.tmpl
+++ b/templates/marathon.tmpl
@@ -20,7 +20,10 @@
 {{ if hasLoadBalancerLabels $app }}
       [backends."backend{{getBackend $app $serviceName }}".loadbalancer]
         method = "{{getLoadBalancerMethod $app }}"
-        sticky = {{getSticky $app}}
+        {{if hasStickinessLabel $app}}
+        [Backends."backend{{getBackend $app $serviceName }}".LoadBalancer.Stickiness]
+          cookieName = {{getStickinessCookieName $app}}
+        {{end}}
 {{end}}
 {{ if hasCircuitBreakerLabels $app }}
       [backends."backend{{getBackend $app $serviceName }}".circuitbreaker]

--- a/templates/rancher.tmpl
+++ b/templates/rancher.tmpl
@@ -8,7 +8,10 @@
     {{if hasLoadBalancerLabel $backend}}
     [backends.backend-{{$backendName}}.loadbalancer]
       method = "{{getLoadBalancerMethod $backend}}"
-      sticky = {{getSticky $backend}}
+      {{if hasStickinessLabel $backend}}
+      [Backends."{{$backendName}}".LoadBalancer.Stickiness]
+        cookieName = {{getStickinessCookieName $backend}}
+      {{end}}
     {{end}}
 
     {{if hasMaxConnLabels $backend}}

--- a/types/common_label.go
+++ b/types/common_label.go
@@ -2,59 +2,36 @@ package types
 
 import "strings"
 
+// Traefik labels
 const (
-	// LabelPrefix Traefik label
-	LabelPrefix = "traefik."
-	// LabelDomain Traefik label
-	LabelDomain = LabelPrefix + "domain"
-	// LabelEnable Traefik label
-	LabelEnable = LabelPrefix + "enable"
-	// LabelPort Traefik label
-	LabelPort = LabelPrefix + "port"
-	// LabelPortIndex Traefik label
-	LabelPortIndex = LabelPrefix + "portIndex"
-	// LabelProtocol Traefik label
-	LabelProtocol = LabelPrefix + "protocol"
-	// LabelTags Traefik label
-	LabelTags = LabelPrefix + "tags"
-	// LabelWeight Traefik label
-	LabelWeight = LabelPrefix + "weight"
-	// LabelFrontendAuthBasic Traefik label
-	LabelFrontendAuthBasic = LabelPrefix + "frontend.auth.basic"
-	// LabelFrontendEntryPoints Traefik label
-	LabelFrontendEntryPoints = LabelPrefix + "frontend.entryPoints"
-	// LabelFrontendPassHostHeader Traefik label
-	LabelFrontendPassHostHeader = LabelPrefix + "frontend.passHostHeader"
-	// LabelFrontendPriority Traefik label
-	LabelFrontendPriority = LabelPrefix + "frontend.priority"
-	// LabelFrontendRule Traefik label
-	LabelFrontendRule = LabelPrefix + "frontend.rule"
-	// LabelFrontendRuleType Traefik label
-	LabelFrontendRuleType = LabelPrefix + "frontend.rule.type"
-	// LabelTraefikFrontendValue Traefik label
-	LabelTraefikFrontendValue = LabelPrefix + "frontend.value"
-	// LabelTraefikFrontendWhitelistSourceRange Traefik label
-	LabelTraefikFrontendWhitelistSourceRange = LabelPrefix + "frontend.whitelistSourceRange"
-	// LabelBackend Traefik label
-	LabelBackend = LabelPrefix + "backend"
-	// LabelBackendID Traefik label
-	LabelBackendID = LabelPrefix + "backend.id"
-	// LabelTraefikBackendCircuitbreaker Traefik label
-	LabelTraefikBackendCircuitbreaker = LabelPrefix + "backend.circuitbreaker"
-	// LabelBackendCircuitbreakerExpression Traefik label
-	LabelBackendCircuitbreakerExpression = LabelPrefix + "backend.circuitbreaker.expression"
-	// LabelBackendHealthcheckPath Traefik label
-	LabelBackendHealthcheckPath = LabelPrefix + "backend.healthcheck.path"
-	// LabelBackendHealthcheckInterval Traefik label
-	LabelBackendHealthcheckInterval = LabelPrefix + "backend.healthcheck.interval"
-	// LabelBackendLoadbalancerMethod Traefik label
-	LabelBackendLoadbalancerMethod = LabelPrefix + "backend.loadbalancer.method"
-	// LabelBackendLoadbalancerSticky Traefik label
-	LabelBackendLoadbalancerSticky = LabelPrefix + "backend.loadbalancer.sticky"
-	// LabelBackendMaxconnAmount Traefik label
-	LabelBackendMaxconnAmount = LabelPrefix + "backend.maxconn.amount"
-	// LabelBackendMaxconnExtractorfunc Traefik label
-	LabelBackendMaxconnExtractorfunc = LabelPrefix + "backend.maxconn.extractorfunc"
+	LabelPrefix                                  = "traefik."
+	LabelDomain                                  = LabelPrefix + "domain"
+	LabelEnable                                  = LabelPrefix + "enable"
+	LabelPort                                    = LabelPrefix + "port"
+	LabelPortIndex                               = LabelPrefix + "portIndex"
+	LabelProtocol                                = LabelPrefix + "protocol"
+	LabelTags                                    = LabelPrefix + "tags"
+	LabelWeight                                  = LabelPrefix + "weight"
+	LabelFrontendAuthBasic                       = LabelPrefix + "frontend.auth.basic"
+	LabelFrontendEntryPoints                     = LabelPrefix + "frontend.entryPoints"
+	LabelFrontendPassHostHeader                  = LabelPrefix + "frontend.passHostHeader"
+	LabelFrontendPriority                        = LabelPrefix + "frontend.priority"
+	LabelFrontendRule                            = LabelPrefix + "frontend.rule"
+	LabelFrontendRuleType                        = LabelPrefix + "frontend.rule.type"
+	LabelTraefikFrontendValue                    = LabelPrefix + "frontend.value"
+	LabelTraefikFrontendWhitelistSourceRange     = LabelPrefix + "frontend.whitelistSourceRange"
+	LabelBackend                                 = LabelPrefix + "backend"
+	LabelBackendID                               = LabelPrefix + "backend.id"
+	LabelTraefikBackendCircuitbreaker            = LabelPrefix + "backend.circuitbreaker"
+	LabelBackendCircuitbreakerExpression         = LabelPrefix + "backend.circuitbreaker.expression"
+	LabelBackendHealthcheckPath                  = LabelPrefix + "backend.healthcheck.path"
+	LabelBackendHealthcheckInterval              = LabelPrefix + "backend.healthcheck.interval"
+	LabelBackendLoadbalancerMethod               = LabelPrefix + "backend.loadbalancer.method"
+	LabelBackendLoadbalancerSticky               = LabelPrefix + "backend.loadbalancer.sticky"
+	LabelBackendLoadbalancerStickiness           = LabelPrefix + "backend.loadbalancer.stickiness"
+	LabelBackendLoadbalancerStickinessCookieName = LabelPrefix + "backend.loadbalancer.stickiness.cookieName"
+	LabelBackendMaxconnAmount                    = LabelPrefix + "backend.maxconn.amount"
+	LabelBackendMaxconnExtractorfunc             = LabelPrefix + "backend.maxconn.extractorfunc"
 )
 
 //ServiceLabel converts a key value of Label*, given a serviceName, into a pattern <LabelPrefix>.<serviceName>.<property>

--- a/types/types.go
+++ b/types/types.go
@@ -34,7 +34,7 @@ type MaxConn struct {
 // LoadBalancer holds load balancing configuration.
 type LoadBalancer struct {
 	Method     string      `json:"method,omitempty"`
-	Sticky     bool        `json:"sticky,omitempty"` // Deprecated
+	Sticky     bool        `json:"sticky,omitempty"` // Deprecated: use Stickiness instead
 	Stickiness *Stickiness `json:"stickiness,omitempty"`
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -33,8 +33,14 @@ type MaxConn struct {
 
 // LoadBalancer holds load balancing configuration.
 type LoadBalancer struct {
-	Method string `json:"method,omitempty"`
-	Sticky bool   `json:"sticky,omitempty"`
+	Method     string      `json:"method,omitempty"`
+	Sticky     bool        `json:"sticky,omitempty"` // Deprecated
+	Stickiness *Stickiness `json:"stickiness,omitempty"`
+}
+
+// Stickiness holds sticky session configuration.
+type Stickiness struct {
+	CookieName string `json:"cookieName,omitempty"`
 }
 
 // CircuitBreaker holds circuit breaker configuration.


### PR DESCRIPTION
### Description

- add an option to configure manually cookie name (ensures compatibility).
- use a hash as cookie name by default.

Fixes #2175