### PR TITLE
 Postfix windows binaries with .exe

### DIFF
--- a/script/crossbinary-default
+++ b/script/crossbinary-default
@@ -25,22 +25,16 @@ GO_BUILD_CMD="go build -ldflags"
 GO_BUILD_OPT="-s -w -X ${GIT_REPO_URL}.Version=${VERSION} -X ${GIT_REPO_URL}.Codename=${CODENAME} -X ${GIT_REPO_URL}.BuildDate=${DATE}"
 
 # Build amd64 binaries
-OS_PLATFORM_ARG=(linux darwin)
+OS_PLATFORM_ARG=(linux windows darwin)
 OS_ARCH_ARG=(amd64)
 for OS in ${OS_PLATFORM_ARG[@]}; do
+  BIN_EXT=''
+  if [ "$OS" == "windows" ]; then
+    BIN_EXT='.exe'
+  fi
   for ARCH in ${OS_ARCH_ARG[@]}; do
     echo "Building binary for ${OS}/${ARCH}..."
-    GOARCH=${ARCH} GOOS=${OS} CGO_ENABLED=0 ${GO_BUILD_CMD} "${GO_BUILD_OPT}" -o "dist/traefik_${OS}-${ARCH}" ./cmd/traefik/
-  done
-done
-
-# Build amd64 binaries
-OS_PLATFORM_ARG=(windows)
-OS_ARCH_ARG=(amd64)
-for OS in ${OS_PLATFORM_ARG[@]}; do
-  for ARCH in ${OS_ARCH_ARG[@]}; do
-    echo "Building binary for ${OS}/${ARCH}..."
-    GOARCH=${ARCH} GOOS=${OS} CGO_ENABLED=0 ${GO_BUILD_CMD} "${GO_BUILD_OPT}" -o "dist/traefik_${OS}-${ARCH}.exe" ./cmd/traefik/
+    GOARCH=${ARCH} GOOS=${OS} CGO_ENABLED=0 ${GO_BUILD_CMD} "${GO_BUILD_OPT}" -o "dist/traefik_${OS}-${ARCH}${BIN_EXT}" ./cmd/traefik/
   done
 done
 

--- a/script/crossbinary-default
+++ b/script/crossbinary-default
@@ -24,13 +24,23 @@ GIT_REPO_URL='github.com/containous/traefik/version'
 GO_BUILD_CMD="go build -ldflags"
 GO_BUILD_OPT="-s -w -X ${GIT_REPO_URL}.Version=${VERSION} -X ${GIT_REPO_URL}.Codename=${CODENAME} -X ${GIT_REPO_URL}.BuildDate=${DATE}"
 
-# Build 386 amd64 binaries
-OS_PLATFORM_ARG=(linux windows darwin)
+# Build amd64 binaries
+OS_PLATFORM_ARG=(linux darwin)
 OS_ARCH_ARG=(amd64)
 for OS in ${OS_PLATFORM_ARG[@]}; do
   for ARCH in ${OS_ARCH_ARG[@]}; do
     echo "Building binary for ${OS}/${ARCH}..."
     GOARCH=${ARCH} GOOS=${OS} CGO_ENABLED=0 ${GO_BUILD_CMD} "${GO_BUILD_OPT}" -o "dist/traefik_${OS}-${ARCH}" ./cmd/traefik/
+  done
+done
+
+# Build amd64 binaries
+OS_PLATFORM_ARG=(windows)
+OS_ARCH_ARG=(amd64)
+for OS in ${OS_PLATFORM_ARG[@]}; do
+  for ARCH in ${OS_ARCH_ARG[@]}; do
+    echo "Building binary for ${OS}/${ARCH}..."
+    GOARCH=${ARCH} GOOS=${OS} CGO_ENABLED=0 ${GO_BUILD_CMD} "${GO_BUILD_OPT}" -o "dist/traefik_${OS}-${ARCH}.exe" ./cmd/traefik/
   done
 done
 

--- a/script/crossbinary-others
+++ b/script/crossbinary-others
@@ -25,22 +25,16 @@ GO_BUILD_CMD="go build -ldflags"
 GO_BUILD_OPT="-s -w -X ${GIT_REPO_URL}.Version=${VERSION} -X ${GIT_REPO_URL}.Codename=${CODENAME} -X ${GIT_REPO_URL}.BuildDate=${DATE}"
 
 # Build arm binaries
-OS_PLATFORM_ARG=(linux darwin)
+OS_PLATFORM_ARG=(linux windows darwin)
 OS_ARCH_ARG=(386)
 for OS in ${OS_PLATFORM_ARG[@]}; do
+  BIN_EXT=''
+  if [ "$OS" == "windows" ]; then
+    BIN_EXT='.exe'
+  fi
   for ARCH in ${OS_ARCH_ARG[@]}; do
-    echo "Building binary for $OS/$ARCH..."
-    GOARCH=${ARCH} GOOS=${OS} CGO_ENABLED=0 ${GO_BUILD_CMD} "$GO_BUILD_OPT" -o "dist/traefik_$OS-$ARCH" ./cmd/traefik/
-  done
-done
-
-# Build arm binaries
-OS_PLATFORM_ARG=(windows)
-OS_ARCH_ARG=(386)
-for OS in ${OS_PLATFORM_ARG[@]}; do
-  for ARCH in ${OS_ARCH_ARG[@]}; do
-    echo "Building binary for $OS/$ARCH..."
-    GOARCH=${ARCH} GOOS=${OS} CGO_ENABLED=0 ${GO_BUILD_CMD} "$GO_BUILD_OPT" -o "dist/traefik_$OS-$ARCH.exe" ./cmd/traefik/
+    echo "Building binary for ${OS}/${ARCH}..."
+    GOARCH=${ARCH} GOOS=${OS} CGO_ENABLED=0 ${GO_BUILD_CMD} "${GO_BUILD_OPT}" -o "dist/traefik_${OS}-${ARCH}${BIN_EXT}" ./cmd/traefik/
   done
 done
 

--- a/script/crossbinary-others
+++ b/script/crossbinary-others
@@ -25,12 +25,22 @@ GO_BUILD_CMD="go build -ldflags"
 GO_BUILD_OPT="-s -w -X ${GIT_REPO_URL}.Version=${VERSION} -X ${GIT_REPO_URL}.Codename=${CODENAME} -X ${GIT_REPO_URL}.BuildDate=${DATE}"
 
 # Build arm binaries
-OS_PLATFORM_ARG=(linux windows darwin)
+OS_PLATFORM_ARG=(linux darwin)
 OS_ARCH_ARG=(386)
 for OS in ${OS_PLATFORM_ARG[@]}; do
   for ARCH in ${OS_ARCH_ARG[@]}; do
     echo "Building binary for $OS/$ARCH..."
     GOARCH=${ARCH} GOOS=${OS} CGO_ENABLED=0 ${GO_BUILD_CMD} "$GO_BUILD_OPT" -o "dist/traefik_$OS-$ARCH" ./cmd/traefik/
+  done
+done
+
+# Build arm binaries
+OS_PLATFORM_ARG=(windows)
+OS_ARCH_ARG=(386)
+for OS in ${OS_PLATFORM_ARG[@]}; do
+  for ARCH in ${OS_ARCH_ARG[@]}; do
+    echo "Building binary for $OS/$ARCH..."
+    GOARCH=${ARCH} GOOS=${OS} CGO_ENABLED=0 ${GO_BUILD_CMD} "$GO_BUILD_OPT" -o "dist/traefik_$OS-$ARCH.exe" ./cmd/traefik/
   done
 done
 


### PR DESCRIPTION
### Description

Build binaries for windows does not have the ".exe" postfix so it's always a hassle to rename the files. In addition to that, some people (mostly beginners) do have problems start using traefik the first time.
This PR is adding the ".exe" postfix to the filename on build.