### PR TITLE
Fix wrong defaultentrypoint and unexisting entrypoint issue

### DIFF
--- a/cmd/traefik/configuration.go
+++ b/cmd/traefik/configuration.go
@@ -279,7 +279,7 @@ func NewTraefikConfiguration() *TraefikConfiguration {
 			LogLevel:                  "ERROR",
 			EntryPoints:               map[string]*configuration.EntryPoint{},
 			Constraints:               types.Constraints{},
-			DefaultEntryPoints:        []string{},
+			DefaultEntryPoints:        []string{"http"},
 			ProvidersThrottleDuration: flaeg.Duration(2 * time.Second),
 			MaxIdleConnsPerHost:       200,
 			IdleTimeout:               flaeg.Duration(0),

--- a/server/server.go
+++ b/server/server.go
@@ -910,13 +910,17 @@ func (s *Server) loadConfig(configurations types.Configurations, globalConfigura
 				log.Errorf("Skipping frontend %s...", frontendName)
 				continue frontend
 			}
-
+			var failedEntrypoints int
 			for _, entryPointName := range frontend.EntryPoints {
 				log.Debugf("Wiring frontend %s to entryPoint %s", frontendName, entryPointName)
 				if _, ok := serverEntryPoints[entryPointName]; !ok {
 					log.Errorf("Undefined entrypoint '%s' for frontend %s", entryPointName, frontendName)
-					log.Errorf("Skipping frontend %s...", frontendName)
-					continue frontend
+					failedEntrypoints++
+					if failedEntrypoints == len(frontend.EntryPoints) {
+						log.Errorf("Skipping frontend %s...", frontendName)
+						continue frontend
+					}
+					continue
 				}
 
 				newServerRoute := &serverRoute{route: serverEntryPoints[entryPointName].httpRouter.GetHandler().NewRoute().Name(frontendName)}


### PR DESCRIPTION
### What does this PR do?

Fix issue when we set only the http entrypoint, `defaultEntrypoints` was no longer `[ http ]`, but `[]`
Fix issue when a frontend use two entrypoints and if the first entrypoint doesn't exist, the frontend is skipped

### Motivation

fixes #2494 #680 

### More
- [x] Added/updated tests