### PR TITLE
fix healthcheck when web is not specified

### DIFF
--- a/cmd/traefik/healthcheck.go
+++ b/cmd/traefik/healthcheck.go
@@ -64,6 +64,9 @@ func healthCheck(globalConfiguration configuration.GlobalConfiguration) (*http.R
 		}
 		client.Transport = tr
 	}
-
-	return client.Head(protocol + "://" + pingEntryPoint.Address + globalConfiguration.Web.Path + "ping")
+	path := "/"
+	if globalConfiguration.Web != nil {
+		path = globalConfiguration.Web.Path
+	}
+	return client.Head(protocol + "://" + pingEntryPoint.Address + path + "ping")
 }

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -620,7 +620,7 @@ This command allows to check the health of Traefik. Its exit status is `0` if Tr
 This can be used with Docker [HEALTHCHECK](https://docs.docker.com/engine/reference/builder/#healthcheck) instruction or any other health check orchestration mechanism.
 
 !!! note
-    The [`web` provider](/configuration/backends/web) must be enabled to allow `/ping` calls by the `healthcheck` command.
+    The [`ping`](/configuration/ping) must be enabled to allow `/ping` calls by the `healthcheck` command.
 
 ```bash
 traefik healthcheck

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -620,7 +620,7 @@ This command allows to check the health of Traefik. Its exit status is `0` if Tr
 This can be used with Docker [HEALTHCHECK](https://docs.docker.com/engine/reference/builder/#healthcheck) instruction or any other health check orchestration mechanism.
 
 !!! note
-    The [`ping`](/configuration/ping) must be enabled to allow `/ping` calls by the `healthcheck` command.
+    The [`ping`](/configuration/ping) must be enabled to allow the `healthcheck` command to call `/ping`.
 
 ```bash
 traefik healthcheck


### PR DESCRIPTION
### Motivation
We tried to add the `web.path`, even if `web` is not defined. Moreover `web` is deprecated, we may use `ping` instead.

fixes #2524 

### More
- [x] Added/updated documentation