### PR TITLE
Marathon constraints filtering

### DIFF
--- a/docs/configuration/backends/marathon.md
+++ b/docs/configuration/backends/marathon.md
@@ -68,6 +68,13 @@ domain = "marathon.localhost"
 #
 # marathonLBCompatibility = true
 
+# Enable marathon constraints.
+#
+# Optional
+# Default: false
+#
+# marathonConstraints = true
+
 # Enable Marathon basic authentication.
 #
 # Optional

--- a/docs/configuration/backends/marathon.md
+++ b/docs/configuration/backends/marathon.md
@@ -69,6 +69,9 @@ domain = "marathon.localhost"
 # marathonLBCompatibility = true
 
 # Enable marathon constraints.
+# If enabled, Traefik will read Marathon constrains, as defined in https://mesosphere.github.io/marathon/docs/constraints.html
+# Each individual constraint will be treated as a verbatum compounded tag. 
+# i.e. "rack_id:CLUSTER:rack-1", with all constraint groups concatenated together using ":"
 #
 # Optional
 # Default: false

--- a/docs/configuration/backends/marathon.md
+++ b/docs/configuration/backends/marathon.md
@@ -68,15 +68,15 @@ domain = "marathon.localhost"
 #
 # marathonLBCompatibility = true
 
-# Enable marathon constraints.
-# If enabled, Traefik will read Marathon constrains, as defined in https://mesosphere.github.io/marathon/docs/constraints.html
-# Each individual constraint will be treated as a verbatum compounded tag. 
+# Enable filtering using Marathon constraints..
+# If enabled, Traefik will read Marathon constraints, as defined in https://mesosphere.github.io/marathon/docs/constraints.html
+# Each individual constraint will be treated as a verbatim compounded tag. 
 # i.e. "rack_id:CLUSTER:rack-1", with all constraint groups concatenated together using ":"
 #
 # Optional
 # Default: false
 #
-# marathonConstraints = true
+# filterMarathonConstraints = true
 
 # Enable Marathon basic authentication.
 #

--- a/provider/marathon/builder_test.go
+++ b/provider/marathon/builder_test.go
@@ -44,6 +44,12 @@ func label(key, value string) func(*marathon.Application) {
 	}
 }
 
+func constraint(value string) func(*marathon.Application) {
+	return func(app *marathon.Application) {
+		app.AddConstraint(strings.Split(value, ":")...)
+	}
+}
+
 func labelWithService(key, value string, serviceName string) func(*marathon.Application) {
 	if len(serviceName) == 0 {
 		panic("serviceName can not be empty")

--- a/provider/marathon/marathon.go
+++ b/provider/marathon/marathon.go
@@ -59,6 +59,7 @@ type Provider struct {
 	GroupsAsSubDomains      bool             `description:"Convert Marathon groups to subdomains" export:"true"`
 	DCOSToken               string           `description:"DCOSToken for DCOS environment, This will override the Authorization header" export:"true"`
 	MarathonLBCompatibility bool             `description:"Add compatibility with marathon-lb labels" export:"true"`
+	MarathonConstraints     bool             `description:"Enable use of Marathon constraints in constraint filtering" export:"true"`
 	TLS                     *types.ClientTLS `description:"Enable Docker TLS support" export:"true"`
 	DialerTimeout           flaeg.Duration   `description:"Set a non-default connection timeout for Marathon" export:"true"`
 	KeepAlive               flaeg.Duration   `description:"Set a non-default TCP Keep Alive time in seconds" export:"true"`
@@ -245,6 +246,13 @@ func (p *Provider) applicationFilter(app marathon.Application) bool {
 	if p.MarathonLBCompatibility {
 		if label, ok := p.getAppLabel(app, "HAPROXY_GROUP"); ok {
 			constraintTags = append(constraintTags, label)
+		}
+	}
+	if p.MarathonConstraints {
+		if app.Constraints != nil && len(*app.Constraints) > 0 {
+			for _, list := range *app.Constraints {
+				constraintTags = append(constraintTags, strings.Join(list, ":"))
+			}
 		}
 	}
 	if ok, failingConstraint := p.MatchConstraints(constraintTags); !ok {

--- a/provider/marathon/marathon.go
+++ b/provider/marathon/marathon.go
@@ -248,7 +248,7 @@ func (p *Provider) applicationFilter(app marathon.Application) bool {
 			constraintTags = append(constraintTags, label)
 		}
 	}
-	if p.FilterMarathonConstraints && app.Constraints != nil && len(*app.Constraints) > 0 {
+	if p.FilterMarathonConstraints && app.Constraints != nil {
 		for _, constraintParts := range *app.Constraints {
 			constraintTags = append(constraintTags, strings.Join(constraintParts, ":"))
 		}

--- a/provider/marathon/marathon.go
+++ b/provider/marathon/marathon.go
@@ -53,21 +53,21 @@ var servicesPropertiesRegexp = regexp.MustCompile(`^traefik\.(?P<service_name>.+
 // Provider holds configuration of the provider.
 type Provider struct {
 	provider.BaseProvider
-	Endpoint                string           `description:"Marathon server endpoint. You can also specify multiple endpoint for Marathon" export:"true"`
-	Domain                  string           `description:"Default domain used" export:"true"`
-	ExposedByDefault        bool             `description:"Expose Marathon apps by default" export:"true"`
-	GroupsAsSubDomains      bool             `description:"Convert Marathon groups to subdomains" export:"true"`
-	DCOSToken               string           `description:"DCOSToken for DCOS environment, This will override the Authorization header" export:"true"`
-	MarathonLBCompatibility bool             `description:"Add compatibility with marathon-lb labels" export:"true"`
-	MarathonConstraints     bool             `description:"Enable use of Marathon constraints in constraint filtering" export:"true"`
-	TLS                     *types.ClientTLS `description:"Enable Docker TLS support" export:"true"`
-	DialerTimeout           flaeg.Duration   `description:"Set a non-default connection timeout for Marathon" export:"true"`
-	KeepAlive               flaeg.Duration   `description:"Set a non-default TCP Keep Alive time in seconds" export:"true"`
-	ForceTaskHostname       bool             `description:"Force to use the task's hostname." export:"true"`
-	Basic                   *Basic           `description:"Enable basic authentication" export:"true"`
-	RespectReadinessChecks  bool             `description:"Filter out tasks with non-successful readiness checks during deployments" export:"true"`
-	readyChecker            *readinessChecker
-	marathonClient          marathon.Marathon
+	Endpoint                  string           `description:"Marathon server endpoint. You can also specify multiple endpoint for Marathon" export:"true"`
+	Domain                    string           `description:"Default domain used" export:"true"`
+	ExposedByDefault          bool             `description:"Expose Marathon apps by default" export:"true"`
+	GroupsAsSubDomains        bool             `description:"Convert Marathon groups to subdomains" export:"true"`
+	DCOSToken                 string           `description:"DCOSToken for DCOS environment, This will override the Authorization header" export:"true"`
+	MarathonLBCompatibility   bool             `description:"Add compatibility with marathon-lb labels" export:"true"`
+	FilterMarathonConstraints bool             `description:"Enable use of Marathon constraints in constraint filtering" export:"true"`
+	TLS                       *types.ClientTLS `description:"Enable Docker TLS support" export:"true"`
+	DialerTimeout             flaeg.Duration   `description:"Set a non-default connection timeout for Marathon" export:"true"`
+	KeepAlive                 flaeg.Duration   `description:"Set a non-default TCP Keep Alive time in seconds" export:"true"`
+	ForceTaskHostname         bool             `description:"Force to use the task's hostname." export:"true"`
+	Basic                     *Basic           `description:"Enable basic authentication" export:"true"`
+	RespectReadinessChecks    bool             `description:"Filter out tasks with non-successful readiness checks during deployments" export:"true"`
+	readyChecker              *readinessChecker
+	marathonClient            marathon.Marathon
 }
 
 // Basic holds basic authentication specific configurations
@@ -248,11 +248,9 @@ func (p *Provider) applicationFilter(app marathon.Application) bool {
 			constraintTags = append(constraintTags, label)
 		}
 	}
-	if p.MarathonConstraints {
-		if app.Constraints != nil && len(*app.Constraints) > 0 {
-			for _, list := range *app.Constraints {
-				constraintTags = append(constraintTags, strings.Join(list, ":"))
-			}
+	if p.FilterMarathonConstraints && app.Constraints != nil && len(*app.Constraints) > 0 {
+		for _, constraintParts := range *app.Constraints {
+			constraintTags = append(constraintTags, strings.Join(constraintParts, ":"))
 		}
 	}
 	if ok, failingConstraint := p.MatchConstraints(constraintTags); !ok {

--- a/provider/marathon/marathon_test.go
+++ b/provider/marathon/marathon_test.go
@@ -529,14 +529,12 @@ func TestMarathonApplicationFilterConstraints(t *testing.T) {
 			desc:                    "tags missing",
 			application:             application(),
 			marathonLBCompatibility: false,
-			marathonConstraints:     false,
 			expected:                false,
 		},
 		{
 			desc:                    "tag matching",
 			application:             application(label(types.LabelTags, "valid")),
 			marathonLBCompatibility: false,
-			marathonConstraints:     false,
 			expected:                true,
 		},
 		{
@@ -576,9 +574,9 @@ func TestMarathonApplicationFilterConstraints(t *testing.T) {
 		t.Run(c.desc, func(t *testing.T) {
 			t.Parallel()
 			provider := &Provider{
-				ExposedByDefault:        true,
-				MarathonLBCompatibility: c.marathonLBCompatibility,
-				MarathonConstraints:     c.marathonConstraints,
+				ExposedByDefault:          true,
+				MarathonLBCompatibility:   c.marathonLBCompatibility,
+				FilterMarathonConstraints: c.marathonConstraints,
 			}
 			constraint, err := types.NewConstraint("tag==valid")
 			if err != nil {

--- a/provider/marathon/marathon_test.go
+++ b/provider/marathon/marathon_test.go
@@ -522,18 +522,42 @@ func TestMarathonApplicationFilterConstraints(t *testing.T) {
 		desc                    string
 		application             marathon.Application
 		marathonLBCompatibility bool
+		marathonConstraints     bool
 		expected                bool
 	}{
 		{
 			desc:                    "tags missing",
 			application:             application(),
 			marathonLBCompatibility: false,
+			marathonConstraints:     false,
 			expected:                false,
 		},
 		{
 			desc:                    "tag matching",
 			application:             application(label(types.LabelTags, "valid")),
 			marathonLBCompatibility: false,
+			marathonConstraints:     false,
+			expected:                true,
+		},
+		{
+			desc:                    "constraint missing",
+			application:             application(),
+			marathonLBCompatibility: false,
+			marathonConstraints:     true,
+			expected:                false,
+		},
+		{
+			desc:                    "constraint invalid",
+			application:             application(constraint("service_cluster:CLUSTER:test")),
+			marathonLBCompatibility: false,
+			marathonConstraints:     true,
+			expected:                false,
+		},
+		{
+			desc:                    "constraint valid",
+			application:             application(constraint("valid")),
+			marathonLBCompatibility: false,
+			marathonConstraints:     true,
 			expected:                true,
 		},
 		{
@@ -554,6 +578,7 @@ func TestMarathonApplicationFilterConstraints(t *testing.T) {
 			provider := &Provider{
 				ExposedByDefault:        true,
 				MarathonLBCompatibility: c.marathonLBCompatibility,
+				MarathonConstraints:     c.marathonConstraints,
 			}
 			constraint, err := types.NewConstraint("tag==valid")
 			if err != nil {

--- a/provider/marathon/marathon_test.go
+++ b/provider/marathon/marathon_test.go
@@ -519,11 +519,11 @@ func TestMarathonTaskFilter(t *testing.T) {
 
 func TestMarathonApplicationFilterConstraints(t *testing.T) {
 	cases := []struct {
-		desc                    string
-		application             marathon.Application
-		marathonLBCompatibility bool
-		marathonConstraints     bool
-		expected                bool
+		desc                      string
+		application               marathon.Application
+		marathonLBCompatibility   bool
+		filterMarathonConstraints bool
+		expected                  bool
 	}{
 		{
 			desc:                    "tags missing",
@@ -538,25 +538,25 @@ func TestMarathonApplicationFilterConstraints(t *testing.T) {
 			expected:                true,
 		},
 		{
-			desc:                    "constraint missing",
-			application:             application(),
-			marathonLBCompatibility: false,
-			marathonConstraints:     true,
-			expected:                false,
+			desc:                      "constraint missing",
+			application:               application(),
+			marathonLBCompatibility:   false,
+			filterMarathonConstraints: true,
+			expected:                  false,
 		},
 		{
-			desc:                    "constraint invalid",
-			application:             application(constraint("service_cluster:CLUSTER:test")),
-			marathonLBCompatibility: false,
-			marathonConstraints:     true,
-			expected:                false,
+			desc:                      "constraint invalid",
+			application:               application(constraint("service_cluster:CLUSTER:test")),
+			marathonLBCompatibility:   false,
+			filterMarathonConstraints: true,
+			expected:                  false,
 		},
 		{
-			desc:                    "constraint valid",
-			application:             application(constraint("valid")),
-			marathonLBCompatibility: false,
-			marathonConstraints:     true,
-			expected:                true,
+			desc:                      "constraint valid",
+			application:               application(constraint("valid")),
+			marathonLBCompatibility:   false,
+			filterMarathonConstraints: true,
+			expected:                  true,
 		},
 		{
 			desc: "LB compatibility tag matching",
@@ -576,7 +576,7 @@ func TestMarathonApplicationFilterConstraints(t *testing.T) {
 			provider := &Provider{
 				ExposedByDefault:          true,
 				MarathonLBCompatibility:   c.marathonLBCompatibility,
-				FilterMarathonConstraints: c.marathonConstraints,
+				FilterMarathonConstraints: c.filterMarathonConstraints,
 			}
 			constraint, err := types.NewConstraint("tag==valid")
 			if err != nil {


### PR DESCRIPTION
### What does this PR do?

Add support for filtering based on Marathon-defined constraints, as described in https://mesosphere.github.io/marathon/docs/constraints.html

### Motivation

Many Marathon clusters have applications deployed with various "constraints", configuring things like application service affinity, cluster binding, etc.  It would be very helpful to not have to add additional/duplicate `traefik.tags` labels to the applications and to be able to filter using already defined Marathon constraints instead.

### More

- [x] Added/updated tests
- [x] Added/updated documentation
