### PR TITLE
Add trusted whitelist proxy protocol

### DIFF
--- a/cmd/traefik/anonymize/anonymize_config_test.go
+++ b/cmd/traefik/anonymize/anonymize_config_test.go
@@ -84,7 +84,9 @@ func TestDo_globalConfiguration(t *testing.T) {
 			},
 			WhitelistSourceRange: []string{"foo WhitelistSourceRange 1", "foo WhitelistSourceRange 2", "foo WhitelistSourceRange 3"},
 			Compress:             true,
-			ProxyProtocol:        true,
+			ProxyProtocol: &configuration.ProxyProtocol{
+				TrustedIPs: []string{"127.0.0.1/32", "192.168.0.1"},
+			},
 		},
 		"fii": {
 			Network: "fii Network",
@@ -125,7 +127,9 @@ func TestDo_globalConfiguration(t *testing.T) {
 			},
 			WhitelistSourceRange: []string{"fii WhitelistSourceRange 1", "fii WhitelistSourceRange 2", "fii WhitelistSourceRange 3"},
 			Compress:             true,
-			ProxyProtocol:        true,
+			ProxyProtocol: &configuration.ProxyProtocol{
+				TrustedIPs: []string{"127.0.0.1/32", "192.168.0.1"},
+			},
 		},
 	}
 	config.Cluster = &types.Cluster{

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -234,8 +234,7 @@ func (ep *EntryPoints) Set(value string) error {
 
 	var proxyProtocol *ProxyProtocol
 	if len(result["ProxyProtocol"]) > 0 {
-		trustedIPs := []string{}
-		trustedIPs = strings.Split(result["ProxyProtocol"], ",")
+		trustedIPs := strings.Split(result["ProxyProtocol"], ",")
 		proxyProtocol = &ProxyProtocol{
 			TrustedIPs: trustedIPs,
 		}
@@ -254,7 +253,7 @@ func (ep *EntryPoints) Set(value string) error {
 }
 
 func parseEntryPointsConfiguration(value string) (map[string]string, error) {
-	regex := regexp.MustCompile(`(?:Name:(?P<Name>\S*))\s*(?:Address:(?P<Address>\S*))?\s*(?:TLS:(?P<TLS>\S*))?\s*(?P<TLSACME>TLS)?\s*(?:CA:(?P<CA>\S*))?\s*(?:Redirect\.EntryPoint:(?P<RedirectEntryPoint>\S*))?\s*(?:Redirect\.Regex:(?P<RedirectRegex>\S*))?\s*(?:Redirect\.Replacement:(?P<RedirectReplacement>\S*))?\s*(?:Compress:(?P<Compress>\S*))?\s*(?:WhiteListSourceRange:(?P<WhiteListSourceRange>\S*))?\s*(?:ProxyProtocol:(?P<ProxyProtocol>\S*))?`)
+	regex := regexp.MustCompile(`(?:Name:(?P<Name>\S*))\s*(?:Address:(?P<Address>\S*))?\s*(?:TLS:(?P<TLS>\S*))?\s*(?P<TLSACME>TLS)?\s*(?:CA:(?P<CA>\S*))?\s*(?:Redirect\.EntryPoint:(?P<RedirectEntryPoint>\S*))?\s*(?:Redirect\.Regex:(?P<RedirectRegex>\S*))?\s*(?:Redirect\.Replacement:(?P<RedirectReplacement>\S*))?\s*(?:Compress:(?P<Compress>\S*))?\s*(?:WhiteListSourceRange:(?P<WhiteListSourceRange>\S*))?\s*(?:ProxyProtocol\.TrustedIPs:(?P<ProxyProtocol>\S*))?`)
 	match := regex.FindAllStringSubmatch(value, -1)
 	if match == nil {
 		return nil, fmt.Errorf("bad EntryPoints format: %s", value)

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -231,7 +231,15 @@ func (ep *EntryPoints) Set(value string) error {
 	}
 
 	compress := toBool(result, "Compress")
-	proxyProtocol := toBool(result, "ProxyProtocol")
+
+	var proxyProtocol *ProxyProtocol
+	if len(result["ProxyProtocol"]) > 0 {
+		trustedIPs := []string{}
+		trustedIPs = strings.Split(result["ProxyProtocol"], ",")
+		proxyProtocol = &ProxyProtocol{
+			TrustedIPs: trustedIPs,
+		}
+	}
 
 	(*ep)[result["Name"]] = &EntryPoint{
 		Address:              result["Address"],
@@ -293,8 +301,8 @@ type EntryPoint struct {
 	Redirect             *Redirect   `export:"true"`
 	Auth                 *types.Auth `export:"true"`
 	WhitelistSourceRange []string
-	Compress             bool `export:"true"`
-	ProxyProtocol        bool `export:"true"`
+	Compress             bool           `export:"true"`
+	ProxyProtocol        *ProxyProtocol `export:"true"`
 }
 
 // Redirect configures a redirection of an entry point to another, or to an URL
@@ -442,4 +450,9 @@ type RespondingTimeouts struct {
 type ForwardingTimeouts struct {
 	DialTimeout           flaeg.Duration `description:"The amount of time to wait until a connection to a backend server can be established. Defaults to 30 seconds. If zero, no timeout exists" export:"true"`
 	ResponseHeaderTimeout flaeg.Duration `description:"The amount of time to wait for a server's response headers after fully writing the request (including its body, if any). If zero, no timeout exists" export:"true"`
+}
+
+// ProxyProtocol contains Proxy-Protocol configuration
+type ProxyProtocol struct {
+	TrustedIPs []string
 }

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -16,7 +16,7 @@ func Test_parseEntryPointsConfiguration(t *testing.T) {
 	}{
 		{
 			name:  "all parameters",
-			value: "Name:foo Address:bar TLS:goo TLS CA:car Redirect.EntryPoint:RedirectEntryPoint Redirect.Regex:RedirectRegex Redirect.Replacement:RedirectReplacement Compress:true WhiteListSourceRange:WhiteListSourceRange ProxyProtocol:true",
+			value: "Name:foo Address:bar TLS:goo TLS CA:car Redirect.EntryPoint:RedirectEntryPoint Redirect.Regex:RedirectRegex Redirect.Replacement:RedirectReplacement Compress:true WhiteListSourceRange:WhiteListSourceRange ProxyProtocol.TrustedIPs:192.168.0.1",
 			expectedResult: map[string]string{
 				"Name":                 "foo",
 				"Address":              "bar",
@@ -27,16 +27,8 @@ func Test_parseEntryPointsConfiguration(t *testing.T) {
 				"RedirectRegex":        "RedirectRegex",
 				"RedirectReplacement":  "RedirectReplacement",
 				"WhiteListSourceRange": "WhiteListSourceRange",
-				"ProxyProtocol":        "true",
+				"ProxyProtocol":        "192.168.0.1",
 				"Compress":             "true",
-			},
-		},
-		{
-			name:  "proxy protocol on",
-			value: "Name:foo ProxyProtocol:on",
-			expectedResult: map[string]string{
-				"Name":          "foo",
-				"ProxyProtocol": "on",
 			},
 		},
 		{
@@ -142,7 +134,7 @@ func TestEntryPoints_Set(t *testing.T) {
 	}{
 		{
 			name:                   "all parameters",
-			expression:             "Name:foo Address:bar TLS:goo,gii TLS CA:car Redirect.EntryPoint:RedirectEntryPoint Redirect.Regex:RedirectRegex Redirect.Replacement:RedirectReplacement Compress:true WhiteListSourceRange:Range ProxyProtocol:192.168.0.1",
+			expression:             "Name:foo Address:bar TLS:goo,gii TLS CA:car Redirect.EntryPoint:RedirectEntryPoint Redirect.Regex:RedirectRegex Redirect.Replacement:RedirectReplacement Compress:true WhiteListSourceRange:Range ProxyProtocol.TrustedIPs:192.168.0.1",
 			expectedEntryPointName: "foo",
 			expectedEntryPoint: &EntryPoint{
 				Address: "bar",

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -142,7 +142,7 @@ func TestEntryPoints_Set(t *testing.T) {
 	}{
 		{
 			name:                   "all parameters",
-			expression:             "Name:foo Address:bar TLS:goo,gii TLS CA:car Redirect.EntryPoint:RedirectEntryPoint Redirect.Regex:RedirectRegex Redirect.Replacement:RedirectReplacement Compress:true WhiteListSourceRange:Range ProxyProtocol:true",
+			expression:             "Name:foo Address:bar TLS:goo,gii TLS CA:car Redirect.EntryPoint:RedirectEntryPoint Redirect.Regex:RedirectRegex Redirect.Replacement:RedirectReplacement Compress:true WhiteListSourceRange:Range ProxyProtocol:192.168.0.1",
 			expectedEntryPointName: "foo",
 			expectedEntryPoint: &EntryPoint{
 				Address: "bar",
@@ -151,8 +151,10 @@ func TestEntryPoints_Set(t *testing.T) {
 					Regex:       "RedirectRegex",
 					Replacement: "RedirectReplacement",
 				},
-				Compress:             true,
-				ProxyProtocol:        true,
+				Compress: true,
+				ProxyProtocol: &ProxyProtocol{
+					TrustedIPs: []string{"192.168.0.1"},
+				},
 				WhitelistSourceRange: []string{"Range"},
 				TLS: &TLS{
 					ClientCAFiles: []string{"car"},

--- a/docs/configuration/entrypoints.md
+++ b/docs/configuration/entrypoints.md
@@ -185,16 +185,20 @@ To enable IP whitelisting at the entrypoint level.
 [entryPoints]
   [entryPoints.http]
   address = ":80"
-  whiteListSourceRange = ["127.0.0.1/32"]
+  whiteListSourceRange = ["127.0.0.1/32", "192.168.1.7"]
 ```
 
 ## ProxyProtocol Support
 
 To enable [ProxyProtocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) support.
+Only IPs in `trustedIPs` will lead to remote client address replacement: you should declare your load-balancer IP or CIDR range here.
+
 
 ```toml
 [entryPoints]
   [entryPoints.http]
   address = ":80"
-  proxyprotocol = true
+  [entryPoints.http.proxyProtocol]
+    trustedIPs = ["127.0.0.1/32", "192.168.1.7"]
 ```
+²

--- a/middlewares/ip_whitelister.go
+++ b/middlewares/ip_whitelister.go
@@ -6,57 +6,65 @@ import (
 	"net/http"
 
 	"github.com/containous/traefik/log"
+	"github.com/containous/traefik/whitelist"
 	"github.com/pkg/errors"
 	"github.com/urfave/negroni"
 )
 
-// IPWhitelister is a middleware that provides Checks of the Requesting IP against a set of Whitelists
-type IPWhitelister struct {
-	handler    negroni.Handler
-	whitelists []*net.IPNet
+// IPWhiteLister is a middleware that provides Checks of the Requesting IP against a set of Whitelists
+type IPWhiteLister struct {
+	handler     negroni.Handler
+	whiteLister *whitelist.IP
 }
 
-// NewIPWhitelister builds a new IPWhitelister given a list of CIDR-Strings to whitelist
-func NewIPWhitelister(whitelistStrings []string) (*IPWhitelister, error) {
+// NewIPWhitelister builds a new IPWhiteLister given a list of CIDR-Strings to whitelist
+func NewIPWhitelister(whitelistStrings []string) (*IPWhiteLister, error) {
 
 	if len(whitelistStrings) == 0 {
 		return nil, errors.New("no whitelists provided")
 	}
 
-	whitelister := IPWhitelister{}
+	whiteLister := IPWhiteLister{}
 
-	for _, whitelistString := range whitelistStrings {
-		_, whitelist, err := net.ParseCIDR(whitelistString)
-		if err != nil {
-			return nil, fmt.Errorf("parsing CIDR whitelist %s: %v", whitelist, err)
-		}
-		whitelister.whitelists = append(whitelister.whitelists, whitelist)
+	ip, err := whitelist.NewIP(whitelistStrings)
+	if err != nil {
+		return nil, fmt.Errorf("parsing CIDR whitelist %s: %v", whitelistStrings, err)
 	}
+	whiteLister.whiteLister = ip
 
-	whitelister.handler = negroni.HandlerFunc(whitelister.handle)
-	log.Debugf("configured %u IP whitelists: %s", len(whitelister.whitelists), whitelister.whitelists)
+	whiteLister.handler = negroni.HandlerFunc(whiteLister.handle)
+	log.Debugf("configured %u IP whitelists: %s", len(whitelistStrings), whitelistStrings)
 
-	return &whitelister, nil
+	return &whiteLister, nil
 }
 
-func (whitelister *IPWhitelister) handle(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-	remoteIP, err := ipFromRemoteAddr(r.RemoteAddr)
+func (whiteLister *IPWhiteLister) handle(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	ipAddress, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
 		log.Warnf("unable to parse remote-address from header: %s - rejecting", r.RemoteAddr)
 		reject(w)
 		return
 	}
 
-	for _, whitelist := range whitelister.whitelists {
-		if whitelist.Contains(*remoteIP) {
-			log.Debugf("source-IP %s matched whitelist %s - passing", remoteIP, whitelist)
-			next.ServeHTTP(w, r)
-			return
-		}
+	allowed, ip, err := whiteLister.whiteLister.Contains(ipAddress)
+	if err != nil {
+		log.Debugf("source-IP %s matched none of the whitelists - rejecting", ipAddress)
+		reject(w)
+		return
 	}
 
-	log.Debugf("source-IP %s matched none of the whitelists - rejecting", remoteIP)
+	if allowed {
+		log.Debugf("source-IP %s matched whitelist %s - passing", ipAddress, whiteLister.whiteLister)
+		next.ServeHTTP(w, r)
+		return
+	}
+
+	log.Debugf("source-IP %s matched none of the whitelists - rejecting", ip)
 	reject(w)
+}
+
+func (whiteLister *IPWhiteLister) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	whiteLister.handler.ServeHTTP(rw, r, next)
 }
 
 func reject(w http.ResponseWriter) {
@@ -64,22 +72,4 @@ func reject(w http.ResponseWriter) {
 
 	w.WriteHeader(statusCode)
 	w.Write([]byte(http.StatusText(statusCode)))
-}
-
-func ipFromRemoteAddr(addr string) (*net.IP, error) {
-	ip, _, err := net.SplitHostPort(addr)
-	if err != nil {
-		return nil, fmt.Errorf("can't extract IP/Port from address %s: %s", addr, err)
-	}
-
-	userIP := net.ParseIP(ip)
-	if userIP == nil {
-		return nil, fmt.Errorf("can't parse IP from address %s", ip)
-	}
-
-	return &userIP, nil
-}
-
-func (whitelister *IPWhitelister) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-	whitelister.handler.ServeHTTP(rw, r, next)
 }

--- a/middlewares/ip_whitelister.go
+++ b/middlewares/ip_whitelister.go
@@ -38,7 +38,7 @@ func NewIPWhitelister(whitelistStrings []string) (*IPWhiteLister, error) {
 	return &whiteLister, nil
 }
 
-func (whiteLister *IPWhiteLister) handle(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+func (wl *IPWhiteLister) handle(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	ipAddress, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
 		log.Warnf("unable to parse remote-address from header: %s - rejecting", r.RemoteAddr)
@@ -46,7 +46,7 @@ func (whiteLister *IPWhiteLister) handle(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	allowed, ip, err := whiteLister.whiteLister.Contains(ipAddress)
+	allowed, ip, err := wl.whiteLister.Contains(ipAddress)
 	if err != nil {
 		log.Debugf("source-IP %s matched none of the whitelists - rejecting", ipAddress)
 		reject(w)
@@ -54,7 +54,7 @@ func (whiteLister *IPWhiteLister) handle(w http.ResponseWriter, r *http.Request,
 	}
 
 	if allowed {
-		log.Debugf("source-IP %s matched whitelist %s - passing", ipAddress, whiteLister.whiteLister)
+		log.Debugf("source-IP %s matched whitelist %s - passing", ipAddress, wl.whiteLister)
 		next.ServeHTTP(w, r)
 		return
 	}
@@ -63,8 +63,8 @@ func (whiteLister *IPWhiteLister) handle(w http.ResponseWriter, r *http.Request,
 	reject(w)
 }
 
-func (whiteLister *IPWhiteLister) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-	whiteLister.handler.ServeHTTP(rw, r, next)
+func (wl *IPWhiteLister) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	wl.handler.ServeHTTP(rw, r, next)
 }
 
 func reject(w http.ResponseWriter) {

--- a/server/server.go
+++ b/server/server.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -18,7 +19,6 @@ import (
 	"sync"
 	"time"
 
-	"fmt"
 	"github.com/armon/go-proxyproto"
 	"github.com/containous/mux"
 	"github.com/containous/traefik/cluster"
@@ -667,14 +667,7 @@ func (server *Server) prepareServer(entryPointName string, entryPoint *configura
 				if !ok {
 					return false, fmt.Errorf("Type error %v", addr)
 				}
-				contains, err := IPs.ContainsIP(ip.IP)
-				if err != nil {
-					return false, err
-				}
-				if contains {
-					return true, nil
-				}
-				return false, nil
+				return IPs.ContainsIP(ip.IP)
 			},
 		}
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -355,7 +355,7 @@ func TestNewServerWithWhitelistSourceRange(t *testing.T) {
 				"foo",
 			},
 			middlewareConfigured: false,
-			errMessage:           "parsing CIDR whitelist <nil>: invalid CIDR address: foo",
+			errMessage:           "parsing CIDR whitelist [foo]: parsing CIDR whitelist <nil>: invalid CIDR address: foo",
 		},
 	}
 
@@ -536,7 +536,7 @@ func TestServerEntrypointWhitelistConfig(t *testing.T) {
 			handler := srvEntryPoint.httpServer.Handler.(*negroni.Negroni)
 			found := false
 			for _, handler := range handler.Handlers() {
-				if reflect.TypeOf(handler) == reflect.TypeOf((*middlewares.IPWhitelister)(nil)) {
+				if reflect.TypeOf(handler) == reflect.TypeOf((*middlewares.IPWhiteLister)(nil)) {
 					found = true
 				}
 			}

--- a/whitelist/ip.go
+++ b/whitelist/ip.go
@@ -1,0 +1,75 @@
+package whitelist
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/pkg/errors"
+)
+
+// IP allows to check that addresses are in a white list
+type IP struct {
+	whiteListsIPs []*net.IP
+	whiteListsNet []*net.IPNet
+}
+
+// NewIP builds a new IP given a list of CIDR-Strings to whitelist
+func NewIP(whitelistStrings []string) (*IP, error) {
+	if len(whitelistStrings) == 0 {
+		return nil, errors.New("no whiteListsNet provided")
+	}
+
+	ip := IP{}
+
+	for _, whitelistString := range whitelistStrings {
+		ipAddr := net.ParseIP(whitelistString)
+		if ipAddr != nil {
+			ip.whiteListsIPs = append(ip.whiteListsIPs, &ipAddr)
+		} else {
+			_, whitelist, err := net.ParseCIDR(whitelistString)
+			if err != nil {
+				return nil, fmt.Errorf("parsing CIDR whitelist %s: %v", whitelist, err)
+			}
+			ip.whiteListsNet = append(ip.whiteListsNet, whitelist)
+		}
+	}
+
+	return &ip, nil
+}
+
+// Contains checks if provided address is in the white list
+func (ip *IP) Contains(addr string) (bool, net.IP, error) {
+	ipAddr, err := ipFromRemoteAddr(addr)
+	if err != nil {
+		return false, nil, fmt.Errorf("unable to parse address: %s: %s", addr, err)
+	}
+
+	contains, err := ip.ContainsIP(ipAddr)
+	return contains, ipAddr, err
+}
+
+// ContainsIP checks if provided address is in the white list
+func (ip *IP) ContainsIP(addr net.IP) (bool, error) {
+	for _, whiteListIP := range ip.whiteListsIPs {
+		if whiteListIP.Equal(addr) {
+			return true, nil
+		}
+	}
+
+	for _, whiteListNet := range ip.whiteListsNet {
+		if whiteListNet.Contains(addr) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func ipFromRemoteAddr(addr string) (net.IP, error) {
+	userIP := net.ParseIP(addr)
+	if userIP == nil {
+		return nil, fmt.Errorf("can't parse IP from address %s", addr)
+	}
+
+	return userIP, nil
+}


### PR DESCRIPTION
### Description

This PR adds mandatory trusted IP ranges declaration while enabling proxy protocol.
:warning:  **This change will break any `1.4.0-rcx` config with proxy protocol enabled.**
You need to update your config from:

```toml
[entryPoints]
  [entryPoints.http]
  address = ":80"
  proxyprotocol = true
```

to 

```toml
[entryPoints]
  [entryPoints.http]
  address = ":80"
  [entryPoints.http.proxyProtocol]
    trustedIPs = ["10.5.0.2", "127.0.0.1/8"]
```
with `10.5.0.2` being the IP address of your front load balancer.

I'm working on adding an integration test.
