### PR TITLE
Reload configuration when port change for one service

### DIFF
--- a/integration/consul_catalog_test.go
+++ b/integration/consul_catalog_test.go
@@ -419,6 +419,46 @@ func (s *ConsulCatalogSuite) TestCircuitBreaker(c *check.C) {
 	c.Assert(err, checker.IsNil)
 }
 
+func (s *ConsulCatalogSuite) TestRefreshConfigPortChange(c *check.C) {
+	cmd, display := s.traefikCmd(
+		withConfigFile("fixtures/consul_catalog/simple.toml"),
+		"--consulCatalog",
+		"--consulCatalog.exposedByDefault=false",
+		"--consulCatalog.watch=true",
+		"--consulCatalog.endpoint="+s.consulIP+":8500",
+		"--consulCatalog.domain=consul.localhost")
+	defer display(c)
+	err := cmd.Start()
+	c.Assert(err, checker.IsNil)
+	defer cmd.Process.Kill()
+
+	nginx := s.composeProject.Container(c, "nginx1")
+
+	err = s.registerService("test", nginx.NetworkSettings.IPAddress, 81, []string{"name=nginx1", "traefik.enable=true"})
+	c.Assert(err, checker.IsNil, check.Commentf("Error registering service"))
+
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8000/", nil)
+	c.Assert(err, checker.IsNil)
+	req.Host = "test.consul.localhost"
+
+	err = try.Request(req, 20*time.Second, try.StatusCodeIs(http.StatusBadGateway))
+	c.Assert(err, checker.IsNil)
+
+	err = try.GetRequest("http://127.0.0.1:8080/api/providers/consul_catalog/backends", 5*time.Second, try.BodyContains("nginx1"))
+	c.Assert(err, checker.IsNil)
+
+	err = s.registerService("test", nginx.NetworkSettings.IPAddress, 80, []string{"name=nginx1", "traefik.enable=true"})
+	c.Assert(err, checker.IsNil, check.Commentf("Error registering service"))
+
+	defer s.deregisterService("test", nginx.NetworkSettings.IPAddress)
+
+	err = try.GetRequest("http://127.0.0.1:8080/api/providers/consul_catalog/backends", 60*time.Second, try.BodyContains("nginx1"))
+	c.Assert(err, checker.IsNil)
+
+	err = try.Request(req, 20*time.Second, try.StatusCodeIs(http.StatusOK), try.HasBody())
+	c.Assert(err, checker.IsNil)
+}
+
 func (s *ConsulCatalogSuite) TestRetryWithConsulServer(c *check.C) {
 	//Scale consul to 0 to be able to start traefik before and test retry
 	s.composeProject.Scale(c, "consul", 0)

--- a/provider/consul/consul_catalog_test.go
+++ b/provider/consul/consul_catalog_test.go
@@ -1094,7 +1094,7 @@ func TestConsulCatalogHasNodeOrTagschanged(t *testing.T) {
 			expected: false,
 		},
 		{
-			desc: "Change detected con tags",
+			desc: "Change detected on tags",
 			current: map[string]Service{
 				"foo-service": {
 					Name:  "foo",
@@ -1111,6 +1111,66 @@ func TestConsulCatalogHasNodeOrTagschanged(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			desc: "Change detected on ports",
+			current: map[string]Service{
+				"foo-service": {
+					Name:  "foo",
+					Nodes: []string{"node1"},
+					Tags:  []string{"foo=bar"},
+					Ports: []int{80},
+				},
+			},
+			previous: map[string]Service{
+				"foo-service": {
+					Name:  "foo",
+					Nodes: []string{"node1"},
+					Tags:  []string{"foo"},
+					Ports: []int{81},
+				},
+			},
+			expected: true,
+		},
+		{
+			desc: "Change detected on ports",
+			current: map[string]Service{
+				"foo-service": {
+					Name:  "foo",
+					Nodes: []string{"node1"},
+					Tags:  []string{"foo=bar"},
+					Ports: []int{80},
+				},
+			},
+			previous: map[string]Service{
+				"foo-service": {
+					Name:  "foo",
+					Nodes: []string{"node1"},
+					Tags:  []string{"foo"},
+					Ports: []int{81, 82},
+				},
+			},
+			expected: true,
+		},
+		{
+			desc: "No Change detected",
+			current: map[string]Service{
+				"foo-service": {
+					Name:  "foo",
+					Nodes: []string{"node1"},
+					Tags:  []string{"foo"},
+					Ports: []int{80},
+				},
+			},
+			previous: map[string]Service{
+				"foo-service": {
+					Name:  "foo",
+					Nodes: []string{"node1"},
+					Tags:  []string{"foo"},
+					Ports: []int{80},
+				},
+			},
+			expected: false,
+		},
 	}
 
 	for _, test := range testCases {
@@ -1118,7 +1178,7 @@ func TestConsulCatalogHasNodeOrTagschanged(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			actual := hasNodeOrTagsChanged(test.current, test.previous)
+			actual := hasServiceChanged(test.current, test.previous)
 			assert.Equal(t, test.expected, actual)
 		})
 	}


### PR DESCRIPTION
### What does this PR do?

When a consul service port change, Træfik configuration was not reloading

Fixes #2572 

### More

- [x] Added/updated tests
