### PR TITLE
Improve logging output for failing healthchecks

### DIFF
--- a/healthcheck/healthcheck_test.go
+++ b/healthcheck/healthcheck_test.go
@@ -81,7 +81,7 @@ func TestSetBackendsConfiguration(t *testing.T) {
 				Path:     "/path",
 				Interval: healthCheckInterval,
 				LB:       lb,
-			})
+			}, "backendName")
 			serverURL := testhelpers.MustParseURL(ts.URL)
 			if test.startHealthy {
 				lb.servers = append(lb.servers, serverURL)
@@ -95,7 +95,7 @@ func TestSetBackendsConfiguration(t *testing.T) {
 			wg := sync.WaitGroup{}
 			wg.Add(1)
 			go func() {
-				check.execute(ctx, "id", backend)
+				check.execute(ctx, backend)
 				wg.Done()
 			}()
 
@@ -168,7 +168,7 @@ func TestNewRequest(t *testing.T) {
 				Options{
 					Path: test.path,
 					Port: test.port,
-				})
+				}, "backendName")
 
 			u := &url.URL{
 				Scheme: "http",

--- a/server/server.go
+++ b/server/server.go
@@ -1049,7 +1049,7 @@ func (s *Server) loadConfig(configurations types.Configurations, globalConfigura
 						if hcOpts != nil {
 							log.Debugf("Setting up backend health check %s", *hcOpts)
 							hcOpts.Transport = s.defaultForwardingRoundTripper
-							backendsHealthCheck[entryPointName+frontend.Backend] = healthcheck.NewBackendHealthCheck(*hcOpts)
+							backendsHealthCheck[entryPointName+frontend.Backend] = healthcheck.NewBackendHealthCheck(*hcOpts, frontend.Backend)
 						}
 						lb = middlewares.NewEmptyBackendHandler(rebalancer, lb)
 					case types.Wrr:
@@ -1071,7 +1071,7 @@ func (s *Server) loadConfig(configurations types.Configurations, globalConfigura
 						if hcOpts != nil {
 							log.Debugf("Setting up backend health check %s", *hcOpts)
 							hcOpts.Transport = s.defaultForwardingRoundTripper
-							backendsHealthCheck[entryPointName+frontend.Backend] = healthcheck.NewBackendHealthCheck(*hcOpts)
+							backendsHealthCheck[entryPointName+frontend.Backend] = healthcheck.NewBackendHealthCheck(*hcOpts, frontend.Backend)
 						}
 						lb = middlewares.NewEmptyBackendHandler(rr, lb)
 					}


### PR DESCRIPTION
It's useful to understand why health checks failed in the case they do. Therefore I improved the logging output of the health checks, so that you can see whether it was e.g. an http/net issue or a wrong response code.

I also use now the backend name only in the logs. Before, for some logs something like `entryPointName+backendName` was used, but in most places we seem to log the backend name only.