### PR TITLE
Fix kubernetes path prefix rule with rewrite-target

### DIFF
--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -325,13 +325,13 @@ func getRuleForPath(pa v1beta1.HTTPIngressPath, i *v1beta1.Ingress) string {
 		ruleType = ruleTypePathPrefix
 	}
 
-	rule := ruleType + ":" + pa.Path
+	rules := []string{ruleType + ":" + pa.Path}
 
 	if rewriteTarget := i.Annotations[annotationKubernetesRewriteTarget]; rewriteTarget != "" {
-		rule = ruleTypeReplacePath + ":" + rewriteTarget
+		rules = append(rules, ruleTypeReplacePath+":"+rewriteTarget)
 	}
 
-	return rule
+	return strings.Join(rules, ";")
 }
 
 func (p *Provider) getPriority(path v1beta1.HTTPIngressPath, i *v1beta1.Ingress) int {

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -1728,7 +1728,7 @@ func TestIngressAnnotations(t *testing.T) {
 				PassHostHeader: true,
 				Routes: map[string]types.Route{
 					"/api": {
-						Rule: "ReplacePath:/",
+						Rule: "PathPrefix:/api;ReplacePath:/",
 					},
 					"rewrite": {
 						Rule: "Host:rewrite",


### PR DESCRIPTION
When rewrite-target is specified, any existing PathPrefix rule is
removed. Hence an ingress with rewrite-target is always matched
for the same host regardless of path prefix.