### PR TITLE
Fix high memory usage in retry middleware for big files

### DIFF
--- a/cmd/traefik/configuration.go
+++ b/cmd/traefik/configuration.go
@@ -159,6 +159,13 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 	defaultDynamoDB.TableName = "traefik"
 	defaultDynamoDB.Watch = true
 
+	var defaultRety configuration.Retry
+	defaultRety.Attempts = 0
+	defaultRety.CacheInitialCapacity = 4 * 1024
+	defaultRety.CacheMaxCapacity = 32 * 1024
+	defaultRety.TempDir = "/tmp"
+	defaultRety.RetryInterval = 0
+
 	// default Eureka
 	var defaultEureka eureka.Provider
 	defaultEureka.Delay = "30s"
@@ -246,7 +253,7 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 		Rancher:            &defaultRancher,
 		Eureka:             &defaultEureka,
 		DynamoDB:           &defaultDynamoDB,
-		Retry:              &configuration.Retry{},
+		Retry:              &defaultRety,
 		HealthCheck:        &healthCheck,
 		RespondingTimeouts: &respondingTimeouts,
 		ForwardingTimeouts: &forwardingTimeouts,

--- a/cmd/traefik/configuration.go
+++ b/cmd/traefik/configuration.go
@@ -162,7 +162,7 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 	var defaultRety configuration.Retry
 	defaultRety.Attempts = 0
 	defaultRety.CacheInitialCapacity = 4 * 1024
-	defaultRety.CacheMaxCapacity = 32 * 1024
+	defaultRety.CacheMaxCapacity = 0
 	defaultRety.TempDir = "/tmp"
 	defaultRety.RetryInterval = 0
 

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -437,7 +437,11 @@ type Redirect struct {
 
 // Retry contains request retry config
 type Retry struct {
-	Attempts int `description:"Number of attempts" export:"true"`
+	Attempts             int    `description:"Number of attempts" export:"true"`
+	CacheInitialCapacity int    `description:"Initial capacity of cache when creating (in bytes)" export:"true"`
+	CacheMaxCapacity     int    `description:"Maximum allowed capacity for cache (in bytes) when upstream data is bigger than this value, retry starts caching data into file" export:"true"`
+	TempDir              string `description:"Place to store temporary files" export:"true"`
+	RetryInterval        int64  `description:"Retry interval in milliseconds before next try" export:"true"`
 }
 
 // HealthCheckConfig contains health check configuration parameters.

--- a/docs/configuration/commons.md
+++ b/docs/configuration/commons.md
@@ -283,12 +283,42 @@ For dynamic providers, the corresponding template file needs to be customized ac
 # Enable retry sending request if network error
 [retry]
 
+# Retry logic uses caching mechanism in order to download data fully from upstream server and supplies it to downstream when it receives all data
+
 # Number of attempts
 #
 # Optional
 # Default: (number servers in backend) -1
 #
 # attempts = 3
+
+# Initial capacity of cache when creating buffers (in bytes)
+#
+# Optional
+# Default: 4kb
+#
+# cacheinitialcapacity = 4096
+
+# Maximum allowed capacity for cache (in bytes), when upstream data is bigger than this value, retry starts caching data into file
+#
+# Optional
+# Default: 32kb
+#
+# cachemaxcapacity = 32768
+
+# Place to store temporary files
+#
+# Optional
+# Default: /tmp
+#
+# tempdir = /tmp
+
+# Retry interval in milliseconds before next try
+#
+# Optional
+# Default: 0
+#
+# retryinterval = 0
 ```
 
 

--- a/docs/configuration/commons.md
+++ b/docs/configuration/commons.md
@@ -299,12 +299,12 @@ For dynamic providers, the corresponding template file needs to be customized ac
 #
 # cacheinitialcapacity = 4096
 
-# Maximum allowed capacity for cache (in bytes), when upstream data is bigger than this value, retry starts caching data into file
+# Maximum allowed capacity for cache (in bytes), when upstream data is bigger than this value, retry starts caching data into file. if set to 0 all data will be cached in memory
 #
 # Optional
-# Default: 32kb
+# Default: 0
 #
-# cachemaxcapacity = 32768
+# cachemaxcapacity = 0
 
 # Place to store temporary files
 #

--- a/middlewares/error_pages.go
+++ b/middlewares/error_pages.go
@@ -53,8 +53,7 @@ func NewErrorPagesHandler(errorPage types.ErrorPage, backendURL string) (*ErrorP
 }
 
 func (ep *ErrorPagesHandler) ServeHTTP(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
-	buf := make([]byte, 0, 16*1024)
-	recorder := newRetryResponseRecorder(buf, 64*1024, nil)
+	recorder := newRetryResponseRecorder(0, 0, nil)
 	recorder.responseWriter = w
 	defer recorder.Reset()
 	next.ServeHTTP(recorder, req)

--- a/middlewares/retry.go
+++ b/middlewares/retry.go
@@ -2,11 +2,15 @@ package middlewares
 
 import (
 	"bufio"
-	"bytes"
 	"context"
+	"errors"
+	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
+	"sync"
+	"time"
 
 	"github.com/containous/traefik/log"
 	"github.com/vulcand/oxy/utils"
@@ -14,42 +18,68 @@ import (
 
 // Compile time validation responseRecorder implements http interfaces correctly.
 var (
-	_ Stateful = &retryResponseRecorder{}
+	_                      Stateful  = &retryResponseRecorder{}
+	_                      io.Reader = (*retryResponseRecorder)(nil)
+	ErrorInconsistentWrite           = errors.New("inconsistent write")
+	ErrorNotEnoughSpace              = errors.New("not enough space")
 )
+
+// RetrySettings is a settings for Retry middleware
+type RetrySettings struct {
+	Attempts             int           // Number of attempts
+	CacheInitialCapacity int           // Initial capacity of cache when creating (in bytes)
+	CacheMaxCapacity     int           // Maximum allowed capacity for cache (in bytes) when upstream data is bigger than this value, retry starts caching data into file
+	TempDir              string        // Place to store temporary files
+	RetryInterval        time.Duration // Retry interval in milliseconds before next try
+}
 
 // Retry is a middleware that retries requests
 type Retry struct {
-	attempts int
-	next     http.Handler
-	listener RetryListener
+	next       http.Handler
+	listener   RetryListener
+	hotMemPool sync.Pool
+	conf       *RetrySettings
 }
 
 // NewRetry returns a new Retry instance
-func NewRetry(attempts int, next http.Handler, listener RetryListener) *Retry {
-	return &Retry{
-		attempts: attempts,
+func NewRetry(conf *RetrySettings, next http.Handler, listener RetryListener) *Retry {
+	retry := &Retry{
 		next:     next,
 		listener: listener,
+		conf:     conf,
 	}
+
+	retry.hotMemPool = sync.Pool{
+		New: func() interface{} {
+			return make([]byte, 0, retry.conf.CacheInitialCapacity)
+		},
+	}
+
+	return retry
 }
 
 func (retry *Retry) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	// if we might make multiple attempts, swap the body for an ioutil.NopCloser
 	// cf https://github.com/containous/traefik/issues/1008
-	if retry.attempts > 1 {
+	if retry.conf.Attempts > 1 {
 		body := r.Body
 		defer body.Close()
 		r.Body = ioutil.NopCloser(body)
 	}
 	attempts := 1
+
+	buf := retry.hotMemPool.Get().([]byte)
+	defer retry.hotMemPool.Put(buf)
+
+	recorder := newRetryResponseRecorder(buf, int64(retry.conf.CacheMaxCapacity), &retry.conf.TempDir)
+	recorder.responseWriter = rw
+	defer recorder.Reset()
+
 	for {
 		netErrorOccurred := false
 		// We pass in a pointer to netErrorOccurred so that we can set it to true on network errors
 		// when proxying the HTTP requests to the backends. This happens in the custom RecordingErrorHandler.
 		newCtx := context.WithValue(r.Context(), defaultNetErrCtxKey, &netErrorOccurred)
-
-		recorder := newRetryResponseRecorder()
-		recorder.responseWriter = rw
 
 		retry.next.ServeHTTP(recorder, r.WithContext(newCtx))
 
@@ -59,15 +89,21 @@ func (retry *Retry) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 			break
 		}
 
-		if !netErrorOccurred || attempts >= retry.attempts {
+		if !netErrorOccurred || attempts >= retry.conf.Attempts {
 			utils.CopyHeaders(rw.Header(), recorder.Header())
 			rw.WriteHeader(recorder.Code)
-			rw.Write(recorder.Body.Bytes())
+			recorder.Seek(0, 0)
+			io.Copy(rw, recorder)
 			break
 		}
 		attempts++
 		log.Debugf("New attempt %d for request: %v", attempts, r.URL)
 		retry.listener.Retried(r, attempts)
+		recorder.Reset()
+
+		if retry.conf.RetryInterval != 0 {
+			<-time.After(retry.conf.RetryInterval * time.Millisecond)
+		}
 	}
 }
 
@@ -117,21 +153,39 @@ func (l RetryListeners) Retried(req *http.Request, attempt int) {
 // retryResponseRecorder is an implementation of http.ResponseWriter that
 // records its mutations for later inspection.
 type retryResponseRecorder struct {
-	Code      int           // the HTTP response code from WriteHeader
-	HeaderMap http.Header   // the HTTP response headers
-	Body      *bytes.Buffer // if non-nil, the bytes.Buffer to append written data to
+	Code      int         // the HTTP response code from WriteHeader
+	HeaderMap http.Header // the HTTP response headers
 
 	responseWriter           http.ResponseWriter
 	err                      error
 	streamingResponseStarted bool
+
+	// hot
+	hotMem            []byte
+	hotMemCapacity    int64
+	writePos, readPos int64
+
+	// cold
+	fileReader *bufio.Reader
+	fileWriter *bufio.Writer
+	fileDir    *string
+	file       *os.File
 }
 
 // newRetryResponseRecorder returns an initialized retryResponseRecorder.
-func newRetryResponseRecorder() *retryResponseRecorder {
+func newRetryResponseRecorder(buff []byte, maxCapacity int64, fileDir *string) *retryResponseRecorder {
+	if fileDir == nil {
+		maxCapacity *= 100
+	}
+
 	return &retryResponseRecorder{
-		HeaderMap: make(http.Header),
-		Body:      new(bytes.Buffer),
-		Code:      http.StatusOK,
+		HeaderMap:      make(http.Header),
+		Code:           http.StatusOK,
+		hotMemCapacity: maxCapacity,
+		hotMem:         buff,
+		writePos:       0,
+		readPos:        0,
+		fileDir:        fileDir,
 	}
 }
 
@@ -145,12 +199,98 @@ func (rw *retryResponseRecorder) Header() http.Header {
 	return m
 }
 
+// Seek sets the offset for the next Read or Write on file to offset, interpreted
+// according to whence: 0 means relative to the origin of the file, 1 means
+// relative to the current offset, and 2 means relative to the end.
+// It returns the new offset and an error, if any.
+// The behavior of Seek on a file opened with O_APPEND is not specified.
+func (rw *retryResponseRecorder) Seek(offset int64, whence int) (int64, error) {
+	if rw.file != nil {
+		return rw.file.Seek(offset, whence)
+	}
+
+	if whence == io.SeekStart {
+		rw.readPos = offset
+	} else if whence == io.SeekCurrent {
+		rw.readPos = rw.readPos + offset
+	} else if whence == io.SeekEnd {
+		rw.readPos = rw.writePos + offset
+	}
+
+	if rw.readPos > rw.writePos {
+		rw.readPos = rw.writePos
+	} else if rw.readPos < 0 {
+		rw.readPos = 0
+	}
+	return rw.readPos, nil
+}
+
+func (rw *retryResponseRecorder) Read(buf []byte) (n int, err error) {
+	if rw.fileWriter != nil {
+		return rw.fileReader.Read(buf)
+	}
+
+	n = copy(buf, rw.hotMem[rw.readPos:rw.writePos])
+	rw.readPos += int64(n)
+	err = nil
+	if rw.readPos == rw.writePos {
+		err = io.EOF
+	}
+	return n, err
+}
+
 // Write always succeeds and writes to rw.Body, if not nil.
-func (rw *retryResponseRecorder) Write(buf []byte) (int, error) {
+func (rw *retryResponseRecorder) Write(buf []byte) (n int, err error) {
 	if rw.err != nil {
 		return 0, rw.err
 	}
-	return rw.Body.Write(buf)
+
+	if rw.fileWriter != nil {
+		// cold mem is already enabled
+		return rw.fileWriter.Write(buf)
+	}
+
+	// still writing to hot mem
+	if int64(len(buf))+rw.writePos < rw.hotMemCapacity {
+		// enough capacity for buf in hotMem
+		if int64(len(buf)) > int64(len(rw.hotMem))-rw.writePos {
+			// not enough space in current hotMem
+			prevPos := rw.writePos
+			n = copy(rw.hotMem[rw.writePos:], buf)
+			rw.writePos += int64(n)
+			rw.hotMem = append(rw.hotMem, buf[n:]...)
+			rw.writePos = int64(len(rw.hotMem))
+			n = int(rw.writePos - prevPos)
+		} else {
+			n = copy(rw.hotMem[rw.writePos:], buf)
+			rw.writePos += int64(n)
+		}
+		return n, nil
+	} else {
+		// create file
+		if rw.fileDir == nil {
+			return 0, ErrorNotEnoughSpace
+		}
+		rw.file, err = ioutil.TempFile(*rw.fileDir, "traefik-")
+		if err != nil {
+			log.Errorf("Failed to open temp file in retryResponseRecorder in folder(%s): %s", *rw.fileDir, err.Error())
+			return 0, err
+		}
+		rw.fileWriter = bufio.NewWriter(rw.file)
+		rw.fileReader = bufio.NewReader(rw.file)
+
+		n, err := rw.fileWriter.Write(rw.hotMem[:rw.writePos])
+		if err != nil {
+			return 0, err
+		}
+		if int64(n) != rw.writePos {
+			return 0, ErrorInconsistentWrite
+		}
+		rw.fileWriter.Flush()
+		rw.writePos = 0
+
+		return rw.Write(buf)
+	}
 }
 
 // WriteHeader sets rw.Code.
@@ -178,14 +318,31 @@ func (rw *retryResponseRecorder) Flush() {
 		rw.streamingResponseStarted = true
 	}
 
-	_, err := rw.responseWriter.Write(rw.Body.Bytes())
+	rw.Seek(0, 0)
+	_, err := io.Copy(rw.responseWriter, rw)
 	if err != nil {
 		log.Errorf("Error writing response in retryResponseRecorder: %s", err)
 		rw.err = err
 	}
-	rw.Body.Reset()
+	rw.Reset()
+	// rw.Body.Reset()
 	flusher, ok := rw.responseWriter.(http.Flusher)
 	if ok {
 		flusher.Flush()
+	}
+}
+
+func (rw *retryResponseRecorder) Reset() {
+	rw.writePos = 0
+	rw.readPos = 0
+
+	rw.fileReader = nil
+	rw.fileWriter = nil
+	rw.fileDir = nil
+
+	if rw.file != nil {
+		rw.file.Close()
+		os.Remove(rw.file.Name())
+		rw.file = nil
 	}
 }

--- a/middlewares/retry.go
+++ b/middlewares/retry.go
@@ -266,31 +266,31 @@ func (rw *retryResponseRecorder) Write(buf []byte) (n int, err error) {
 			rw.writePos += int64(n)
 		}
 		return n, nil
-	} else {
-		// create file
-		if rw.fileDir == nil {
-			return 0, ErrorNotEnoughSpace
-		}
-		rw.file, err = ioutil.TempFile(*rw.fileDir, "traefik-")
-		if err != nil {
-			log.Errorf("Failed to open temp file in retryResponseRecorder in folder(%s): %s", *rw.fileDir, err.Error())
-			return 0, err
-		}
-		rw.fileWriter = bufio.NewWriter(rw.file)
-		rw.fileReader = bufio.NewReader(rw.file)
-
-		n, err := rw.fileWriter.Write(rw.hotMem[:rw.writePos])
-		if err != nil {
-			return 0, err
-		}
-		if int64(n) != rw.writePos {
-			return 0, ErrorInconsistentWrite
-		}
-		rw.fileWriter.Flush()
-		rw.writePos = 0
-
-		return rw.Write(buf)
 	}
+
+	// create file
+	if rw.fileDir == nil {
+		return 0, ErrorNotEnoughSpace
+	}
+	rw.file, err = ioutil.TempFile(*rw.fileDir, "traefik-")
+	if err != nil {
+		log.Errorf("Failed to open temp file in retryResponseRecorder in folder(%s): %s", *rw.fileDir, err.Error())
+		return 0, err
+	}
+	rw.fileWriter = bufio.NewWriter(rw.file)
+	rw.fileReader = bufio.NewReader(rw.file)
+
+	n, err = rw.fileWriter.Write(rw.hotMem[:rw.writePos])
+	if err != nil {
+		return 0, err
+	}
+	if int64(n) != rw.writePos {
+		return 0, ErrorInconsistentWrite
+	}
+	rw.fileWriter.Flush()
+	rw.writePos = 0
+
+	return rw.Write(buf)
 }
 
 // WriteHeader sets rw.Code.

--- a/middlewares/retry_test.go
+++ b/middlewares/retry_test.go
@@ -36,13 +36,16 @@ func TestRetry(t *testing.T) {
 	for _, tc := range testCases {
 		// bind tc locally
 		tc := tc
+		stg := &RetrySettings{
+			Attempts: tc.attempts,
+		}
 		tcName := fmt.Sprintf("FailAtCalls(%v) RetryAttempts(%v)", tc.failAtCalls, tc.attempts)
 
 		t.Run(tcName, func(t *testing.T) {
 			t.Parallel()
 
 			var httpHandler http.Handler = &networkFailingHTTPHandler{failAtCalls: tc.failAtCalls, netErrorRecorder: &DefaultNetErrorRecorder{}}
-			httpHandler = NewRetry(tc.attempts, httpHandler, tc.listener)
+			httpHandler = NewRetry(stg, httpHandler, tc.listener)
 
 			recorder := httptest.NewRecorder()
 			req, err := http.NewRequest(http.MethodGet, "http://localhost:3000/ok", ioutil.NopCloser(nil))

--- a/server/server.go
+++ b/server/server.go
@@ -1462,5 +1462,11 @@ func (server *Server) buildRetryMiddleware(handler http.Handler, globalConfig co
 
 	log.Debugf("Creating retries max attempts %d", retryAttempts)
 
-	return middlewares.NewRetry(retryAttempts, handler, retryListeners)
+	stg := &middlewares.RetrySettings{}
+	stg.Attempts = retryAttempts
+	stg.CacheInitialCapacity = globalConfig.Retry.CacheInitialCapacity
+	stg.CacheMaxCapacity = globalConfig.Retry.CacheMaxCapacity
+	stg.TempDir = globalConfig.Retry.TempDir
+	stg.RetryInterval = time.Duration(globalConfig.Retry.RetryInterval)
+	return middlewares.NewRetry(stg, handler, retryListeners)
 }


### PR DESCRIPTION
### What does this PR do?
Decreases memory usage in retry middleware when served big files

### Motivation
Fixes #1064 


### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes
Old logic downloaded and buffered all the data from upstream server then send to downstream. This causes high memory usage when downloading >500Mb files. In order to avoid memory usage, this pull request proposes file based buffering, where each requested data will be buffered in memory until it reaches `CacheMaxCapacity` (new configuration option for retry), after that it starts buffering data into temporary file.

Small benchmarks shows that depending on load/storage on traefik hosted server, current retry logic under performs 1.3-2.5x times when retry logic not used.