### PR TITLE
Fix stickiness bug due to template syntax error

### DIFF
--- a/autogen/gentemplates/gen.go
+++ b/autogen/gentemplates/gen.go
@@ -532,7 +532,7 @@ var _templatesKvTmpl = []byte(`{{$frontends := List .Prefix "/frontends/" }}
     sticky = {{ getSticky . }}
     {{if hasStickinessLabel $backend}}
     [backends."{{$backendName}}".loadBalancer.stickiness]
-      cookieName = {{getStickinessCookieName $backend}}
+      cookieName = "{{getStickinessCookieName $backend}}"
     {{end}}
 {{end}}
 

--- a/templates/kv.tmpl
+++ b/templates/kv.tmpl
@@ -20,7 +20,7 @@
     sticky = {{ getSticky . }}
     {{if hasStickinessLabel $backend}}
     [backends."{{$backendName}}".loadBalancer.stickiness]
-      cookieName = {{getStickinessCookieName $backend}}
+      cookieName = "{{getStickinessCookieName $backend}}"
     {{end}}
 {{end}}
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?
fix bug.the type of "stickiness" show be string,if not,code will panic when decode  the toml file.



### Motivation

My traefik read configuration from etcd,when i try to test the stickiness func of the loadbalancer,i found it doesn't work after i write my conf to etcd server,and after switch  the loglevel to debug,i found some panic logs.




### Additional Notes

<!-- Anything else we should know when reviewing? -->
