### PR TITLE
Make frontend names differents for similar routes

### DIFF
--- a/provider/docker/docker.go
+++ b/provider/docker/docker.go
@@ -301,8 +301,8 @@ func (p *Provider) loadDockerConfig(containersInspected []dockerData) *types.Con
 	frontends := map[string][]dockerData{}
 	backends := map[string]dockerData{}
 	servers := map[string][]dockerData{}
-	for _, container := range filteredContainers {
-		frontendName := p.getFrontendName(container)
+	for idx, container := range filteredContainers {
+		frontendName := p.getFrontendName(container, idx)
 		frontends[frontendName] = append(frontends[frontendName], container)
 		backendName := p.getBackend(container)
 		backends[backendName] = container
@@ -549,9 +549,9 @@ func (p *Provider) containerFilter(container dockerData) bool {
 	return true
 }
 
-func (p *Provider) getFrontendName(container dockerData) string {
+func (p *Provider) getFrontendName(container dockerData, idx int) string {
 	// Replace '.' with '-' in quoted keys because of this issue https://github.com/BurntSushi/toml/issues/78
-	return provider.Normalize(p.getFrontendRule(container))
+	return provider.Normalize(p.getFrontendRule(container) + "-" + strconv.Itoa(idx))
 }
 
 // GetFrontendRule returns the frontend rule for the specified container, using

--- a/provider/docker/docker_test.go
+++ b/provider/docker/docker_test.go
@@ -20,38 +20,38 @@ func TestDockerGetFrontendName(t *testing.T) {
 	}{
 		{
 			container: containerJSON(name("foo")),
-			expected:  "Host-foo-docker-localhost",
+			expected:  "Host-foo-docker-localhost-0",
 		},
 		{
 			container: containerJSON(labels(map[string]string{
 				types.LabelFrontendRule: "Headers:User-Agent,bat/0.1.0",
 			})),
-			expected: "Headers-User-Agent-bat-0-1-0",
+			expected: "Headers-User-Agent-bat-0-1-0-0",
 		},
 		{
 			container: containerJSON(labels(map[string]string{
 				"com.docker.compose.project": "foo",
 				"com.docker.compose.service": "bar",
 			})),
-			expected: "Host-bar-foo-docker-localhost",
+			expected: "Host-bar-foo-docker-localhost-0",
 		},
 		{
 			container: containerJSON(labels(map[string]string{
 				types.LabelFrontendRule: "Host:foo.bar",
 			})),
-			expected: "Host-foo-bar",
+			expected: "Host-foo-bar-0",
 		},
 		{
 			container: containerJSON(labels(map[string]string{
 				types.LabelFrontendRule: "Path:/test",
 			})),
-			expected: "Path-test",
+			expected: "Path-test-0",
 		},
 		{
 			container: containerJSON(labels(map[string]string{
 				types.LabelFrontendRule: "PathPrefix:/test2",
 			})),
-			expected: "PathPrefix-test2",
+			expected: "PathPrefix-test2-0",
 		},
 	}
 
@@ -63,7 +63,7 @@ func TestDockerGetFrontendName(t *testing.T) {
 			provider := &Provider{
 				Domain: "docker.localhost",
 			}
-			actual := provider.getFrontendName(dockerData)
+			actual := provider.getFrontendName(dockerData, 0)
 			if actual != e.expected {
 				t.Errorf("expected %q, got %q", e.expected, actual)
 			}
@@ -884,13 +884,13 @@ func TestDockerLoadDockerConfig(t *testing.T) {
 				),
 			},
 			expectedFrontends: map[string]*types.Frontend{
-				"frontend-Host-test-docker-localhost": {
+				"frontend-Host-test-docker-localhost-0": {
 					Backend:        "backend-test",
 					PassHostHeader: true,
 					EntryPoints:    []string{},
 					BasicAuth:      []string{},
 					Routes: map[string]types.Route{
-						"route-frontend-Host-test-docker-localhost": {
+						"route-frontend-Host-test-docker-localhost-0": {
 							Rule: "Host:test.docker.localhost",
 						},
 					},
@@ -934,24 +934,24 @@ func TestDockerLoadDockerConfig(t *testing.T) {
 				),
 			},
 			expectedFrontends: map[string]*types.Frontend{
-				"frontend-Host-test1-docker-localhost": {
+				"frontend-Host-test1-docker-localhost-0": {
 					Backend:        "backend-foobar",
 					PassHostHeader: true,
 					EntryPoints:    []string{"http", "https"},
 					BasicAuth:      []string{"test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/", "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"},
 					Routes: map[string]types.Route{
-						"route-frontend-Host-test1-docker-localhost": {
+						"route-frontend-Host-test1-docker-localhost-0": {
 							Rule: "Host:test1.docker.localhost",
 						},
 					},
 				},
-				"frontend-Host-test2-docker-localhost": {
+				"frontend-Host-test2-docker-localhost-1": {
 					Backend:        "backend-foobar",
 					PassHostHeader: true,
 					EntryPoints:    []string{},
 					BasicAuth:      []string{},
 					Routes: map[string]types.Route{
-						"route-frontend-Host-test2-docker-localhost": {
+						"route-frontend-Host-test2-docker-localhost-1": {
 							Rule: "Host:test2.docker.localhost",
 						},
 					},
@@ -992,13 +992,13 @@ func TestDockerLoadDockerConfig(t *testing.T) {
 				),
 			},
 			expectedFrontends: map[string]*types.Frontend{
-				"frontend-Host-test1-docker-localhost": {
+				"frontend-Host-test1-docker-localhost-0": {
 					Backend:        "backend-foobar",
 					PassHostHeader: true,
 					EntryPoints:    []string{"http", "https"},
 					BasicAuth:      []string{},
 					Routes: map[string]types.Route{
-						"route-frontend-Host-test1-docker-localhost": {
+						"route-frontend-Host-test1-docker-localhost-0": {
 							Rule: "Host:test1.docker.localhost",
 						},
 					},

--- a/provider/docker/swarm_test.go
+++ b/provider/docker/swarm_test.go
@@ -23,28 +23,28 @@ func TestSwarmGetFrontendName(t *testing.T) {
 	}{
 		{
 			service:  swarmService(serviceName("foo")),
-			expected: "Host-foo-docker-localhost",
+			expected: "Host-foo-docker-localhost-0",
 			networks: map[string]*docker.NetworkResource{},
 		},
 		{
 			service: swarmService(serviceLabels(map[string]string{
 				types.LabelFrontendRule: "Headers:User-Agent,bat/0.1.0",
 			})),
-			expected: "Headers-User-Agent-bat-0-1-0",
+			expected: "Headers-User-Agent-bat-0-1-0-0",
 			networks: map[string]*docker.NetworkResource{},
 		},
 		{
 			service: swarmService(serviceLabels(map[string]string{
 				types.LabelFrontendRule: "Host:foo.bar",
 			})),
-			expected: "Host-foo-bar",
+			expected: "Host-foo-bar-0",
 			networks: map[string]*docker.NetworkResource{},
 		},
 		{
 			service: swarmService(serviceLabels(map[string]string{
 				types.LabelFrontendRule: "Path:/test",
 			})),
-			expected: "Path-test",
+			expected: "Path-test-0",
 			networks: map[string]*docker.NetworkResource{},
 		},
 		{
@@ -54,7 +54,7 @@ func TestSwarmGetFrontendName(t *testing.T) {
 					types.LabelFrontendRule: "PathPrefix:/test2",
 				}),
 			),
-			expected: "PathPrefix-test2",
+			expected: "PathPrefix-test2-0",
 			networks: map[string]*docker.NetworkResource{},
 		},
 	}
@@ -68,7 +68,7 @@ func TestSwarmGetFrontendName(t *testing.T) {
 				Domain:    "docker.localhost",
 				SwarmMode: true,
 			}
-			actual := provider.getFrontendName(dockerData)
+			actual := provider.getFrontendName(dockerData, 0)
 			if actual != e.expected {
 				t.Errorf("expected %q, got %q", e.expected, actual)
 			}
@@ -660,13 +660,13 @@ func TestSwarmLoadDockerConfig(t *testing.T) {
 				),
 			},
 			expectedFrontends: map[string]*types.Frontend{
-				"frontend-Host-test-docker-localhost": {
+				"frontend-Host-test-docker-localhost-0": {
 					Backend:        "backend-test",
 					PassHostHeader: true,
 					EntryPoints:    []string{},
 					BasicAuth:      []string{},
 					Routes: map[string]types.Route{
-						"route-frontend-Host-test-docker-localhost": {
+						"route-frontend-Host-test-docker-localhost-0": {
 							Rule: "Host:test.docker.localhost",
 						},
 					},
@@ -714,24 +714,24 @@ func TestSwarmLoadDockerConfig(t *testing.T) {
 				),
 			},
 			expectedFrontends: map[string]*types.Frontend{
-				"frontend-Host-test1-docker-localhost": {
+				"frontend-Host-test1-docker-localhost-0": {
 					Backend:        "backend-foobar",
 					PassHostHeader: true,
 					EntryPoints:    []string{"http", "https"},
 					BasicAuth:      []string{"test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/", "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"},
 					Routes: map[string]types.Route{
-						"route-frontend-Host-test1-docker-localhost": {
+						"route-frontend-Host-test1-docker-localhost-0": {
 							Rule: "Host:test1.docker.localhost",
 						},
 					},
 				},
-				"frontend-Host-test2-docker-localhost": {
+				"frontend-Host-test2-docker-localhost-1": {
 					Backend:        "backend-foobar",
 					PassHostHeader: true,
 					EntryPoints:    []string{},
 					BasicAuth:      []string{},
 					Routes: map[string]types.Route{
-						"route-frontend-Host-test2-docker-localhost": {
+						"route-frontend-Host-test2-docker-localhost-1": {
 							Rule: "Host:test2.docker.localhost",
 						},
 					},


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### Description

Because the frontend names are based on the `route` names, it's not possible to set frontends with similar routes (as described in #1070).

This PR adds an index to all frontends names to avoid the problem.

Fixes #1070 
<!--
Briefly describe the pull request in a few paragraphs.
-->