### PR TITLE
Fix pprof route order.

### DIFF
--- a/api/debug.go
+++ b/api/debug.go
@@ -38,9 +38,9 @@ func (g DebugHandler) AddRoutes(router *mux.Router) {
 			fmt.Fprint(w, "\n}\n")
 		})
 
-	router.Methods(http.MethodGet).PathPrefix("/debug/pprof/").HandlerFunc(pprof.Index)
 	router.Methods(http.MethodGet).PathPrefix("/debug/pprof/cmdline").HandlerFunc(pprof.Cmdline)
 	router.Methods(http.MethodGet).PathPrefix("/debug/pprof/profile").HandlerFunc(pprof.Profile)
 	router.Methods(http.MethodGet).PathPrefix("/debug/pprof/symbol").HandlerFunc(pprof.Symbol)
 	router.Methods(http.MethodGet).PathPrefix("/debug/pprof/trace").HandlerFunc(pprof.Trace)
+	router.Methods(http.MethodGet).PathPrefix("/debug/pprof/").HandlerFunc(pprof.Index)
 }


### PR DESCRIPTION
Index must go last, otherwise more specific endpoints are ignored.