### PR TITLE
Missing Backend key in configuration when application has no tasks

### DIFF
--- a/provider/marathon/marathon_test.go
+++ b/provider/marathon/marathon_test.go
@@ -93,7 +93,9 @@ func TestMarathonLoadConfigNonAPIErrors(t *testing.T) {
 					},
 				},
 			},
-			expectedBackends: nil,
+			expectedBackends: map[string]*types.Backend{
+				"backend-app": {},
+			},
 		},
 		{
 			desc: "load balancer / circuit breaker labels",

--- a/templates/marathon.tmpl
+++ b/templates/marathon.tmpl
@@ -12,6 +12,7 @@
 
 {{range $app := $apps}}
 {{range $serviceIndex, $serviceName := getServiceNames $app}}
+[backends."backend{{getBackend $app $serviceName }}"]
 {{ if hasMaxConnLabels $app }}
       [backends."backend{{getBackend $app $serviceName }}".maxconn]
         amount = {{getMaxConnAmount $app }}


### PR DESCRIPTION
Fixed an issue of missing Backend key in configuration when no tasks are available for an application

If Marathon application has no valid tasks in existence (either because the tasks are in bad state or they are in the process of being started or shut down), the generated configuration is completely missing the Backend key entry for the bound Frontend, resulting in a 404 response from Traefik instead of the expected 503.