### PR TITLE
Exclude GRPC from compress

### DIFF
--- a/middlewares/compress.go
+++ b/middlewares/compress.go
@@ -3,6 +3,7 @@ package middlewares
 import (
 	"compress/gzip"
 	"net/http"
+	"strings"
 
 	"github.com/NYTimes/gziphandler"
 	"github.com/containous/traefik/log"
@@ -13,7 +14,12 @@ type Compress struct{}
 
 // ServerHTTP is a function used by Negroni
 func (c *Compress) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-	gzipHandler(next).ServeHTTP(rw, r)
+	contentType := r.Header.Get("Content-Type")
+	if strings.HasPrefix(contentType, "application/grpc") {
+		next.ServeHTTP(rw, r)
+	} else {
+		gzipHandler(next).ServeHTTP(rw, r)
+	}
 }
 
 func gzipHandler(h http.Handler) http.Handler {


### PR DESCRIPTION
### What does this PR do?

Exclude GRPC from compress

### Motivation

GRPC provide an internal compression [system](https://github.com/grpc/grpc/blob/master/doc/compression.md). 

### More

- [x] Added/updated tests