### PR TITLE
Configure the docker container with environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM scratch
+FROM alpine
+COPY docker-entrypoint.sh /
 COPY script/ca-certificates.crt /etc/ssl/certs/
 COPY dist/traefik /
 EXPOSE 80
-ENTRYPOINT ["/traefik"]
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["traefik"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+set -e
+
+# make traefik command line options from environment variables starting with 'TRAEFIK_'
+options=""
+while IFS= read -r line
+do
+  var="${line%%=*}"
+  if [ "${var#TRAEFIK_}" != "${var}" ]; then
+    option=$(echo "--${var#TRAEFIK_}" | tr _ . | tr '[:upper:]' '[:lower:]')
+    options="${options} ${option}"
+
+    value="${line#${var}}"
+    if [ "$value" != "=" ]; then
+        options="${options}${value}"
+    fi
+  fi
+done << EOF
+$(env)
+EOF
+
+# this if will check if the first argument is a flag
+# but only works if all arguments require a hyphenated flag
+# -v; -SL; -f arg; etc will work, but not arg1 arg2
+if [ "${1:0:1}" = '-' ]; then
+    set -- /traefik $options "$@"
+fi
+
+# check for the expected command
+if [ "$1" = 'traefik' ]; then
+    exec /traefik $options "$@"
+fi
+
+# check for the debugoptions command
+if [ "$1" = 'debugoptions' ]; then
+    shift
+    set -- /traefik $options "$@"
+    echo "would execute: $@"
+    exit
+fi
+
+# else default to run whatever the user wanted like "bash"
+exec "$@"

--- a/docs/index.md
+++ b/docs/index.md
@@ -123,6 +123,33 @@ networks:
     driver: bridge
 ```
 
+or, using environment variables
+
+```yaml
+version: '2'
+
+services:
+  proxy:
+    image: traefik
+    environment:
+      - TRAEFIK_WEB=true
+      - TRAEFIK_DOCKER=true
+      - TRAEFIK_DOCKER_DOMAIN=docker.localhost
+      - TRAEFIK_LOGLEVEL=DEBUG
+    networks:
+      - webgateway
+    ports:
+      - "80:80"
+      - "8080:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /dev/null:/traefik.toml
+
+networks:
+  webgateway:
+    driver: bridge
+```
+
 Start it from within the `traefik` folder:
 
 ```shell


### PR DESCRIPTION
### What does this PR do?

This PR adds a shell script in the Traefik docker image which uses it as an entrypoint. This new entrypoint looks for environment variables starting with `TRAEFIK_` and convert them to traefik command line options.

### Motivation

I deploy Traefik docker images on a few servers and while I have no issue with the current way of managing the docker container configuration (providing a .toml config with volumes, providing command line options), I'd like to use tools that orchestrate my docker containers for me. Such tools usually plays very well with environment variables.

Docker users are used to configure their containers through environment variables. This PR should make Traefik more straight forward to play with.

Also, I found an old issue (#7) requesting such a feature.

You can find a few examples on f717515 comment and a docker-compose.yml in the doc (6a3b060)

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

I'm not familiar with Golang integration tests. I figured out integration/docker_test.go defines a few tests around the Traefik docker container use, and my understanding of it is that those tests do not verify anything regarding passing command line options to traefik. 
I suppose then that it is fine not to add tests verifying those new environment variables do their job.

There is a drawback with this PR: the docker images size gain weight since it is now based on the Alpine docker image. Still this base image is small (2 MB) and since it is popular most users already have its layers on their systems.