### PR TITLE
dumpcerts.sh: Fix call to "base64" for Alpine

### DIFF
--- a/contrib/scripts/dumpcerts.sh
+++ b/contrib/scripts/dumpcerts.sh
@@ -43,7 +43,7 @@ set -o nounset
 USAGE="$(basename "$0") <path to acme> <destination cert directory>"
 
 # Platform variations
-case `uname` in
+case $(uname) in
 	'Linux')
 		# On Linux, -d should always work. --decode does not work with Alpine's busybox-binary
 		CMD_DECODE_BASE64="base64 -d"

--- a/contrib/scripts/dumpcerts.sh
+++ b/contrib/scripts/dumpcerts.sh
@@ -42,6 +42,18 @@ set -o nounset
 
 USAGE="$(basename "$0") <path to acme> <destination cert directory>"
 
+# Platform variations
+case `uname` in
+	'Linux')
+		# On Linux, -d should always work. --decode does not work with Alpine's busybox-binary
+		CMD_DECODE_BASE64="base64 -d"
+		;;
+	*)
+		# Max OS-X supports --decode and -D, but --decode may be supported by other platforms as well.
+		CMD_DECODE_BASE64="base64 --decode"
+		;;
+esac
+
 # Allow us to exit on a missing jq binary
 exit_jq() {
 	echo "
@@ -149,10 +161,10 @@ for domain in $(jq -r '.DomainsCertificate.Certs[].Certificate.Domain' ${acmefil
 	echo "Extracting cert bundle for ${domain}"
 	cert=$(jq -e -r --arg domain "$domain" '.DomainsCertificate.Certs[].Certificate |
          	select (.Domain == $domain )| .Certificate' ${acmefile}) || bad_acme
-	echo "${cert}" | base64 -d > "${cdir}/${domain}.crt"
+	echo "${cert}" | ${CMD_DECODE_BASE64} > "${cdir}/${domain}.crt"
 
 	echo "Extracting private key for ${domain}"
 	key=$(jq -e -r --arg domain "$domain" '.DomainsCertificate.Certs[].Certificate |
 		select (.Domain == $domain )| .PrivateKey' ${acmefile}) || bad_acme
-	echo "${key}" | base64 -d > "${pdir}/${domain}.key"
+	echo "${key}" | ${CMD_DECODE_BASE64} > "${pdir}/${domain}.key"
 done

--- a/contrib/scripts/dumpcerts.sh
+++ b/contrib/scripts/dumpcerts.sh
@@ -149,10 +149,10 @@ for domain in $(jq -r '.DomainsCertificate.Certs[].Certificate.Domain' ${acmefil
 	echo "Extracting cert bundle for ${domain}"
 	cert=$(jq -e -r --arg domain "$domain" '.DomainsCertificate.Certs[].Certificate |
          	select (.Domain == $domain )| .Certificate' ${acmefile}) || bad_acme
-	echo "${cert}" | base64 --decode > "${cdir}/${domain}.crt"
+	echo "${cert}" | base64 -d > "${cdir}/${domain}.crt"
 
 	echo "Extracting private key for ${domain}"
 	key=$(jq -e -r --arg domain "$domain" '.DomainsCertificate.Certs[].Certificate |
 		select (.Domain == $domain )| .PrivateKey' ${acmefile}) || bad_acme
-	echo "${key}" | base64 --decode > "${pdir}/${domain}.key"
+	echo "${key}" | base64 -d > "${pdir}/${domain}.key"
 done

--- a/contrib/scripts/dumpcerts.sh
+++ b/contrib/scripts/dumpcerts.sh
@@ -43,7 +43,7 @@ set -o nounset
 USAGE="$(basename "$0") <path to acme> <destination cert directory>"
 
 # Platform variations
-case $(uname) in
+case "$(uname)" in
 	'Linux')
 		# On Linux, -d should always work. --decode does not work with Alpine's busybox-binary
 		CMD_DECODE_BASE64="base64 -d"


### PR DESCRIPTION
Alpine Linux' "base64" does not support the `--decode` option. Only `-d`. 
In order to run `dumpcerts.sh` inside the office "traefik:1.4-alpine" docker-image,
`base64` must be called with `-d`
