### PR TITLE
Fix issue with label traefik.backend.loadbalancer.stickiness.cookieName

### DIFF
--- a/provider/rancher/rancher.go
+++ b/provider/rancher/rancher.go
@@ -126,7 +126,7 @@ func (p *Provider) hasStickinessLabel(service rancherData) bool {
 	return errStickiness == nil && len(labelStickiness) > 0 && strings.EqualFold(strings.TrimSpace(labelStickiness), "true")
 }
 
-func (p *Provider) getStickinessCookieName(service rancherData, backendName string) string {
+func (p *Provider) getStickinessCookieName(service rancherData) string {
 	if label, err := getServiceLabel(service, types.LabelBackendLoadbalancerStickinessCookieName); err == nil {
 		return label
 	}


### PR DESCRIPTION
### What does this PR do?

Fix issue using label `traefik.backend.loadbalancer.stickiness.cookieName` at rancher provider.

When label `traefik.backend.loadbalancer.stickiness.cookieName` is used with rancher provider, 
get errors message 
`18/11/2017 13:28:59time="2017-11-18T12:28:59Z" level=error msg="template: :14:24: executing "" at <getStickinessCookieN...>: wrong number of args for getStickinessCookieName: want 2 got 1"` 


### Motivation

https://github.com/rawmind0/rancher-traefik/issues/57
