### PR TITLE
Add secret creation to docs for kubernetes backend

### DIFF
--- a/docs/configuration/backends/kubernetes.md
+++ b/docs/configuration/backends/kubernetes.md
@@ -118,10 +118,10 @@ If one of the Net-Specifications are invalid, the whole list is invalid and allo
 ### Authentication
 
 Is possible to add additional authentication annotations in the Ingress rule.
-The source of the authentication is a secret that contains usernames and passwords inside the the key auth.
+The source of the authentication is a secret that contains usernames and passwords inside the key auth.
 
 - `ingress.kubernetes.io/auth-type`: `basic`
-- `ingress.kubernetes.io/auth-secret`  
+- `ingress.kubernetes.io/auth-secret`: `mysecret`  
     Contains the usernames and passwords with access to the paths defined in the Ingress Rule.
 
 The secret must be created in the same namespace as the Ingress rule.

--- a/docs/user-guide/kubernetes.md
+++ b/docs/user-guide/kubernetes.md
@@ -79,7 +79,7 @@ It is possible to use Træfik with a [Deployment](https://kubernetes.io/docs/con
 
 The Deployment objects looks like this:
 
-```yml
+```yaml
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -326,6 +326,72 @@ echo "$(minikube ip) traefik-ui.minikube" | sudo tee -a /etc/hosts
 ```
 
 We should now be able to visit [traefik-ui.minikube](http://traefik-ui.minikube) in the browser and view the Træfik Web UI.
+
+## Basic Authentication
+
+It's possible to add additional authentication annotations in the Ingress rule.
+The source of the authentication is a secret that contains usernames and passwords inside the key auth.
+To read about basic auth limitations see the [Kubernetes Ingress](/configuration/backends/kubernetes) configuration page.
+
+#### Creating the Secret
+
+A. Use `htpasswd` to create a file containing the username and the base64-encoded password:
+
+```shell
+htpasswd -c ./auth myusername
+```
+
+You will be prompted for a password which you will have to enter twice.
+`htpasswd` will create a file with the following:
+
+```shell
+cat auth
+```
+```
+myusername:$apr1$78Jyn/1K$ERHKVRPPlzAX8eBtLuvRZ0
+```
+
+B. Now use `kubectl` to create a secret in the monitoring namespace using the file created by `htpasswd`.
+
+```shell
+kubectl create secret generic mysecret --from-file auth --namespace=monitoring
+```
+
+!!! note
+    Secret must be in same namespace as the ingress rule.
+
+C. Create the ingress using the following annotations to specify basic auth and that the username and password is stored in `mysecret`.
+
+- `ingress.kubernetes.io/auth-type: "basic"`
+- `ingress.kubernetes.io/auth-secret: "mysecret"`
+
+Following is a full ingress example based on Prometheus:
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+ name: prometheus-dashboard
+ namespace: monitoring
+ annotations:
+   kubernetes.io/ingress.class: traefik
+   ingress.kubernetes.io/auth-type: "basic"
+   ingress.kubernetes.io/auth-secret: "mysecret"
+spec:
+ rules:
+ - host: dashboard.prometheus.example.com
+   http:
+     paths:
+     - backend:
+         serviceName: prometheus
+         servicePort: 9090
+```
+
+You can apply the example ingress as following:
+
+```shell
+kubectl create -f prometheus-ingress.yaml -n monitoring
+```
 
 ## Name based routing
 


### PR DESCRIPTION
### What does this PR do?
Adds additional documentation to help people setup basic auth with kubernetes ingress.
<!-- A brief description of the change being made with this pull request. -->


### Motivation
I was unable to easily find the information I needed to create the secret. I had to resort to tracking down the original PR for that feature.
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated documentation

### Additional Notes
I think the instructions to create the dashboard auth user and password (types of encryption) is the same for adding auth to an ingress but I could not confirm so I let it as is.
<!-- Anything else we should know when reviewing? -->

Note: Sublime must have removed some invisible trailing spaces, I see a bunch of lines that are modified but not changed.
