### PR TITLE
Backward compatibility for sticky

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -354,21 +354,19 @@ The default cookie name is an abbreviation of a sha1 (ex: `_1d52e`).
 On subsequent requests, the client will be directed to the backend stored in the cookie if it is still healthy.
 If not, a new backend will be assigned.
 
-To activate sticky session:
 
 ```toml
 [backends]
   [backends.backend1]
+    # Enable sticky session
     [backends.backend1.loadbalancer.stickiness]
-```
 
-To customize the cookie name:
-
-```toml
-[backends]
-  [backends.backend1]
-    [backends.backend1.loadbalancer.stickiness]
-      cookieName = "my_cookie"
+    # Customize the cookie name
+    #
+    # Optional
+    # Default: a sha1 (6 chars)
+    #
+    #  cookieName = "my_cookie"
 ```
 
 The deprecated way:

--- a/provider/consul/consul_catalog.go
+++ b/provider/consul/consul_catalog.go
@@ -397,17 +397,19 @@ func (p *CatalogProvider) getBasicAuth(tags []string) []string {
 	return []string{}
 }
 
-func (p *CatalogProvider) hasStickinessLabel(tags []string) bool {
-	stickinessTag := p.getTag(types.LabelBackendLoadbalancerStickiness, tags, "")
-
+func (p *CatalogProvider) getSticky(tags []string) string {
 	stickyTag := p.getTag(types.LabelBackendLoadbalancerSticky, tags, "")
 	if len(stickyTag) > 0 {
 		log.Warnf("Deprecated configuration found: %s. Please use %s.", types.LabelBackendLoadbalancerSticky, types.LabelBackendLoadbalancerStickiness)
+	} else {
+		stickyTag = "false"
 	}
+	return stickyTag
+}
 
-	stickiness := len(stickinessTag) > 0 && strings.EqualFold(strings.TrimSpace(stickinessTag), "true")
-	sticky := len(stickyTag) > 0 && strings.EqualFold(strings.TrimSpace(stickyTag), "true")
-	return stickiness || sticky
+func (p *CatalogProvider) hasStickinessLabel(tags []string) bool {
+	stickinessTag := p.getTag(types.LabelBackendLoadbalancerStickiness, tags, "")
+	return len(stickinessTag) > 0 && strings.EqualFold(strings.TrimSpace(stickinessTag), "true")
 }
 
 func (p *CatalogProvider) getStickinessCookieName(tags []string) string {
@@ -465,6 +467,7 @@ func (p *CatalogProvider) buildConfig(catalog []catalogUpdate) *types.Configurat
 		"getBackendName":          p.getBackendName,
 		"getBackendAddress":       p.getBackendAddress,
 		"getBasicAuth":            p.getBasicAuth,
+		"getSticky":               p.getSticky,
 		"hasStickinessLabel":      p.hasStickinessLabel,
 		"getStickinessCookieName": p.getStickinessCookieName,
 		"getAttribute":            p.getAttribute,

--- a/provider/consul/consul_catalog_test.go
+++ b/provider/consul/consul_catalog_test.go
@@ -905,42 +905,18 @@ func TestConsulCatalogHasStickinessLabel(t *testing.T) {
 			expected: false,
 		},
 		{
-			desc: "sticky=true",
-			tags: []string{
-				"traefik.backend.loadbalancer.sticky=true",
-			},
-			expected: true,
-		},
-		{
 			desc: "stickiness=true",
 			tags: []string{
-				"traefik.backend.loadbalancer.stickiness=true",
+				types.LabelBackendLoadbalancerStickiness + "=true",
 			},
 			expected: true,
 		},
 		{
-			desc: "sticky=true and stickiness=true",
+			desc: "stickiness=false",
 			tags: []string{
-				"traefik.backend.loadbalancer.sticky=true",
-				"traefik.backend.loadbalancer.stickiness=true",
+				types.LabelBackendLoadbalancerStickiness + "=false",
 			},
-			expected: true,
-		},
-		{
-			desc: "sticky=false and stickiness=true",
-			tags: []string{
-				"traefik.backend.loadbalancer.sticky=true",
-				"traefik.backend.loadbalancer.stickiness=false",
-			},
-			expected: true,
-		},
-		{
-			desc: "sticky=true and stickiness=false",
-			tags: []string{
-				"traefik.backend.loadbalancer.sticky=true",
-				"traefik.backend.loadbalancer.stickiness=false",
-			},
-			expected: true,
+			expected: false,
 		},
 	}
 

--- a/provider/docker/docker_test.go
+++ b/provider/docker/docker_test.go
@@ -1060,23 +1060,9 @@ func TestDockerHasStickinessLabel(t *testing.T) {
 		expected  bool
 	}{
 		{
-			desc:      "no sticky/stickiness-label",
+			desc:      "no stickiness-label",
 			container: containerJSON(),
 			expected:  false,
-		},
-		{
-			desc: "sticky true",
-			container: containerJSON(labels(map[string]string{
-				types.LabelBackendLoadbalancerSticky: "true",
-			})),
-			expected: true,
-		},
-		{
-			desc: "sticky false",
-			container: containerJSON(labels(map[string]string{
-				types.LabelBackendLoadbalancerSticky: "false",
-			})),
-			expected: false,
 		},
 		{
 			desc: "stickiness true",
@@ -1088,30 +1074,6 @@ func TestDockerHasStickinessLabel(t *testing.T) {
 		{
 			desc: "stickiness false",
 			container: containerJSON(labels(map[string]string{
-				types.LabelBackendLoadbalancerStickiness: "false",
-			})),
-			expected: false,
-		},
-		{
-			desc: "sticky true + stickiness false",
-			container: containerJSON(labels(map[string]string{
-				types.LabelBackendLoadbalancerSticky:     "true",
-				types.LabelBackendLoadbalancerStickiness: "false",
-			})),
-			expected: true,
-		},
-		{
-			desc: "sticky false + stickiness true",
-			container: containerJSON(labels(map[string]string{
-				types.LabelBackendLoadbalancerSticky:     "false",
-				types.LabelBackendLoadbalancerStickiness: "true",
-			})),
-			expected: true,
-		},
-		{
-			desc: "sticky false + stickiness false",
-			container: containerJSON(labels(map[string]string{
-				types.LabelBackendLoadbalancerSticky:     "false",
 				types.LabelBackendLoadbalancerStickiness: "false",
 			})),
 			expected: false,

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -248,13 +248,15 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 					templateObjects.Backends[r.Host+pa.Path].LoadBalancer.Method = "drr"
 				}
 
-				if len(service.Annotations[types.LabelBackendLoadbalancerSticky]) > 0 {
+				if sticky := service.Annotations[types.LabelBackendLoadbalancerSticky]; len(sticky) > 0 {
 					log.Warnf("Deprecated configuration found: %s. Please use %s.", types.LabelBackendLoadbalancerSticky, types.LabelBackendLoadbalancerStickiness)
+					templateObjects.Backends[r.Host+pa.Path].LoadBalancer.Sticky = strings.EqualFold(strings.TrimSpace(sticky), "true")
 				}
 
-				if service.Annotations[types.LabelBackendLoadbalancerSticky] == "true" || service.Annotations[types.LabelBackendLoadbalancerStickiness] == "true" {
-					templateObjects.Backends[r.Host+pa.Path].LoadBalancer.Stickiness = &types.Stickiness{
-						CookieName: r.Host + pa.Path,
+				if service.Annotations[types.LabelBackendLoadbalancerStickiness] == "true" {
+					templateObjects.Backends[r.Host+pa.Path].LoadBalancer.Stickiness = &types.Stickiness{}
+					if cookieName := service.Annotations[types.LabelBackendLoadbalancerStickinessCookieName]; len(cookieName) > 0 {
+						templateObjects.Backends[r.Host+pa.Path].LoadBalancer.Stickiness.CookieName = cookieName
 					}
 				}
 

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -1325,9 +1325,7 @@ func TestServiceAnnotations(t *testing.T) {
 				CircuitBreaker: nil,
 				LoadBalancer: &types.LoadBalancer{
 					Method: "wrr",
-					Stickiness: &types.Stickiness{
-						CookieName: "bar",
-					},
+					Sticky: true,
 				},
 			},
 		},
@@ -1356,7 +1354,7 @@ func TestServiceAnnotations(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, expected, actual)
+	assert.EqualValues(t, expected, actual)
 }
 
 func TestIngressAnnotations(t *testing.T) {

--- a/provider/kv/kv.go
+++ b/provider/kv/kv.go
@@ -144,6 +144,7 @@ func (p *Provider) loadConfig() *types.Configuration {
 		"Get":                     p.get,
 		"SplitGet":                p.splitGet,
 		"Last":                    p.last,
+		"getSticky":               p.getSticky,
 		"hasStickinessLabel":      p.hasStickinessLabel,
 		"getStickinessCookieName": p.getStickinessCookieName,
 	}
@@ -242,18 +243,19 @@ func (p *Provider) checkConstraints(keys ...string) bool {
 	return true
 }
 
-func (p *Provider) hasStickinessLabel(rootPath string) bool {
-	stickyValue := p.get("false", rootPath, "/loadbalancer", "/sticky")
-
-	sticky := len(stickyValue) != 0 && strings.EqualFold(strings.TrimSpace(stickyValue), "true")
-	if sticky {
+func (p *Provider) getSticky(rootPath string) string {
+	stickyValue := p.get("", rootPath, "/loadbalancer", "/sticky")
+	if len(stickyValue) > 0 {
 		log.Warnf("Deprecated configuration found: %s. Please use %s.", "loadbalancer/sticky", "loadbalancer/stickiness")
+	} else {
+		stickyValue = "false"
 	}
+	return stickyValue
+}
 
+func (p *Provider) hasStickinessLabel(rootPath string) bool {
 	stickinessValue := p.get("false", rootPath, "/loadbalancer", "/stickiness")
-	stickiness := len(stickinessValue) > 0 && strings.EqualFold(strings.TrimSpace(stickinessValue), "true")
-
-	return stickiness || sticky
+	return len(stickinessValue) > 0 && strings.EqualFold(strings.TrimSpace(stickinessValue), "true")
 }
 
 func (p *Provider) getStickinessCookieName(rootPath string) string {

--- a/provider/kv/kv_test.go
+++ b/provider/kv/kv_test.go
@@ -399,48 +399,6 @@ func TestKVHasStickinessLabel(t *testing.T) {
 			},
 			expected: true,
 		},
-		{
-			desc: "stickiness=true and sticky=true",
-			KVPairs: []*store.KVPair{
-				{
-					Key:   "loadbalancer/stickiness",
-					Value: []byte("true"),
-				},
-				{
-					Key:   "loadbalancer/sticky",
-					Value: []byte("true"),
-				},
-			},
-			expected: true,
-		},
-		{
-			desc: "stickiness=false and sticky=true",
-			KVPairs: []*store.KVPair{
-				{
-					Key:   "loadbalancer/stickiness",
-					Value: []byte("false"),
-				},
-				{
-					Key:   "loadbalancer/sticky",
-					Value: []byte("true"),
-				},
-			},
-			expected: true,
-		},
-		{
-			desc: "stickiness=true and sticky=false",
-			KVPairs: []*store.KVPair{
-				{
-					Key:   "loadbalancer/stickiness",
-					Value: []byte("true"),
-				},
-				{
-					Key:   "loadbalancer/sticky",
-					Value: []byte("false"),
-				},
-			},
-			expected: true,
-		},
 	}
 
 	for _, test := range testCases {

--- a/provider/marathon/marathon.go
+++ b/provider/marathon/marathon.go
@@ -188,8 +188,9 @@ func (p *Provider) loadMarathonConfig() *types.Configuration {
 		"getMaxConnAmount":            p.getMaxConnAmount,
 		"getLoadBalancerMethod":       p.getLoadBalancerMethod,
 		"getCircuitBreakerExpression": p.getCircuitBreakerExpression,
-		"getStickinessCookieName":     p.getStickinessCookieName,
+		"getSticky":                   p.getSticky,
 		"hasStickinessLabel":          p.hasStickinessLabel,
+		"getStickinessCookieName":     p.getStickinessCookieName,
 		"hasHealthCheckLabels":        p.hasHealthCheckLabels,
 		"getHealthCheckPath":          p.getHealthCheckPath,
 		"getHealthCheckInterval":      p.getHealthCheckInterval,
@@ -429,17 +430,17 @@ func (p *Provider) getProtocol(application marathon.Application, serviceName str
 	return "http"
 }
 
+func (p *Provider) getSticky(application marathon.Application) string {
+	if sticky, ok := p.getAppLabel(application, types.LabelBackendLoadbalancerSticky); ok {
+		log.Warnf("Deprecated configuration found: %s. Please use %s.", types.LabelBackendLoadbalancerSticky, types.LabelBackendLoadbalancerStickiness)
+		return sticky
+	}
+	return "false"
+}
+
 func (p *Provider) hasStickinessLabel(application marathon.Application) bool {
 	labelStickiness, okStickiness := p.getAppLabel(application, types.LabelBackendLoadbalancerStickiness)
-
-	labelSticky, okSticky := p.getAppLabel(application, types.LabelBackendLoadbalancerSticky)
-	if len(labelSticky) > 0 {
-		log.Warnf("Deprecated configuration found: %s. Please use %s.", types.LabelBackendLoadbalancerSticky, types.LabelBackendLoadbalancerStickiness)
-	}
-
-	stickiness := okStickiness && len(labelStickiness) > 0 && strings.EqualFold(strings.TrimSpace(labelStickiness), "true")
-	sticky := okSticky && len(labelSticky) > 0 && strings.EqualFold(strings.TrimSpace(labelSticky), "true")
-	return stickiness || sticky
+	return okStickiness && len(labelStickiness) > 0 && strings.EqualFold(strings.TrimSpace(labelStickiness), "true")
 }
 
 func (p *Provider) getStickinessCookieName(application marathon.Application) string {

--- a/provider/marathon/marathon_test.go
+++ b/provider/marathon/marathon_test.go
@@ -854,6 +854,36 @@ func TestMarathonGetProtocol(t *testing.T) {
 		})
 	}
 }
+func TestMarathonGetSticky(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		application marathon.Application
+		expected    string
+	}{
+		{
+			desc:        "label missing",
+			application: application(),
+			expected:    "false",
+		},
+		{
+			desc:        "label existing",
+			application: application(label(types.LabelBackendLoadbalancerSticky, "true")),
+			expected:    "true",
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+			provider := &Provider{}
+			actual := provider.getSticky(test.application)
+			if actual != test.expected {
+				t.Errorf("actual %q, expected %q", actual, test.expected)
+			}
+		})
+	}
+}
 
 func TestMarathonHasStickinessLabel(t *testing.T) {
 	testCases := []struct {
@@ -867,16 +897,6 @@ func TestMarathonHasStickinessLabel(t *testing.T) {
 			expected:    false,
 		},
 		{
-			desc:        "sticky=true (deprecated)",
-			application: application(label(types.LabelBackendLoadbalancerSticky, "true")),
-			expected:    true,
-		},
-		{
-			desc:        "sticky=false (deprecated)",
-			application: application(label(types.LabelBackendLoadbalancerSticky, "false")),
-			expected:    false,
-		},
-		{
 			desc:        "stickiness=true",
 			application: application(label(types.LabelBackendLoadbalancerStickiness, "true")),
 			expected:    true,
@@ -885,20 +905,6 @@ func TestMarathonHasStickinessLabel(t *testing.T) {
 			desc:        "stickiness=false ",
 			application: application(label(types.LabelBackendLoadbalancerStickiness, "true")),
 			expected:    true,
-		},
-		{
-			desc: "sticky=false stickiness=true ",
-			application: application(
-				label(types.LabelBackendLoadbalancerStickiness, "true"),
-				label(types.LabelBackendLoadbalancerSticky, "false")),
-			expected: true,
-		},
-		{
-			desc: "sticky=true stickiness=false ",
-			application: application(
-				label(types.LabelBackendLoadbalancerStickiness, "false"),
-				label(types.LabelBackendLoadbalancerSticky, "true")),
-			expected: true,
 		},
 	}
 

--- a/provider/rancher/rancher.go
+++ b/provider/rancher/rancher.go
@@ -92,10 +92,10 @@ func (p *Provider) getLoadBalancerMethod(service rancherData) string {
 func (p *Provider) hasLoadBalancerLabel(service rancherData) bool {
 	_, errMethod := getServiceLabel(service, types.LabelBackendLoadbalancerMethod)
 	_, errSticky := getServiceLabel(service, types.LabelBackendLoadbalancerSticky)
-	if errMethod != nil && errSticky != nil {
-		return false
-	}
-	return true
+	_, errStickiness := getServiceLabel(service, types.LabelBackendLoadbalancerStickiness)
+	_, errCookieName := getServiceLabel(service, types.LabelBackendLoadbalancerStickinessCookieName)
+
+	return errMethod == nil || errSticky == nil || errStickiness == nil || errCookieName == nil
 }
 
 func (p *Provider) hasCircuitBreakerLabel(service rancherData) bool {
@@ -112,17 +112,18 @@ func (p *Provider) getCircuitBreakerExpression(service rancherData) string {
 	return "NetworkErrorRatio() > 1"
 }
 
+func (p *Provider) getSticky(service rancherData) string {
+	if _, err := getServiceLabel(service, types.LabelBackendLoadbalancerSticky); err == nil {
+		log.Warnf("Deprecated configuration found: %s. Please use %s.", types.LabelBackendLoadbalancerSticky, types.LabelBackendLoadbalancerStickiness)
+		return "true"
+	}
+	return "false"
+}
+
 func (p *Provider) hasStickinessLabel(service rancherData) bool {
 	labelStickiness, errStickiness := getServiceLabel(service, types.LabelBackendLoadbalancerStickiness)
 
-	labelSticky, errSticky := getServiceLabel(service, types.LabelBackendLoadbalancerSticky)
-	if len(labelSticky) > 0 {
-		log.Warnf("Deprecated configuration found: %s. Please use %s.", types.LabelBackendLoadbalancerSticky, types.LabelBackendLoadbalancerStickiness)
-	}
-
-	stickiness := errStickiness == nil && len(labelStickiness) > 0 && strings.EqualFold(strings.TrimSpace(labelStickiness), "true")
-	sticky := errSticky == nil && len(labelSticky) > 0 && strings.EqualFold(strings.TrimSpace(labelSticky), "true")
-	return stickiness || sticky
+	return errStickiness == nil && len(labelStickiness) > 0 && strings.EqualFold(strings.TrimSpace(labelStickiness), "true")
 }
 
 func (p *Provider) getStickinessCookieName(service rancherData, backendName string) string {
@@ -235,6 +236,7 @@ func (p *Provider) loadRancherConfig(services []rancherData) *types.Configuratio
 		"hasMaxConnLabels":            p.hasMaxConnLabels,
 		"getMaxConnAmount":            p.getMaxConnAmount,
 		"getMaxConnExtractorFunc":     p.getMaxConnExtractorFunc,
+		"getSticky":                   p.getSticky,
 		"hasStickinessLabel":          p.hasStickinessLabel,
 		"getStickinessCookieName":     p.getStickinessCookieName,
 	}

--- a/provider/rancher/rancher_test.go
+++ b/provider/rancher/rancher_test.go
@@ -617,16 +617,6 @@ func TestRancherHasStickinessLabel(t *testing.T) {
 			expected: false,
 		},
 		{
-			desc: "sticky=true",
-			service: rancherData{
-				Name: "test-service",
-				Labels: map[string]string{
-					types.LabelBackendLoadbalancerSticky: "true",
-				},
-			},
-			expected: true,
-		},
-		{
 			desc: "stickiness=true",
 			service: rancherData{
 				Name: "test-service",
@@ -637,48 +627,14 @@ func TestRancherHasStickinessLabel(t *testing.T) {
 			expected: true,
 		},
 		{
-			desc: "sticky=true and stickiness=true",
+			desc: "stickiness=true",
 			service: rancherData{
 				Name: "test-service",
 				Labels: map[string]string{
-					types.LabelBackendLoadbalancerSticky:     "true",
-					types.LabelBackendLoadbalancerStickiness: "true",
-				},
-			},
-			expected: true,
-		},
-		{
-			desc: "sticky=false and stickiness=false",
-			service: rancherData{
-				Name: "test-service",
-				Labels: map[string]string{
-					types.LabelBackendLoadbalancerSticky:     "false",
 					types.LabelBackendLoadbalancerStickiness: "false",
 				},
 			},
 			expected: false,
-		},
-		{
-			desc: "sticky=true and stickiness=false",
-			service: rancherData{
-				Name: "test-service",
-				Labels: map[string]string{
-					types.LabelBackendLoadbalancerSticky:     "true",
-					types.LabelBackendLoadbalancerStickiness: "false",
-				},
-			},
-			expected: true,
-		},
-		{
-			desc: "sticky=false and stickiness=true",
-			service: rancherData{
-				Name: "test-service",
-				Labels: map[string]string{
-					types.LabelBackendLoadbalancerSticky:     "false",
-					types.LabelBackendLoadbalancerStickiness: "true",
-				},
-			},
-			expected: true,
 		},
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -1172,7 +1172,8 @@ func (server *Server) configureFrontends(frontends map[string]*types.Frontend) {
 }
 
 func (*Server) configureBackends(backends map[string]*types.Backend) {
-	for backendName, backend := range backends {
+	for backendName := range backends {
+		backend := backends[backendName]
 		if backend.LoadBalancer != nil && backend.LoadBalancer.Sticky {
 			log.Warnf("Deprecated configuration found: %s. Please use %s.", "backend.LoadBalancer.Sticky", "backend.LoadBalancer.Stickiness")
 		}

--- a/templates/consul_catalog.tmpl
+++ b/templates/consul_catalog.tmpl
@@ -18,9 +18,9 @@
 
   [backends."backend-{{$service}}".loadbalancer]
     method = "{{getAttribute "backend.loadbalancer" .Attributes "wrr"}}"
-    sticky = {{getAttribute "backend.loadbalancer.sticky" .Attributes "false"}}
+    sticky = {{getSticky .Attributes}}
     {{if hasStickinessLabel .Attributes}}
-    [Backends."backend-{{$service}}".LoadBalancer.Stickiness]
+    [backends."backend-{{$service}}".loadbalancer.stickiness]
       cookieName = "{{getStickinessCookieName .Attributes}}"
     {{end}}
 

--- a/templates/docker.tmpl
+++ b/templates/docker.tmpl
@@ -8,8 +8,9 @@
     {{if hasLoadBalancerLabel $backend}}
     [backends.backend-{{$backendName}}.loadbalancer]
       method = "{{getLoadBalancerMethod $backend}}"
+      sticky = {{getSticky $backend}}
       {{if hasStickinessLabel $backend}}
-      [Backends."{{$backendName}}".LoadBalancer.Stickiness]
+      [backends.backend-{{$backendName}}.loadBalancer.stickiness]
         cookieName = "{{getStickinessCookieName $backend}}"
       {{end}}
     {{end}}

--- a/templates/ecs.tmpl
+++ b/templates/ecs.tmpl
@@ -1,8 +1,9 @@
 [backends]{{range $serviceName, $instances := .Services}}
   [backends.backend-{{ $serviceName }}.loadbalancer]
     method = "{{ getLoadBalancerMethod $instances}}"
+    sticky = {{ getLoadBalancerSticky $instances}}
     {{if hasStickinessLabel $instances}} 
-    [Backends.backend-{{ $serviceName }}.LoadBalancer.Stickiness]
+    [backends.backend-{{ $serviceName }}.loadbalancer.stickiness]
       cookieName = "{{getStickinessCookieName $instances}}"
     {{end}}
 

--- a/templates/kubernetes.tmpl
+++ b/templates/kubernetes.tmpl
@@ -6,8 +6,11 @@
     {{end}}
     [backends."{{$backendName}}".loadbalancer]
       method = "{{$backend.LoadBalancer.Method}}"
+      {{if $backend.LoadBalancer.Sticky}}
+      sticky = true
+      {{end}}
       {{if $backend.LoadBalancer.Stickiness}}
-      [Backends."{{$backendName}}".LoadBalancer.Stickiness]
+      [backends."{{$backendName}}".loadbalancer.stickiness]
         cookieName = "{{$backend.LoadBalancer.Stickiness.CookieName}}"
       {{end}}
     {{range $serverName, $server := $backend.Servers}}

--- a/templates/kv.tmpl
+++ b/templates/kv.tmpl
@@ -16,9 +16,9 @@
 {{with $loadBalancer}}
 [backends."{{$backendName}}".loadBalancer]
     method = "{{$loadBalancer}}"
-    sticky = {{ Get "false" . "/loadbalancer/" "sticky" }}
+    sticky = {{ getSticky . }}
     {{if hasStickinessLabel $backend}}
-    [Backends."{{$backendName}}".LoadBalancer.Stickiness]
+    [backends."{{$backendName}}".loadBalancer.stickiness]
       cookieName = {{getStickinessCookieName $backend}}
     {{end}}
 {{end}}

--- a/templates/marathon.tmpl
+++ b/templates/marathon.tmpl
@@ -20,8 +20,9 @@
 {{ if hasLoadBalancerLabels $app }}
       [backends."backend{{getBackend $app $serviceName }}".loadbalancer]
         method = "{{getLoadBalancerMethod $app }}"
+        sticky = {{getSticky $app}}
         {{if hasStickinessLabel $app}}
-        [Backends."backend{{getBackend $app $serviceName }}".LoadBalancer.Stickiness]
+        [backends."backend{{getBackend $app $serviceName }}".loadbalancer.stickiness]
           cookieName = "{{getStickinessCookieName $app}}"
         {{end}}
 {{end}}

--- a/templates/rancher.tmpl
+++ b/templates/rancher.tmpl
@@ -8,8 +8,9 @@
     {{if hasLoadBalancerLabel $backend}}
     [backends.backend-{{$backendName}}.loadbalancer]
       method = "{{getLoadBalancerMethod $backend}}"
+      sticky = {{getSticky $backend}}
       {{if hasStickinessLabel $backend}}
-      [Backends."{{$backendName}}".LoadBalancer.Stickiness]
+      [backends.backend-{{$backendName}}.loadbalancer.stickiness]
         cookieName = "{{getStickinessCookieName $backend}}"
       {{end}}
     {{end}}


### PR DESCRIPTION
### Description

if `sticky=true` -> `cookieName="_TRAEFIK_BACKEND"`

for new custom `cookieName` feature:
- must add `stickiness=true`
- add `cookieName="MyCookie"`

----
summary:

| Options                                   | Result                                                                              |
|-------------------------------------------|-------------------------------------------------------------------------------------|
| only`stickiness=true`                     | activate sticky session and use a 6 chars cookie name (abbrev sha1)                 |
| only`sticky=true`                         | (deprecated) activate sticky session and use the old cookie name `_TRAEFIK_BACKEND` |
| `stickiness=true` and `sticky=true`       | same as `stickiness=true`                                                           |
| `stickiness=true` and `cookieName=foobar` | activate sticky session and use `foobar` as the cookie name                            |
| only`cookieName=foobar`                   | do nothing                                                                          |
| `sticky=true` and `cookieName=foobar`     | same as `sticky=true`, doesn't use the `cookieName` value                             |
----

@MichaelErmer could you retry with this image `ldez/traefik:sticky`?


Related to #2251, #2238, #2232