### PR TITLE
Fix mkdocs version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs>=0.16.1
+mkdocs==0.16.3
 pymdown-extensions>=1.4
 mkdocs-bootswatch>=0.4.0
 mkdocs-material>=1.8.1


### PR DESCRIPTION
### Description
The build failed because of mkdocs version.

```console
Traceback (most recent call last):

File "/home/travis/.local/bin/mkdocs", line 11, in <module>
sys.exit(cli())
File "/home/travis/.local/lib/python2.7/site-packages/click/core.py", line 722, in __call__
return self.main(*args, **kwargs)
File "/home/travis/.local/lib/python2.7/site-packages/click/core.py", line 697, in main
rv = self.invoke(ctx)
File "/home/travis/.local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File "/home/travis/.local/lib/python2.7/site-packages/click/core.py", line 895, in invoke
return ctx.invoke(self.callback, **ctx.params)
File "/home/travis/.local/lib/python2.7/site-packages/click/core.py", line 535, in invoke
return callback(*args, **kwargs)
File "/home/travis/.local/lib/python2.7/site-packages/mkdocs/__main__.py", line 155, in build_command
site_dir=site_dir
File "/home/travis/.local/lib/python2.7/site-packages/mkdocs/config/base.py", line 181, in load_config
errors, warnings = cfg.validate()
File "/home/travis/.local/lib/python2.7/site-packages/mkdocs/config/base.py", line 105, in validate
post_failed, post_warnings = self._post_validate()
File "/home/travis/.local/lib/python2.7/site-packages/mkdocs/config/base.py", line 85, in _post_validate
config_option.post_validation(self, key_name=key)
File "/home/travis/.local/lib/python2.7/site-packages/mkdocs/config/config_options.py", line 433, in post_validation
config[key_name] = theme.Theme(**theme_config)
File "/home/travis/.local/lib/python2.7/site-packages/mkdocs/theme.py", line 47, in __init__
self._load_theme_config(name)
File "/home/travis/.local/lib/python2.7/site-packages/mkdocs/theme.py", line 77, in _load_theme_config
theme_dir = utils.get_theme_dir(name)
File "/home/travis/.local/lib/python2.7/site-packages/mkdocs/utils/__init__.py", line 373, in get_theme_dir
return os.path.dirname(os.path.abspath(theme.load().__file__))
File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2315, in load
self.require(*args, **kwargs)
File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2338, in require
items = working_set.resolve(reqs, env, installer, extras=self.extras)
File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 863, in resolve
raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.VersionConflict: (mkdocs 0.17.0 (/home/travis/.local/lib/python2.7/site-packages), Requirement.parse('mkdocs==0.16.3'))
```

This temporary fix fixes mkdocs version to 0.16.3
<!--
Briefly describe the pull request in a few paragraphs.
-->