### PR TITLE
Reduce logs with new Kubernetes security annotations

### DIFF
--- a/provider/kubernetes/annotations_parser.go
+++ b/provider/kubernetes/annotations_parser.go
@@ -19,7 +19,7 @@ func getBoolAnnotation(meta *v1beta1.Ingress, name string, defaultValue bool) bo
 	case annotationStringValue == "true":
 		annotationValue = true
 	default:
-		log.Warnf("Unknown value %q for %q, falling back to %q", annotationStringValue, name, defaultValue)
+		log.Warnf("Unknown value %q for %q, falling back to %v", annotationStringValue, name, defaultValue)
 	}
 	return annotationValue
 }
@@ -41,21 +41,26 @@ func getSliceAnnotation(meta *v1beta1.Ingress, name string) []string {
 	return value
 }
 
-func getMapAnnotation(meta *v1beta1.Ingress, labelName string) map[string]string {
-	if values, ok := meta.Annotations[labelName]; ok {
-		mapValue := make(map[string]string)
+func getMapAnnotation(meta *v1beta1.Ingress, annotName string) map[string]string {
+	if values, ok := meta.Annotations[annotName]; ok {
 
+		if len(values) == 0 {
+			log.Errorf("Missing value for annotation %q", annotName)
+			return nil
+		}
+
+		mapValue := make(map[string]string)
 		for _, parts := range strings.Split(values, ",") {
 			pair := strings.Split(parts, ":")
 			if len(pair) != 2 {
-				log.Warnf("Could not load %q: %v, skipping...", labelName, pair)
+				log.Warnf("Could not load %q: %v, skipping...", annotName, pair)
 			} else {
 				mapValue[pair[0]] = pair[1]
 			}
 		}
 
 		if len(mapValue) == 0 {
-			log.Errorf("Could not load %q, skipping...", labelName)
+			log.Errorf("Could not load %q, skipping...", annotName)
 			return nil
 		}
 		return mapValue

--- a/provider/kubernetes/annotations_parser.go
+++ b/provider/kubernetes/annotations_parser.go
@@ -41,21 +41,25 @@ func getSliceAnnotation(meta *v1beta1.Ingress, name string) []string {
 	return value
 }
 
-func getMapAnnotation(meta *v1beta1.Ingress, name string) map[string]string {
-	value := make(map[string]string)
-	if annotation := meta.Annotations[name]; annotation != "" {
-		for _, v := range strings.Split(annotation, ",") {
-			pair := strings.Split(v, ":")
+func getMapAnnotation(meta *v1beta1.Ingress, labelName string) map[string]string {
+	if values, ok := meta.Annotations[labelName]; ok {
+		mapValue := make(map[string]string)
+
+		for _, parts := range strings.Split(values, ",") {
+			pair := strings.Split(parts, ":")
 			if len(pair) != 2 {
-				log.Debugf("Could not load annotation (%v) with value: %v, skipping...", name, pair)
+				log.Warnf("Could not load %q: %v, skipping...", labelName, pair)
 			} else {
-				value[pair[0]] = pair[1]
+				mapValue[pair[0]] = pair[1]
 			}
 		}
+
+		if len(mapValue) == 0 {
+			log.Errorf("Could not load %q, skipping...", labelName)
+			return nil
+		}
+		return mapValue
 	}
-	if len(value) == 0 {
-		log.Debugf("Could not load %v annotation, skipping...", name)
-		return nil
-	}
-	return value
+
+	return nil
 }


### PR DESCRIPTION
### What does this PR do?

Reduce logs with new Kubernetes security annotations.

### Motivation

Limit the number of unneeded logs.

### More

- [x] Added/updated tests

### Additional Notes

Fixes #2500
