### PR TITLE
New entry point parser.

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"regexp"
 	"strings"
 	"time"
 
@@ -193,55 +192,52 @@ func (ep *EntryPoints) String() string {
 // Set's argument is a string to be parsed to set the flag.
 // It's a comma-separated list, so we split it.
 func (ep *EntryPoints) Set(value string) error {
-	result, err := parseEntryPointsConfiguration(value)
-	if err != nil {
-		return err
-	}
+	result := parseEntryPointsConfiguration(value)
 
 	var configTLS *TLS
-	if len(result["TLS"]) > 0 {
+	if len(result["tls"]) > 0 {
 		certs := Certificates{}
-		if err := certs.Set(result["TLS"]); err != nil {
+		if err := certs.Set(result["tls"]); err != nil {
 			return err
 		}
 		configTLS = &TLS{
 			Certificates: certs,
 		}
-	} else if len(result["TLSACME"]) > 0 {
+	} else if len(result["tls_acme"]) > 0 {
 		configTLS = &TLS{
 			Certificates: Certificates{},
 		}
 	}
-	if len(result["CA"]) > 0 {
-		files := strings.Split(result["CA"], ",")
+	if len(result["ca"]) > 0 {
+		files := strings.Split(result["ca"], ",")
 		configTLS.ClientCAFiles = files
 	}
 	var redirect *Redirect
-	if len(result["RedirectEntryPoint"]) > 0 || len(result["RedirectRegex"]) > 0 || len(result["RedirectReplacement"]) > 0 {
+	if len(result["redirect_entrypoint"]) > 0 || len(result["redirect_regex"]) > 0 || len(result["redirect_replacement"]) > 0 {
 		redirect = &Redirect{
-			EntryPoint:  result["RedirectEntryPoint"],
-			Regex:       result["RedirectRegex"],
-			Replacement: result["RedirectReplacement"],
+			EntryPoint:  result["redirect_entrypoint"],
+			Regex:       result["redirect_regex"],
+			Replacement: result["redirect_replacement"],
 		}
 	}
 
 	whiteListSourceRange := []string{}
-	if len(result["WhiteListSourceRange"]) > 0 {
-		whiteListSourceRange = strings.Split(result["WhiteListSourceRange"], ",")
+	if len(result["whitelistsourcerange"]) > 0 {
+		whiteListSourceRange = strings.Split(result["whitelistsourcerange"], ",")
 	}
 
-	compress := toBool(result, "Compress")
+	compress := toBool(result, "compress")
 
 	var proxyProtocol *ProxyProtocol
-	if len(result["ProxyProtocol"]) > 0 {
-		trustedIPs := strings.Split(result["ProxyProtocol"], ",")
+	if len(result["proxyprotocol_trustedips"]) > 0 {
+		trustedIPs := strings.Split(result["proxyprotocol_trustedips"], ",")
 		proxyProtocol = &ProxyProtocol{
 			TrustedIPs: trustedIPs,
 		}
 	}
 
-	(*ep)[result["Name"]] = &EntryPoint{
-		Address:              result["Address"],
+	(*ep)[result["name"]] = &EntryPoint{
+		Address:              result["address"],
 		TLS:                  configTLS,
 		Redirect:             redirect,
 		Compress:             compress,
@@ -252,20 +248,24 @@ func (ep *EntryPoints) Set(value string) error {
 	return nil
 }
 
-func parseEntryPointsConfiguration(value string) (map[string]string, error) {
-	regex := regexp.MustCompile(`(?:Name:(?P<Name>\S*))\s*(?:Address:(?P<Address>\S*))?\s*(?:TLS:(?P<TLS>\S*))?\s*(?P<TLSACME>TLS)?\s*(?:CA:(?P<CA>\S*))?\s*(?:Redirect\.EntryPoint:(?P<RedirectEntryPoint>\S*))?\s*(?:Redirect\.Regex:(?P<RedirectRegex>\S*))?\s*(?:Redirect\.Replacement:(?P<RedirectReplacement>\S*))?\s*(?:Compress:(?P<Compress>\S*))?\s*(?:WhiteListSourceRange:(?P<WhiteListSourceRange>\S*))?\s*(?:ProxyProtocol\.TrustedIPs:(?P<ProxyProtocol>\S*))?`)
-	match := regex.FindAllStringSubmatch(value, -1)
-	if match == nil {
-		return nil, fmt.Errorf("bad EntryPoints format: %s", value)
-	}
-	matchResult := match[0]
-	result := make(map[string]string)
-	for i, name := range regex.SubexpNames() {
-		if i != 0 && len(matchResult[i]) != 0 {
-			result[name] = matchResult[i]
+func parseEntryPointsConfiguration(raw string) map[string]string {
+	sections := strings.Fields(raw)
+
+	config := make(map[string]string)
+	for _, part := range sections {
+		field := strings.SplitN(part, ":", 2)
+		name := strings.ToLower(strings.Replace(field[0], ".", "_", -1))
+		if len(field) > 1 {
+			config[name] = field[1]
+		} else {
+			if strings.EqualFold(name, "TLS") {
+				config["tls_acme"] = "TLS"
+			} else {
+				config[name] = ""
+			}
 		}
 	}
-	return result, nil
+	return config
 }
 
 func toBool(conf map[string]string, key string) bool {


### PR DESCRIPTION
### Description

Fix a problem when you write `--entryPoints='Name:http Address::8080'` (you must add a space at the end : `--entryPoints='Name:http Address::8080 '`)

Side effect:
- entrypoint configuration is now case insensitive 🎉 