### PR TITLE
Doesn't ignore web params when web.metrics.prometheus is set

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 4595cac0a682ce8e36b78630f12a3cfab75307fc58cb4a1f5e416017d3ae20d6
-updated: 2017-11-29T12:05:49.613148632+01:00
+updated: 2017-11-30T10:34:41.246378337+01:00
 imports:
 - name: cloud.google.com/go
   version: 2e6a95edb1071d750f6d7db777bf66cd2997af6c
@@ -88,7 +88,7 @@ imports:
 - name: github.com/codegangsta/cli
   version: bf4a526f48af7badd25d2cb02d587e1b01be3b50
 - name: github.com/containous/flaeg
-  version: b5d2dc5878df07c2d74413348186982e7b865871
+  version: 60c87a513a955ca7225e1b1c772581cea8420cb4
 - name: github.com/containous/mux
   version: 06ccd3e75091eb659b1d720cda0e16bc7057954c
 - name: github.com/containous/staert

--- a/vendor/github.com/containous/flaeg/flaeg.go
+++ b/vendor/github.com/containous/flaeg/flaeg.go
@@ -343,7 +343,7 @@ func fillStructRecursive(objValue reflect.Value, defaultPointerValmap map[string
 		contains := false
 		for flag := range valmap {
 			// TODO replace by regexp
-			if strings.Contains(flag, name+".") {
+			if strings.HasPrefix(flag, name+".") {
 				contains = true
 				break
 			}


### PR DESCRIPTION
### What does this PR do?
Update flaeg with containous/flaeg#39

### Motivation
Fix bug when you set `--web.metrics.prometheus`

### More
When you set `--web.metrics.prometheus`, a flaeg bug set `--metrics` default value too.
When `--web` is set with `--metrics`, we ignore web options so `--web.metrics.prometheus` break the web option !
