### PR TITLE
Fix typo in frontend.headers.customresponseheaders label

### DIFF
--- a/types/common_label.go
+++ b/types/common_label.go
@@ -15,7 +15,7 @@ const (
 	LabelFrontendAuthBasic                       = LabelPrefix + "frontend.auth.basic"
 	LabelFrontendEntryPoints                     = LabelPrefix + "frontend.entryPoints"
 	LabelFrontendRequestHeader                   = LabelPrefix + "frontend.headers.customrequestheaders"
-	LabelFrontendResponseHeader                  = LabelPrefix + "frontend.headers.customresoponseheaders"
+	LabelFrontendResponseHeader                  = LabelPrefix + "frontend.headers.customresponseheaders"
 	LabelFrontendPassHostHeader                  = LabelPrefix + "frontend.passHostHeader"
 	LabelFrontendPriority                        = LabelPrefix + "frontend.priority"
 	LabelFrontendRule                            = LabelPrefix + "frontend.rule"


### PR DESCRIPTION
When looking for the supported labels I noticed a typo in the "...frontend.headers.customresponseheaders" label. This PR fixes this typo.