### PR TITLE
Add option -s to gofmt for autogen

### DIFF
--- a/autogen/gentemplates/gen.go
+++ b/autogen/gentemplates/gen.go
@@ -884,17 +884,17 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"templates": &bintree{nil, map[string]*bintree{
-		"consul_catalog.tmpl": &bintree{templatesConsul_catalogTmpl, map[string]*bintree{}},
-		"docker.tmpl":         &bintree{templatesDockerTmpl, map[string]*bintree{}},
-		"ecs.tmpl":            &bintree{templatesEcsTmpl, map[string]*bintree{}},
-		"eureka.tmpl":         &bintree{templatesEurekaTmpl, map[string]*bintree{}},
-		"kubernetes.tmpl":     &bintree{templatesKubernetesTmpl, map[string]*bintree{}},
-		"kv.tmpl":             &bintree{templatesKvTmpl, map[string]*bintree{}},
-		"marathon.tmpl":       &bintree{templatesMarathonTmpl, map[string]*bintree{}},
-		"mesos.tmpl":          &bintree{templatesMesosTmpl, map[string]*bintree{}},
-		"notFound.tmpl":       &bintree{templatesNotfoundTmpl, map[string]*bintree{}},
-		"rancher.tmpl":        &bintree{templatesRancherTmpl, map[string]*bintree{}},
+	"templates": {nil, map[string]*bintree{
+		"consul_catalog.tmpl": {templatesConsul_catalogTmpl, map[string]*bintree{}},
+		"docker.tmpl":         {templatesDockerTmpl, map[string]*bintree{}},
+		"ecs.tmpl":            {templatesEcsTmpl, map[string]*bintree{}},
+		"eureka.tmpl":         {templatesEurekaTmpl, map[string]*bintree{}},
+		"kubernetes.tmpl":     {templatesKubernetesTmpl, map[string]*bintree{}},
+		"kv.tmpl":             {templatesKvTmpl, map[string]*bintree{}},
+		"marathon.tmpl":       {templatesMarathonTmpl, map[string]*bintree{}},
+		"mesos.tmpl":          {templatesMesosTmpl, map[string]*bintree{}},
+		"notFound.tmpl":       {templatesNotfoundTmpl, map[string]*bintree{}},
+		"rancher.tmpl":        {templatesRancherTmpl, map[string]*bintree{}},
 	}},
 }}
 

--- a/generate.go
+++ b/generate.go
@@ -2,7 +2,7 @@
 //go:generate rm -vf autogen/genstatic/gen.go
 //go:generate mkdir -p static
 //go:generate go-bindata -pkg gentemplates -nometadata -nocompress -o autogen/gentemplates/gen.go ./templates/...
-//go:generate gofmt -w autogen/gentemplates/gen.go
+//go:generate gofmt -s -w autogen/gentemplates/gen.go
 //go:generate go-bindata -pkg genstatic -nocompress -o autogen/genstatic/gen.go ./static/...
 
 package main


### PR DESCRIPTION
### What does this PR do?

To be homogeneous with `make fmt` command this PR add option `-s` to gofmt for autogen

