### PR TITLE
Register pprof handlers.

### DIFF
--- a/api/debug.go
+++ b/api/debug.go
@@ -4,6 +4,7 @@ import (
 	"expvar"
 	"fmt"
 	"net/http"
+	"net/http/pprof"
 	"runtime"
 
 	"github.com/containous/mux"
@@ -36,4 +37,10 @@ func (g DebugHandler) AddRoutes(router *mux.Router) {
 			})
 			fmt.Fprint(w, "\n}\n")
 		})
+
+	router.Methods(http.MethodGet).PathPrefix("/debug/pprof/").HandlerFunc(pprof.Index)
+	router.Methods(http.MethodGet).PathPrefix("/debug/pprof/cmdline").HandlerFunc(pprof.Cmdline)
+	router.Methods(http.MethodGet).PathPrefix("/debug/pprof/profile").HandlerFunc(pprof.Profile)
+	router.Methods(http.MethodGet).PathPrefix("/debug/pprof/symbol").HandlerFunc(pprof.Symbol)
+	router.Methods(http.MethodGet).PathPrefix("/debug/pprof/trace").HandlerFunc(pprof.Trace)
 }

--- a/docs/configuration/api.md
+++ b/docs/configuration/api.md
@@ -17,7 +17,10 @@
   #
   dashboard = true
   
-  # Enabled debug mode
+  # Enable debug mode.
+  # This will install HTTP handlers to expose Go expvars under /debug/vars and
+  # pprof profiling data under /debug/pprof.
+  # Additionally, the log level will be set to DEBUG.
   #
   # Optional
   # Default: false

--- a/docs/configuration/commons.md
+++ b/docs/configuration/commons.md
@@ -17,6 +17,9 @@
 # graceTimeOut = "10s"
 
 # Enable debug mode.
+# This will install HTTP handlers to expose Go expvars under /debug/vars and
+# pprof profiling data under /debug/pprof.
+# Additionally, the log level will be set to DEBUG.
 #
 # Optional
 # Default: false


### PR DESCRIPTION
### What does this PR do?

The handlers will be hooked up under the `/debug/pprof` endpoint (enabled via the `--debug` flag).

### Motivation

This is to assist debugging performance problems.

### More

- [x] Added/updated documentation

### Additional Notes

Closes #1648