### PR TITLE
Improve Marathon service label documentation.

### DIFF
--- a/docs/configuration/backends/marathon.md
+++ b/docs/configuration/backends/marathon.md
@@ -150,12 +150,15 @@ domain = "marathon.localhost"
 
 To enable constraints see [backend-specific constraints section](/configuration/commons/#backend-specific).
 
-
 ## Labels: overriding default behaviour
 
-### On Containers
+Marathon labels may be used to dynamically change the routing and forwarding behaviour.
 
-Labels can be used on containers to override default behaviour:
+They may be specified on one of two levels: Application or service.
+
+### Application Level
+
+The following labels can be defined on Marathon applications. They adjust the behaviour for the entire application.
 
 | Label                                                                 | Description                                                                                                                                                                        |
 |-----------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -180,9 +183,9 @@ Labels can be used on containers to override default behaviour:
 | `traefik.frontend.entryPoints=http,https`                             | assign this frontend to entry points `http` and `https`. Overrides `defaultEntryPoints`.                                                                                           |
 | `traefik.frontend.auth.basic=EXPR`                                    | Sets basic authentication for that frontend in CSV format: `User:Hash,User:Hash`.                                                                                                  |
 
-### On Services
+### Service Level
 
-If several ports need to be exposed from a container, the services labels can be used:
+For applications that expose multiple ports, specific labels can be used to extract one frontend/backend configuration pair per port. Each such pair is called a _service_. The (freely choosable) name of the service is an integral part of the service label name.
 
 | Label                                                  | Description                                                                                          |
 |--------------------------------------------------------|------------------------------------------------------------------------------------------------------|

--- a/docs/user-guide/marathon.md
+++ b/docs/user-guide/marathon.md
@@ -28,6 +28,24 @@ Following is the order by which Traefik tries to identify the port (the first on
 1. The port from the application's `portDefinitions` field (possibly indexed through the `traefik.portIndex` label, otherwise the first one).
 1. The port from the application's `ipAddressPerTask` field (possibly indexed through the `traefik.portIndex` label, otherwise the first one).
 
+## Applications with multiple ports
+
+Some Marathon applications may expose multiple ports. Traefik supports creating one so-called _service_ per port using [specific labels](/configuration/backends/marathon#service-level).
+
+For instance, assume that a Marathon application exposes a web API on port 80 and an admin interface on port 8080. It would then be possible to make each service available by specifying the following Marathon labels:
+
+```
+traefik.web.port=80
+```
+
+```
+traefik.admin.port=8080
+```
+
+(Note that the service names `web` and `admin` can be chosen arbitrarily.)
+
+Technically, Traefik will create one pair of frontend and backend configurations for each service.
+
 ## Achieving high availability
 
 ### Scenarios


### PR DESCRIPTION
### What does this PR do?

Improve documentation on Marathon service labels.

### Motivation

End-user support questions demonstrated that the distinction between application and service labels wasn't clear. Specifically, it wasn't obvious that services can be used to leverage Marathon applications exposing multiple ports.