### PR TITLE
Remote HTTP provider

### DIFF
--- a/cmd/traefik/configuration.go
+++ b/cmd/traefik/configuration.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containous/traefik/provider/marathon"
 	"github.com/containous/traefik/provider/mesos"
 	"github.com/containous/traefik/provider/rancher"
+	"github.com/containous/traefik/provider/remote"
 	"github.com/containous/traefik/provider/rest"
 	"github.com/containous/traefik/provider/zk"
 	"github.com/containous/traefik/types"
@@ -48,6 +49,10 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 	// default Rest
 	var defaultRest rest.Provider
 	defaultRest.EntryPoint = configuration.DefaultInternalEntryPointName
+
+	// default Remote
+	var defaultRemote remote.Provider
+	defaultRemote.Watch = true
 
 	// TODO: Deprecated - Web provider, use REST provider instead
 	var defaultWeb configuration.WebCompatibility
@@ -234,6 +239,7 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 		File:               &defaultFile,
 		Web:                &defaultWeb,
 		Rest:               &defaultRest,
+		Remote:             &defaultRemote,
 		Marathon:           &defaultMarathon,
 		Consul:             &defaultConsul,
 		ConsulCatalog:      &defaultConsulCatalog,

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -22,6 +22,7 @@ import (
 	"github.com/containous/traefik/provider/marathon"
 	"github.com/containous/traefik/provider/mesos"
 	"github.com/containous/traefik/provider/rancher"
+	"github.com/containous/traefik/provider/remote"
 	"github.com/containous/traefik/provider/rest"
 	"github.com/containous/traefik/provider/zk"
 	"github.com/containous/traefik/tls"
@@ -91,6 +92,7 @@ type GlobalConfiguration struct {
 	API                       *api.Handler            `description:"Enable api/dashboard" export:"true"`
 	Metrics                   *types.Metrics          `description:"Enable a metrics exporter" export:"true"`
 	Ping                      *ping.Handler           `description:"Enable ping" export:"true"`
+	Remote                    *remote.Provider        `description:"Enable remote http backend with default settings" expoert:"true"`
 }
 
 // WebCompatibility is a configuration to handle compatibility with deprecated web provider options

--- a/docs/configuration/backends/remote.md
+++ b/docs/configuration/backends/remote.md
@@ -1,0 +1,51 @@
+# Remote Backend
+
+Træfik can be configured to use remote HTTP endpoint as a source of backend configuration.
+
+```toml
+################################################################
+# Remote configuration backend
+################################################################
+
+# Enable Remote HTTP configuration backend.
+[remote]
+
+# Remote server endpoint.
+#
+# Required
+#
+url = "http://my.config.server/toml"
+
+# Configure time to wait for configuration before trying again.
+# The configured value will be appended to 'url' query parameter as 'wait=%ds' in seconds
+#
+#  
+#
+# Optional
+#
+#longPollDuration = "1m"
+
+# Configure refresh interval if long-poll is not used/supported.
+#
+# Optional
+#
+# repeatInterval = "30s"
+
+# TLS client configuration. https://golang.org/pkg/crypto/tls/#Config
+#
+# Optional
+#
+#    [remote.TLS]
+#    CA = "/etc/ssl/ca.crt"
+#    Cert = "/etc/ssl/https.cert"
+#    Key = "/etc/ssl/https.key"
+#    InsecureSkipVerify = true
+
+#If you want Træfik to watch file changes automatically, just add:
+watch = true
+```
+
+!!! warning
+    If you are using `longPollDuration` make sure the server indeed supports Long Polling.  
+    Otherwise requests will be fired immediately as soon as the previous ones succeed, possibly resulting in DDoS!
+    If you want to query remote server for config at a pre-determinted interval, make sure to use `repeatInterval` option instead!  

--- a/provider/remote/remote.go
+++ b/provider/remote/remote.go
@@ -1,0 +1,165 @@
+package remote
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/BurntSushi/toml"
+	"github.com/containous/traefik/log"
+	"github.com/containous/traefik/provider"
+	"github.com/containous/traefik/safe"
+	"github.com/containous/traefik/types"
+	"github.com/hashicorp/go-cleanhttp"
+)
+
+var _ provider.Provider = (*Provider)(nil)
+
+// Provider holds configurations of the provider.
+type Provider struct {
+	provider.BaseProvider `mapstructure:",squash" export:"true"`
+	URL                   string           `description:"External URL to call using HTTP GET to retrieve the content of a .toml configuration" export:"true"`
+	TLS                   *types.ClientTLS `description:"Enable TLS support" export:"true"`
+	LongPollDuration      string           `description:"In case 'watch' is set to true, this indicates how long to wait for a socket long poll before retrying.  This value will be passed as additional 'wait' query parameter in seconds" export:"true"`
+	RepeatInterval        string           `description:"In case 'watch' is set to true, but no 'longPollDuration' is configured, this indicates how long to wait till repeating HTTP call again.  If no value is set, 10s will be used by default." export:"true"`
+	httpClient            *http.Client
+	httpTransport         *http.Transport
+	pollDuration          time.Duration
+	refreshDuration       time.Duration
+}
+
+// Provide allows the remote http provider to provide configurations to traefik
+// using the given configuration channel.
+func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *safe.Pool, constraints types.Constraints) error {
+	p.httpTransport = cleanhttp.DefaultPooledTransport()
+	if p.TLS != nil {
+		tlsConfig, err := p.TLS.CreateTLSConfig()
+		if err != nil {
+			return err
+		}
+		p.httpTransport.TLSClientConfig = tlsConfig
+	}
+
+	if len(p.LongPollDuration) > 0 {
+		longPollDuration, err := time.ParseDuration(p.LongPollDuration)
+		if err != nil {
+			return err
+		}
+		p.pollDuration = longPollDuration
+	}
+	if len(p.RepeatInterval) > 0 {
+		interval, err := time.ParseDuration(p.RepeatInterval)
+		if err != nil {
+			return err
+		}
+		p.refreshDuration = interval
+	}
+	p.httpClient = &http.Client{
+		Transport: p.httpTransport,
+		Timeout:   p.pollDuration,
+	}
+	configuration, err := p.loadConfig()
+
+	if err != nil {
+		return err
+	}
+
+	if p.Watch {
+		if err := p.addWatcher(pool, configurationChan, p.watcherCallback); err != nil {
+			return err
+		}
+	}
+
+	sendConfigToChannel(configurationChan, configuration)
+	return nil
+}
+
+func (p *Provider) addWatcher(pool *safe.Pool, configurationChan chan<- types.ConfigMessage, callback func(chan<- types.ConfigMessage)) error {
+	// Process events
+	pool.Go(func(stop chan bool) {
+		defer p.httpTransport.CloseIdleConnections()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				if p.Watch && p.refreshDuration != 0 {
+					time.Sleep(p.refreshDuration)
+				}
+				// Guard against spamming the HTTP server, if no RepeatInterval and LongPollDuration are configured, but Wait is selected.
+				if p.Watch && p.refreshDuration == 0 && p.pollDuration == 0 {
+					time.Sleep(10 * time.Second)
+				}
+				callback(configurationChan)
+			}
+		}
+	})
+	return nil
+}
+
+func sendConfigToChannel(configurationChan chan<- types.ConfigMessage, configuration *types.Configuration) {
+	configurationChan <- types.ConfigMessage{
+		ProviderName:  "remote",
+		Configuration: configuration,
+	}
+}
+
+func parseConfigFromContent(data io.Reader) (*types.Configuration, error) {
+	configuration := new(types.Configuration)
+	if _, err := toml.DecodeReader(data, configuration); err != nil {
+		return nil, fmt.Errorf("error reading configuration content: %s", err)
+	}
+	return configuration, nil
+}
+
+func (p *Provider) watcherCallback(configurationChan chan<- types.ConfigMessage) {
+	configuration, err := p.loadConfig()
+
+	if err != nil {
+		log.Errorf("Error occurred during watcher callback: %s", err)
+		return
+	}
+
+	sendConfigToChannel(configurationChan, configuration)
+}
+
+func (p *Provider) createHTTPRequest() (*http.Request, error) {
+	u, err := url.Parse(p.URL)
+	if err != nil {
+		return nil, err
+	}
+
+	if p.Watch && p.pollDuration != 0 {
+		query := u.Query()
+		query.Add("wait", fmt.Sprintf("%ds", int(p.pollDuration.Seconds())))
+		u.RawQuery = query.Encode()
+	}
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	req.Header.Add("User-Agent", "Traefik")
+
+	// TODO: Add other relevant/useful headers, etc.
+	return req, err
+}
+
+func (p *Provider) loadConfig() (*types.Configuration, error) {
+	req, err := p.createHTTPRequest()
+
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := p.httpClient.Do(req)
+
+	if err != nil || resp == nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Failed to retrieve remote config via calling %s: received %d-%s", p.URL, resp.StatusCode, resp.Status)
+	}
+
+	return parseConfigFromContent(resp.Body)
+}

--- a/provider/remote/remote_test.go
+++ b/provider/remote/remote_test.go
@@ -1,0 +1,349 @@
+package remote
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/containous/traefik/safe"
+	"github.com/containous/traefik/types"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+)
+
+func TestProvideAndWatch(t *testing.T) {
+	tempDir := createTempDir(t, "testfile")
+	defer os.RemoveAll(tempDir)
+
+	expectedNumFrontends := 2
+	expectedNumBackends := 2
+	expectedNumTLSConf := 2
+
+	tempFile := createFile(t,
+		tempDir, "simple.toml",
+		createFrontendConfiguration(expectedNumFrontends),
+		createBackendConfiguration(expectedNumBackends),
+		createTLSConfiguration(expectedNumTLSConf))
+
+	server := createHTTPServer(func(w http.ResponseWriter, r *http.Request) {
+		data, err := ioutil.ReadFile(tempFile.Name())
+		assert.NoError(t, err)
+		w.Write(data)
+	})
+	defer server.Close()
+
+	configurationChan, signal := createConfigurationRoutine(t, &expectedNumFrontends, &expectedNumBackends, &expectedNumTLSConf)
+
+	pool := provide(configurationChan, watch, withURL(server.URL))
+	defer pool.Stop()
+
+	// Wait for initial message to be tested
+	err := waitForSignal(signal, 2*time.Second, "initial config")
+	assert.NoError(t, err)
+
+	// Now test again with single frontend and backend
+	expectedNumFrontends = 1
+	expectedNumBackends = 1
+	expectedNumTLSConf = 1
+
+	createFile(t,
+		tempDir, "simple.toml",
+		createFrontendConfiguration(expectedNumFrontends),
+		createBackendConfiguration(expectedNumBackends),
+		createTLSConfiguration(expectedNumTLSConf))
+
+	err = waitForSignal(signal, 12*time.Second, "single frontend, backend, TLS configuration")
+	assert.NoError(t, err)
+}
+
+func TestProvideAndNotWatch(t *testing.T) {
+	tempDir := createTempDir(t, "testfile")
+	defer os.RemoveAll(tempDir)
+
+	expectedNumFrontends := 2
+	expectedNumBackends := 2
+	expectedNumTLSConf := 2
+
+	tempFile := createFile(t,
+		tempDir, "simple.toml",
+		createFrontendConfiguration(expectedNumFrontends),
+		createBackendConfiguration(expectedNumBackends),
+		createTLSConfiguration(expectedNumTLSConf))
+
+	server := createHTTPServer(func(w http.ResponseWriter, r *http.Request) {
+		data, err := ioutil.ReadFile(tempFile.Name())
+		assert.NoError(t, err)
+		w.Write(data)
+	})
+	defer server.Close()
+
+	configurationChan, signal := createConfigurationRoutine(t, &expectedNumFrontends, &expectedNumBackends, &expectedNumTLSConf)
+
+	pool := provide(configurationChan, withURL(server.URL))
+	defer pool.Stop()
+
+	// Wait for initial message to be tested
+	err := waitForSignal(signal, 2*time.Second, "initial config")
+	assert.NoError(t, err)
+
+	// Now test again with single frontend and backend
+	expectedNumFrontends = 1
+	expectedNumBackends = 1
+	expectedNumTLSConf = 1
+
+	createFile(t,
+		tempDir, "simple.toml",
+		createFrontendConfiguration(expectedNumFrontends),
+		createBackendConfiguration(expectedNumBackends),
+		createTLSConfiguration(expectedNumTLSConf))
+
+	// Must fail because we don't watch the changes
+	err = waitForSignal(signal, 2*time.Second, "single frontend, backend and TLS configuration")
+	assert.Error(t, err)
+}
+
+func TestProvideAndWatchWithLongPoll(t *testing.T) {
+	tempDir := createTempDir(t, "testfile")
+	defer os.RemoveAll(tempDir)
+
+	expectedNumFrontends := 2
+	expectedNumBackends := 2
+	expectedNumTLSConf := 2
+
+	tempFile := createFile(t,
+		tempDir, "simple.toml",
+		createFrontendConfiguration(expectedNumFrontends),
+		createBackendConfiguration(expectedNumBackends),
+		createTLSConfiguration(expectedNumTLSConf))
+
+	duration := 5 * time.Second
+	server := createHTTPServer(func(w http.ResponseWriter, r *http.Request) {
+		checkQuery := fmt.Sprintf("wait=%ds", int(duration.Seconds()))
+		assert.True(t, strings.HasSuffix(r.RequestURI, checkQuery), "Expected query of %s, RequestURI was: %s", checkQuery, r.RequestURI)
+		data, err := ioutil.ReadFile(tempFile.Name())
+		assert.NoError(t, err)
+		w.Write(data)
+	})
+	defer server.Close()
+
+	configurationChan, signal := createConfigurationRoutine(t, &expectedNumFrontends, &expectedNumBackends, &expectedNumTLSConf)
+
+	pool := provide(configurationChan, watch, withURL(server.URL), withLongPollDuration(duration))
+	defer pool.Stop()
+
+	// Wait for initial message to be tested
+	err := waitForSignal(signal, 2*time.Second, "initial config")
+	assert.NoError(t, err)
+
+	// Now test again with single frontend and backend
+	expectedNumFrontends = 1
+	expectedNumBackends = 1
+	expectedNumTLSConf = 1
+
+	createFile(t,
+		tempDir, "simple.toml",
+		createFrontendConfiguration(expectedNumFrontends),
+		createBackendConfiguration(expectedNumBackends),
+		createTLSConfiguration(expectedNumTLSConf))
+
+	err = waitForSignal(signal, 7*time.Second, "single frontend, backend, TLS configuration")
+	assert.NoError(t, err)
+}
+
+func TestProvideAndWatchWithInterval(t *testing.T) {
+	tempDir := createTempDir(t, "testfile")
+	defer os.RemoveAll(tempDir)
+
+	expectedNumFrontends := 2
+	expectedNumBackends := 2
+	expectedNumTLSConf := 2
+
+	tempFile := createFile(t,
+		tempDir, "simple.toml",
+		createFrontendConfiguration(expectedNumFrontends),
+		createBackendConfiguration(expectedNumBackends),
+		createTLSConfiguration(expectedNumTLSConf))
+
+	duration := 3 * time.Second
+	server := createHTTPServer(func(w http.ResponseWriter, r *http.Request) {
+		data, err := ioutil.ReadFile(tempFile.Name())
+		assert.NoError(t, err)
+		w.Write(data)
+	})
+	defer server.Close()
+
+	configurationChan, signal := createConfigurationRoutine(t, &expectedNumFrontends, &expectedNumBackends, &expectedNumTLSConf)
+
+	pool := provide(configurationChan, watch, withURL(server.URL), withRepeatInterval(duration))
+	defer pool.Stop()
+
+	// Wait for initial message to be tested
+	err := waitForSignal(signal, 2*time.Second, "initial config")
+	assert.NoError(t, err)
+
+	// Now test again with single frontend and backend
+	expectedNumFrontends = 1
+	expectedNumBackends = 1
+	expectedNumTLSConf = 1
+
+	createFile(t,
+		tempDir, "simple.toml",
+		createFrontendConfiguration(expectedNumFrontends),
+		createBackendConfiguration(expectedNumBackends),
+		createTLSConfiguration(expectedNumTLSConf))
+
+	err = waitForSignal(signal, 5*time.Second, "single frontend, backend, TLS configuration")
+	assert.NoError(t, err)
+}
+
+func createHTTPServer(handler http.HandlerFunc) *httptest.Server {
+	return httptest.NewServer(handler)
+}
+
+func createConfigurationRoutine(t *testing.T, expectedNumFrontends *int, expectedNumBackends *int, expectedNumTLSConfigurations *int) (chan types.ConfigMessage, chan interface{}) {
+	configurationChan := make(chan types.ConfigMessage)
+	signal := make(chan interface{})
+
+	safe.Go(func() {
+		for {
+			data := <-configurationChan
+			assert.Equal(t, "remote", data.ProviderName)
+			assert.Len(t, data.Configuration.Frontends, *expectedNumFrontends)
+			assert.Len(t, data.Configuration.Backends, *expectedNumBackends)
+			assert.Len(t, data.Configuration.TLSConfiguration, *expectedNumTLSConfigurations)
+			signal <- nil
+		}
+	})
+
+	return configurationChan, signal
+}
+
+func waitForSignal(signal chan interface{}, timeout time.Duration, caseName string) error {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case <-signal:
+
+	case <-timer.C:
+		return fmt.Errorf("Timed out waiting for assertions to be tested: %s", caseName)
+	}
+	return nil
+}
+
+func provide(configurationChan chan types.ConfigMessage, builders ...func(p *Provider)) *safe.Pool {
+	pvd := &Provider{}
+
+	for _, builder := range builders {
+		builder(pvd)
+	}
+
+	pool := safe.NewPool(context.Background())
+	pvd.Provide(configurationChan, pool, nil)
+	return pool
+}
+
+func watch(pvd *Provider) {
+	pvd.Watch = true
+}
+
+func withURL(url string) func(*Provider) {
+	return func(pvd *Provider) {
+		pvd.URL = url
+	}
+}
+
+func withRepeatInterval(interval time.Duration) func(*Provider) {
+	return func(pvd *Provider) {
+		pvd.RepeatInterval = interval.String()
+	}
+}
+
+func withLongPollDuration(duration time.Duration) func(*Provider) {
+	return func(pvd *Provider) {
+		pvd.LongPollDuration = duration.String()
+	}
+}
+
+// createRandomFile Helper
+func createRandomFile(t *testing.T, tempDir string, contents ...string) *os.File {
+	return createFile(t, tempDir, fmt.Sprintf("temp%d.toml", time.Now().UnixNano()), contents...)
+}
+
+// createFile Helper
+func createFile(t *testing.T, tempDir string, name string, contents ...string) *os.File {
+	t.Helper()
+	fileName := path.Join(tempDir, name)
+
+	tempFile, err := os.Create(fileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, content := range contents {
+		_, err := tempFile.WriteString(content)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	err = tempFile.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return tempFile
+}
+
+// createTempDir Helper
+func createTempDir(t *testing.T, dir string) string {
+	t.Helper()
+	d, err := ioutil.TempDir("", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+// createFrontendConfiguration Helper
+func createFrontendConfiguration(n int) string {
+	conf := "[frontends]\n"
+	for i := 1; i <= n; i++ {
+		conf += fmt.Sprintf(`  [frontends.frontend%[1]d]
+  backend = "backend%[1]d"
+`, i)
+	}
+	return conf
+}
+
+// createBackendConfiguration Helper
+func createBackendConfiguration(n int) string {
+	conf := "[backends]\n"
+	for i := 1; i <= n; i++ {
+		conf += fmt.Sprintf(`  [backends.backend%[1]d]
+    [backends.backend%[1]d.servers.server1]
+    url = "http://172.17.0.%[1]d:80"
+`, i)
+	}
+	return conf
+}
+
+// createTLSConfiguration Helper
+func createTLSConfiguration(n int) string {
+	var conf string
+	for i := 1; i <= n; i++ {
+		conf += fmt.Sprintf(`[[TLSConfiguration]]
+	EntryPoints = ["https"]
+	[TLSConfiguration.Certificate]
+	CertFile = "integration/fixtures/https/snitest%[1]d.com.cert"
+	KeyFile = "integration/fixtures/https/snitest%[1]d.com.key"
+`, i)
+	}
+	return conf
+}

--- a/server/server.go
+++ b/server/server.go
@@ -525,6 +525,9 @@ func (server *Server) configureProviders() {
 		server.providers = append(server.providers, server.globalConfiguration.Rest)
 		server.globalConfiguration.Rest.CurrentConfigurations = &server.currentConfigurations
 	}
+	if server.globalConfiguration.Remote != nil {
+		server.providers = append(server.providers, server.globalConfiguration.Remote)
+	}
 	if server.globalConfiguration.Consul != nil {
 		server.providers = append(server.providers, server.globalConfiguration.Consul)
 	}


### PR DESCRIPTION
### What does this PR do?

Add support for Remote HTTP configuration provider


### Motivation

To enable custom integrations with various config management tools, the use of Remote HTTP configuration provider enables to call an HTTP endpoint either at pre-configured interval or using long-poll option to retrieve Traefik configuration in a TOML format

### More

- [x] Added/updated tests
- [x] Added/updated documentation
