### PR TITLE
Specify default backend name in Kubernetes config backend

### DIFF
--- a/docs/configuration/backends/kubernetes.md
+++ b/docs/configuration/backends/kubernetes.md
@@ -71,6 +71,13 @@ See also [Kubernetes user guide](/user-guide/kubernetes).
 # Default: <built-in template>
 #
 # filename = "kubernetes.tmpl"
+
+# Default backend name to use when ingress has no endpoint.
+#
+# Optional
+# Default: empty (no backend servers)
+#
+# defaultBackend = "default-backend"
 ```
 
 ### `endpoint`


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

This PR add a new option in Kubernetes config backend to specify a default backend name when Kubernetes ingress has no available endpoints. 

### Motivation

The Kubernetes Ingress controller for nginx has an option to specify a “default backend”. This backend handles all traffic when nginx doesn’t know how to handle the request. This backend is also used when there is no pod to serve the request.

I am trying to replicate the same behavior in traefik such that when there is no upstream servers serving the frontend, the request is routed to a default backend. The default backend can then present content rather than returning an error.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

The new option has an empty default, which preserve existing behavior (backend config is still created even if no upstream servers are available).

When a default backend name is specified, this default backend name is used in these two cases:

* when no kubernetes service is found
* when there is no available endpoints for the kubernetes ingress

The default backend config has to be configured manually. This is because the kubernetes config backend only creates a backend config when there is an ingress. If this is not desirable, I can change this PR so that a user can specify a kubernetes service as the default backend instead, but the PR is likely to grow much bigger because I need to extract the logic for creating backend config from kubernetes service.