### PR TITLE
Add app-root annotation support for kubernetes ingress

### DIFF
--- a/docs/configuration/backends/kubernetes.md
+++ b/docs/configuration/backends/kubernetes.md
@@ -127,7 +127,7 @@ The following general annotations are applicable on the Ingress object:
 | `traefik.ingress.kubernetes.io/rewrite-target: /users`                          | Replaces each matched Ingress path with the specified one, and adds the old path to the `X-Replaced-Path` header.                               |
 | `traefik.ingress.kubernetes.io/rule-type: PathPrefixStrip`                      | Override the default frontend rule type. Default: `PathPrefix`.                                                                                 |
 | `traefik.ingress.kubernetes.io/whitelist-source-range: "1.2.3.0/24, fe80::/16"` | A comma-separated list of IP ranges permitted for access. all source IPs are permitted if the list is empty or a single range is ill-formatted. |
-| `traefik.ingress.kubernetes.io/app-root: "/index.html"` | Redirects all requests for / to the defined path. Non-root paths will not be affected by this annotation and handled normally. This annotation may not be combined with the ReplacePath rule type or any other annotation leveraging that rule type. Trying to do so leads to an error and the corresponding Ingress object being ignored. |
+| `traefik.ingress.kubernetes.io/app-root: "/index.html"` | Redirects all requests for `/` to the defined path. Non-root paths will not be affected by this annotation and handled normally. This annotation may not be combined with the `ReplacePath` rule type or any other annotation leveraging that rule type. Trying to do so leads to an error and the corresponding Ingress object being ignored. |
 
 <1> `traefik.ingress.kubernetes.io/error-pages` example:
 

--- a/docs/configuration/backends/kubernetes.md
+++ b/docs/configuration/backends/kubernetes.md
@@ -127,6 +127,7 @@ The following general annotations are applicable on the Ingress object:
 | `traefik.ingress.kubernetes.io/rewrite-target: /users`                          | Replaces each matched Ingress path with the specified one, and adds the old path to the `X-Replaced-Path` header.                               |
 | `traefik.ingress.kubernetes.io/rule-type: PathPrefixStrip`                      | Override the default frontend rule type. Default: `PathPrefix`.                                                                                 |
 | `traefik.ingress.kubernetes.io/whitelist-source-range: "1.2.3.0/24, fe80::/16"` | A comma-separated list of IP ranges permitted for access. all source IPs are permitted if the list is empty or a single range is ill-formatted. |
+| `traefik.ingress.kubernetes.io/app-root: "/index.html"` | Redirects all requests for / to the defined path. Non-root paths will not be affected by this annotation and handled normally. This annotation may not be combined with the ReplacePath rule type or any other annotation leveraging that rule type. Trying to do so leads to an error and the corresponding Ingress object being ignored. |
 
 <1> `traefik.ingress.kubernetes.io/error-pages` example:
 

--- a/provider/kubernetes/annotations.go
+++ b/provider/kubernetes/annotations.go
@@ -29,6 +29,7 @@ const (
 	annotationKubernetesRateLimit                = "ingress.kubernetes.io/rate-limit"
 	annotationKubernetesErrorPages               = "ingress.kubernetes.io/error-pages"
 	annotationKubernetesBuffering                = "ingress.kubernetes.io/buffering"
+	annotationKubernetesAppRoot                  = "ingress.kubernetes.io/app-root"
 
 	annotationKubernetesSSLRedirect             = "ingress.kubernetes.io/ssl-redirect"
 	annotationKubernetesHSTSMaxAge              = "ingress.kubernetes.io/hsts-max-age"

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -229,11 +229,11 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 				rule, err := getRuleForPath(pa, i)
 				if err != nil {
 					log.Errorf("Failed to get rule for ingress %s/%s: %s", i.Namespace, i.Name, err)
-					delete(templateObjects.Frontends, r.Host+pa.Path)
+					delete(templateObjects.Frontends, baseName)
 					continue
 				}
 				if rule != "" {
-					templateObjects.Frontends[r.Host+pa.Path].Routes[pa.Path] = types.Route{
+					templateObjects.Frontends[baseName].Routes[pa.Path] = types.Route{
 						Rule: rule,
 					}
 				}

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -228,7 +228,7 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 
 				rule, err := getRuleForPath(pa, i)
 				if err != nil {
-					log.Errorf("fail to get rule from ingress path: %s", err)
+					log.Errorf("Failed to get rule for ingress %s/%s: %s", i.Namespace, i.Name, err)
 					delete(templateObjects.Frontends, r.Host+pa.Path)
 					continue
 				}
@@ -328,6 +328,9 @@ func getRuleForPath(pa extensionsv1beta1.HTTPIngressPath, i *extensionsv1beta1.I
 	rules := []string{ruleType + ":" + pa.Path}
 
 	var pathReplaceAnnotation string
+	if ruleType == ruleTypeReplacePath {
+		pathReplaceAnnotation = annotationKubernetesRuleType
+	}
 
 	if rewriteTarget := getStringValue(i.Annotations, annotationKubernetesRewriteTarget, ""); rewriteTarget != "" {
 		if pathReplaceAnnotation != "" {

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -752,6 +752,32 @@ rateset:
 		),
 		buildIngress(
 			iNamespace("testing"),
+			iAnnotation(annotationKubernetesAppRoot, "/root2"),
+			iAnnotation(annotationKubernetesRewriteTarget, "/abc"),
+			iRules(
+				iRule(
+					iHost("root2"),
+					iPaths(
+						onePath(iPath("/"), iBackend("service2", intstr.FromInt(80))),
+					),
+				),
+			),
+		),
+		buildIngress(
+			iNamespace("testing"),
+			iAnnotation(annotationKubernetesRuleType, ruleTypeReplacePath),
+			iAnnotation(annotationKubernetesRewriteTarget, "/abc"),
+			iRules(
+				iRule(
+					iHost("root2"),
+					iPaths(
+						onePath(iPath("/"), iBackend("service2", intstr.FromInt(80))),
+					),
+				),
+			),
+		),
+		buildIngress(
+			iNamespace("testing"),
 			iAnnotation(annotationKubernetesIngressClass, "traefik"),
 			iAnnotation(annotationKubernetesCustomRequestHeaders, "Access-Control-Allow-Methods:POST,GET,OPTIONS || Content-type: application/json; charset=utf-8"),
 			iAnnotation(annotationKubernetesCustomResponseHeaders, "Access-Control-Allow-Methods:POST,GET,OPTIONS || Content-type: application/json; charset=utf-8"),
@@ -901,6 +927,10 @@ rateset:
 			backend("root/root1",
 				servers(
 					server("http://example.com", weight(1))),
+				lbMethod("wrr"),
+			),
+			backend("root2/",
+				servers(),
 				lbMethod("wrr"),
 			),
 		),

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -739,6 +739,19 @@ rateset:
 		),
 		buildIngress(
 			iNamespace("testing"),
+			iAnnotation(annotationKubernetesAppRoot, "/root"),
+			iRules(
+				iRule(
+					iHost("root"),
+					iPaths(
+						onePath(iPath("/"), iBackend("service1", intstr.FromInt(80))),
+						onePath(iPath("/root1"), iBackend("service1", intstr.FromInt(80))),
+					),
+				),
+			),
+		),
+		buildIngress(
+			iNamespace("testing"),
 			iAnnotation(annotationKubernetesIngressClass, "traefik"),
 			iAnnotation(annotationKubernetesCustomRequestHeaders, "Access-Control-Allow-Methods:POST,GET,OPTIONS || Content-type: application/json; charset=utf-8"),
 			iAnnotation(annotationKubernetesCustomResponseHeaders, "Access-Control-Allow-Methods:POST,GET,OPTIONS || Content-type: application/json; charset=utf-8"),
@@ -880,6 +893,16 @@ rateset:
 					server("http://example.com", weight(1))),
 				lbMethod("wrr"),
 			),
+			backend("root/",
+				servers(
+					server("http://example.com", weight(1))),
+				lbMethod("wrr"),
+			),
+			backend("root/root1",
+				servers(
+					server("http://example.com", weight(1))),
+				lbMethod("wrr"),
+			),
 		),
 		frontends(
 			frontend("foo/bar",
@@ -993,6 +1016,20 @@ rateset:
 				routes(
 					route("/customheaders", "PathPrefix:/customheaders"),
 					route("custom-headers", "Host:custom-headers")),
+			),
+			frontend("root/",
+				passHostHeader(),
+				routes(
+					route("/", "PathPrefix:/;ReplacePath:/root"),
+					route("root", "Host:root"),
+				),
+			),
+			frontend("root/root1",
+				passHostHeader(),
+				routes(
+					route("/root1", "PathPrefix:/root1"),
+					route("root", "Host:root"),
+				),
 			),
 		),
 	)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?
Rediret only root path elsewhere by ingress annotation. Like Nginx Ingress Controller [documented](https://github.com/kubernetes/ingress-nginx/blob/27c863085e2503e5f3249b596f24529fc2488baa/docs/examples/rewrite/README.md#deployment). Implementing this annotation will only perform `ReplacePath` on `/` path on all hosts present in the annotated ingress.

`ingress.kubernetes.io/app-root` or `traefik.ingress.kubernetes.io/app-root`

### Motivation

<!-- What inspired you to submit this pull request? -->
We catch this use case in production deployment.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes
Seems like many new annotation support will be added to Kubernetes provider on 1.5 release, I hope this annotation can also be supported.


<!-- Anything else we should know when reviewing? -->
