### PR TITLE
Simplify storing renewed acme certificate

### DIFF
--- a/acme/acme.go
+++ b/acme/acme.go
@@ -405,7 +405,7 @@ func (a *ACME) renewCertificates() {
 					continue
 				}
 				operation := func() error {
-					return a.storeRenewedCertificate(account, certificateResource, renewedACMECert)
+					return a.storeRenewedCertificate(certificateResource, renewedACMECert)
 				}
 				notify := func(err error, time time.Duration) {
 					log.Warnf("Renewed certificate storage error: %v, retrying in %s", err, time)
@@ -443,14 +443,14 @@ func (a *ACME) renewACMECertificate(certificateResource *DomainsCertificate) (*C
 	}, nil
 }
 
-func (a *ACME) storeRenewedCertificate(account *Account, certificateResource *DomainsCertificate, renewedACMECert *Certificate) error {
+func (a *ACME) storeRenewedCertificate(certificateResource *DomainsCertificate, renewedACMECert *Certificate) error {
 	transaction, object, err := a.store.Begin()
 	if err != nil {
 		return fmt.Errorf("error during transaction initialization for renewing certificate: %v", err)
 	}
 
 	log.Infof("Renewing certificate in data store : %+v ", certificateResource.Domains)
-	account = object.(*Account)
+	account := object.(*Account)
 	err = account.DomainsCertificate.renewCertificates(renewedACMECert, certificateResource.Domains)
 	if err != nil {
 		return fmt.Errorf("error renewing certificate in datastore: %v ", err)


### PR DESCRIPTION
### What does this PR do?

Simplification in storing renewed certificate in acme certificate renewal.

### Motivation

Not to mislead readers.

### Additional Notes

Account argument was passed but it was actually accessed through store and there was no need to pass it so dropped that argument.