### PR TITLE
fix seconds to really be seconds

### DIFF
--- a/provider/rancher/metadata.go
+++ b/provider/rancher/metadata.go
@@ -85,7 +85,7 @@ func (p *Provider) intervalPoll(client rancher.Client, updateConfiguration func(
 	_, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ticker := time.NewTicker(time.Duration(p.RefreshSeconds))
+	ticker := time.NewTicker(time.Second * time.Duration(p.RefreshSeconds))
 	defer ticker.Stop()
 
 	var version string


### PR DESCRIPTION
### Description

This one fixes #2255. The Metadata Provider assumed for the Intervall Poll, that the given value is in seconds but instead it was in ms. So a multiplication with seconds was needed. 

You can test it upfront with my experimental image:

santode/traefik:heavy_load

![image](https://user-images.githubusercontent.com/1031255/31499385-e8dde8f8-af64-11e7-947f-64f069105c49.png)
