### PR TITLE
Add tests for TLS dynamic configuration in ETCD3

### DIFF
--- a/integration/etcd3_test.go
+++ b/integration/etcd3_test.go
@@ -588,9 +588,6 @@ func (s *Etcd3Suite) TestDeleteSNIDynamicTlsConfig(c *check.C) {
 	defer display(c)
 
 	// prepare to config
-	whoami1IP := s.composeProject.Container(c, "whoami1").NetworkSettings.IPAddress
-	whoami2IP := s.composeProject.Container(c, "whoami2").NetworkSettings.IPAddress
-
 	snitestComCert, err := ioutil.ReadFile("fixtures/https/snitest.com.cert")
 	c.Assert(err, checker.IsNil)
 	snitestComKey, err := ioutil.ReadFile("fixtures/https/snitest.com.key")
@@ -598,9 +595,9 @@ func (s *Etcd3Suite) TestDeleteSNIDynamicTlsConfig(c *check.C) {
 
 	backend1 := map[string]string{
 		"/traefik/backends/backend1/circuitbreaker/expression": "NetworkErrorRatio() > 0.5",
-		"/traefik/backends/backend1/servers/server1/url":       "http://" + whoami1IP + ":80",
+		"/traefik/backends/backend1/servers/server1/url":       "http://" + ipWhoami01 + ":80",
 		"/traefik/backends/backend1/servers/server1/weight":    "1",
-		"/traefik/backends/backend1/servers/server2/url":       "http://" + whoami2IP + ":80",
+		"/traefik/backends/backend1/servers/server2/url":       "http://" + ipWhoami02 + ":80",
 		"/traefik/backends/backend1/servers/server2/weight":    "1",
 	}
 
@@ -650,7 +647,7 @@ func (s *Etcd3Suite) TestDeleteSNIDynamicTlsConfig(c *check.C) {
 	defer cmd.Process.Kill()
 
 	// wait for Træfik
-	err = try.GetRequest("http://127.0.0.1:8081/api/providers", 60*time.Second, try.BodyContains(string("MIIEpQIBAAKCAQEA1RducBK6EiFDv3TYB8ZcrfKWRVaSfHzWicO3J5WdST9oS7h")))
+	err = try.GetRequest(traefikWebEtcdURL+"api/providers", 60*time.Second, try.BodyContains(string("MIIEpQIBAAKCAQEA1RducBK6EiFDv3TYB8ZcrfKWRVaSfHzWicO3J5WdST9oS7h")))
 	c.Assert(err, checker.IsNil)
 
 	req, err := http.NewRequest(http.MethodGet, "https://127.0.0.1:4443/", nil)
@@ -672,7 +669,7 @@ func (s *Etcd3Suite) TestDeleteSNIDynamicTlsConfig(c *check.C) {
 	}
 
 	// waiting for Træfik to pull configuration
-	err = try.GetRequest("http://127.0.0.1:8081/api/providers", 30*time.Second, try.BodyNotContains("MIIEpQIBAAKCAQEA1RducBK6EiFDv3TYB8ZcrfKWRVaSfHzWicO3J5WdST9oS7h"))
+	err = try.GetRequest(traefikWebEtcdURL+"api/providers", 30*time.Second, try.BodyNotContains("MIIEpQIBAAKCAQEA1RducBK6EiFDv3TYB8ZcrfKWRVaSfHzWicO3J5WdST9oS7h"))
 	c.Assert(err, checker.IsNil)
 
 	req, err = http.NewRequest(http.MethodGet, "https://127.0.0.1:4443/", nil)

--- a/integration/etcd3_test.go
+++ b/integration/etcd3_test.go
@@ -573,6 +573,116 @@ func (s *Etcd3Suite) TestSNIDynamicTlsConfig(c *check.C) {
 	req.Header.Set("Host", tr2.TLSClientConfig.ServerName)
 	req.Header.Set("Accept", "*/*")
 	resp, err = client.Do(req)
+	c.Assert(err, checker.IsNil)
 	cn = resp.TLS.PeerCertificates[0].Subject.CommonName
 	c.Assert(cn, checker.Equals, "snitest.org")
+}
+
+func (s *Etcd3Suite) TestDeleteSNIDynamicTlsConfig(c *check.C) {
+	// start Træfik
+	cmd, display := s.traefikCmd(
+		withConfigFile("fixtures/etcd/simple_https.toml"),
+		"--etcd",
+		"--etcd.endpoint="+ipEtcd+":4001",
+		"--etcd.useAPIV3=true")
+	defer display(c)
+
+	// prepare to config
+	whoami1IP := s.composeProject.Container(c, "whoami1").NetworkSettings.IPAddress
+	whoami2IP := s.composeProject.Container(c, "whoami2").NetworkSettings.IPAddress
+
+	snitestComCert, err := ioutil.ReadFile("fixtures/https/snitest.com.cert")
+	c.Assert(err, checker.IsNil)
+	snitestComKey, err := ioutil.ReadFile("fixtures/https/snitest.com.key")
+	c.Assert(err, checker.IsNil)
+
+	backend1 := map[string]string{
+		"/traefik/backends/backend1/circuitbreaker/expression": "NetworkErrorRatio() > 0.5",
+		"/traefik/backends/backend1/servers/server1/url":       "http://" + whoami1IP + ":80",
+		"/traefik/backends/backend1/servers/server1/weight":    "1",
+		"/traefik/backends/backend1/servers/server2/url":       "http://" + whoami2IP + ":80",
+		"/traefik/backends/backend1/servers/server2/weight":    "1",
+	}
+
+	frontend1 := map[string]string{
+		"/traefik/frontends/frontend1/backend":            "backend1",
+		"/traefik/frontends/frontend1/entrypoints":        "https",
+		"/traefik/frontends/frontend1/priority":           "1",
+		"/traefik/frontends/frontend1/routes/test_1/rule": "Host:snitest.com",
+	}
+
+	tlsconfigure1 := map[string]string{
+		"/traefik/tlsconfiguration/snitestcom/entrypoints":          "https",
+		"/traefik/tlsconfiguration/snitestcom/certificate/keyfile":  string(snitestComKey),
+		"/traefik/tlsconfiguration/snitestcom/certificate/certfile": string(snitestComCert),
+	}
+
+	// config backends,frontends and first tls keypair
+	for key, value := range backend1 {
+		err := s.kv.Put(key, []byte(value), nil)
+		c.Assert(err, checker.IsNil)
+	}
+	for key, value := range frontend1 {
+		err := s.kv.Put(key, []byte(value), nil)
+		c.Assert(err, checker.IsNil)
+	}
+	for key, value := range tlsconfigure1 {
+		err := s.kv.Put(key, []byte(value), nil)
+		c.Assert(err, checker.IsNil)
+	}
+
+	tr1 := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+			ServerName:         "snitest.com",
+		},
+	}
+
+	// wait for etcd
+	err = try.Do(60*time.Second, func() error {
+		_, err := s.kv.Get("/traefik/tlsconfiguration/snitestcom/certificate/keyfile", nil)
+		return err
+	})
+	c.Assert(err, checker.IsNil)
+
+	err = cmd.Start()
+	c.Assert(err, checker.IsNil)
+	defer cmd.Process.Kill()
+
+	// wait for Træfik
+	err = try.GetRequest("http://127.0.0.1:8081/api/providers", 60*time.Second, try.BodyContains(string("MIIEpQIBAAKCAQEA1RducBK6EiFDv3TYB8ZcrfKWRVaSfHzWicO3J5WdST9oS7h")))
+	c.Assert(err, checker.IsNil)
+
+	req, err := http.NewRequest(http.MethodGet, "https://127.0.0.1:4443/", nil)
+	c.Assert(err, checker.IsNil)
+	client := &http.Client{Transport: tr1}
+	req.Host = tr1.TLSClientConfig.ServerName
+	req.Header.Set("Host", tr1.TLSClientConfig.ServerName)
+	req.Header.Set("Accept", "*/*")
+	var resp *http.Response
+	resp, err = client.Do(req)
+	c.Assert(err, checker.IsNil)
+	cn := resp.TLS.PeerCertificates[0].Subject.CommonName
+	c.Assert(cn, checker.Equals, "snitest.com")
+
+	// now we delete the tls cert/key pairs,so the endpoint show use default cert/key pair
+	for key := range tlsconfigure1 {
+		err := s.kv.Delete(key)
+		c.Assert(err, checker.IsNil)
+	}
+
+	// waiting for Træfik to pull configuration
+	err = try.GetRequest("http://127.0.0.1:8081/api/providers", 30*time.Second, try.BodyNotContains("MIIEpQIBAAKCAQEA1RducBK6EiFDv3TYB8ZcrfKWRVaSfHzWicO3J5WdST9oS7h"))
+	c.Assert(err, checker.IsNil)
+
+	req, err = http.NewRequest(http.MethodGet, "https://127.0.0.1:4443/", nil)
+	c.Assert(err, checker.IsNil)
+	client = &http.Client{Transport: tr1}
+	req.Host = tr1.TLSClientConfig.ServerName
+	req.Header.Set("Host", tr1.TLSClientConfig.ServerName)
+	req.Header.Set("Accept", "*/*")
+	resp, err = client.Do(req)
+	c.Assert(err, checker.IsNil)
+	cn = resp.TLS.PeerCertificates[0].Subject.CommonName
+	c.Assert(cn, checker.Equals, "TRAEFIK DEFAULT CERT")
 }

--- a/integration/try/condition.go
+++ b/integration/try/condition.go
@@ -34,6 +34,25 @@ func BodyContains(values ...string) ResponseCondition {
 	}
 }
 
+// BodyNotContains returns a retry condition function.
+// The condition returns an error if the request body  contain one of the given
+// strings.
+func BodyNotContains(values ...string) ResponseCondition {
+	return func(res *http.Response) error {
+		body, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return fmt.Errorf("failed to read response body: %s", err)
+		}
+
+		for _, value := range values {
+			if strings.Contains(string(body), value) {
+				return fmt.Errorf("find '%s' in body '%s'", value, string(body))
+			}
+		}
+		return nil
+	}
+}
+
 // BodyContainsOr returns a retry condition function.
 // The condition returns an error if the request body does not contain one of the given
 // strings.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
When I delete all the tls cert/key pairs in my etcd(v3),the debug log and api(/api/providers) show  traefik has read configurations which has an empty tlsconfigure.But Actually it does't work.
After reading the code,I think traefik skip delete when the all the tlsconfigurations in etcd be deleted in a very short time. 

And I wrote some test for this.
### Motivation

<!-- What inspired you to submit this pull request? -->
when i write test case in my own project,I delete the tls cert/key pairs,expecting recevie the "TRAEFIK DEFAULT CERT" from traefik,but what i receive is still the deleted one after a very long wait.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
