### PR TITLE
Mesos: Integrate the Events API to get up to date information about tasks.

### DIFF
--- a/docs/configuration/backends/mesos.md
+++ b/docs/configuration/backends/mesos.md
@@ -62,12 +62,26 @@ domain = "mesos.localhost"
 #
 # ZkDetectionTimeout = 30
 
-# Polling interval (in seconds).
+# Polling interval (in seconds). If the polling interval is set to 0, polling is disabled.
 #
 # Optional
 # Default: 30
 #
 # RefreshSeconds = 30
+
+# Subscribe to events from the mesos master when tasks are added and destroyed. Requires Mesos >1.1.
+#
+# Optional
+# Default: false
+#
+# Subscribe = true
+
+# Only update the configuration in response to changes from tasks with the following labels (comma separated)
+#
+# Optional
+# Default: ""
+#
+# SubscribeLabels = "traefik.frontend.rule"
 
 # IP sources (e.g. host, docker, mesos, rkt).
 #

--- a/provider/mesos/config.go
+++ b/provider/mesos/config.go
@@ -17,7 +17,7 @@ import (
 	"github.com/mesosphere/mesos-dns/records/state"
 )
 
-func (p *Provider) buildConfiguration() *types.Configuration {
+func (p *Provider) buildConfiguration() (*types.Configuration, []state.Task) {
 	var mesosFuncMap = template.FuncMap{
 		"getBackend":         getBackend,
 		"getPort":            p.getPort,
@@ -38,7 +38,7 @@ func (p *Provider) buildConfiguration() *types.Configuration {
 	st, err := rg.FindMaster(p.Masters...)
 	if err != nil {
 		log.Errorf("Failed to create a client for Mesos, error: %v", err)
-		return nil
+		return nil, nil
 	}
 	tasks := taskRecords(st)
 
@@ -72,7 +72,7 @@ func (p *Provider) buildConfiguration() *types.Configuration {
 	if err != nil {
 		log.Error(err)
 	}
-	return configuration
+	return configuration, templateObjects.Tasks
 }
 
 func taskRecords(st state.State) []state.Task {

--- a/provider/mesos/config_test.go
+++ b/provider/mesos/config_test.go
@@ -29,7 +29,7 @@ func TestBuildConfiguration(t *testing.T) {
 			Domain:           "docker.localhost",
 			ExposedByDefault: true,
 		}
-		actualConfig := provider.buildConfiguration()
+		actualConfig, _ := provider.buildConfiguration()
 		if c.expectedNil {
 			if actualConfig != nil {
 				t.Fatalf("Should have been nil, got %v", actualConfig)

--- a/provider/mesos/mesos.go
+++ b/provider/mesos/mesos.go
@@ -49,7 +49,7 @@ type mesosEvent struct {
 	Type      string `json:"type"`
 	TaskAdded struct {
 		Task struct {
-			TaskId struct {
+			TaskID struct {
 				Value string `json:"value"`
 			} `json:"task_id"`
 			Labels struct {
@@ -61,15 +61,15 @@ type mesosEvent struct {
 		} `json:"task"`
 	} `json:"task_added"`
 	TaskUpdated struct {
-		FrameworkId struct {
+		FrameworkID struct {
 			Value string `json:"value"`
 		} `json:"framework_id"`
 		State  string `json:"state"`
 		Status struct {
-			TaskId struct {
+			TaskID struct {
 				Value string `json:"value"`
 			} `json:"task_id"`
-			AgentId struct {
+			AgentID struct {
 				Value string `json:"value"`
 			} `json:"agent_id"`
 		} `json:"status"`
@@ -258,16 +258,16 @@ func detectMasters(zk string, masters []string) <-chan []string {
 
 func (p *Provider) subscribeMesos(masters []string) (<-chan state.Task, <-chan state.Task) {
 	var subscribeResp *http.Response
-	var masterUri url.URL
+	var masterURI url.URL
 
 	for _, master := range masters {
 		log.Debugf("Attempting to connect to master %v", master)
-		masterUri = url.URL{
+		masterURI = url.URL{
 			Scheme: "http",
 			Host:   master,
 			Path:   "api/v1",
 		}
-		r, err := http.NewRequest("POST", masterUri.String(), strings.NewReader(`{"type":"SUBSCRIBE"}`))
+		r, err := http.NewRequest("POST", masterURI.String(), strings.NewReader(`{"type":"SUBSCRIBE"}`))
 		r.Header.Set("Content-Type", "application/json")
 		r.Header.Set("Accept", "application/json")
 		if err != nil {
@@ -280,6 +280,7 @@ func (p *Provider) subscribeMesos(masters []string) (<-chan state.Task, <-chan s
 			continue
 		}
 		subscribeResp = resp
+		break
 	}
 	if subscribeResp == nil {
 		return nil, nil
@@ -292,7 +293,7 @@ func (p *Provider) subscribeMesos(masters []string) (<-chan state.Task, <-chan s
 			close(taskAdded)
 			close(taskUpdated)
 		}()
-		log.Debugf("Starting mesos task subscription on %v", masterUri.String())
+		log.Debugf("Starting mesos task subscription on %v", masterURI.String())
 		reader := bufio.NewReader(resp.Body)
 		readBuff := []byte{}
 		for {
@@ -325,7 +326,7 @@ func (p *Provider) subscribeMesos(masters []string) (<-chan state.Task, <-chan s
 								for _, taskLabel := range event.TaskAdded.Task.Labels.Labels {
 									if taskLabel.Key == label {
 										taskAdded <- state.Task{
-											ID: event.TaskAdded.Task.TaskId.Value,
+											ID: event.TaskAdded.Task.TaskID.Value,
 										}
 										break matchLabel
 									}
@@ -334,7 +335,7 @@ func (p *Provider) subscribeMesos(masters []string) (<-chan state.Task, <-chan s
 						}
 					} else if event.Type == "TASK_UPDATED" {
 						t := state.Task{
-							ID: event.TaskUpdated.Status.TaskId.Value,
+							ID: event.TaskUpdated.Status.TaskID.Value,
 						}
 						switch event.TaskUpdated.State {
 						case "TASK_RUNNING":

--- a/provider/mesos/mesos.go
+++ b/provider/mesos/mesos.go
@@ -1,7 +1,13 @@
 package mesos
 
 import (
+	"bufio"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -16,6 +22,7 @@ import (
 	_ "github.com/mesos/mesos-go/detector/zoo"
 	"github.com/mesosphere/mesos-dns/detect"
 	"github.com/mesosphere/mesos-dns/logging"
+	"github.com/mesosphere/mesos-dns/records/state"
 	"github.com/mesosphere/mesos-dns/util"
 )
 
@@ -24,15 +31,49 @@ var _ provider.Provider = (*Provider)(nil)
 //Provider holds configuration of the provider.
 type Provider struct {
 	provider.BaseProvider
-	Endpoint           string `description:"Mesos server endpoint. You can also specify multiple endpoint for Mesos"`
-	Domain             string `description:"Default domain used"`
-	ExposedByDefault   bool   `description:"Expose Mesos apps by default" export:"true"`
-	GroupsAsSubDomains bool   `description:"Convert Mesos groups to subdomains" export:"true"`
-	ZkDetectionTimeout int    `description:"Zookeeper timeout (in seconds)" export:"true"`
-	RefreshSeconds     int    `description:"Polling interval (in seconds)" export:"true"`
-	IPSources          string `description:"IPSources (e.g. host, docker, mesos, rkt)" export:"true"`
-	StateTimeoutSecond int    `description:"HTTP Timeout (in seconds)" export:"true"`
-	Masters            []string
+	Endpoint              string `description:"Mesos server endpoint. You can also specify multiple endpoint for Mesos"`
+	Domain                string `description:"Default domain used"`
+	ExposedByDefault      bool   `description:"Expose Mesos apps by default" export:"true"`
+	GroupsAsSubDomains    bool   `description:"Convert Mesos groups to subdomains" export:"true"`
+	ZkDetectionTimeout    int    `description:"Zookeeper timeout (in seconds)" export:"true"`
+	RefreshSeconds        int    `description:"Polling interval (in seconds)" export:"true"`
+	IPSources             string `description:"IPSources (e.g. host, docker, mesos, rkt)" export:"true"`
+	StateTimeoutSecond    int    `description:"HTTP Timeout (in seconds)" export:"true"`
+	Masters               []string
+	Subscribe             bool   `description:"Subscribe to Mesos task events (Mesos 1.1 or later only)" export:"true"`
+	SubscribeLabels       string `description:"Filter subscriptions to only tasks with these labels" export:"true"`
+	SubscribeFilterLabels []string
+}
+
+type mesosEvent struct {
+	Type      string `json:"type"`
+	TaskAdded struct {
+		Task struct {
+			TaskId struct {
+				Value string `json:"value"`
+			} `json:"task_id"`
+			Labels struct {
+				Labels []struct {
+					Key   string `json:"key"`
+					Value string `json:"value"`
+				} `json:"labels"`
+			} `json:"labels"`
+		} `json:"task"`
+	} `json:"task_added"`
+	TaskUpdated struct {
+		FrameworkId struct {
+			Value string `json:"value"`
+		} `json:"framework_id"`
+		State  string `json:"state"`
+		Status struct {
+			TaskId struct {
+				Value string `json:"value"`
+			} `json:"task_id"`
+			AgentId struct {
+				Value string `json:"value"`
+			} `json:"agent_id"`
+		} `json:"status"`
+	} `json:"task_updated"`
 }
 
 // Provide allows the mesos provider to provide configurations to traefik
@@ -47,6 +88,9 @@ func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *s
 
 		var zk string
 		var masters []string
+		var reload *time.Ticker
+		var taskAddedChan <-chan state.Task
+		var taskUpdatedChan <-chan state.Task
 
 		if strings.HasPrefix(p.Endpoint, "zk://") {
 			zk = p.Endpoint
@@ -55,9 +99,14 @@ func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *s
 		}
 
 		errch := make(chan error)
+		subscribed := false
 
 		changed := detectMasters(zk, masters)
-		reload := time.NewTicker(time.Second * time.Duration(p.RefreshSeconds))
+		if p.RefreshSeconds == 0 {
+			reload = time.NewTicker(time.Second * 100)
+		} else {
+			reload = time.NewTicker(time.Second * time.Duration(p.RefreshSeconds))
+		}
 		zkTimeout := time.Second * time.Duration(p.ZkDetectionTimeout)
 		timeout := time.AfterFunc(zkTimeout, func() {
 			if zkTimeout > 0 {
@@ -72,16 +121,88 @@ func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *s
 			reload.Stop()
 			timeout.Stop()
 		}
+		if p.RefreshSeconds == 0 {
+			reload.Stop()
+		}
+
+		if len(p.SubscribeLabels) > 0 {
+			p.SubscribeFilterLabels = strings.Split(p.SubscribeLabels, ",")
+		}
+
+		runningTasks := make(map[string]string)
+		updateTasks := func(tasks []state.Task) {
+			for k, v := range runningTasks {
+				if v != "ADDED" {
+					delete(runningTasks, k)
+				}
+			}
+			for _, t := range tasks {
+				runningTasks[t.ID] = "RUNNING"
+			}
+		}
 
 		for {
 			select {
 			case <-reload.C:
-				configuration := p.buildConfiguration()
+				configuration, tasks := p.buildConfiguration()
 				if configuration != nil {
+					updateTasks(tasks)
 					configurationChan <- types.ConfigMessage{
 						ProviderName:  "mesos",
 						Configuration: configuration,
 					}
+				}
+			case task, ok := <-taskAddedChan:
+				if ok {
+					// Keep track that the ask was added, but wait until
+					// it is in the running state to rebuild the configuration
+					if _, ok := runningTasks[task.ID]; !ok {
+						runningTasks[task.ID] = "ADDED"
+					}
+				} else {
+					// the subscribe listener closed, restart it (maybe
+					// there was a leader re-election).
+					if len(p.Masters) == 0 {
+						subscribed = false
+						taskAddedChan = nil
+					} else {
+						taskAddedChan, taskUpdatedChan = p.subscribeMesos(p.Masters)
+						if taskAddedChan == nil {
+							subscribed = false
+						}
+					}
+				}
+			case task, ok := <-taskUpdatedChan:
+				if ok {
+					var configuration *types.Configuration
+					var tasks []state.Task
+					if taskStatus, ok := runningTasks[task.ID]; ok {
+						if taskStatus == "ADDED" {
+							if task.State == "RUNNING" {
+								configuration, tasks = p.buildConfiguration()
+							} else {
+								delete(runningTasks, task.ID)
+							}
+						} else {
+							if task.State == "EXITED" {
+								delete(runningTasks, task.ID)
+								configuration, tasks = p.buildConfiguration()
+							}
+						}
+					} else {
+						if task.State == "RUNNING" && len(p.SubscribeLabels) == 0 {
+							configuration, tasks = p.buildConfiguration()
+						}
+					}
+					if configuration != nil {
+						updateTasks(tasks)
+						configurationChan <- types.ConfigMessage{
+							ProviderName:  "mesos",
+							Configuration: configuration,
+						}
+					}
+				} else {
+					taskUpdatedChan = nil
 				}
 			case masters := <-changed:
 				if len(masters) == 0 || masters[0] == "" {
@@ -92,8 +213,13 @@ func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *s
 				}
 				log.Debugf("new masters detected: %v", masters)
 				p.Masters = masters
-				configuration := p.buildConfiguration()
+				if p.Subscribe && len(masters) > 0 && !subscribed {
+					taskAddedChan, taskUpdatedChan = p.subscribeMesos(p.Masters)
+					subscribed = taskAddedChan != nil
+				}
+				configuration, tasks := p.buildConfiguration()
 				if configuration != nil {
+					updateTasks(tasks)
 					configurationChan <- types.ConfigMessage{
 						ProviderName:  "mesos",
 						Configuration: configuration,
@@ -128,4 +254,109 @@ func detectMasters(zk string, masters []string) <-chan []string {
 		changed <- masters
 	}
 	return changed
+}
+
+func (p *Provider) subscribeMesos(masters []string) (<-chan state.Task, <-chan state.Task) {
+	var subscribeResp *http.Response
+	var masterUri url.URL
+
+	for _, master := range masters {
+		log.Debugf("Attempting to connect to master %v", master)
+		masterUri = url.URL{
+			Scheme: "http",
+			Host:   master,
+			Path:   "api/v1",
+		}
+		r, err := http.NewRequest("POST", masterUri.String(), strings.NewReader(`{"type":"SUBSCRIBE"}`))
+		r.Header.Set("Content-Type", "application/json")
+		r.Header.Set("Accept", "application/json")
+		if err != nil {
+			log.Errorf("Failed to initialize mesos task subscription: %v", err)
+			continue
+		}
+		resp, err := (&http.Client{}).Do(r)
+		if err != nil {
+			log.Errorf("Failed to start mesos task subscription: %v", err)
+			continue
+		}
+		subscribeResp = resp
+	}
+	if subscribeResp == nil {
+		return nil, nil
+	}
+
+	taskAdded := make(chan state.Task)
+	taskUpdated := make(chan state.Task)
+	go func(resp *http.Response) {
+		defer func() {
+			close(taskAdded)
+			close(taskUpdated)
+		}()
+		log.Debugf("Starting mesos task subscription on %v", masterUri.String())
+		reader := bufio.NewReader(resp.Body)
+		readBuff := []byte{}
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				log.Errorf("Error reading length response from mesos subscription: %v", err)
+				return
+			}
+			line = line[:len(line)-1]
+			if sz, err := strconv.Atoi(line); err == nil {
+				if cap(readBuff) < sz {
+					readBuff = make([]byte, sz)
+				} else {
+					readBuff = readBuff[:sz]
+				}
+				if n, err := io.ReadFull(reader, readBuff); err != nil {
+					log.Errorf("Error reading data response from mesos subscription: %v", err)
+					return
+				} else if n != sz {
+					log.Errorf("Error reading data response from mesos subscription: expected data of length %d but got %d", sz, n)
+					return
+				}
+				var event mesosEvent
+				if err := json.Unmarshal(readBuff, &event); err == nil {
+					log.Debugf("Received event of type %v from mesos.", event.Type)
+					if event.Type == "TASK_ADDED" {
+						if len(p.SubscribeFilterLabels) > 0 {
+						matchLabel:
+							for _, label := range p.SubscribeFilterLabels {
+								for _, taskLabel := range event.TaskAdded.Task.Labels.Labels {
+									if taskLabel.Key == label {
+										taskAdded <- state.Task{
+											ID: event.TaskAdded.Task.TaskId.Value,
+										}
+										break matchLabel
+									}
+								}
+							}
+						}
+					} else if event.Type == "TASK_UPDATED" {
+						t := state.Task{
+							ID: event.TaskUpdated.Status.TaskId.Value,
+						}
+						switch event.TaskUpdated.State {
+						case "TASK_RUNNING":
+							t.State = "RUNNING"
+						case "TASK_FINISHED", "TASK_FAILED", "TASK_KILLED", "TASK_ERROR",
+							"TASK_DROPPED", "TASK_GONE":
+							t.State = "EXITED"
+						}
+
+						if t.State != "" {
+							taskUpdated <- t
+						}
+					}
+				} else {
+					log.Errorf("Error parsing data response from mesos subscription: %v", err)
+					return
+				}
+			} else {
+				log.Errorf("Error parsing length response from mesos subscription: %v", err)
+				return
+			}
+		}
+	}(subscribeResp)
+	return taskAdded, taskUpdated
 }


### PR DESCRIPTION
### What does this PR do?

Currently, the Mesos backend doesn't respond to events, and the way Traefik gets it's information about Mesos tasks is by polling. Every 30 seconds (the default) Traefik will ping Mesos about its current state and refresh it's configuration. This obviously has some drawbacks - when deploying a new application, the entire process could take less than 30 seconds, but due to the way polling works, your clients will see your application as down until Traefik updates its state.

In Mesos 1.1, the [events](http://mesos.apache.org/documentation/latest/operator-http-api/#events) API was introduced so that operators could listen to events on the Mesos state. This allows services, like Traefik, to have an up to date view on the Mesos cluster state.

This PR introduces two new options, `Subscribe` (boolean) and `SubscribeLabels`, and changes the functionality of `RefreshSeconds`. When `Subscribe` is set to true, Traefik will use the Events API to listen on Mesos state. Traefik will refresh the state when a task goes in to the `RUNNING` state or when a task is killed that Traefik is currently routing traffic to. Optionally `SubscribeLabels` can be set so that only tasks with a certain label cause a state refresh. With these new options `RefreshSeconds` can be set to 0 to disable polling. Setting `watch` to false will disable both options.

These new options are not enabled by default in order to maintain backwards compatibility.

### Motivation

With the addition of the events API (and the health check API added some time ago), this brings the Mesos backend almost up to par with other backends. I prefer using the Mesos backend as the API is more stable than Marathon's and the Mesos backend will support other frameworks (like Aurora). 

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Implementation Details:

I built off the current existing code in order to maintain backwards compatibility with Mesos <1.1. However, ideally this can built by exclusively using the subscribe command and maintaining state there, which would probably be a bit more performant.

Tests:

I haven't added any tests because the new functionality depends quite a bit a mesos (since it only plugs in the Event API into the current existing architecture). It would require integration tests with e a Mesos instance which I think may be cumbersome to setup.