### PR TITLE
Fix RawPath handling in addPrefix

### DIFF
--- a/middlewares/addPrefix.go
+++ b/middlewares/addPrefix.go
@@ -12,6 +12,9 @@ type AddPrefix struct {
 
 func (s *AddPrefix) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r.URL.Path = s.Prefix + r.URL.Path
+	if r.URL.RawPath != "" {
+		r.URL.RawPath = s.Prefix + r.URL.RawPath
+	}
 	r.RequestURI = r.URL.RequestURI()
 	s.Handler.ServeHTTP(w, r)
 }


### PR DESCRIPTION
This is an extension of PR #2382 for addPrefix.

This PR fixes forwarding of URL encoded characters to the backend servers.

Below is a copy straight from PR #2382 :

Given that Traefik receives a request path in the form: `/some/a%2Fb` it should forward the same path to the backend. This is the case when using e.g. the rule type `PathPrefix`, but as soon as the rule type is either `AddPrefix` the path was forwarded in the decoded form like: `/some/a/b`.

The reason why this solution fixes our problem is that go uses the `String()` method of the URL object when it constructs the request. The docs state for this:

```go
// String reassembles the URL into a valid URL string.
// The general form of the result is one of:
//
//	scheme:opaque?query#fragment
//	scheme://userinfo@host/path?query#fragment
//
// If u.Opaque is non-empty, String uses the first form;
// otherwise it uses the second form.
// To obtain the path, String uses u.EscapedPath().
```

For us the relevant part is with `u.EscapedPath()` and there the docs state:

```go
// EscapedPath returns the escaped form of u.Path.
// In general there are multiple possible escaped forms of any path.
// EscapedPath returns u.RawPath when it is a valid escaping of u.Path.
// Otherwise EscapedPath ignores u.RawPath and computes an escaped
// form on its own.
// The String and RequestURI methods use EscapedPath to construct
// their results.
// In general, code should call EscapedPath instead of
// reading u.RawPath directly.
```

To understand the problem, note the sentence: `EscapedPath` returns `u.RawPath` when it is a valid escaping of `u.Path`. By stripping only the `Path` and not the `RawPath` we violated this statement and therefore the http package decided to use the `Path`.