### PR TITLE
remove obsolete links in k8s docs

### DIFF
--- a/docs/configuration/backends/kubernetes.md
+++ b/docs/configuration/backends/kubernetes.md
@@ -120,8 +120,6 @@ Annotations can be used on the Kubernetes service to override default behaviour:
 - `traefik.backend.loadbalancer.sticky=true`      
     Enable backend sticky sessions (DEPRECATED)
 
-You can find here an example [ingress](https://raw.githubusercontent.com/containous/traefik/master/examples/k8s/cheese-ingress.yaml) and [replication controller](https://raw.githubusercontent.com/containous/traefik/master/examples/k8s/traefik.yaml).
-
 Additionally, an annotation can be used on Kubernetes services to set the [circuit breaker expression](/basics/#backends) for a backend.
 
 - `traefik.backend.circuitbreaker: <expression>`  


### PR DESCRIPTION
**Update**: as suggested by @timoreimann I removed the links completely. 