### PR TITLE
Replace base64 "--decode" by "-d" for alpine linux

### DIFF
--- a/contrib/scripts/dumpcerts.sh
+++ b/contrib/scripts/dumpcerts.sh
@@ -147,5 +147,5 @@ for domain in $(jq -r '.DomainsCertificate.Certs[].Certificate.Domain' acme.json
 	echo "Extracting cert bundle for ${domain}"
 	cert=$(jq -e -r --arg domain "$domain" '.DomainsCertificate.Certs[].Certificate |
          	select (.Domain == $domain )| .Certificate' ${acmefile}) || bad_acme
-	echo "${cert}" | base64 --decode > "${cdir}/${domain}.pem"
+	echo "${cert}" | base64 -d > "${cdir}/${domain}.pem"
 done


### PR DESCRIPTION
This is required in order to use "dumpcerts.sh" inside the traefik:1.4-alpine docker-image
The base64-version that is installed in this image does not understand "base64 --decode", only "base64 -d"
