### PR TITLE
Fix raw path handling in strip prefix

### DIFF
--- a/middlewares/stripPrefix.go
+++ b/middlewares/stripPrefix.go
@@ -16,8 +16,11 @@ type StripPrefix struct {
 
 func (s *StripPrefix) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	for _, prefix := range s.Prefixes {
-		if p := strings.TrimPrefix(r.URL.Path, prefix); len(p) < len(r.URL.Path) {
-			r.URL.Path = "/" + strings.TrimPrefix(p, "/")
+		if strings.HasPrefix(r.URL.Path, prefix) {
+			r.URL.Path = stripPrefix(r.URL.Path, prefix)
+			if r.URL.RawPath != "" {
+				r.URL.RawPath = stripPrefix(r.URL.RawPath, prefix)
+			}
 			s.serveRequest(w, r, strings.TrimSpace(prefix))
 			return
 		}
@@ -34,4 +37,12 @@ func (s *StripPrefix) serveRequest(w http.ResponseWriter, r *http.Request, prefi
 // SetHandler sets handler
 func (s *StripPrefix) SetHandler(Handler http.Handler) {
 	s.Handler = Handler
+}
+
+func stripPrefix(s, prefix string) string {
+	return ensureLeadingSlash(strings.TrimPrefix(s, prefix))
+}
+
+func ensureLeadingSlash(str string) string {
+	return "/" + strings.TrimPrefix(str, "/")
 }

--- a/middlewares/stripPrefixRegex.go
+++ b/middlewares/stripPrefixRegex.go
@@ -40,6 +40,9 @@ func (s *StripPrefixRegex) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		r.URL.Path = r.URL.Path[len(prefix.Path):]
+		if r.URL.RawPath != "" {
+			r.URL.RawPath = r.URL.RawPath[len(prefix.Path):]
+		}
 		r.Header.Add(ForwardedPrefixHeader, prefix.Path)
 		r.RequestURI = r.URL.RequestURI()
 		s.Handler.ServeHTTP(w, r)


### PR DESCRIPTION
This PR fixes forwarding of URL encoded characters to the backend servers. 

Given that Traefik receives a request path in the form: `/some/a%2Fb` it should forward the same path to the backend. This is the case when using e.g. the rule type `PathPrefix`, but as soon as the rule type is either `PathPrefixStrip` or `PathPrefixStripRegex` the path was forwarded in the decoded form like: `/some/a/b`.

The reason why this solution fixes our problem is that go uses the `String()` method of the `URL` object when it constructs the request. The docs state for this:

> // String reassembles the URL into a valid URL string.
// The general form of the result is one of:
//
//	scheme:opaque?query#fragment
//	scheme://userinfo@host/path?query#fragment
//
// If u.Opaque is non-empty, String uses the first form;
// otherwise it uses the second form.
// To obtain the path, String uses u.EscapedPath().


For us the relevant part is with `u.EscapedPath()` and there the docs state:

> // EscapedPath returns the escaped form of u.Path.
// In general there are multiple possible escaped forms of any path.
// EscapedPath returns u.RawPath when it is a valid escaping of u.Path.
// Otherwise EscapedPath ignores u.RawPath and computes an escaped
// form on its own.
// The String and RequestURI methods use EscapedPath to construct
// their results.
// In general, code should call EscapedPath instead of
// reading u.RawPath directly.

To understand the problem, note the sentence: `EscapedPath returns u.RawPath when it is a valid escaping of u.Path.` By stripping only the Path and not the RawPath we violated this statement and therefore the http package decided to use the `Path`.