### PR TITLE
Use default entryPoints when certificates are added with no entryPoints.

### DIFF
--- a/docs/configuration/backends/file.md
+++ b/docs/configuration/backends/file.md
@@ -92,7 +92,10 @@ entryPoints = ["https"]
 ```
 
 !!! note
-    adding certificates directly to the entrypoint is still maintained but certificates declared in this way cannot be managed dynamically.
+    If `tlsConfiguration.entryPoints` is not defined, the certificate is attached to all the `defaultEntryPoints` with a TLS configuration.
+
+!!! note
+    Adding certificates directly to the entryPoint is still maintained but certificates declared in this way cannot be managed dynamically.
     It's recommended to use the file provider to declare certificates.
 
 ## Rules in a Separate File

--- a/docs/user-guide/kv-config.md
+++ b/docs/user-guide/kv-config.md
@@ -271,7 +271,6 @@ Here is the toml configuration we would like to store in the store :
   rule = "Path:/test"
 
 [[tlsConfiguration]]
-entryPoints = ["https"]
   [tlsConfiguration.certificate]
     certFile = "path/to/your.cert"
     keyFile = "path/to/your.key"
@@ -333,9 +332,11 @@ And there, the same dynamic configuration in a KV Store (using `prefix = "traefi
 
 | Key                                                | Value              |
 |----------------------------------------------------|--------------------|
-| `/traefik/tlsconfiguration/1/entrypoints`          | `https`            |
 | `/traefik/tlsconfiguration/1/certificate/certfile` | `path/to/your.cert`|
 | `/traefik/tlsconfiguration/1/certificate/keyfile`  | `path/to/your.key` |
+
+!!! note
+    As `/traefik/tlsconfiguration/1/entrypoints` is not defined, the certificate will be attached to all `defaulEntryPoints` with a TLS configuration (in the example, the entryPoint `https`)
 
 - certificate 2
 

--- a/integration/https_test.go
+++ b/integration/https_test.go
@@ -534,7 +534,6 @@ func modifyCertificateConfFileContent(c *check.C, certFileName, confFileName str
 					CertFile: traefikTls.FileOrContent("fixtures/https/" + certFileName + ".cert"),
 					KeyFile:  traefikTls.FileOrContent("fixtures/https/" + certFileName + ".key"),
 				},
-				EntryPoints: []string{"https"},
 			},
 		},
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -619,15 +619,16 @@ func TestNewServerWithWhitelistSourceRange(t *testing.T) {
 func TestServerLoadConfigEmptyBasicAuth(t *testing.T) {
 	globalConfig := configuration.GlobalConfiguration{
 		EntryPoints: configuration.EntryPoints{
-			"http": &configuration.EntryPoint{ForwardedHeaders: &configuration.ForwardedHeaders{Insecure: true}},
+			"https": &configuration.EntryPoint{TLS: &tls.TLS{}, ForwardedHeaders: &configuration.ForwardedHeaders{Insecure: true}},
 		},
+		DefaultEntryPoints: []string{"https"},
 	}
 
 	dynamicConfigs := types.Configurations{
 		"config": &types.Configuration{
 			Frontends: map[string]*types.Frontend{
 				"frontend": {
-					EntryPoints: []string{"http"},
+					EntryPoints: []string{"https"},
 					Backend:     "backend",
 					BasicAuth:   []string{""},
 				},
@@ -636,7 +637,7 @@ func TestServerLoadConfigEmptyBasicAuth(t *testing.T) {
 				"backend": {
 					Servers: map[string]types.Server{
 						"server": {
-							URL: "http://localhost",
+							URL: "https://localhost",
 						},
 					},
 					LoadBalancer: &types.LoadBalancer{
@@ -650,7 +651,6 @@ func TestServerLoadConfigEmptyBasicAuth(t *testing.T) {
 						CertFile: localhostCert,
 						KeyFile:  localhostKey,
 					},
-					EntryPoints: []string{"http"},
 				},
 			},
 		},

--- a/tls/certificate.go
+++ b/tls/certificate.go
@@ -67,6 +67,20 @@ func (f FileOrContent) String() string {
 	return string(f)
 }
 
+func (f FileOrContent) Path() bool {
+	_, err := os.Stat(f.String())
+	return err == nil
+}
+
+func (f FileOrContent) GetBeginContent() (string, error) {
+	content, err := f.Read()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimPrefix(string(content), "-----BEGIN CERTIFICATE-----\n")[:50], nil
+
+}
+
 func (f FileOrContent) Read() ([]byte, error) {
 	var content []byte
 	if _, err := os.Stat(f.String()); err == nil {

--- a/tls/certificate.go
+++ b/tls/certificate.go
@@ -160,7 +160,7 @@ func (c *Certificate) AppendCertificates(certs map[string]*DomainsCertificates, 
 		}
 	}
 	if certExists {
-		log.Warnf("Into EntryPoint %s, try to add certificate for domains which already have a certificate (%s). The new certificate will not be append to the EntryPoint.", ep, certKey)
+		log.Warnf("Into EntryPoint %s, try to add certificate for domains which already have this certificate (%s). The new certificate will not be append to the EntryPoint.", ep, certKey)
 	} else {
 		log.Debugf("Add certificate for domains %s", certKey)
 		err = certs[ep].add(certKey, &tlsCert)

--- a/tls/certificate.go
+++ b/tls/certificate.go
@@ -67,18 +67,10 @@ func (f FileOrContent) String() string {
 	return string(f)
 }
 
+// Path returns true if the FileOrContent is a file path, otherwise returns false
 func (f FileOrContent) Path() bool {
 	_, err := os.Stat(f.String())
 	return err == nil
-}
-
-func (f FileOrContent) GetBeginContent() (string, error) {
-	content, err := f.Read()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimPrefix(string(content), "-----BEGIN CERTIFICATE-----\n")[:50], nil
-
 }
 
 func (f FileOrContent) Read() ([]byte, error) {

--- a/tls/certificate.go
+++ b/tls/certificate.go
@@ -67,8 +67,8 @@ func (f FileOrContent) String() string {
 	return string(f)
 }
 
-// Path returns true if the FileOrContent is a file path, otherwise returns false
-func (f FileOrContent) Path() bool {
+// IsPath returns true if the FileOrContent is a file path, otherwise returns false
+func (f FileOrContent) IsPath() bool {
 	_, err := os.Stat(f.String())
 	return err == nil
 }

--- a/tls/tls.go
+++ b/tls/tls.go
@@ -96,6 +96,7 @@ func SortTLSConfigurationPerEntryPoints(configurations []*Configuration, epConfi
 	for _, conf := range configurations {
 		if conf.EntryPoints == nil || len(conf.EntryPoints) == 0 {
 			certName := conf.Certificate.CertFile.String()
+			// Keep only 50 characters to generate a readable log
 			if len(certName) > 50 {
 				certName = certName[0:50]
 			}

--- a/tls/tls.go
+++ b/tls/tls.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/containous/traefik/log"
 )
 
@@ -95,12 +96,14 @@ func SortTLSConfigurationPerEntryPoints(configurations []*Configuration, epConfi
 	}
 	for _, conf := range configurations {
 		if conf.EntryPoints == nil || len(conf.EntryPoints) == 0 {
-			certName := conf.Certificate.CertFile.String()
-			// Keep only 50 characters to generate a readable log
-			if len(certName) > 50 {
-				certName = certName[0:50]
+			if log.GetLevel() >= logrus.DebugLevel {
+				certName := conf.Certificate.CertFile.String()
+				// Keep only 50 characters to generate a readable log
+				if len(certName) > 50 {
+					certName = certName[:50]
+				}
+				log.Debugf("No entryPoint is defined to add the certificate %s, it will be added to the default entryPoints: %s", certName, strings.Join(defaultEntryPoints, ", "))
 			}
-			log.Debugf("No entryPoint is defined to add the certificate %s, it will be added to the default entryPoints: %s", certName, strings.Join(defaultEntryPoints, ","))
 			conf.EntryPoints = append(conf.EntryPoints, defaultEntryPoints...)
 		}
 		for _, ep := range conf.EntryPoints {

--- a/tls/tls.go
+++ b/tls/tls.go
@@ -101,11 +101,7 @@ func SortTLSConfigurationPerEntryPoints(configurations []*Configuration, epConfi
 				if conf.Certificate.CertFile.Path() {
 					certName = conf.Certificate.CertFile.String()
 				} else {
-					content, err := conf.Certificate.CertFile.GetBeginContent()
-					if err != nil {
-						return err
-					}
-					certName = content
+					certName = strings.TrimPrefix(conf.Certificate.CertFile.String(), "-----BEGIN CERTIFICATE-----\n")[:50]
 				}
 				log.Debugf("No entryPoint is defined to add the certificate %s, it will be added to the default entryPoints: %s", certName, strings.Join(defaultEntryPoints, ", "))
 			}

--- a/tls/tls.go
+++ b/tls/tls.go
@@ -97,10 +97,15 @@ func SortTLSConfigurationPerEntryPoints(configurations []*Configuration, epConfi
 	for _, conf := range configurations {
 		if conf.EntryPoints == nil || len(conf.EntryPoints) == 0 {
 			if log.GetLevel() >= logrus.DebugLevel {
-				certName := conf.Certificate.CertFile.String()
-				// Keep only 50 characters to generate a readable log
-				if len(certName) > 50 {
-					certName = certName[:50]
+				var certName string
+				if conf.Certificate.CertFile.Path() {
+					certName = conf.Certificate.CertFile.String()
+				} else {
+					content, err := conf.Certificate.CertFile.GetBeginContent()
+					if err != nil {
+						return err
+					}
+					certName = content
 				}
 				log.Debugf("No entryPoint is defined to add the certificate %s, it will be added to the default entryPoints: %s", certName, strings.Join(defaultEntryPoints, ", "))
 			}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

The PR allows introducing a mechanism _by default_ for all the providers which add  TLScertificates dynamically.
If no entryPoints are given, the certificates are added to all of the `defaultEntryPoints` (from Træfik global configuration) wich have a TLS configuration.

### Motivation

<!-- What inspired you to submit this pull request? -->
This PR helps to create the certificates management from K8s secret (#2439)

### More

- [x] Added/updated tests
- [x] Added/updated documentation

