### PR TITLE
 Add all available annotations to k8s Backend

### DIFF
--- a/docs/configuration/backends/kubernetes.md
+++ b/docs/configuration/backends/kubernetes.md
@@ -100,40 +100,80 @@ See [label-selectors](https://kubernetes.io/docs/concepts/overview/working-with-
 
 The following general annotations are applicable on the Ingress object:
 
-- `traefik.frontend.rule.type: PathPrefixStrip`
-    Override the default frontend rule type. Default: `PathPrefix`.
-- `traefik.frontend.priority: "3"`
-    Override the default frontend rule priority.
-- `traefik.frontend.redirect.entryPoint: https`:
-    Enables Redirect to another entryPoint for that frontend (e.g. HTTPS).
-- `traefik.frontend.redirect.regex: ^http://localhost/(.*)`:
-    Redirect to another URL for that frontend. Must be set with `traefik.frontend.redirect.replacement`.
-- `traefik.frontend.redirect.replacement: http://mydomain/$1`:
-    Redirect to another URL for that frontend. Must be set with `traefik.frontend.redirect.regex`.
-- `traefik.frontend.entryPoints: http,https`
-    Override the default frontend endpoints.
-- `traefik.frontend.passTLSCert: true`
-    Override the default frontend PassTLSCert value. Default: `false`.
-- `ingress.kubernetes.io/rewrite-target: /users`
-    Replaces each matched Ingress path with the specified one, and adds the old path to the `X-Replaced-Path` header.
-- `ingress.kubernetes.io/whitelist-source-range: "1.2.3.0/24, fe80::/16"`
-    A comma-separated list of IP ranges permitted for access. all source IPs are permitted if the list is empty or a single range is ill-formatted.
+| Annotation                                                                      | Description                                                                                                                                     |
+|---------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| `traefik.ingress.kubernetes.io/buffering: <YML>`                                | (3) See [buffering](/configuration/commons/#buffering) section.                                                                                 |
+| `traefik.ingress.kubernetes.io/error-pages: <YML>`                              | (1) See [custom error pages](/configuration/commons/#custom-error-pages) section.                                                               |
+| `traefik.ingress.kubernetes.io/frontend-entry-points: http,https`               | Override the default frontend endpoints.                                                                                                        |
+| `traefik.ingress.kubernetes.io/pass-tls-cert: true`                             | Override the default frontend PassTLSCert value. Default: `false`.                                                                              |
+| `traefik.ingress.kubernetes.io/preserve-host: true`                             | Forward client `Host` header to the backend.                                                                                                    |
+| `traefik.ingress.kubernetes.io/priority: "3"`                                   | Override the default frontend rule priority.                                                                                                    |
+| `traefik.ingress.kubernetes.io/rate-limit: <YML>`                               | (2) See [custom error pages](/configuration/commons/#rate-limiting) section.                                                                    |
+| `traefik.ingress.kubernetes.io/redirect-entry-point: https`                     | Enables Redirect to another entryPoint for that frontend (e.g. HTTPS).                                                                          |
+| `traefik.ingress.kubernetes.io/redirect-regex: ^http://localhost/(.*)`          | Redirect to another URL for that frontend. Must be set with `traefik.ingress.kubernetes.io/redirect-replacement`.                               |
+| `traefik.ingress.kubernetes.io/redirect-replacement: http://mydomain/$1`        | Redirect to another URL for that frontend. Must be set with `traefik.ingress.kubernetes.io/redirect-regex`.                                     |
+| `traefik.ingress.kubernetes.io/rewrite-target: /users`                          | Replaces each matched Ingress path with the specified one, and adds the old path to the `X-Replaced-Path` header.                               |
+| `traefik.ingress.kubernetes.io/rule-type: PathPrefixStrip`                      | Override the default frontend rule type. Default: `PathPrefix`.                                                                                 |
+| `traefik.ingress.kubernetes.io/whitelist-source-range: "1.2.3.0/24, fe80::/16"` | A comma-separated list of IP ranges permitted for access. all source IPs are permitted if the list is empty or a single range is ill-formatted. |
+
+<1> `traefik.ingress.kubernetes.io/error-pages` example:
+
+```yaml
+foo:
+  status:
+  - "404"
+  backend: bar
+  query: /bar
+fii:
+  status:
+  - "503"
+  - "500"
+  backend: bar
+  query: /bir
+```
+
+<2> `traefik.ingress.kubernetes.io/rate-limit` example:
+
+```yaml
+extractorfunc: client.ip
+rateset:
+  bar:
+    period: 3s
+    average: 6
+    burst: 9
+  foo:
+    period: 6s
+    average: 12
+    burst: 18
+```
+
+<3> `traefik.ingress.kubernetes.io/buffering` example:
+
+```yaml
+maxrequestbodybytes: 10485760
+memrequestbodybytes: 2097153
+maxresponsebodybytes: 10485761
+memresponsebodybytes: 2097152
+retryexpression: IsNetworkError() && Attempts() <= 2
+```
 
 !!! note
-    Please note that `traefik.frontend.redirect.regex` and `traefik.frontend.redirect.replacement` do not have to be set if `traefik.frontend.redirect.entryPoint` is defined for the redirection (they will not be used in this case).
+    Please note that `traefik.ingress.kubernetes.io/redirect-regex` and `traefik.ingress.kubernetes.io/redirect-replacement` do not have to be set if `traefik.ingress.kubernetes.io/redirect-entry-point` is defined for the redirection (they will not be used in this case).
 
 The following annotations are applicable on the Service object associated with a particular Ingress object:
 
-- `traefik.backend.loadbalancer.method=drr`
-    Override the default `wrr` load balancer algorithm.
-- `traefik.backend.loadbalancer.stickiness=true`
-    Enable backend sticky sessions.
-- `traefik.backend.loadbalancer.stickiness.cookieName=NAME`
-    Manually set the cookie name for sticky sessions.
-- `traefik.backend.loadbalancer.sticky=true`
-    Enable backend sticky sessions (DEPRECATED).
-- `traefik.backend.circuitbreaker: <expression>`
-    Set the circuit breaker expression for the backend.
+| Annotation                                                               | Description                                                                                                                                                                           |
+|--------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `traefik.backend.loadbalancer.sticky=true`                               | Enable backend sticky sessions (DEPRECATED).                                                                                                                                          |
+| `traefik.ingress.kubernetes.io/affinity: true`                           | Enable backend sticky sessions.                                                                                                                                                       |
+| `traefik.ingress.kubernetes.io/circuit-breaker-expression: <expression>` | Set the circuit breaker expression for the backend.                                                                                                                                   |
+| `traefik.ingress.kubernetes.io/load-balancer-method: drr`                | Override the default `wrr` load balancer algorithm.                                                                                                                                   |
+| `traefik.ingress.kubernetes.io/max-conn-amount: 10`                      | Set a maximum number of connections to the backend.<br>Must be used in conjunction with the below label to take effect.                                                               |
+| `traefik.ingress.kubernetes.io/max-conn-extractor-func: client.ip`       | Set the function to be used against the request to determine what to limit maximum connections to the backend by.<br>Must be used in conjunction with the above label to take effect. |
+| `traefik.ingress.kubernetes.io/session-cookie-name: <NAME>`              | Manually set the cookie name for sticky sessions.                                                                                                                                     |
+
+!!! note
+    `traefik.ingress.kubernetes.io/` and `ingress.kubernetes.io/` are supported prefixes.
 
 ### Security annotations
 
@@ -150,7 +190,7 @@ The following security annotations are applicable on the Ingress object:
 | `ingress.kubernetes.io/ssl-host:HOST`                    | This setting configures the hostname that redirects will be based on. Default is "", which is the same host as the request.                                                                         |
 | `ingress.kubernetes.io/ssl-proxy-headers:EXPR`           | Header combinations that would signify a proper SSL Request (Such as `X-Forwarded-For:https`). Format: <code>HEADER:value&vert;&vert;HEADER2:value2</code>                                          |
 | `ingress.kubernetes.io/hsts-max-age:315360000`           | Sets the max-age of the HSTS header.                                                                                                                                                                |
-| `ingress.kubernetes.io/hsts-include-subdomains:true`      | Adds the IncludeSubdomains section of the STS  header.                                                                                                                                              |
+| `ingress.kubernetes.io/hsts-include-subdomains:true`     | Adds the IncludeSubdomains section of the STS  header.                                                                                                                                              |
 | `ingress.kubernetes.io/hsts-preload:true`                | Adds the preload flag to the HSTS  header.                                                                                                                                                          |
 | `ingress.kubernetes.io/force-hsts:false`                 | Adds the STS  header to non-SSL requests.                                                                                                                                                           |
 | `ingress.kubernetes.io/frame-deny:false`                 | Adds the `X-Frame-Options` header with the value of `DENY`.                                                                                                                                         |
@@ -167,10 +207,10 @@ The following security annotations are applicable on the Ingress object:
 Is possible to add additional authentication annotations to the Ingress object.
 The source of the authentication is a Secret object that contains the credentials.
 
-- `ingress.kubernetes.io/auth-type`: `basic`
-    Contains the authentication type. The only permitted type is `basic`.
-- `ingress.kubernetes.io/auth-secret`: `mysecret`
-    Contains the username and password with access to the paths defined in the Ingress object.
+| Annotation                                   | Description                                                                                |
+|----------------------------------------------|--------------------------------------------------------------------------------------------|
+| `ingress.kubernetes.io/auth-type:basic`      | Contains the authentication type. The only permitted type is `basic`.                      |
+| `ingress.kubernetes.io/auth-secret:mysecret` | Contains the username and password with access to the paths defined in the Ingress object. |
 
 The secret must be created in the same namespace as the Ingress object.
 

--- a/provider/kubernetes/annotations.go
+++ b/provider/kubernetes/annotations.go
@@ -1,0 +1,117 @@
+package kubernetes
+
+import (
+	"github.com/containous/traefik/provider/label"
+)
+
+const (
+	annotationKubernetesIngressClass             = "kubernetes.io/ingress.class"
+	annotationKubernetesAuthRealm                = "ingress.kubernetes.io/auth-realm"
+	annotationKubernetesAuthType                 = "ingress.kubernetes.io/auth-type"
+	annotationKubernetesAuthSecret               = "ingress.kubernetes.io/auth-secret"
+	annotationKubernetesRewriteTarget            = "ingress.kubernetes.io/rewrite-target"
+	annotationKubernetesWhitelistSourceRange     = "ingress.kubernetes.io/whitelist-source-range"
+	annotationKubernetesPreserveHost             = "ingress.kubernetes.io/preserve-host"
+	annotationKubernetesPassTLSCert              = "ingress.kubernetes.io/pass-tls-cert"
+	annotationKubernetesFrontendEntryPoints      = "ingress.kubernetes.io/frontend-entry-points"
+	annotationKubernetesPriority                 = "ingress.kubernetes.io/priority"
+	annotationKubernetesCircuitBreakerExpression = "ingress.kubernetes.io/circuit-breaker-expression"
+	annotationKubernetesLoadBalancerMethod       = "ingress.kubernetes.io/load-balancer-method"
+	annotationKubernetesAffinity                 = "ingress.kubernetes.io/affinity"
+	annotationKubernetesSessionCookieName        = "ingress.kubernetes.io/session-cookie-name"
+	annotationKubernetesRuleType                 = "ingress.kubernetes.io/rule-type"
+	annotationKubernetesRedirectEntryPoint       = "ingress.kubernetes.io/redirect-entry-point"
+	annotationKubernetesRedirectRegex            = "ingress.kubernetes.io/redirect-regex"
+	annotationKubernetesRedirectReplacement      = "ingress.kubernetes.io/redirect-replacement"
+	annotationKubernetesMaxConnAmount            = "ingress.kubernetes.io/max-conn-amount"
+	annotationKubernetesMaxConnExtractorFunc     = "ingress.kubernetes.io/max-conn-extractor-func"
+	annotationKubernetesRateLimit                = "ingress.kubernetes.io/rate-limit"
+	annotationKubernetesErrorPages               = "ingress.kubernetes.io/error-pages"
+	annotationKubernetesBuffering                = "ingress.kubernetes.io/buffering"
+
+	annotationKubernetesSSLRedirect             = "ingress.kubernetes.io/ssl-redirect"
+	annotationKubernetesHSTSMaxAge              = "ingress.kubernetes.io/hsts-max-age"
+	annotationKubernetesHSTSIncludeSubdomains   = "ingress.kubernetes.io/hsts-include-subdomains"
+	annotationKubernetesCustomRequestHeaders    = "ingress.kubernetes.io/custom-request-headers"
+	annotationKubernetesCustomResponseHeaders   = "ingress.kubernetes.io/custom-response-headers"
+	annotationKubernetesAllowedHosts            = "ingress.kubernetes.io/allowed-hosts"
+	annotationKubernetesProxyHeaders            = "ingress.kubernetes.io/proxy-headers"
+	annotationKubernetesSSLTemporaryRedirect    = "ingress.kubernetes.io/ssl-temporary-redirect"
+	annotationKubernetesSSLHost                 = "ingress.kubernetes.io/ssl-host"
+	annotationKubernetesSSLProxyHeaders         = "ingress.kubernetes.io/ssl-proxy-headers"
+	annotationKubernetesHSTSPreload             = "ingress.kubernetes.io/hsts-preload"
+	annotationKubernetesForceHSTSHeader         = "ingress.kubernetes.io/force-hsts"
+	annotationKubernetesFrameDeny               = "ingress.kubernetes.io/frame-deny"
+	annotationKubernetesCustomFrameOptionsValue = "ingress.kubernetes.io/custom-frame-options-value"
+	annotationKubernetesContentTypeNosniff      = "ingress.kubernetes.io/content-type-nosniff"
+	annotationKubernetesBrowserXSSFilter        = "ingress.kubernetes.io/browser-xss-filter"
+	annotationKubernetesContentSecurityPolicy   = "ingress.kubernetes.io/content-security-policy"
+	annotationKubernetesPublicKey               = "ingress.kubernetes.io/public-key"
+	annotationKubernetesReferrerPolicy          = "ingress.kubernetes.io/referrer-policy"
+	annotationKubernetesIsDevelopment           = "ingress.kubernetes.io/is-development"
+)
+
+// TODO [breaking] remove label support
+var compatibilityMapping = map[string]string{
+	annotationKubernetesPreserveHost:             "traefik.frontend.passHostHeader",
+	annotationKubernetesPassTLSCert:              "traefik.frontend.passTLSCert",
+	annotationKubernetesFrontendEntryPoints:      "traefik.frontend.entryPoints",
+	annotationKubernetesPriority:                 "traefik.frontend.priority",
+	annotationKubernetesCircuitBreakerExpression: "traefik.backend.circuitbreaker",
+	annotationKubernetesLoadBalancerMethod:       "traefik.backend.loadbalancer.method",
+	annotationKubernetesAffinity:                 "traefik.backend.loadbalancer.stickiness",
+	annotationKubernetesSessionCookieName:        "traefik.backend.loadbalancer.stickiness.cookieName",
+	annotationKubernetesRuleType:                 "traefik.frontend.rule.type",
+	annotationKubernetesRedirectEntryPoint:       "traefik.frontend.redirect.entrypoint",
+	annotationKubernetesRedirectRegex:            "traefik.frontend.redirect.regex",
+	annotationKubernetesRedirectReplacement:      "traefik.frontend.redirect.replacement",
+}
+
+func getAnnotationName(annotations map[string]string, name string) string {
+	if _, ok := annotations[name]; ok {
+		return name
+	}
+
+	if _, ok := annotations[label.Prefix+name]; ok {
+		return name
+	}
+
+	// TODO [breaking] remove label support
+	if lbl, compat := compatibilityMapping[name]; compat {
+		if _, ok := annotations[lbl]; ok {
+			return name
+		}
+	}
+
+	return name
+}
+
+func getStringValue(annotations map[string]string, annotation string, defaultValue string) string {
+	annotationName := getAnnotationName(annotations, annotation)
+	return label.GetStringValue(annotations, annotationName, defaultValue)
+}
+
+func getBoolValue(annotations map[string]string, annotation string, defaultValue bool) bool {
+	annotationName := getAnnotationName(annotations, annotation)
+	return label.GetBoolValue(annotations, annotationName, defaultValue)
+}
+
+func getIntValue(annotations map[string]string, annotation string, defaultValue int) int {
+	annotationName := getAnnotationName(annotations, annotation)
+	return label.GetIntValue(annotations, annotationName, defaultValue)
+}
+
+func getInt64Value(annotations map[string]string, annotation string, defaultValue int64) int64 {
+	annotationName := getAnnotationName(annotations, annotation)
+	return label.GetInt64Value(annotations, annotationName, defaultValue)
+}
+
+func getSliceStringValue(annotations map[string]string, annotation string) []string {
+	annotationName := getAnnotationName(annotations, annotation)
+	return label.GetSliceStringValue(annotations, annotationName)
+}
+
+func getMapValue(annotations map[string]string, annotation string) map[string]string {
+	annotationName := getAnnotationName(annotations, annotation)
+	return label.GetMapValue(annotations, annotationName)
+}

--- a/provider/kubernetes/builder_configuration_test.go
+++ b/provider/kubernetes/builder_configuration_test.go
@@ -214,9 +214,9 @@ func priority(value int) func(*types.Frontend) {
 	}
 }
 
-func headers() func(*types.Frontend) {
+func headers(h *types.Headers) func(*types.Frontend) {
 	return func(f *types.Frontend) {
-		f.Headers = &types.Headers{}
+		f.Headers = h
 	}
 }
 

--- a/provider/kubernetes/builder_configuration_test.go
+++ b/provider/kubernetes/builder_configuration_test.go
@@ -133,6 +133,24 @@ func retrying(exp string) func(*types.Buffering) {
 	}
 }
 
+func maxConnExtractorFunc(exp string) func(*types.Backend) {
+	return func(b *types.Backend) {
+		if b.MaxConn == nil {
+			b.MaxConn = &types.MaxConn{}
+		}
+		b.MaxConn.ExtractorFunc = exp
+	}
+}
+
+func maxConnAmount(value int64) func(*types.Backend) {
+	return func(b *types.Backend) {
+		if b.MaxConn == nil {
+			b.MaxConn = &types.MaxConn{}
+		}
+		b.MaxConn.Amount = value
+	}
+}
+
 // Frontend
 
 func buildFrontends(opts ...func(*types.Frontend) string) map[string]*types.Frontend {

--- a/provider/kubernetes/builder_configuration_test.go
+++ b/provider/kubernetes/builder_configuration_test.go
@@ -219,6 +219,39 @@ func redirectRegex(regex, replacement string) func(*types.Frontend) {
 	}
 }
 
+func errorPage(name string, opts ...func(*types.ErrorPage)) func(*types.Frontend) {
+	return func(f *types.Frontend) {
+		if f.Errors == nil {
+			f.Errors = make(map[string]*types.ErrorPage)
+		}
+
+		if len(name) > 0 {
+			f.Errors[name] = &types.ErrorPage{}
+			for _, opt := range opts {
+				opt(f.Errors[name])
+			}
+		}
+	}
+}
+
+func errorStatus(status ...string) func(*types.ErrorPage) {
+	return func(page *types.ErrorPage) {
+		page.Status = status
+	}
+}
+
+func errorQuery(query string) func(*types.ErrorPage) {
+	return func(page *types.ErrorPage) {
+		page.Query = query
+	}
+}
+
+func errorBackend(backend string) func(*types.ErrorPage) {
+	return func(page *types.ErrorPage) {
+		page.Backend = backend
+	}
+}
+
 func passTLSCert() func(*types.Frontend) {
 	return func(f *types.Frontend) {
 		f.PassTLSCert = true

--- a/provider/kubernetes/builder_configuration_test.go
+++ b/provider/kubernetes/builder_configuration_test.go
@@ -2,7 +2,9 @@ package kubernetes
 
 import (
 	"testing"
+	"time"
 
+	"github.com/containous/flaeg"
 	"github.com/containous/traefik/tls"
 	"github.com/containous/traefik/types"
 	"github.com/stretchr/testify/assert"
@@ -249,6 +251,57 @@ func errorQuery(query string) func(*types.ErrorPage) {
 func errorBackend(backend string) func(*types.ErrorPage) {
 	return func(page *types.ErrorPage) {
 		page.Backend = backend
+	}
+}
+
+func rateLimit(opts ...func(*types.RateLimit)) func(*types.Frontend) {
+	return func(f *types.Frontend) {
+		if f.RateLimit == nil {
+			f.RateLimit = &types.RateLimit{}
+		}
+
+		for _, opt := range opts {
+			opt(f.RateLimit)
+		}
+	}
+}
+
+func rateExtractorFunc(exp string) func(*types.RateLimit) {
+	return func(limit *types.RateLimit) {
+		limit.ExtractorFunc = exp
+	}
+}
+
+func rateSet(name string, opts ...func(*types.Rate)) func(*types.RateLimit) {
+	return func(limit *types.RateLimit) {
+		if limit.RateSet == nil {
+			limit.RateSet = make(map[string]*types.Rate)
+		}
+
+		if len(name) > 0 {
+			limit.RateSet[name] = &types.Rate{}
+			for _, opt := range opts {
+				opt(limit.RateSet[name])
+			}
+		}
+	}
+}
+
+func limitAverage(avg int64) func(*types.Rate) {
+	return func(rate *types.Rate) {
+		rate.Average = avg
+	}
+}
+
+func limitBurst(burst int64) func(*types.Rate) {
+	return func(rate *types.Rate) {
+		rate.Burst = burst
+	}
+}
+
+func limitPeriod(period time.Duration) func(*types.Rate) {
+	return func(rate *types.Rate) {
+		rate.Period = flaeg.Duration(period)
 	}
 }
 

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -198,9 +198,6 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 					}
 				}
 
-				passHostHeader := label.GetBoolValue(i.Annotations, label.TraefikFrontendPassHostHeader, !p.DisablePassHostHeaders)
-				passTLSCert := label.GetBoolValue(i.Annotations, label.TraefikFrontendPassTLSCert, p.EnablePassTLSCert)
-
 				if realm := i.Annotations[annotationKubernetesAuthRealm]; realm != "" && realm != traefikDefaultRealm {
 					log.Errorf("Value for annotation %q on ingress %s/%s invalid: no realm customization supported", annotationKubernetesAuthRealm, i.ObjectMeta.Namespace, i.ObjectMeta.Name)
 					delete(templateObjects.Backends, r.Host+pa.Path)
@@ -213,6 +210,9 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 						log.Errorf("Failed to retrieve basic auth configuration for ingress %s/%s: %s", i.ObjectMeta.Namespace, i.ObjectMeta.Name, err)
 						continue
 					}
+
+					passHostHeader := label.GetBoolValue(i.Annotations, label.TraefikFrontendPassHostHeader, !p.DisablePassHostHeaders)
+					passTLSCert := label.GetBoolValue(i.Annotations, label.TraefikFrontendPassTLSCert, p.EnablePassTLSCert)
 
 					priority := label.GetIntValue(i.Annotations, label.TraefikFrontendPriority, 0)
 

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -220,6 +220,8 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 
 					whitelistSourceRange := label.GetSliceStringValue(i.Annotations, annotationKubernetesWhitelistSourceRange)
 
+					errorPages := label.ParseErrorPages(i.Annotations, label.Prefix+label.BaseFrontendErrorPage, label.RegexpFrontendErrorPage)
+
 					templateObjects.Frontends[r.Host+pa.Path] = &types.Frontend{
 						Backend:              r.Host + pa.Path,
 						PassHostHeader:       passHostHeader,
@@ -231,6 +233,7 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 						Redirect:             getFrontendRedirect(i),
 						EntryPoints:          entryPoints,
 						Headers:              getHeader(i),
+						Errors:               errorPages,
 					}
 				}
 

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -558,7 +558,7 @@ func getStickiness(service *v1.Service) *types.Stickiness {
 }
 
 func getHeader(i *v1beta1.Ingress) *types.Headers {
-	return &types.Headers{
+	headers := &types.Headers{
 		CustomRequestHeaders:    label.GetMapValue(i.Annotations, annotationKubernetesCustomRequestHeaders),
 		CustomResponseHeaders:   label.GetMapValue(i.Annotations, annotationKubernetesCustomResponseHeaders),
 		AllowedHosts:            label.GetSliceStringValue(i.Annotations, annotationKubernetesAllowedHosts),
@@ -580,6 +580,12 @@ func getHeader(i *v1beta1.Ingress) *types.Headers {
 		ReferrerPolicy:          label.GetStringValue(i.Annotations, annotationKubernetesReferrerPolicy, ""),
 		IsDevelopment:           label.GetBoolValue(i.Annotations, annotationKubernetesIsDevelopment, false),
 	}
+
+	if !headers.HasSecureHeadersDefined() && !headers.HasCustomHeadersDefined() {
+		return nil
+	}
+
+	return headers
 }
 
 func getRateLimit(i *v1beta1.Ingress) *types.RateLimit {

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -202,7 +202,7 @@ func TestRuleType(t *testing.T) {
 			)))
 
 			if test.ingressRuleType != "" {
-				ingress.ObjectMeta.Annotations = map[string]string{
+				ingress.Annotations = map[string]string{
 					label.TraefikFrontendRuleType: test.ingressRuleType,
 				}
 			}

--- a/templates/kubernetes.tmpl
+++ b/templates/kubernetes.tmpl
@@ -18,6 +18,12 @@
         cookieName = "{{$backend.LoadBalancer.Stickiness.CookieName}}"
       {{end}}
 
+    {{if $backend.MaxConn}}
+    [backends.backend-{{$backendName}}.maxConn]
+      amount = {{ $backend.MaxConn.Amount }}
+      extractorFunc = "{{ $backend.MaxConn.ExtractorFunc }}"
+    {{end}}
+
     {{if $backend.Buffering }}
     [backends."{{ $backendName }}".buffering]
       maxRequestBodyBytes = {{ $backend.Buffering.MaxRequestBodyBytes }}

--- a/templates/kubernetes.tmpl
+++ b/templates/kubernetes.tmpl
@@ -42,6 +42,7 @@
     backend = "{{$frontend.Backend}}"
     priority = {{$frontend.Priority}}
     passHostHeader = {{$frontend.PassHostHeader}}
+    passTLSCert = {{$frontend.PassTLSCert}}
 
     entryPoints = [{{range $frontend.EntryPoints}}
       "{{.}}",

--- a/templates/kubernetes.tmpl
+++ b/templates/kubernetes.tmpl
@@ -63,6 +63,18 @@
       replacement = "{{$frontend.RedirectReplacement}}"
     {{end}}
 
+    {{ if $frontend.Errors }}
+    [frontends."frontend-{{$frontendName}}".errors]
+      {{ range $pageName, $page := $frontend.Errors }}
+      [frontends."frontend-{{$frontendName}}".errors.{{ $pageName }}]
+        status = [{{range $page.Status}}
+          "{{.}}",
+          {{end}}]
+        backend = "{{$page.Backend}}"
+        query = "{{$page.Query}}"
+      {{end}}
+    {{end}}
+
   {{if $frontend.Headers }}
   [frontends."{{$frontendName}}".headers]
     SSLRedirect = {{$frontend.Headers.SSLRedirect}}

--- a/templates/kubernetes.tmpl
+++ b/templates/kubernetes.tmpl
@@ -1,25 +1,23 @@
 [backends]
-{{range $backendName, $backend := .Backends}}
+{{range $backendName, $backend := .Backends }}
 
-  [backends."{{$backendName}}"]
+  [backends."{{ $backendName }}"]
 
-    {{if $backend.CircuitBreaker}}
-    [backends."{{$backendName}}".circuitBreaker]
-      expression = "{{$backend.CircuitBreaker.Expression}}"
+    {{if $backend.CircuitBreaker }}
+    [backends."{{ $backendName }} ".circuitBreaker]
+      expression = "{{ $backend.CircuitBreaker.Expression }}"
     {{end}}
 
-    [backends."{{$backendName}}".loadBalancer]
-      method = "{{$backend.LoadBalancer.Method}}"
-      {{if $backend.LoadBalancer.Sticky}}
-      sticky = true
-      {{end}}
-      {{if $backend.LoadBalancer.Stickiness}}
-      [backends."{{$backendName}}".loadBalancer.stickiness]
-        cookieName = "{{$backend.LoadBalancer.Stickiness.CookieName}}"
+    [backends."{{ $backendName }}".loadBalancer]
+      method = "{{ $backend.LoadBalancer.Method }}"
+      sticky = {{ $backend.LoadBalancer.Sticky }}
+      {{if $backend.LoadBalancer.Stickiness }}
+      [backends."{{ $backendName }}".loadBalancer.stickiness]
+        cookieName = "{{ $backend.LoadBalancer.Stickiness.CookieName }}"
       {{end}}
 
-    {{if $backend.MaxConn}}
-    [backends.backend-{{$backendName}}.maxConn]
+    {{if $backend.MaxConn }}
+    [backends.backend-{{ $backendName }}.maxConn]
       amount = {{ $backend.MaxConn.Amount }}
       extractorFunc = "{{ $backend.MaxConn.ExtractorFunc }}"
     {{end}}
@@ -33,60 +31,60 @@
       retryExpression = "{{ $backend.Buffering.RetryExpression }}"
     {{end}}
 
-    {{range $serverName, $server := $backend.Servers}}
-    [backends."{{$backendName}}".servers."{{$serverName}}"]
-      url = "{{$server.URL}}"
-      weight = {{$server.Weight}}
+    {{range $serverName, $server := $backend.Servers }}
+    [backends."{{ $backendName }}".servers."{{ $serverName }}"]
+      url = "{{ $server.URL }}"
+      weight = {{ $server.Weight }}
     {{end}}
 
 {{end}}
 
 [frontends]
-{{range $frontendName, $frontend := .Frontends}}
+{{range $frontendName, $frontend := .Frontends }}
 
-  [frontends."{{$frontendName}}"]
-    backend = "{{$frontend.Backend}}"
-    priority = {{$frontend.Priority}}
-    passHostHeader = {{$frontend.PassHostHeader}}
-    passTLSCert = {{$frontend.PassTLSCert}}
+  [frontends."{{ $frontendName }}"]
+    backend = "{{ $frontend.Backend }}"
+    priority = {{ $frontend.Priority }}
+    passHostHeader = {{ $frontend.PassHostHeader }}
+    passTLSCert = {{ $frontend.PassTLSCert }}
 
-    entryPoints = [{{range $frontend.EntryPoints}}
+    entryPoints = [{{range $frontend.EntryPoints }}
       "{{.}}",
       {{end}}]
 
-    basicAuth = [{{range $frontend.BasicAuth}}
+    basicAuth = [{{range $frontend.BasicAuth }}
       "{{.}}",
       {{end}}]
 
-    whitelistSourceRange = [{{range $frontend.WhitelistSourceRange}}
+    whitelistSourceRange = [{{range $frontend.WhitelistSourceRange }}
       "{{.}}",
       {{end}}]
 
-    {{if $frontend.Redirect}}
-    [frontends."{{$frontendName}}".redirect]
-      entryPoint = "{{$frontend.RedirectEntryPoint}}"
-      regex = "{{$frontend.RedirectRegex}}"
-      replacement = "{{$frontend.RedirectReplacement}}"
+    {{if $frontend.Redirect }}
+    [frontends."{{ $frontendName }}".redirect]
+      entryPoint = "{{ $frontend.Redirect.EntryPoint }}"
+      regex = "{{ $frontend.Redirect.Regex }}"
+      replacement = "{{ $frontend.Redirect.Replacement }}"
     {{end}}
 
-    {{ if $frontend.Errors }}
-    [frontends."frontend-{{$frontendName}}".errors]
-      {{ range $pageName, $page := $frontend.Errors }}
-      [frontends."frontend-{{$frontendName}}".errors.{{ $pageName }}]
-        status = [{{range $page.Status}}
+    {{if $frontend.Errors }}
+    [frontends."frontend-{{ $frontendName }}".errors]
+      {{range $pageName, $page := $frontend.Errors }}
+      [frontends."frontend-{{ $frontendName }}".errors.{{ $pageName }}]
+        status = [{{range $page.Status }}
           "{{.}}",
           {{end}}]
-        backend = "{{$page.Backend}}"
-        query = "{{$page.Query}}"
+        backend = "{{ $page.Backend }}"
+        query = "{{ $page.Query }}"
       {{end}}
     {{end}}
 
-    {{ if $frontend.RateLimit }}
-    [frontends."frontend-{{$frontendName}}".rateLimit]
+    {{if $frontend.RateLimit }}
+    [frontends."frontend-{{ $frontendName }}".rateLimit]
       extractorFunc = "{{ $frontend.RateLimit.ExtractorFunc }}"
-      [frontends."frontend-{{$frontendName}}".rateLimit.rateSet]
-        {{ range $limitName, $limit := $frontend.RateLimit.RateSet }}
-        [frontends."frontend-{{$frontendName}}".rateLimit.rateSet.{{ $limitName }}]
+      [frontends."frontend-{{ $frontendName }}".rateLimit.rateSet]
+        {{range $limitName, $limit := $frontend.RateLimit.RateSet }}
+        [frontends."frontend-{{ $frontendName }}".rateLimit.rateSet.{{ $limitName }}]
           period = "{{ $limit.Period }}"
           average = {{ $limit.Average }}
           burst = {{ $limit.Burst }}
@@ -94,55 +92,55 @@
     {{end}}
 
   {{if $frontend.Headers }}
-  [frontends."{{$frontendName}}".headers]
-    SSLRedirect = {{$frontend.Headers.SSLRedirect}}
-    SSLTemporaryRedirect = {{$frontend.Headers.SSLTemporaryRedirect}}
-    SSLHost = "{{$frontend.Headers.SSLHost}}"
-    STSSeconds = {{$frontend.Headers.STSSeconds}}
-    STSIncludeSubdomains = {{$frontend.Headers.STSIncludeSubdomains}}
-    STSPreload = {{$frontend.Headers.STSPreload}}
-    ForceSTSHeader = {{$frontend.Headers.ForceSTSHeader}}
-    FrameDeny = {{$frontend.Headers.FrameDeny}}
-    CustomFrameOptionsValue = "{{$frontend.Headers.CustomFrameOptionsValue}}"
-    ContentTypeNosniff = {{$frontend.Headers.ContentTypeNosniff}}
-    BrowserXSSFilter = {{$frontend.Headers.BrowserXSSFilter}}
-    ContentSecurityPolicy = "{{$frontend.Headers.ContentSecurityPolicy}}"
-    PublicKey = "{{$frontend.Headers.PublicKey}}"
-    ReferrerPolicy = "{{$frontend.Headers.ReferrerPolicy}}"
-    IsDevelopment = {{$frontend.Headers.IsDevelopment}}
-    {{if $frontend.Headers.AllowedHosts}}
-    AllowedHosts = [{{range $frontend.Headers.AllowedHosts}}
+  [frontends."{{ $frontendName }}".headers]
+    SSLRedirect = {{ $frontend.Headers.SSLRedirect }}
+    SSLTemporaryRedirect = {{ $frontend.Headers.SSLTemporaryRedirect }}
+    SSLHost = "{{ $frontend.Headers.SSLHost }}"
+    STSSeconds = {{ $frontend.Headers.STSSeconds }}
+    STSIncludeSubdomains = {{ $frontend.Headers.STSIncludeSubdomains }}
+    STSPreload = {{ $frontend.Headers.STSPreload }}
+    ForceSTSHeader = {{ $frontend.Headers.ForceSTSHeader }}
+    FrameDeny = {{ $frontend.Headers.FrameDeny }}
+    CustomFrameOptionsValue = "{{ $frontend.Headers.CustomFrameOptionsValue }}"
+    ContentTypeNosniff = {{ $frontend.Headers.ContentTypeNosniff }}
+    BrowserXSSFilter = {{ $frontend.Headers.BrowserXSSFilter }}
+    ContentSecurityPolicy = "{{ $frontend.Headers.ContentSecurityPolicy }}"
+    PublicKey = "{{ $frontend.Headers.PublicKey }}"
+    ReferrerPolicy = "{{ $frontend.Headers.ReferrerPolicy }}"
+    IsDevelopment = {{ $frontend.Headers.IsDevelopment }}
+    {{if $frontend.Headers.AllowedHosts }}
+    AllowedHosts = [{{range $frontend.Headers.AllowedHosts }}
       "{{.}}",
       {{end}}]
     {{end}}
-    {{if $frontend.Headers.HostsProxyHeaders}}
-    HostsProxyHeaders = [{{range $frontend.Headers.HostsProxyHeaders}}
+    {{if $frontend.Headers.HostsProxyHeaders }}
+    HostsProxyHeaders = [{{range $frontend.Headers.HostsProxyHeaders }}
       "{{.}}",
       {{end}}]
     {{end}}
-    {{if $frontend.Headers.CustomRequestHeaders}}
-    [frontends."{{$frontendName}}".headers.customrequestheaders]
-      {{range $k, $v := $frontend.Headers.CustomRequestHeaders}}
-      {{$k}} = "{{$v}}"
+    {{if $frontend.Headers.CustomRequestHeaders }}
+    [frontends."{{ $frontendName }}".headers.customRequestHeaders]
+      {{range $k, $v := $frontend.Headers.CustomRequestHeaders }}
+      {{ $k }} = "{{ $v }}"
       {{end}}
     {{end}}
-    {{if $frontend.Headers.CustomResponseHeaders}}
-    [frontends."{{$frontendName}}".headers.customresponseheaders]
-      {{range $k, $v := $frontend.Headers.CustomResponseHeaders}}
-      {{$k}} = "{{$v}}"
+    {{if $frontend.Headers.CustomResponseHeaders }}
+    [frontends."{{ $frontendName }}".headers.customResponseHeaders]
+      {{range $k, $v := $frontend.Headers.CustomResponseHeaders }}
+      {{ $k }} = "{{ $v }}"
       {{end}}
     {{end}}
-    {{if $frontend.Headers.SSLProxyHeaders}}
-    [frontends."{{$frontendName}}".headers.SSLProxyHeaders]
-      {{range $k, $v := $frontend.Headers.SSLProxyHeaders}}
-      {{$k}} = "{{$v}}"
+    {{if $frontend.Headers.SSLProxyHeaders }}
+    [frontends."{{ $frontendName }}".headers.SSLProxyHeaders]
+      {{range $k, $v := $frontend.Headers.SSLProxyHeaders }}
+      {{ $k }} = "{{ $v }}"
       {{end}}
     {{end}}
   {{end}}
 
-    {{range $routeName, $route := $frontend.Routes}}
-    [frontends."{{$frontendName}}".routes."{{$routeName}}"]
-      rule = "{{$route.Rule}}"
+    {{range $routeName, $route := $frontend.Routes }}
+    [frontends."{{ $frontendName }}".routes."{{ $routeName }}"]
+      rule = "{{ $route.Rule }}"
     {{end}}
 
 {{end}}

--- a/templates/kubernetes.tmpl
+++ b/templates/kubernetes.tmpl
@@ -75,6 +75,18 @@
       {{end}}
     {{end}}
 
+    {{ if $frontend.RateLimit }}
+    [frontends."frontend-{{$frontendName}}".rateLimit]
+      extractorFunc = "{{ $frontend.RateLimit.ExtractorFunc }}"
+      [frontends."frontend-{{$frontendName}}".rateLimit.rateSet]
+        {{ range $limitName, $limit := $frontend.RateLimit.RateSet }}
+        [frontends."frontend-{{$frontendName}}".rateLimit.rateSet.{{ $limitName }}]
+          period = "{{ $limit.Period }}"
+          average = {{ $limit.Average }}
+          burst = {{ $limit.Burst }}
+        {{end}}
+    {{end}}
+
   {{if $frontend.Headers }}
   [frontends."{{$frontendName}}".headers]
     SSLRedirect = {{$frontend.Headers.SSLRedirect}}

--- a/templates/kubernetes.tmpl
+++ b/templates/kubernetes.tmpl
@@ -1,16 +1,20 @@
-[backends]{{range $backendName, $backend := .Backends}}
-    [backends."{{$backendName}}"]
+[backends]
+{{range $backendName, $backend := .Backends}}
+
+  [backends."{{$backendName}}"]
+
     {{if $backend.CircuitBreaker}}
-    [backends."{{$backendName}}".circuitbreaker]
+    [backends."{{$backendName}}".circuitBreaker]
       expression = "{{$backend.CircuitBreaker.Expression}}"
     {{end}}
-    [backends."{{$backendName}}".loadbalancer]
+
+    [backends."{{$backendName}}".loadBalancer]
       method = "{{$backend.LoadBalancer.Method}}"
       {{if $backend.LoadBalancer.Sticky}}
       sticky = true
       {{end}}
       {{if $backend.LoadBalancer.Stickiness}}
-      [backends."{{$backendName}}".loadbalancer.stickiness]
+      [backends."{{$backendName}}".loadBalancer.stickiness]
         cookieName = "{{$backend.LoadBalancer.Stickiness.CookieName}}"
       {{end}}
 
@@ -25,91 +29,99 @@
 
     {{range $serverName, $server := $backend.Servers}}
     [backends."{{$backendName}}".servers."{{$serverName}}"]
-    url = "{{$server.URL}}"
-    weight = {{$server.Weight}}
+      url = "{{$server.URL}}"
+      weight = {{$server.Weight}}
     {{end}}
+
 {{end}}
 
-[frontends]{{range $frontendName, $frontend := .Frontends}}
-  [frontends."{{$frontendName}}"]
-  backend = "{{$frontend.Backend}}"
-  priority = {{$frontend.Priority}}
-  passHostHeader = {{$frontend.PassHostHeader}}
-  entryPoints = [{{range $frontend.EntryPoints}}
-    "{{.}}",
-    {{end}}]
-  basicAuth = [{{range $frontend.BasicAuth}}
-      "{{.}}",
-  {{end}}]
-  whitelistSourceRange = [{{range $frontend.WhitelistSourceRange}}
-    "{{.}}",
-  {{end}}]
+[frontends]
+{{range $frontendName, $frontend := .Frontends}}
 
-  {{if $frontend.Redirect}}
-  [frontends."{{$frontendName}}".redirect]
-  entryPoint = "{{$frontend.Redirect.EntryPoint}}"
-  regex = "{{$frontend.Redirect.Regex}}"
-  replacement = "{{$frontend.Redirect.Replacement}}"
-  {{end}}
+  [frontends."{{$frontendName}}"]
+    backend = "{{$frontend.Backend}}"
+    priority = {{$frontend.Priority}}
+    passHostHeader = {{$frontend.PassHostHeader}}
+
+    entryPoints = [{{range $frontend.EntryPoints}}
+      "{{.}}",
+      {{end}}]
+
+    basicAuth = [{{range $frontend.BasicAuth}}
+      "{{.}}",
+      {{end}}]
+
+    whitelistSourceRange = [{{range $frontend.WhitelistSourceRange}}
+      "{{.}}",
+      {{end}}]
+
+    {{if $frontend.Redirect}}
+    [frontends."{{$frontendName}}".redirect]
+      entryPoint = "{{$frontend.RedirectEntryPoint}}"
+      regex = "{{$frontend.RedirectRegex}}"
+      replacement = "{{$frontend.RedirectReplacement}}"
+    {{end}}
 
   {{if $frontend.Headers }}
   [frontends."{{$frontendName}}".headers]
-  SSLRedirect = {{$frontend.Headers.SSLRedirect}}
-  SSLTemporaryRedirect = {{$frontend.Headers.SSLTemporaryRedirect}}
-  SSLHost = "{{$frontend.Headers.SSLHost}}"
-  STSSeconds = {{$frontend.Headers.STSSeconds}}
-  STSIncludeSubdomains = {{$frontend.Headers.STSIncludeSubdomains}}
-  STSPreload = {{$frontend.Headers.STSPreload}}
-  ForceSTSHeader = {{$frontend.Headers.ForceSTSHeader}}
-  FrameDeny = {{$frontend.Headers.FrameDeny}}
-  CustomFrameOptionsValue = "{{$frontend.Headers.CustomFrameOptionsValue}}"
-  ContentTypeNosniff = {{$frontend.Headers.ContentTypeNosniff}}
-  BrowserXSSFilter = {{$frontend.Headers.BrowserXSSFilter}}
-  ContentSecurityPolicy = "{{$frontend.Headers.ContentSecurityPolicy}}"
-  PublicKey = "{{$frontend.Headers.PublicKey}}"
-  ReferrerPolicy = "{{$frontend.Headers.ReferrerPolicy}}"
-  IsDevelopment = {{$frontend.Headers.IsDevelopment}}
-  {{if $frontend.Headers.AllowedHosts}}
-  AllowedHosts = [{{range $frontend.Headers.AllowedHosts}}
-    "{{.}}",
-    {{end}}]
-  {{end}}
-  {{if $frontend.Headers.HostsProxyHeaders}}
-  HostsProxyHeaders = [{{range $frontend.Headers.HostsProxyHeaders}}
-    "{{.}}",
-    {{end}}]
-  {{end}}
-{{if $frontend.Headers.CustomRequestHeaders}}
+    SSLRedirect = {{$frontend.Headers.SSLRedirect}}
+    SSLTemporaryRedirect = {{$frontend.Headers.SSLTemporaryRedirect}}
+    SSLHost = "{{$frontend.Headers.SSLHost}}"
+    STSSeconds = {{$frontend.Headers.STSSeconds}}
+    STSIncludeSubdomains = {{$frontend.Headers.STSIncludeSubdomains}}
+    STSPreload = {{$frontend.Headers.STSPreload}}
+    ForceSTSHeader = {{$frontend.Headers.ForceSTSHeader}}
+    FrameDeny = {{$frontend.Headers.FrameDeny}}
+    CustomFrameOptionsValue = "{{$frontend.Headers.CustomFrameOptionsValue}}"
+    ContentTypeNosniff = {{$frontend.Headers.ContentTypeNosniff}}
+    BrowserXSSFilter = {{$frontend.Headers.BrowserXSSFilter}}
+    ContentSecurityPolicy = "{{$frontend.Headers.ContentSecurityPolicy}}"
+    PublicKey = "{{$frontend.Headers.PublicKey}}"
+    ReferrerPolicy = "{{$frontend.Headers.ReferrerPolicy}}"
+    IsDevelopment = {{$frontend.Headers.IsDevelopment}}
+    {{if $frontend.Headers.AllowedHosts}}
+    AllowedHosts = [{{range $frontend.Headers.AllowedHosts}}
+      "{{.}}",
+      {{end}}]
+    {{end}}
+    {{if $frontend.Headers.HostsProxyHeaders}}
+    HostsProxyHeaders = [{{range $frontend.Headers.HostsProxyHeaders}}
+      "{{.}}",
+      {{end}}]
+    {{end}}
+    {{if $frontend.Headers.CustomRequestHeaders}}
     [frontends."{{$frontendName}}".headers.customrequestheaders]
-    {{range $k, $v := $frontend.Headers.CustomRequestHeaders}}
-    {{$k}} = "{{$v}}"
+      {{range $k, $v := $frontend.Headers.CustomRequestHeaders}}
+      {{$k}} = "{{$v}}"
+      {{end}}
     {{end}}
-{{end}}
-{{if $frontend.Headers.CustomResponseHeaders}}
+    {{if $frontend.Headers.CustomResponseHeaders}}
     [frontends."{{$frontendName}}".headers.customresponseheaders]
-    {{range $k, $v := $frontend.Headers.CustomResponseHeaders}}
-    {{$k}} = "{{$v}}"
+      {{range $k, $v := $frontend.Headers.CustomResponseHeaders}}
+      {{$k}} = "{{$v}}"
+      {{end}}
     {{end}}
-{{end}}
-{{if $frontend.Headers.SSLProxyHeaders}}
+    {{if $frontend.Headers.SSLProxyHeaders}}
     [frontends."{{$frontendName}}".headers.SSLProxyHeaders]
-    {{range $k, $v := $frontend.Headers.SSLProxyHeaders}}
-    {{$k}} = "{{$v}}"
+      {{range $k, $v := $frontend.Headers.SSLProxyHeaders}}
+      {{$k}} = "{{$v}}"
+      {{end}}
     {{end}}
-{{end}}
-{{end}}
+  {{end}}
+
     {{range $routeName, $route := $frontend.Routes}}
     [frontends."{{$frontendName}}".routes."{{$routeName}}"]
-    rule = "{{$route.Rule}}"
+      rule = "{{$route.Rule}}"
     {{end}}
+
 {{end}}
 
-{{range $tls := .TLS}}
+{{range $tls := .TLS }}
 [[tls]]
-  entryPoints = [{{range $tls.EntryPoints}}
+  entryPoints = [{{range $tls.EntryPoints }}
     "{{.}}",
-   {{end}}]
+    {{end}}]
   [tls.certificate]
-    certFile = """{{$tls.Certificate.CertFile}}"""
-    keyFile = """{{$tls.Certificate.KeyFile}}"""
+    certFile = """{{ $tls.Certificate.CertFile }}"""
+    keyFile = """{{ $tls.Certificate.KeyFile }}"""
 {{end}}


### PR DESCRIPTION
### What does this PR do?

- add all available annotations
  - add passTLSCert annotations.
  - add error pages annotations.
  - add max conn annotations.
  - add rate limit annotations.
- enhance template readability

### Motivation

Homogenization of the providers [part2]: all providers must have the same options available.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Several PRs will come after that for each provider.

Related to #618,  #1465
Closes #2783