### PR TITLE
Fix the k8s docs example deployment yaml

### DIFF
--- a/docs/user-guide/kubernetes.md
+++ b/docs/user-guide/kubernetes.md
@@ -118,6 +118,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: traefik-ingress-service
+  namespace: kube-system
 spec:
   selector:
     k8s-app: traefik-ingress-lb
@@ -182,6 +183,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: traefik-ingress-service
+  namespace: kube-system
 spec:
   selector:
     k8s-app: traefik-ingress-lb


### PR DESCRIPTION
This fixes the namespace in the docs to also be kube-system, just like
the yaml in the examples says.