### PR TITLE
Improve documentation for Cloudflare API key

### DIFF
--- a/docs/configuration/acme.md
+++ b/docs/configuration/acme.md
@@ -135,7 +135,7 @@ Select the provider that matches the DNS domain that will host the challenge TXT
 |--------------------------------------------------------|----------------|---------------------------------------------------------------------------------------------------------------------------|
 | [Auroradns](https://www.pcextreme.com/aurora/dns)      | `auroradns`    | `AURORA_USER_ID`, `AURORA_KEY`, `AURORA_ENDPOINT`                                                                         |
 | [Azure](https://azure.microsoft.com/services/dns/)     | `azure`        | `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_SUBSCRIPTION_ID`, `AZURE_TENANT_ID`, `AZURE_RESOURCE_GROUP`              |
-| [Cloudflare](https://www.cloudflare.com)               | `cloudflare`   | `CLOUDFLARE_EMAIL`, `CLOUDFLARE_API_KEY`                                                                                  |
+| [Cloudflare](https://www.cloudflare.com)               | `cloudflare`   | `CLOUDFLARE_EMAIL`, `CLOUDFLARE_API_KEY` - The Cloudflare `Global API Key` needs to be used and not the `Origin CA Key`   |
 | [DigitalOcean](https://www.digitalocean.com)           | `digitalocean` | `DO_AUTH_TOKEN`                                                                                                           |
 | [DNSimple](https://dnsimple.com)                       | `dnsimple`     | `DNSIMPLE_OAUTH_TOKEN`, `DNSIMPLE_BASE_URL`                                                                               |
 | [DNS Made Easy](https://dnsmadeeasy.com)               | `dnsmadeeasy`  | `DNSMADEEASY_API_KEY`, `DNSMADEEASY_API_SECRET`, `DNSMADEEASY_SANDBOX`                                                    |

--- a/docs/configuration/backends/consul.md
+++ b/docs/configuration/backends/consul.md
@@ -88,6 +88,12 @@ endpoint = "127.0.0.1:8500"
 #
 exposedByDefault = false
 
+# Default domain used.
+#
+# Optional
+#
+domain = "consul.localhost"
+
 # Prefix for Consul catalog tags.
 #
 # Optional


### PR DESCRIPTION
### What does this PR do?

This PR improve documentation for DNS provider
The Cloudflare `Global API Key` needs to be used and not the `Origin CA Key`

### More

- [x] Added/updated documentation

Fixes: #2219 