### PR TITLE
Send empty configuration from file provider

### DIFF
--- a/provider/file/file.go
+++ b/provider/file/file.go
@@ -127,9 +127,8 @@ func sendConfigToChannel(configurationChan chan<- types.ConfigMessage, configura
 
 func loadFileConfig(filename string) (*types.Configuration, error) {
 	configuration := &types.Configuration{
-		Frontends:        make(map[string]*types.Frontend),
-		Backends:         make(map[string]*types.Backend),
-		TLSConfiguration: make([]*tls.Configuration, 0),
+		Frontends: make(map[string]*types.Frontend),
+		Backends:  make(map[string]*types.Backend),
 	}
 	if _, err := toml.DecodeFile(filename, configuration); err != nil {
 		return nil, fmt.Errorf("error reading configuration file: %s", err)
@@ -146,9 +145,8 @@ func loadFileConfigFromDirectory(directory string, configuration *types.Configur
 
 	if configuration == nil {
 		configuration = &types.Configuration{
-			Frontends:        make(map[string]*types.Frontend),
-			Backends:         make(map[string]*types.Backend),
-			TLSConfiguration: make([]*tls.Configuration, 0),
+			Frontends: make(map[string]*types.Frontend),
+			Backends:  make(map[string]*types.Backend),
 		}
 	}
 

--- a/provider/file/file.go
+++ b/provider/file/file.go
@@ -126,7 +126,11 @@ func sendConfigToChannel(configurationChan chan<- types.ConfigMessage, configura
 }
 
 func loadFileConfig(filename string) (*types.Configuration, error) {
-	configuration := new(types.Configuration)
+	configuration := &types.Configuration{
+		Frontends:        make(map[string]*types.Frontend),
+		Backends:         make(map[string]*types.Backend),
+		TLSConfiguration: make([]*tls.Configuration, 0),
+	}
 	if _, err := toml.DecodeFile(filename, configuration); err != nil {
 		return nil, fmt.Errorf("error reading configuration file: %s", err)
 	}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

This PR allows sending empty configuration from `file` provider which is taken in account by Træfik.

### Motivation

<!-- What inspired you to submit this pull request? -->

Træfik filters dynamic configurations which have backends, frontends and TLS configurations set to nil.
Providers have to send empty configuration to update correctly the information.

The `file` provider sent empty data if it listened to a `directory` but sent nil if it listened to a `fileName` changes.

The PR initializes correctly the dynamic configuration from a `fileName` : if the user delete all his configuration in a file, Træfik will be able to delete the backends, frontends anf TLS configurations.

### More

- [x] Added/updated tests


<!-- Anything else we should know when reviewing? -->
