### PR TITLE
Remove GzipHandler Fork

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,4 +1,4 @@
-hash: bbdbbc9d428937dbaf85e92a3747ebe547f1cc110fbb536c94b5efb3dde6e5ab
+hash: de7e6a0069090a5811c003db434da19fe31efcf0c9429d3ccb676295708f0d2b
 updated: 2017-10-24T14:08:11.364720581+02:00
 imports:
 - name: cloud.google.com/go
@@ -383,9 +383,7 @@ imports:
   repo: https://github.com/ijc25/Gotty.git
   vcs: git
 - name: github.com/NYTimes/gziphandler
-  version: 26a3f68265200656f31940bc15b191f7d10b5bbd
-  repo: https://github.com/containous/gziphandler.git
-  vcs: git
+  version: d6f46609c7629af3a02d791a4666866eed3cbd3e
 - name: github.com/ogier/pflag
   version: 45c278ab3607870051a2ea9040bb85fcb8557481
 - name: github.com/opencontainers/go-digest

--- a/glide.yaml
+++ b/glide.yaml
@@ -79,9 +79,6 @@ import:
   vcs: git
 - package: github.com/abbot/go-http-auth
 - package: github.com/NYTimes/gziphandler
-  version: fork-containous
-  repo: https://github.com/containous/gziphandler.git
-  vcs: git
 - package: github.com/docker/leadership
 - package: github.com/satori/go.uuid
   version: ^1.1.0


### PR DESCRIPTION
### What does this PR do?

Remove GzipHandler Fork

### Motivation

Remove a fork.

### Additional Notes

Related to #2380 and https://github.com/NYTimes/gziphandler/pull/60