### PR TITLE
Make the traefik.port label optional when using service labels in Docker containers.

### DIFF
--- a/docs/configuration/backends/docker.md
+++ b/docs/configuration/backends/docker.md
@@ -187,6 +187,12 @@ Services labels can be used for overriding default behaviour
 | `traefik.<service-name>.frontend.priority`        | Overrides `traefik.frontend.priority`.                                                           |
 | `traefik.<service-name>.frontend.rule`            | Overrides `traefik.frontend.rule`.                                                               |
 
+
+!!! note
+    if a label is defined both as a `container label` and a `service label` (for example `traefik.<service-name>.port=PORT` and `traefik.port=PORT` ), the `service label` is used to defined the `<service-name>` property (`port` in the example).
+    It's possible to mix `container labels` and `service labels`, in this case `container labels` are used as default value for missing `service labels` but no frontends are going to be created with the `container labels`.
+    More details in this [example](/user-guide/docker-and-lets-encrypt/#labels).
+
 !!! warning
     when running inside a container, Træfik will need network access through:
 

--- a/integration/docker_test.go
+++ b/integration/docker_test.go
@@ -192,3 +192,40 @@ func (s *DockerSuite) TestDockerContainersWithOneMissingLabels(c *check.C) {
 	err = try.Request(req, 1500*time.Millisecond, try.StatusCodeIs(http.StatusNotFound))
 	c.Assert(err, checker.IsNil)
 }
+
+// TestDockerContainersWithServiceLabels allows cheking the labels behavior
+// Use service label if defined and compete information with container labels.
+func (s *DockerSuite) TestDockerContainersWithServiceLabels(c *check.C) {
+	file := s.adaptFileForHost(c, "fixtures/docker/simple.toml")
+	defer os.Remove(file)
+	// Start a container with some labels
+	labels := map[string]string{
+		types.LabelPrefix + "servicename.frontend.rule": "Host:my.super.host",
+		types.LabelFrontendRule:                         "Host:my.wrong.host",
+		types.LabelPort:                                 "2375",
+	}
+	s.startContainerWithLabels(c, "swarm:1.0.0", labels, "manage", "token://blabla")
+
+	// Start traefik
+	cmd, display := s.traefikCmd(withConfigFile(file))
+	defer display(c)
+	err := cmd.Start()
+	c.Assert(err, checker.IsNil)
+	defer cmd.Process.Kill()
+
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8000/version", nil)
+	c.Assert(err, checker.IsNil)
+	req.Host = "my.super.host"
+
+	// FIXME Need to wait than 500 milliseconds more (for swarm or traefik to boot up ?)
+	resp, err := try.ResponseUntilStatusCode(req, 1500*time.Millisecond, http.StatusOK)
+	c.Assert(err, checker.IsNil)
+
+	body, err := ioutil.ReadAll(resp.Body)
+	c.Assert(err, checker.IsNil)
+
+	var version map[string]interface{}
+
+	c.Assert(json.Unmarshal(body, &version), checker.IsNil)
+	c.Assert(version["Version"], checker.Equals, "swarm/1.0.0")
+}

--- a/provider/docker/docker.go
+++ b/provider/docker/docker.go
@@ -29,6 +29,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 	"github.com/docker/go-connections/sockets"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -517,9 +518,16 @@ func (p *Provider) getMaxConnExtractorFunc(container dockerData) string {
 }
 
 func (p *Provider) containerFilter(container dockerData) bool {
-	_, err := strconv.Atoi(container.Labels[types.LabelPort])
+	var err error
+	portLabel := "traefik.port label"
+	if p.hasServices(container) {
+		portLabel = "traefik.<serviceName>.port or " + portLabel + "s"
+		err = checkServiceLabelPort(container)
+	} else {
+		_, err = strconv.Atoi(container.Labels[types.LabelPort])
+	}
 	if len(container.NetworkSettings.Ports) == 0 && err != nil {
-		log.Debugf("Filtering container without port and no traefik.port label %s", container.Name)
+		log.Debugf("Filtering container without port and no %s %s : %s", portLabel, container.Name, err.Error())
 		return false
 	}
 
@@ -547,6 +555,38 @@ func (p *Provider) containerFilter(container dockerData) bool {
 	}
 
 	return true
+}
+
+// checkServiceLabelPort checks if all service names have a port service label
+// or if port container label exists for default value
+func checkServiceLabelPort(container dockerData) error {
+	_, err := strconv.Atoi(container.Labels[types.LabelPort])
+	if err != nil {
+		serviceLabelPorts := make(map[string]struct{})
+		serviceLabels := make(map[string]struct{})
+		portRegexp := regexp.MustCompile(`^traefik\.(?P<service_name>.+?)\.port$`)
+		for label := range container.Labels {
+			portLabel := portRegexp.FindStringSubmatch(label)
+			servicesLabelNames := servicesPropertiesRegexp.FindStringSubmatch(label)
+			if portLabel != nil && len(portLabel) > 0 {
+				serviceLabelPorts[portLabel[0]] = struct{}{}
+			}
+			if servicesLabelNames != nil && len(servicesLabelNames) > 0 {
+				serviceLabels[strings.Split(servicesLabelNames[0], ".")[1]] = struct{}{}
+			}
+		}
+		if len(serviceLabels) == len(serviceLabelPorts) {
+			for labelPort := range serviceLabelPorts {
+				_, err = strconv.Atoi(container.Labels[labelPort])
+				if err != nil {
+					break
+				}
+			}
+		} else {
+			err = errors.New("Port service labels missing, please use traefik.port as default value or define all port service labels")
+		}
+	}
+	return err
 }
 
 func (p *Provider) getFrontendName(container dockerData, idx int) string {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### Description

All Docker containers which use `service labels` with no value for the `container label` named `traefik port` are filtered.
This PR fixes this problem.

Fixes : #1321 #1840 
<!--
Briefly describe the pull request in a few paragraphs.
-->