### PR TITLE
Changed Docker network filter to allow any swarm network

### DIFF
--- a/provider/docker/docker.go
+++ b/provider/docker/docker.go
@@ -825,7 +825,7 @@ func (p *Provider) listServices(ctx context.Context, dockerClient client.APIClie
 		return []dockerData{}, err
 	}
 	networkListArgs := filters.NewArgs()
-	networkListArgs.Add("driver", "overlay")
+	networkListArgs.Add("scope", "swarm")
 
 	networkList, err := dockerClient.NetworkList(ctx, dockertypes.NetworkListOptions{Filters: networkListArgs})
 


### PR DESCRIPTION
Changed network filtering parameters in docker provider to allow any swarm scoped network, not only overlay network.

This fixes #2019