### PR TITLE
Close ring buffer used in throttling function.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -374,6 +374,7 @@ func (s *Server) preLoadConfiguration(configMsg types.ConfigMessage) {
 // it will publish the last of the newly received configurations.
 func throttleProviderConfigReload(throttle time.Duration, publish chan<- types.ConfigMessage, in <-chan types.ConfigMessage, stop chan bool) {
 	ring := channels.NewRingChannel(1)
+	defer ring.Close()
 
 	safe.Go(func() {
 		for {


### PR DESCRIPTION
### What does this PR do?

Close the ring buffer used in the throttling function.

### Motivation

Not closing means leaking a buffer-internal goroutine.