### PR TITLE
Add backend specific forwarding timeouts

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -476,6 +476,23 @@ Here is an example of backends and servers definition:
 - `backend2` will forward the traffic to two servers: `http://172.17.0.4:80"` with weight `1` and `http://172.17.0.5:80` with weight `2` using `drr` load-balancing strategy.
 - a circuit breaker is added on `backend1` using the expression `NetworkErrorRatio() > 0.5`: watch error ratio over 10 second sliding window
 
+### Forwarding Timeouts
+
+Global forwarding timeouts can be overridden per backend depending on your requirements. `dialTimeout` is the maximum amount of time that Traefik will spend waiting for a connection to be established, and the `responseHeaderTimeout` is the maximum amount of time that Traefik will spend waiting for a response from the server.
+
+Here is an example of backends with different forwarding timeouts:
+
+```toml
+[backends]
+  [backends.backend1]
+    [backends.backend1.forwardingTimeouts]
+    dialTimeout = "1s"
+    responseHeaderTimeout = "5s"
+  [backends.backend2]
+    [backends.backend2.forwardingTimeouts]
+    dialTimeout = "2s"
+    responseHeaderTimeout = "10s"
+```
 
 ## Configuration
 

--- a/integration/fixtures/timeout/forwarding_timeouts.toml
+++ b/integration/fixtures/timeout/forwarding_timeouts.toml
@@ -26,6 +26,11 @@ responseHeaderTimeout = "300ms"
   [backends.backend2]
     [backends.backend2.servers.server2]
     url = "http://{{.TimeoutEndpoint}}:9000"
+  [backends.backend3]
+    [backends.backend3.forwardingTimeouts]
+    responseHeaderTimeout = "1s"
+    [backends.backend3.servers.server3]
+    url = "http://{{.TimeoutEndpoint}}:9000"
 
 [frontends]
   [frontends.frontend1]
@@ -36,3 +41,7 @@ responseHeaderTimeout = "300ms"
   backend = "backend2"
     [frontends.frontend2.routes.test_2]
     rule = "Path:/responseHeaderTimeout"
+  [frontends.frontend3]
+  backend = "backend3"
+    [frontends.frontend3.routes.test_3]
+    rule = "Path:/backendResponseHeaderTimeout"

--- a/integration/timeout_test.go
+++ b/integration/timeout_test.go
@@ -42,4 +42,14 @@ func (s *TimeoutSuite) TestForwardingTimeouts(c *check.C) {
 	response, err = http.Get("http://127.0.0.1:8000/responseHeaderTimeout?sleep=1000")
 	c.Assert(err, checker.IsNil)
 	c.Assert(response.StatusCode, checker.Equals, http.StatusGatewayTimeout)
+
+	// This simulates the backend increasing the default ResponseHeaderTimeout and not timing out
+	response, err = http.Get("http://127.0.0.1:8000/backendResponseHeaderTimeout?sleep=700")
+	c.Assert(err, checker.IsNil)
+	c.Assert(response.StatusCode, checker.Equals, http.StatusOK)
+
+	// This simulates the backend increasing the default ResponseHeaderTimeout and timing out
+	response, err = http.Get("http://127.0.0.1:8000/backendResponseHeaderTimeout?sleep=1500")
+	c.Assert(err, checker.IsNil)
+	c.Assert(response.StatusCode, checker.Equals, http.StatusGatewayTimeout)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -106,7 +106,7 @@ func NewServer(globalConfiguration configuration.GlobalConfiguration) *Server {
 	}
 
 	server.routinesPool = safe.NewPool(context.Background())
-	server.defaultForwardingRoundTripper = createHTTPTransport(globalConfiguration)
+	server.defaultForwardingRoundTripper = createHTTPTransport(globalConfiguration, nil)
 
 	server.metricsRegistry = metrics.NewVoidRegistry()
 	if globalConfiguration.Metrics != nil {
@@ -137,7 +137,7 @@ func NewServer(globalConfiguration configuration.GlobalConfiguration) *Server {
 // An exception to this is the MaxIdleConns setting as we only provide the option MaxIdleConnsPerHost
 // in Traefik at this point in time. Setting this value to the default of 100 could lead to confusing
 // behaviour and backwards compatibility issues.
-func createHTTPTransport(globalConfiguration configuration.GlobalConfiguration) *http.Transport {
+func createHTTPTransport(globalConfiguration configuration.GlobalConfiguration, backendForwardingTimeouts *types.ForwardingTimeouts) *http.Transport {
 	dialer := &net.Dialer{
 		Timeout:   configuration.DefaultDialTimeout,
 		KeepAlive: 30 * time.Second,
@@ -145,6 +145,9 @@ func createHTTPTransport(globalConfiguration configuration.GlobalConfiguration) 
 	}
 	if globalConfiguration.ForwardingTimeouts != nil {
 		dialer.Timeout = time.Duration(globalConfiguration.ForwardingTimeouts.DialTimeout)
+	}
+	if backendForwardingTimeouts != nil {
+		dialer.Timeout = time.Duration(backendForwardingTimeouts.DialTimeout)
 	}
 
 	transport := &http.Transport{
@@ -157,6 +160,9 @@ func createHTTPTransport(globalConfiguration configuration.GlobalConfiguration) 
 	}
 	if globalConfiguration.ForwardingTimeouts != nil {
 		transport.ResponseHeaderTimeout = time.Duration(globalConfiguration.ForwardingTimeouts.ResponseHeaderTimeout)
+	}
+	if backendForwardingTimeouts != nil {
+		transport.ResponseHeaderTimeout = time.Duration(backendForwardingTimeouts.ResponseHeaderTimeout)
 	}
 	if globalConfiguration.InsecureSkipVerify {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
@@ -862,21 +868,24 @@ func (server *Server) buildEntryPoints(globalConfiguration configuration.GlobalC
 }
 
 // getRoundTripper will either use server.defaultForwardingRoundTripper or create a new one
-// given a custom TLS configuration is passed and the passTLSCert option is set to true.
-func (server *Server) getRoundTripper(entryPointName string, globalConfiguration configuration.GlobalConfiguration, passTLSCert bool, tls *traefikTls.TLS) (http.RoundTripper, error) {
+// given a custom TLS configuration is passed and the passTLSCert option is set to true or if backend specific
+// round tripper timeouts have been configured
+func (server *Server) getRoundTripper(entryPointName string, globalConfiguration configuration.GlobalConfiguration, backendForwardingTimeouts *types.ForwardingTimeouts, passTLSCert bool, tls *traefikTls.TLS) (http.RoundTripper, error) {
+	if !passTLSCert && backendForwardingTimeouts == nil {
+		return server.defaultForwardingRoundTripper, nil
+	}
+
+	transport := createHTTPTransport(globalConfiguration, backendForwardingTimeouts)
 	if passTLSCert {
 		tlsConfig, err := createClientTLSConfig(entryPointName, tls)
 		if err != nil {
 			log.Errorf("Failed to create TLSClientConfig: %s", err)
 			return nil, err
 		}
-
-		transport := createHTTPTransport(globalConfiguration)
 		transport.TLSClientConfig = tlsConfig
-		return transport, nil
 	}
 
-	return server.defaultForwardingRoundTripper, nil
+	return transport, nil
 }
 
 // LoadConfig returns a new gorilla.mux Route from the specified global configuration and the dynamic
@@ -942,9 +951,14 @@ func (server *Server) loadConfig(configurations types.Configurations, globalConf
 					}
 				}
 				if backends[entryPointName+frontend.Backend] == nil {
+					if config.Backends[frontend.Backend] == nil {
+						log.Errorf("Undefined backend '%s' for frontend %s", frontend.Backend, frontendName)
+						log.Errorf("Skipping frontend %s...", frontendName)
+						continue frontend
+					}
 					log.Debugf("Creating backend %s", frontend.Backend)
 
-					roundTripper, err := server.getRoundTripper(entryPointName, globalConfiguration, frontend.PassTLSCert, entryPoint.TLS)
+					roundTripper, err := server.getRoundTripper(entryPointName, globalConfiguration, config.Backends[frontend.Backend].ForwardingTimeouts, frontend.PassTLSCert, entryPoint.TLS)
 					if err != nil {
 						log.Errorf("Failed to create RoundTripper for frontend %s: %v", frontendName, err)
 						log.Errorf("Skipping frontend %s...", frontendName)
@@ -980,12 +994,6 @@ func (server *Server) loadConfig(configurations types.Configurations, globalConf
 						rr, _ = roundrobin.New(saveFrontend)
 					} else {
 						rr, _ = roundrobin.New(fwd)
-					}
-
-					if config.Backends[frontend.Backend] == nil {
-						log.Errorf("Undefined backend '%s' for frontend %s", frontend.Backend, frontendName)
-						log.Errorf("Skipping frontend %s...", frontendName)
-						continue frontend
 					}
 
 					lbMethod, err := types.NewLoadBalancerMethod(config.Backends[frontend.Backend].LoadBalancer)

--- a/types/types.go
+++ b/types/types.go
@@ -20,11 +20,12 @@ import (
 
 // Backend holds backend configuration.
 type Backend struct {
-	Servers        map[string]Server `json:"servers,omitempty"`
-	CircuitBreaker *CircuitBreaker   `json:"circuitBreaker,omitempty"`
-	LoadBalancer   *LoadBalancer     `json:"loadBalancer,omitempty"`
-	MaxConn        *MaxConn          `json:"maxConn,omitempty"`
-	HealthCheck    *HealthCheck      `json:"healthCheck,omitempty"`
+	Servers            map[string]Server   `json:"servers,omitempty"`
+	CircuitBreaker     *CircuitBreaker     `json:"circuitBreaker,omitempty"`
+	LoadBalancer       *LoadBalancer       `json:"loadBalancer,omitempty"`
+	MaxConn            *MaxConn            `json:"maxConn,omitempty"`
+	HealthCheck        *HealthCheck        `json:"healthCheck,omitempty"`
+	ForwardingTimeouts *ForwardingTimeouts `json:"forwardingTimeouts,omitempty"`
 }
 
 // MaxConn holds maximum connection configuration
@@ -55,6 +56,12 @@ type HealthCheck struct {
 	Path     string `json:"path,omitempty"`
 	Port     int    `json:"port,omitempty"`
 	Interval string `json:"interval,omitempty"`
+}
+
+// ForwardingTimeouts contains timeout configurations for forwarding requests to the backend servers.
+type ForwardingTimeouts struct {
+	DialTimeout           flaeg.Duration `json:"dialTimeout,omitempty"`
+	ResponseHeaderTimeout flaeg.Duration `json:"responseHeaderTimeout,omitempty"`
 }
 
 // Server holds server configuration.


### PR DESCRIPTION
### What does this PR do?

Certain applications require a longer (or shorter) timeout than others. This
change enables use of a custom `DialTimeout` and `ResponseHeaderTimeout` in the
backend's `http.RoundTripper`.

### Motivation

This is a requirement for Traefik to replace our current proxy in our environment.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

