### PR TITLE
Update go-marathon

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -261,7 +261,7 @@ imports:
 - name: github.com/fatih/color
   version: 62e9147c64a1ed519147b62a56a14e83e2be02c1
 - name: github.com/gambol99/go-marathon
-  version: dd6cbd4c2d71294a19fb89158f2a00d427f174ab
+  version: 03b46169666c53b9cc953b875ac5714e5103e064
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-ini/ini

--- a/vendor/github.com/gambol99/go-marathon/application_marshalling.go
+++ b/vendor/github.com/gambol99/go-marathon/application_marshalling.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2017 The go-marathon Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package marathon
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Alias aliases the Application struct so that it will be marshaled/unmarshaled automatically
+type Alias Application
+
+// TmpEnvSecret holds the secret values deserialized from the environment variables field
+type TmpEnvSecret struct {
+	Secret string `json:"secret,omitempty"`
+}
+
+// TmpSecret holds the deserialized secrets field in a Marathon application configuration
+type TmpSecret struct {
+	Source string `json:"source,omitempty"`
+}
+
+// UnmarshalJSON unmarshals the given Application JSON as expected except for environment variables and secrets.
+// Environment varialbes are stored in the Env field. Secrets, including the environment variable part,
+// are stored in the Secrets field.
+func (app *Application) UnmarshalJSON(b []byte) error {
+	aux := &struct {
+		*Alias
+		Env     map[string]interface{} `json:"env"`
+		Secrets map[string]TmpSecret   `json:"secrets"`
+	}{
+		Alias: (*Alias)(app),
+	}
+	if err := json.Unmarshal(b, aux); err != nil {
+		return fmt.Errorf("malformed application definition %v", err)
+	}
+	env := &map[string]string{}
+	secrets := &map[string]Secret{}
+
+	for envName, genericEnvValue := range aux.Env {
+		switch envValOrSecret := genericEnvValue.(type) {
+		case string:
+			(*env)[envName] = envValOrSecret
+		case map[string]interface{}:
+			for secret, secretStore := range envValOrSecret {
+				if secStore, ok := secretStore.(string); ok && secret == "secret" {
+					(*secrets)[secStore] = Secret{EnvVar: envName}
+					break
+				}
+				return fmt.Errorf("unexpected secret field %v or value type %T", secret, envValOrSecret[secret])
+			}
+		default:
+			return fmt.Errorf("unexpected environment variable type %T", envValOrSecret)
+		}
+	}
+	app.Env = env
+	for k, v := range aux.Secrets {
+		tmp := (*secrets)[k]
+		tmp.Source = v.Source
+		(*secrets)[k] = tmp
+	}
+	app.Secrets = secrets
+	return nil
+}
+
+// MarshalJSON marshals the given Application as expected except for environment variables and secrets,
+// which are marshaled from specialized structs.  The environment variable piece of the secrets and other
+// normal environment variables are combined and marshaled to the env field.  The secrets and the related
+// source are marshaled into the secrets field.
+func (app *Application) MarshalJSON() ([]byte, error) {
+	env := make(map[string]interface{})
+	secrets := make(map[string]TmpSecret)
+
+	if app.Env != nil {
+		for k, v := range *app.Env {
+			env[string(k)] = string(v)
+		}
+	}
+	if app.Secrets != nil {
+		for k, v := range *app.Secrets {
+			env[v.EnvVar] = TmpEnvSecret{Secret: k}
+			secrets[k] = TmpSecret{v.Source}
+		}
+	}
+	aux := &struct {
+		*Alias
+		Env     map[string]interface{} `json:"env,omitempty"`
+		Secrets map[string]TmpSecret   `json:"secrets,omitempty"`
+	}{Alias: (*Alias)(app), Env: env, Secrets: secrets}
+
+	return json.Marshal(aux)
+}

--- a/vendor/github.com/gambol99/go-marathon/client.go
+++ b/vendor/github.com/gambol99/go-marathon/client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 Rohith All rights reserved.
+Copyright 2014 The go-marathon Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -154,6 +155,24 @@ var (
 	ErrMarathonDown = errors.New("all the Marathon hosts are presently down")
 	// ErrTimeoutError is thrown when the operation has timed out
 	ErrTimeoutError = errors.New("the operation has timed out")
+
+	// Default HTTP client used for SSE subscription requests
+	// It is invalid to set client.Timeout because it includes time to read response so
+	// set dial, tls handshake and response header timeouts instead
+	defaultHTTPSSEClient = &http.Client{
+		Transport: &http.Transport{
+			Dial: (&net.Dialer{
+				Timeout: 5 * time.Second,
+			}).Dial,
+			ResponseHeaderTimeout: 10 * time.Second,
+			TLSHandshakeTimeout:   5 * time.Second,
+		},
+	}
+
+	// Default HTTP client used for non SSE requests
+	defaultHTTPClient = &http.Client{
+		Timeout: 10 * time.Second,
+	}
 )
 
 // EventsChannelContext holds contextual data for an EventsChannel.
@@ -177,8 +196,8 @@ type marathonClient struct {
 	hosts *cluster
 	// a map of service you wish to listen to
 	listeners map[EventsChannel]EventsChannelContext
-	// a custom logger for debug log messages
-	debugLog *log.Logger
+	// a custom log function for debug messages
+	debugLog func(format string, v ...interface{})
 	// the marathon HTTP client to ensure consistency in requests
 	client *httpClient
 }
@@ -196,9 +215,18 @@ type newRequestError struct {
 // NewClient creates a new marathon client
 //		config:			the configuration to use
 func NewClient(config Config) (Marathon, error) {
-	// step: if no http client, set to default
+	// step: if the SSE HTTP client is missing, prefer a configured regular
+	// client, and otherwise use the default SSE HTTP client.
+	if config.HTTPSSEClient == nil {
+		config.HTTPSSEClient = defaultHTTPSSEClient
+		if config.HTTPClient != nil {
+			config.HTTPSSEClient = config.HTTPClient
+		}
+	}
+
+	// step: if a regular HTTP client is missing, use the default one.
 	if config.HTTPClient == nil {
-		config.HTTPClient = http.DefaultClient
+		config.HTTPClient = defaultHTTPClient
 	}
 
 	// step: if no polling wait time is set, default to 500 milliseconds.
@@ -215,16 +243,19 @@ func NewClient(config Config) (Marathon, error) {
 		return nil, err
 	}
 
-	debugLogOutput := config.LogOutput
-	if debugLogOutput == nil {
-		debugLogOutput = ioutil.Discard
+	debugLog := func(string, ...interface{}) {}
+	if config.LogOutput != nil {
+		logger := log.New(config.LogOutput, "", 0)
+		debugLog = func(format string, v ...interface{}) {
+			logger.Printf(format, v...)
+		}
 	}
 
 	return &marathonClient{
 		config:    config,
 		listeners: make(map[EventsChannel]EventsChannelContext),
 		hosts:     hosts,
-		debugLog:  log.New(debugLogOutput, "", 0),
+		debugLog:  debugLog,
 		client:    client,
 	}, nil
 }
@@ -280,7 +311,7 @@ func (r *marathonClient) apiCall(method, path string, body, result interface{}) 
 		if err != nil {
 			r.hosts.markDown(member)
 			// step: attempt the request on another member
-			r.debugLog.Printf("apiCall(): request failed on host: %s, error: %s, trying another\n", member, err)
+			r.debugLog("apiCall(): request failed on host: %s, error: %s, trying another", member, err)
 			continue
 		}
 		defer response.Body.Close()
@@ -292,9 +323,9 @@ func (r *marathonClient) apiCall(method, path string, body, result interface{}) 
 		}
 
 		if len(requestBody) > 0 {
-			r.debugLog.Printf("apiCall(): %v %v %s returned %v %s\n", request.Method, request.URL.String(), requestBody, response.Status, oneLogLine(respBody))
+			r.debugLog("apiCall(): %v %v %s returned %v %s", request.Method, request.URL.String(), requestBody, response.Status, oneLogLine(respBody))
 		} else {
-			r.debugLog.Printf("apiCall(): %v %v returned %v %s\n", request.Method, request.URL.String(), response.Status, oneLogLine(respBody))
+			r.debugLog("apiCall(): %v %v returned %v %s", request.Method, request.URL.String(), response.Status, oneLogLine(respBody))
 		}
 
 		// step: check for a successfull response
@@ -311,7 +342,7 @@ func (r *marathonClient) apiCall(method, path string, body, result interface{}) 
 		if response.StatusCode >= 500 && response.StatusCode <= 599 {
 			// step: mark the host as down
 			r.hosts.markDown(member)
-			r.debugLog.Printf("apiCall(): request failed, host: %s, status: %d, trying another\n", member, response.StatusCode)
+			r.debugLog("apiCall(): request failed, host: %s, status: %d, trying another", member, response.StatusCode)
 			continue
 		}
 
@@ -329,16 +360,28 @@ func (r *marathonClient) buildAPIRequest(method, path string, reader io.Reader) 
 	}
 
 	// Build the HTTP request to Marathon
-	request, err = r.client.buildMarathonRequest(method, member, path, reader)
+	request, err = r.client.buildMarathonJSONRequest(method, member, path, reader)
 	if err != nil {
 		return nil, member, newRequestError{err}
 	}
 	return request, member, nil
 }
 
+// buildMarathonJSONRequest is like buildMarathonRequest but sets the
+// Content-Type and Accept headers to application/json.
+func (rc *httpClient) buildMarathonJSONRequest(method, member, path string, reader io.Reader) (request *http.Request, err error) {
+	req, err := rc.buildMarathonRequest(method, member, path, reader)
+	if err == nil {
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Accept", "application/json")
+	}
+
+	return req, err
+}
+
 // buildMarathonRequest creates a new HTTP request and configures it according to the *httpClient configuration.
 // The path must not contain a leading "/", otherwise buildMarathonRequest will panic.
-func (rc *httpClient) buildMarathonRequest(method string, member string, path string, reader io.Reader) (request *http.Request, err error) {
+func (rc *httpClient) buildMarathonRequest(method, member, path string, reader io.Reader) (request *http.Request, err error) {
 	if strings.HasPrefix(path, "/") {
 		panic(fmt.Sprintf("Path '%s' must not start with a leading slash", path))
 	}
@@ -360,9 +403,6 @@ func (rc *httpClient) buildMarathonRequest(method string, member string, path st
 	if rc.config.DCOSToken != "" {
 		request.Header.Add("Authorization", "token="+rc.config.DCOSToken)
 	}
-
-	request.Header.Add("Content-Type", "application/json")
-	request.Header.Add("Accept", "application/json")
 
 	return request, nil
 }

--- a/vendor/github.com/gambol99/go-marathon/config.go
+++ b/vendor/github.com/gambol99/go-marathon/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 Rohith All rights reserved.
+Copyright 2014 The go-marathon Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,8 +50,10 @@ type Config struct {
 	DCOSToken string
 	// LogOutput the output for debug log messages
 	LogOutput io.Writer
-	// HTTPClient is the http client
+	// HTTPClient is the HTTP client
 	HTTPClient *http.Client
+	// HTTPSSEClient is the HTTP client used for SSE subscriptions, can't have client.Timeout set
+	HTTPSSEClient *http.Client
 	// wait time (in milliseconds) between repetitive requests to the API during polling
 	PollingWaitTime time.Duration
 }

--- a/vendor/github.com/gambol99/go-marathon/const.go
+++ b/vendor/github.com/gambol99/go-marathon/const.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 Rohith All rights reserved.
+Copyright 2014 The go-marathon Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/vendor/github.com/gambol99/go-marathon/deployment.go
+++ b/vendor/github.com/gambol99/go-marathon/deployment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 Rohith All rights reserved.
+Copyright 2014 The go-marathon Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/vendor/github.com/gambol99/go-marathon/error.go
+++ b/vendor/github.com/gambol99/go-marathon/error.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 Rohith All rights reserved.
+Copyright 2015 The go-marathon Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/vendor/github.com/gambol99/go-marathon/events.go
+++ b/vendor/github.com/gambol99/go-marathon/events.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 Rohith All rights reserved.
+Copyright 2014 The go-marathon Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/vendor/github.com/gambol99/go-marathon/group.go
+++ b/vendor/github.com/gambol99/go-marathon/group.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 Rohith All rights reserved.
+Copyright 2014 The go-marathon Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -136,7 +136,7 @@ func (r *marathonClient) GroupBy(name string, opts *GetGroupOpts) (*Group, error
 // 		name:			the identifier for the group
 func (r *marathonClient) HasGroup(name string) (bool, error) {
 	path := fmt.Sprintf("%s/%s", marathonAPIGroups, trimRootPath(name))
-	err := r.apiCall("GET", path, "", nil)
+	err := r.apiGet(path, "", nil)
 	if err != nil {
 		if apiErr, ok := err.(*APIError); ok && apiErr.ErrCode == ErrCodeNotFound {
 			return false, nil

--- a/vendor/github.com/gambol99/go-marathon/health.go
+++ b/vendor/github.com/gambol99/go-marathon/health.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 Rohith All rights reserved.
+Copyright 2014 The go-marathon Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -31,37 +31,37 @@ type HealthCheck struct {
 }
 
 // SetCommand sets the given command on the health check.
-func (h HealthCheck) SetCommand(c Command) HealthCheck {
+func (h *HealthCheck) SetCommand(c Command) *HealthCheck {
 	h.Command = &c
 	return h
 }
 
 // SetPortIndex sets the given port index on the health check.
-func (h HealthCheck) SetPortIndex(i int) HealthCheck {
+func (h *HealthCheck) SetPortIndex(i int) *HealthCheck {
 	h.PortIndex = &i
 	return h
 }
 
 // SetPort sets the given port on the health check.
-func (h HealthCheck) SetPort(i int) HealthCheck {
+func (h *HealthCheck) SetPort(i int) *HealthCheck {
 	h.Port = &i
 	return h
 }
 
 // SetPath sets the given path on the health check.
-func (h HealthCheck) SetPath(p string) HealthCheck {
+func (h *HealthCheck) SetPath(p string) *HealthCheck {
 	h.Path = &p
 	return h
 }
 
 // SetMaxConsecutiveFailures sets the maximum consecutive failures on the health check.
-func (h HealthCheck) SetMaxConsecutiveFailures(i int) HealthCheck {
+func (h *HealthCheck) SetMaxConsecutiveFailures(i int) *HealthCheck {
 	h.MaxConsecutiveFailures = &i
 	return h
 }
 
 // SetIgnoreHTTP1xx sets ignore http 1xx on the health check.
-func (h HealthCheck) SetIgnoreHTTP1xx(ignore bool) HealthCheck {
+func (h *HealthCheck) SetIgnoreHTTP1xx(ignore bool) *HealthCheck {
 	h.IgnoreHTTP1xx = &ignore
 	return h
 }

--- a/vendor/github.com/gambol99/go-marathon/info.go
+++ b/vendor/github.com/gambol99/go-marathon/info.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 Rohith All rights reserved.
+Copyright 2014 The go-marathon Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/vendor/github.com/gambol99/go-marathon/last_task_failure.go
+++ b/vendor/github.com/gambol99/go-marathon/last_task_failure.go
@@ -1,4 +1,5 @@
 /*
+Copyright 2015 The go-marathon Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,6 +21,7 @@ type LastTaskFailure struct {
 	AppID     string `json:"appId,omitempty"`
 	Host      string `json:"host,omitempty"`
 	Message   string `json:"message,omitempty"`
+	SlaveID   string `json:"slaveId,omitempty"`
 	State     string `json:"state,omitempty"`
 	TaskID    string `json:"taskId,omitempty"`
 	Timestamp string `json:"timestamp,omitempty"`

--- a/vendor/github.com/gambol99/go-marathon/port_definition.go
+++ b/vendor/github.com/gambol99/go-marathon/port_definition.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 Rohith All rights reserved.
+Copyright 2016 The go-marathon Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -27,15 +27,39 @@ type PortDefinition struct {
 }
 
 // SetPort sets the given port for the PortDefinition
-func (p PortDefinition) SetPort(port int) PortDefinition {
+func (p *PortDefinition) SetPort(port int) *PortDefinition {
+	if p.Port == nil {
+		p.EmptyPort()
+	}
 	p.Port = &port
+	return p
+}
+
+// EmptyPort sets the port to 0 for the PortDefinition
+func (p *PortDefinition) EmptyPort() *PortDefinition {
+	port := 0
+	p.Port = &port
+	return p
+}
+
+// SetProtocol sets the protocol for the PortDefinition
+// protocol: the protocol as a string
+func (p *PortDefinition) SetProtocol(protocol string) *PortDefinition {
+	p.Protocol = protocol
+	return p
+}
+
+// SetName sets the name for the PortDefinition
+// name: the name of the PortDefinition
+func (p *PortDefinition) SetName(name string) *PortDefinition {
+	p.Name = name
 	return p
 }
 
 // AddLabel adds a label to the PortDefinition
 //		name: the name of the label
 //		value: value for this label
-func (p PortDefinition) AddLabel(name, value string) PortDefinition {
+func (p *PortDefinition) AddLabel(name, value string) *PortDefinition {
 	if p.Labels == nil {
 		p.EmptyLabels()
 	}

--- a/vendor/github.com/gambol99/go-marathon/queue.go
+++ b/vendor/github.com/gambol99/go-marathon/queue.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 Rohith All rights reserved.
+Copyright 2016 The go-marathon Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -52,9 +52,5 @@ func (r *marathonClient) Queue() (*Queue, error) {
 //		appID:		the ID of the application
 func (r *marathonClient) DeleteQueueDelay(appID string) error {
 	path := fmt.Sprintf("%s/%s/delay", marathonAPIQueue, trimRootPath(appID))
-	err := r.apiDelete(path, nil, nil)
-	if err != nil {
-		return err
-	}
-	return nil
+	return r.apiDelete(path, nil, nil)
 }

--- a/vendor/github.com/gambol99/go-marathon/readiness.go
+++ b/vendor/github.com/gambol99/go-marathon/readiness.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 Rohith All rights reserved.
+Copyright 2017 The go-marathon Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/vendor/github.com/gambol99/go-marathon/residency.go
+++ b/vendor/github.com/gambol99/go-marathon/residency.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2017 The go-marathon Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package marathon
+
+import "time"
+
+// TaskLostBehaviorType sets action taken when the resident task is lost
+type TaskLostBehaviorType string
+
+const (
+	// TaskLostBehaviorTypeWaitForever indicates to not take any action when the resident task is lost
+	TaskLostBehaviorTypeWaitForever TaskLostBehaviorType = "WAIT_FOREVER"
+	// TaskLostBehaviorTypeWaitForever indicates to try relaunching the lost resident task on
+	// another node after the relaunch escalation timeout has elapsed
+	TaskLostBehaviorTypeRelaunchAfterTimeout TaskLostBehaviorType = "RELAUNCH_AFTER_TIMEOUT"
+)
+
+// Residency defines how terminal states of tasks with local persistent volumes are handled
+type Residency struct {
+	TaskLostBehavior                 TaskLostBehaviorType `json:"taskLostBehavior,omitempty"`
+	RelaunchEscalationTimeoutSeconds int                  `json:"relaunchEscalationTimeoutSeconds,omitempty"`
+}
+
+// SetTaskLostBehavior sets the residency behavior
+func (r *Residency) SetTaskLostBehavior(behavior TaskLostBehaviorType) *Residency {
+	r.TaskLostBehavior = behavior
+	return r
+}
+
+// SetRelaunchEscalationTimeout sets the residency relaunch escalation timeout with seconds precision
+func (r *Residency) SetRelaunchEscalationTimeout(timeout time.Duration) *Residency {
+	r.RelaunchEscalationTimeoutSeconds = int(timeout.Seconds())
+	return r
+}

--- a/vendor/github.com/gambol99/go-marathon/task.go
+++ b/vendor/github.com/gambol99/go-marathon/task.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 Rohith All rights reserved.
+Copyright 2014 The go-marathon Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -217,7 +217,7 @@ func (r *Task) allHealthChecksAlive() bool {
 	}
 	// step: check the health results then
 	for _, check := range r.HealthCheckResults {
-		if check.Alive == false {
+		if !check.Alive {
 			return false
 		}
 	}

--- a/vendor/github.com/gambol99/go-marathon/unreachable_strategy.go
+++ b/vendor/github.com/gambol99/go-marathon/unreachable_strategy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 Rohith All rights reserved.
+Copyright 2017 The go-marathon Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -65,13 +65,13 @@ func (us *UnreachableStrategy) MarshalJSON() ([]byte, error) {
 }
 
 // SetInactiveAfterSeconds sets the period after which instance will be marked as inactive.
-func (us UnreachableStrategy) SetInactiveAfterSeconds(cap float64) UnreachableStrategy {
+func (us *UnreachableStrategy) SetInactiveAfterSeconds(cap float64) *UnreachableStrategy {
 	us.InactiveAfterSeconds = &cap
 	return us
 }
 
 // SetExpungeAfterSeconds sets the period after which instance will be expunged.
-func (us UnreachableStrategy) SetExpungeAfterSeconds(cap float64) UnreachableStrategy {
+func (us *UnreachableStrategy) SetExpungeAfterSeconds(cap float64) *UnreachableStrategy {
 	us.ExpungeAfterSeconds = &cap
 	return us
 }

--- a/vendor/github.com/gambol99/go-marathon/upgrade_strategy.go
+++ b/vendor/github.com/gambol99/go-marathon/upgrade_strategy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 Rohith All rights reserved.
+Copyright 2014 The go-marathon Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -23,13 +23,13 @@ type UpgradeStrategy struct {
 }
 
 // SetMinimumHealthCapacity sets the minimum health capacity.
-func (us UpgradeStrategy) SetMinimumHealthCapacity(cap float64) UpgradeStrategy {
+func (us *UpgradeStrategy) SetMinimumHealthCapacity(cap float64) *UpgradeStrategy {
 	us.MinimumHealthCapacity = &cap
 	return us
 }
 
 // SetMaximumOverCapacity sets the maximum over capacity.
-func (us UpgradeStrategy) SetMaximumOverCapacity(cap float64) UpgradeStrategy {
+func (us *UpgradeStrategy) SetMaximumOverCapacity(cap float64) *UpgradeStrategy {
 	us.MaximumOverCapacity = &cap
 	return us
 }

--- a/vendor/github.com/gambol99/go-marathon/utils.go
+++ b/vendor/github.com/gambol99/go-marathon/utils.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 Rohith All rights reserved.
+Copyright 2014 The go-marathon Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
### What does this PR do?

Upgrade go-marathon to [03b461696](https://github.com/gambol99/go-marathon/commit/03b46169666c53b9cc953b875ac5714e5103e064).

### Motivation

The updated version of go-marathon brings performance improvement to debug logging, making a non-configured logger a no-op, and consequently reducing heap consumption and GC pressure.