### PR TITLE
Use Node IP in Swarm Standalone with "host" NetworkMode

### DIFF
--- a/provider/docker/builder_test.go
+++ b/provider/docker/builder_test.go
@@ -39,6 +39,14 @@ func networkMode(mode string) func(*docker.ContainerJSON) {
 	}
 }
 
+func nodeIP(ip string) func(*docker.ContainerJSON) {
+	return func(c *docker.ContainerJSON) {
+		c.ContainerJSONBase.Node = &docker.ContainerNode{
+			IPAddress: ip,
+		}
+	}
+}
+
 func labels(labels map[string]string) func(*docker.ContainerJSON) {
 	return func(c *docker.ContainerJSON) {
 		c.Config.Labels = labels

--- a/provider/docker/docker.go
+++ b/provider/docker/docker.go
@@ -597,8 +597,6 @@ func (p *Provider) getIPAddress(container dockerData) string {
 		}
 	}
 
-	// If net==host, quick n' dirty, we return 127.0.0.1
-	// This will work locally, but will fail with swarm.
 	if "host" == container.NetworkSettings.NetworkMode {
 		if container.Node != nil {
 			if container.Node.IPAddress != "" {

--- a/provider/docker/docker.go
+++ b/provider/docker/docker.go
@@ -63,6 +63,7 @@ type dockerData struct {
 	Labels          map[string]string // List of labels set to container or service
 	NetworkSettings networkSettings
 	Health          string
+	Node            *dockertypes.ContainerNode
 }
 
 // NetworkSettings holds the networks data to the Provider p
@@ -599,6 +600,12 @@ func (p *Provider) getIPAddress(container dockerData) string {
 	// If net==host, quick n' dirty, we return 127.0.0.1
 	// This will work locally, but will fail with swarm.
 	if "host" == container.NetworkSettings.NetworkMode {
+		if container.Node != nil {
+			if container.Node.IPAddress != "" {
+				return container.Node.IPAddress
+			}
+		}
+
 		return "127.0.0.1"
 	}
 
@@ -823,6 +830,7 @@ func parseContainer(container dockertypes.ContainerJSON) dockerData {
 	if container.ContainerJSONBase != nil {
 		dockerData.Name = container.ContainerJSONBase.Name
 		dockerData.ServiceName = dockerData.Name //Default ServiceName to be the container's Name.
+		dockerData.Node = container.ContainerJSONBase.Node
 
 		if container.ContainerJSONBase.HostConfig != nil {
 			dockerData.NetworkSettings.NetworkMode = container.ContainerJSONBase.HostConfig.NetworkMode

--- a/provider/docker/docker_test.go
+++ b/provider/docker/docker_test.go
@@ -198,6 +198,19 @@ func TestDockerGetIPAddress(t *testing.T) {
 			),
 			expected: "127.0.0.1",
 		},
+		{
+			container: containerJSON(
+				networkMode("host"),
+			),
+			expected: "127.0.0.1",
+		},
+		{
+			container: containerJSON(
+				networkMode("host"),
+				nodeIP("10.0.0.5"),
+			),
+			expected: "10.0.0.5",
+		},
 	}
 
 	for containerID, e := range containers {


### PR DESCRIPTION
### Description

This adds support for using the Swarm Node IP when running Swarm Standalone mode (https://github.com/docker/swarm) with a container configured with host networking.

The Node IP that is provided through the Swarm API is one that is reachable by the manager, and is generally reachable by each of the Swarm workers: https://github.com/docker/swarm/blob/master/cli/flags.go#L30-L33
