### PR TITLE
Normalize serviceName added to the service backend names

### DIFF
--- a/provider/consul/consul_catalog_test.go
+++ b/provider/consul/consul_catalog_test.go
@@ -12,14 +12,6 @@ import (
 )
 
 func TestConsulCatalogGetFrontendRule(t *testing.T) {
-	provider := &CatalogProvider{
-		Domain:               "localhost",
-		Prefix:               "traefik",
-		FrontEndRule:         "Host:{{.ServiceName}}.{{.Domain}}",
-		frontEndRuleTemplate: template.New("consul catalog frontend rule"),
-	}
-	provider.setupFrontEndTemplate()
-
 	testCases := []struct {
 		desc     string
 		service  serviceUpdate
@@ -70,6 +62,14 @@ func TestConsulCatalogGetFrontendRule(t *testing.T) {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
+
+			provider := &CatalogProvider{
+				Domain:               "localhost",
+				Prefix:               "traefik",
+				FrontEndRule:         "Host:{{.ServiceName}}.{{.Domain}}",
+				frontEndRuleTemplate: template.New("consul catalog frontend rule"),
+			}
+			provider.setupFrontEndTemplate()
 
 			actual := provider.getFrontendRule(test.service)
 			assert.Equal(t, test.expected, actual)

--- a/provider/docker/docker.go
+++ b/provider/docker/docker.go
@@ -433,9 +433,9 @@ func (p *Provider) getServicePriority(container dockerData, serviceName string) 
 // Extract backend from labels for a given service and a given docker container
 func (p *Provider) getServiceBackend(container dockerData, serviceName string) string {
 	if value, ok := getContainerServiceLabel(container, serviceName, "frontend.backend"); ok {
-		return container.ServiceName + "-" + value
+		return provider.Normalize(container.ServiceName + "-" + value)
 	}
-	return strings.TrimPrefix(container.ServiceName, "/") + "-" + p.getBackend(container) + "-" + provider.Normalize(serviceName)
+	return provider.Normalize(strings.TrimPrefix(container.ServiceName, "/") + "-" + p.getBackend(container) + "-" + serviceName)
 }
 
 // Extract rule from labels for a given service and a given docker container

--- a/provider/docker/docker.go
+++ b/provider/docker/docker.go
@@ -435,7 +435,7 @@ func (p *Provider) getServiceBackend(container dockerData, serviceName string) s
 	if value, ok := getContainerServiceLabel(container, serviceName, "frontend.backend"); ok {
 		return provider.Normalize(container.ServiceName + "-" + value)
 	}
-	return provider.Normalize(strings.TrimPrefix(container.ServiceName, "/") + "-" + p.getBackend(container) + "-" + serviceName)
+	return provider.Normalize(container.ServiceName + "-" + p.getBackend(container) + "-" + serviceName)
 }
 
 // Extract rule from labels for a given service and a given docker container

--- a/provider/docker/service_test.go
+++ b/provider/docker/service_test.go
@@ -174,8 +174,18 @@ func TestDockerGetServiceBackend(t *testing.T) {
 			expected:  "foo-foo-myservice",
 		},
 		{
+			container: containerJSON(name("foo.bar")),
+			expected:  "foo-bar-foo-bar-myservice",
+		},
+		{
 			container: containerJSON(labels(map[string]string{
 				types.LabelBackend: "another-backend",
+			})),
+			expected: "fake-another-backend-myservice",
+		},
+		{
+			container: containerJSON(labels(map[string]string{
+				types.LabelBackend: "another.backend",
 			})),
 			expected: "fake-another-backend-myservice",
 		},


### PR DESCRIPTION
### What does this PR do?

This PR fix:

- flaky test in consul
- Normalize serviceName added to the service backends names

### Motivation

Fixes: #2630 

### More

- [x] Added/updated tests
