### PR TITLE
Add defaultEntryPoints into sample config

### DIFF
--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -22,7 +22,7 @@
 # Optional
 # Default: ["http"]
 #
-# defaultEntryPoints = ["http", "https"]
+defaultEntryPoints = ["http", "https"]
 
 # Entrypoints definition
 #


### PR DESCRIPTION
### Context

I tried to run traefik with [traefik image](https://hub.docker.com/r/_/traefik/) and [sample configuration file](https://raw.githubusercontent.com/containous/traefik/master/traefik.sample.toml) but I got only 404 error because no entry point are defined.

### What does this PR do?

Add defaultEntryPoints into sample config.

### Motivation

I think it is useful for newbie to have a out of the box working sample configuration.

### Additional Notes

If it is OK, you have to update [image description, Example usage section](https://hub.docker.com/r/_/traefik/) and add `defaultEntryPoints = ["http", "https"]`.

Maybe, should I do same change into [docs/configuration/commons.md](https://github.com/containous/traefik/blame/master/docs/configuration/commons.md#L71)?
