### PR TITLE
Continue processing on invalid auth-realm annotation.

### DIFF
--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -180,7 +180,9 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 					log.Warnf("Unknown value '%s' for %s, falling back to %s", passHostHeaderAnnotation, types.LabelFrontendPassHostHeader, PassHostHeader)
 				}
 				if realm := i.Annotations[annotationKubernetesAuthRealm]; realm != "" && realm != traefikDefaultRealm {
-					return nil, errors.New("no realm customization supported")
+					log.Errorf("Value for annotation %q on ingress %s/%s invalid: no realm customization supported", annotationKubernetesAuthRealm, i.ObjectMeta.Namespace, i.ObjectMeta.Name)
+					delete(templateObjects.Backends, r.Host+pa.Path)
+					continue
 				}
 
 				witelistSourceRangeAnnotation := i.Annotations[annotationKubernetesWhitelistSourceRange]

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -1531,6 +1531,34 @@ func TestIngressAnnotations(t *testing.T) {
 				},
 			},
 		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace: "testing",
+				Annotations: map[string]string{
+					"ingress.kubernetes.io/auth-realm": "customized",
+				},
+			},
+			Spec: v1beta1.IngressSpec{
+				Rules: []v1beta1.IngressRule{
+					{
+						Host: "auth-realm-customized",
+						IngressRuleValue: v1beta1.IngressRuleValue{
+							HTTP: &v1beta1.HTTPIngressRuleValue{
+								Paths: []v1beta1.HTTPIngressPath{
+									{
+										Path: "/auth-realm-customized",
+										Backend: v1beta1.IngressBackend{
+											ServiceName: "service1",
+											ServicePort: intstr.FromInt(80),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	services := []*v1.Service{
 		{


### PR DESCRIPTION
We previously returned an error, thereby prematurely terminating any further Ingress processing.

Fixes #2239.