### PR TITLE
Fix datastore corruption on reload due to shrinking config size

### DIFF
--- a/cluster/datastore.go
+++ b/cluster/datastore.go
@@ -119,19 +119,8 @@ func (d *Datastore) watchChanges() error {
 
 func (d *Datastore) reload() error {
 	log.Debug("Datastore reload")
-	d.localLock.Lock()
-	err := d.kv.LoadConfig(d.meta)
-	if err != nil {
-		d.localLock.Unlock()
-		return err
-	}
-	err = d.meta.unmarshall()
-	if err != nil {
-		d.localLock.Unlock()
-		return err
-	}
-	d.localLock.Unlock()
-	return nil
+	_, err := d.Load()
+	return err
 }
 
 // Begin creates a transaction with the KV store.


### PR DESCRIPTION
This commit fixes a corruption in the datastore that leads to workers becoming
unresponsive due to an invalid configuration.

The bug occurs when the cluster config serialization output length shrinks
below the current config's output length. This typically only happens on
workers since leaders modify their own config directly instead of importing the
serialized version from the kv backend.

This commit truncates the object field before reloading the new config from the
kv, as is done during initial config load.

fixes #2328