### PR TITLE
Allow deleting dynamically all TLS certificates from an entryPoint

### DIFF
--- a/integration/fixtures/https/dynamic_https_sni.toml
+++ b/integration/fixtures/https/dynamic_https_sni.toml
@@ -6,6 +6,9 @@ defaultEntryPoints = ["https"]
   [entryPoints.https]
   address = ":4443"
   [entryPoints.https.tls]
+  [entryPoints.https02]
+  address = ":8443"
+  [entryPoints.https02.tls]
 
 [web]
   address = ":8080"

--- a/server/server.go
+++ b/server/server.go
@@ -439,10 +439,17 @@ func (s *Server) loadConfiguration(configMsg types.ConfigMessage) {
 	if err == nil {
 		for newServerEntryPointName, newServerEntryPoint := range newServerEntryPoints {
 			s.serverEntryPoints[newServerEntryPointName].httpRouter.UpdateHandler(newServerEntryPoint.httpRouter.GetHandler())
-			if &newServerEntryPoint.certs != nil {
-				s.serverEntryPoints[newServerEntryPointName].certs.Set(newServerEntryPoint.certs.Get())
+			for newServerEntryPointName, newServerEntryPoint := range newServerEntryPoints {
+				s.serverEntryPoints[newServerEntryPointName].httpRouter.UpdateHandler(newServerEntryPoint.httpRouter.GetHandler())
+				if s.globalConfiguration.EntryPoints[newServerEntryPointName].TLS == nil {
+					if newServerEntryPoint.certs.Get() != nil {
+						log.Debugf("Certificates not added to non-TLS entryPoint %s.", newServerEntryPointName)
+					}
+				} else {
+					s.serverEntryPoints[newServerEntryPointName].certs.Set(newServerEntryPoint.certs.Get())
+				}
+				log.Infof("Server configuration reloaded on %s", s.serverEntryPoints[newServerEntryPointName].httpServer.Addr)
 			}
-			log.Infof("Server configuration reloaded on %s", s.serverEntryPoints[newServerEntryPointName].httpServer.Addr)
 		}
 		s.currentConfigurations.Set(newConfigurations)
 		s.postLoadConfiguration()

--- a/server/server.go
+++ b/server/server.go
@@ -439,17 +439,14 @@ func (s *Server) loadConfiguration(configMsg types.ConfigMessage) {
 	if err == nil {
 		for newServerEntryPointName, newServerEntryPoint := range newServerEntryPoints {
 			s.serverEntryPoints[newServerEntryPointName].httpRouter.UpdateHandler(newServerEntryPoint.httpRouter.GetHandler())
-			for newServerEntryPointName, newServerEntryPoint := range newServerEntryPoints {
-				s.serverEntryPoints[newServerEntryPointName].httpRouter.UpdateHandler(newServerEntryPoint.httpRouter.GetHandler())
-				if s.globalConfiguration.EntryPoints[newServerEntryPointName].TLS == nil {
-					if newServerEntryPoint.certs.Get() != nil {
-						log.Debugf("Certificates not added to non-TLS entryPoint %s.", newServerEntryPointName)
-					}
-				} else {
-					s.serverEntryPoints[newServerEntryPointName].certs.Set(newServerEntryPoint.certs.Get())
+			if s.globalConfiguration.EntryPoints[newServerEntryPointName].TLS == nil {
+				if newServerEntryPoint.certs.Get() != nil {
+					log.Debugf("Certificates not added to non-TLS entryPoint %s.", newServerEntryPointName)
 				}
-				log.Infof("Server configuration reloaded on %s", s.serverEntryPoints[newServerEntryPointName].httpServer.Addr)
+			} else {
+				s.serverEntryPoints[newServerEntryPointName].certs.Set(newServerEntryPoint.certs.Get())
 			}
+			log.Infof("Server configuration reloaded on %s", s.serverEntryPoints[newServerEntryPointName].httpServer.Addr)
 		}
 		s.currentConfigurations.Set(newConfigurations)
 		s.postLoadConfiguration()


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
The PR fixes TLS dynamic management by allowing deleting all of certificates from an entryPoint.

### Motivation

<!-- What inspired you to submit this pull request? -->

The entryPoints kept at least one certificate even if user delete all of them from the configuration, the PR fixes this behavior.

### More

- [x] Added/updated tests


<!-- Anything else we should know when reviewing? -->
