### PR TITLE
Mesos: Use slave.PID.Host as task SlaveIP.

### DIFF
--- a/provider/mesos/mesos.go
+++ b/provider/mesos/mesos.go
@@ -408,7 +408,7 @@ func (p *Provider) taskRecords(sj state.State) []state.Task {
 		for _, task := range f.Tasks {
 			for _, slave := range sj.Slaves {
 				if task.SlaveID == slave.ID {
-					task.SlaveIP = slave.Hostname
+					task.SlaveIP = slave.PID.Host
 				}
 			}
 

--- a/provider/mesos/mesos_test.go
+++ b/provider/mesos/mesos_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/containous/traefik/log"
 	"github.com/containous/traefik/types"
+	"github.com/mesos/mesos-go/upid"
 	"github.com/mesosphere/mesos-dns/records/state"
 )
 
@@ -194,6 +195,9 @@ func TestTaskRecords(t *testing.T) {
 		ID:       "s_id",
 		Hostname: "127.0.0.1",
 	}
+
+	slave.PID.UPID = &upid.UPID{}
+	slave.PID.Host = slave.Hostname
 	var state = state.State{
 		Slaves:     []state.Slave{slave},
 		Frameworks: []state.Framework{framework},


### PR DESCRIPTION
### What does this PR do?

This is the proper way to set the SlaveIP as done by the underlying `mesos-dns` helper library

### Motivation

Fixes #2545

### More

- [x] Added/updated tests

