### PR TITLE
Modify ACME configuration migration into KV store

### DIFF
--- a/docs/configuration/acme.md
+++ b/docs/configuration/acme.md
@@ -108,7 +108,7 @@ storage = "acme.json"
 # ...
 ```
 
-File or key used for certificates storage. 
+File or key used for certificates storage.
 
 **WARNING** If you use Træfik in Docker, you have 2 options:
 
@@ -117,7 +117,7 @@ File or key used for certificates storage.
 storage = "acme.json"
 ```
 ```bash
-docker run -v "/my/host/acme.json:acme.json" træfik
+docker run -v "/my/host/acme.json:acme.json" traefik
 ```
 
 - mount the folder containing the file as a volume
@@ -125,7 +125,7 @@ docker run -v "/my/host/acme.json:acme.json" træfik
 storage = "/etc/traefik/acme/acme.json"
 ```
 ```bash
-docker run -v "/my/host/acme:/etc/traefik/acme" træfik
+docker run -v "/my/host/acme:/etc/traefik/acme" traefik
 ```
 
 !!! note

--- a/docs/configuration/acme.md
+++ b/docs/configuration/acme.md
@@ -20,6 +20,12 @@ See also [Let's Encrypt examples](/user-guide/examples/#lets-encrypt-support) an
 #
 email = "test@traefik.io"
 
+# File used for certificates storage.
+#
+# Optional (Deprecated)
+#
+#storageFile = "acme.json"
+
 # File or key used for certificates storage.
 #
 # Required
@@ -55,7 +61,7 @@ entryPoint = "https"
 #
 # acmeLogging = true
 
-# Enable on demand certificate.
+# Enable on demand certificate. (Deprecated)
 #
 # Optional
 #
@@ -89,6 +95,10 @@ entryPoint = "https"
 # main = "local4.com"
 ```
 
+!!! note
+    ACME entryPoint has to be relied to the port 443, otherwise ACME Challenges can not be done.
+    It's a Let's Encrypt limitation as described on the [community forum](https://community.letsencrypt.org/t/support-for-ports-other-than-80-and-443/3419/72).
+
 ### `storage`
 
 ```toml
@@ -98,16 +108,16 @@ storage = "acme.json"
 # ...
 ```
 
-File or key used for certificates storage.
+File or key used for certificates storage. 
 
-**WARNING** If you use Traefik in Docker, you have 2 options:
+**WARNING** If you use Træfik in Docker, you have 2 options:
 
 - create a file on your host and mount it as a volume:
 ```toml
 storage = "acme.json"
 ```
 ```bash
-docker run -v "/my/host/acme.json:acme.json" traefik
+docker run -v "/my/host/acme.json:acme.json" træfik
 ```
 
 - mount the folder containing the file as a volume
@@ -115,8 +125,16 @@ docker run -v "/my/host/acme.json:acme.json" traefik
 storage = "/etc/traefik/acme/acme.json"
 ```
 ```bash
-docker run -v "/my/host/acme:/etc/traefik/acme" traefik
+docker run -v "/my/host/acme:/etc/traefik/acme" træfik
 ```
+
+!!! note
+    `storage` replaces `storageFile` which is deprecated.
+
+!!! note
+    During Træfik configuration migration from a configuration file to a KV store (thanks to `storeconfig` subcommand as described [here](/user-guide/kv-config/#store-configuration-in-key-value-store)), if ACME certificates have to be migrated too, use both `storageFile` and `storage`.
+    `storageFile` will contain the path to the `acme.json` file to migrate.
+    `storage` will contain the key where the certificates will be stored.
 
 ### `dnsProvider`
 
@@ -146,7 +164,7 @@ Select the provider that matches the DNS domain that will host the challenge TXT
 | [GoDaddy](https://godaddy.com/domains)                 | `godaddy`      | `GODADDY_API_KEY`, `GODADDY_API_SECRET`                                                                                   |
 | [Google Cloud DNS](https://cloud.google.com/dns/docs/) | `gcloud`       | `GCE_PROJECT`, `GCE_SERVICE_ACCOUNT_FILE`                                                                                 |
 | [Linode](https://www.linode.com)                       | `linode`       | `LINODE_API_KEY`                                                                                                          |
-| manual                                                 | -              | none, but run Traefik interactively & turn on `acmeLogging` to see instructions & press <kbd>Enter</kbd>.                 |
+| manual                                                 | -              | none, but run Træfik interactively & turn on `acmeLogging` to see instructions & press <kbd>Enter</kbd>.                 |
 | [Namecheap](https://www.namecheap.com)                 | `namecheap`    | `NAMECHEAP_API_USER`, `NAMECHEAP_API_KEY`                                                                                 |
 | [Ns1](https://ns1.com/)                                | `ns1`          | `NS1_API_KEY`                                                                                                             |
 | [Open Telekom Cloud](https://cloud.telekom.de/en/)     | `otc`          | `OTC_DOMAIN_NAME`, `OTC_USER_NAME`, `OTC_PASSWORD`, `OTC_PROJECT_NAME`, `OTC_IDENTITY_ENDPOINT`                           |
@@ -171,7 +189,7 @@ If `delayDontCheckDNS` is greater than zero, avoid this & instead just wait so m
 
 Useful if internal networks block external DNS queries.
 
-### `onDemand`
+### `onDemand` (Deprecated)
 
 ```toml
 [acme]
@@ -188,7 +206,10 @@ This will request a certificate from Let's Encrypt during the first TLS handshak
     TLS handshakes will be slow when requesting a hostname certificate for the first time, this can lead to DoS attacks.
     
 !!! warning
-    Take note that Let's Encrypt have [rate limiting](https://letsencrypt.org/docs/rate-limits)
+    Take note that Let's Encrypt have [rate limiting](https://letsencrypt.org/docs/rate-limits).
+
+!!! warning
+    This option is deprecated.
 
 ### `onHostRule`
 
@@ -238,7 +259,7 @@ main = "local4.com"
 ```
 
 You can provide SANs (alternative domains) to each main domain.
-All domains must have A/AAAA records pointing to Traefik.
+All domains must have A/AAAA records pointing to Træfik.
 
 !!! warning
     Take note that Let's Encrypt have [rate limiting](https://letsencrypt.org/docs/rate-limits).

--- a/examples/cluster/docker-compose.yml
+++ b/examples/cluster/docker-compose.yml
@@ -38,16 +38,7 @@ services:
 
   etcdctl-ping:
       image: tenstartups/etcdctl
-      command: --endpoints=[10.0.1.12:2379] get "traefik/acme/storagefile"
-      environment:
-          ETCDCTL_DIAL_: "TIMEOUT 10s"
-          ETCDCTL_API : "3"
-      networks:
-        - net
-
-  etcdctl-rm:
-      image: tenstartups/etcdctl
-      command: --endpoints=[10.0.1.12:2379] del "/traefik/acme/storagefile"
+      command: --endpoints=[10.0.1.12:2379] get "traefik/acme/storage"
       environment:
           ETCDCTL_DIAL_: "TIMEOUT 10s"
           ETCDCTL_API : "3"
@@ -129,7 +120,6 @@ services:
       image: containous/traefik
       volumes:
         - "./traefik.toml:/traefik.toml:ro"
-        - "./acme.json:/acme.json:ro"
       command: storeconfig --debug
       networks:
         - net

--- a/examples/cluster/traefik.toml.tmpl
+++ b/examples/cluster/traefik.toml.tmpl
@@ -12,7 +12,6 @@ defaultEntryPoints = ["http", "https"]
 [acme]
 email = "test@traefik.io"
 storage = "traefik/acme/account"
-storageFile = "/acme.json"
 entryPoint = "https"
 OnHostRule = true
 caServer = "http://traefik.boulder.com:4000/directory"


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

During Træfik configuration migration (from file to KV store (thanks to the `storeconfig` subcommand)), ACME configuration is not correctly initialized if `storageFile` is not provided.
Træfik can not start in this case!

The PR allows initializing correctly all the KV store keys needed by ACME during `storeconfig` process, even if `storageFile` is not provided.

The PR allows deleting automatically the key`/traefik/acme/storagefile` from KV stores when ACME configuration is migrated. This key has to be deleted because : 

- It is deprecated and has no interest if KV store is used.
- It prevents the ACME challenge mechanism to work correctly.

### Motivation

<!-- What inspired you to submit this pull request? -->
Fixes #927, #2547, #1283

### More

- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
