### PR TITLE
Change Zookeeper default prefix.

### DIFF
--- a/cmd/traefik/configuration.go
+++ b/cmd/traefik/configuration.go
@@ -112,7 +112,7 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 	var defaultZookeeper zk.Provider
 	defaultZookeeper.Watch = true
 	defaultZookeeper.Endpoint = "127.0.0.1:2181"
-	defaultZookeeper.Prefix = "/traefik"
+	defaultZookeeper.Prefix = "traefik"
 	defaultZookeeper.Constraints = types.Constraints{}
 
 	//default Boltdb

--- a/docs/configuration/backends/zookeeper.md
+++ b/docs/configuration/backends/zookeeper.md
@@ -27,9 +27,9 @@ watch = true
 # Prefix used for KV store.
 #
 # Optional
-# Default: "/traefik"
+# Default: "traefik"
 #
-prefix = "/traefik"
+prefix = "traefik"
 
 # Override default configuration template.
 # For advanced users :)


### PR DESCRIPTION
### What does this PR do?

Change Zookeeper default prefix from `/traefik` to `traefik`. 

### Motivation

Fixes #2550

### More

- [x] Added/updated documentation

### Additional Notes

Related to #948.

<!-- Anything else we should know when reviewing? -->
