### PR TITLE
Flush and errorcode

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,4 +1,4 @@
-hash: de7e6a0069090a5811c003db434da19fe31efcf0c9429d3ccb676295708f0d2b
+hash: bbdbbc9d428937dbaf85e92a3747ebe547f1cc110fbb536c94b5efb3dde6e5ab
 updated: 2017-10-24T14:08:11.364720581+02:00
 imports:
 - name: cloud.google.com/go
@@ -383,7 +383,9 @@ imports:
   repo: https://github.com/ijc25/Gotty.git
   vcs: git
 - name: github.com/NYTimes/gziphandler
-  version: 0f67f3f25d3b17590ee0ab93fcb216363ee30967
+  version: 26a3f68265200656f31940bc15b191f7d10b5bbd
+  repo: https://github.com/containous/gziphandler.git
+  vcs: git
 - name: github.com/ogier/pflag
   version: 45c278ab3607870051a2ea9040bb85fcb8557481
 - name: github.com/opencontainers/go-digest

--- a/glide.yaml
+++ b/glide.yaml
@@ -79,6 +79,9 @@ import:
   vcs: git
 - package: github.com/abbot/go-http-auth
 - package: github.com/NYTimes/gziphandler
+  version: fork-containous
+  repo: https://github.com/containous/gziphandler.git
+  vcs: git
 - package: github.com/docker/leadership
 - package: github.com/satori/go.uuid
   version: ^1.1.0

--- a/vendor/github.com/NYTimes/gziphandler/gzip.go
+++ b/vendor/github.com/NYTimes/gziphandler/gzip.go
@@ -82,7 +82,6 @@ type GzipResponseWriter struct {
 	buf     []byte // Holds the first part of the write before reaching the minSize or the end of the write.
 
 	contentTypes []string // Only compress if the response is one of these content-types. All are accepted if empty.
-	flushed      bool     // Indicate if the stream was already flushed
 }
 
 // Write appends data to the gzip writer.
@@ -151,7 +150,9 @@ func (w *GzipResponseWriter) startGzip() error {
 
 // WriteHeader just saves the response code until close or GZIP effective writes.
 func (w *GzipResponseWriter) WriteHeader(code int) {
-	w.code = code
+	if w.code == 0 {
+		w.code = code
+	}
 }
 
 // init graps a new gzip writer from the gzipWriterPool and writes the correct
@@ -168,8 +169,7 @@ func (w *GzipResponseWriter) init() {
 func (w *GzipResponseWriter) Close() error {
 	if w.gw == nil {
 		// Gzip not trigged yet, write out regular response.
-		// WriteHeader only if it wasn't already wrote by a Flush
-		if !w.flushed && w.code != 0 {
+		if w.code != 0 {
 			w.ResponseWriter.WriteHeader(w.code)
 		}
 		if w.buf != nil {
@@ -192,16 +192,18 @@ func (w *GzipResponseWriter) Close() error {
 // http.ResponseWriter if it is an http.Flusher. This makes GzipResponseWriter
 // an http.Flusher.
 func (w *GzipResponseWriter) Flush() {
-	if w.gw != nil {
-		w.gw.Flush()
+	if w.gw == nil {
+		// Only flush once startGzip has been called.
+		//
+		// Flush is thus a no-op until the written body
+		// exceeds minSize.
+		return
 	}
 
+	w.gw.Flush()
+
 	if fw, ok := w.ResponseWriter.(http.Flusher); ok {
-		if !w.flushed && w.code != 0 {
-			w.ResponseWriter.WriteHeader(w.code)
-		}
 		fw.Flush()
-		w.flushed = true
 	}
 }
 


### PR DESCRIPTION

### What does this PR do?

Only flush once startGzip has been called

### Motivation

This prevents the underlying Flusher
from writing the wrong status code or writing
headers before Content-Encoding has been set. 

### More

- [x] Added/updated tests

### Additional Notes

<!-- Anything else we should know when reviewing? -->
