### PR TITLE
Fix bug report command

### DIFF
--- a/cmd/traefik/bug.go
+++ b/cmd/traefik/bug.go
@@ -84,7 +84,7 @@ Add more configuration information here.
 )
 
 // newBugCmd builds a new Bug command
-func newBugCmd(traefikConfiguration interface{}, traefikPointersConfiguration interface{}) *flaeg.Command {
+func newBugCmd(traefikConfiguration *TraefikConfiguration, traefikPointersConfiguration *TraefikConfiguration) *flaeg.Command {
 
 	//version Command init
 	return &flaeg.Command{
@@ -99,7 +99,7 @@ func newBugCmd(traefikConfiguration interface{}, traefikPointersConfiguration in
 	}
 }
 
-func runBugCmd(traefikConfiguration interface{}) func() error {
+func runBugCmd(traefikConfiguration *TraefikConfiguration) func() error {
 	return func() error {
 
 		body, err := createBugReport(traefikConfiguration)
@@ -113,7 +113,7 @@ func runBugCmd(traefikConfiguration interface{}) func() error {
 	}
 }
 
-func createBugReport(traefikConfiguration interface{}) (string, error) {
+func createBugReport(traefikConfiguration *TraefikConfiguration) (string, error) {
 	var version bytes.Buffer
 	if err := getVersionPrint(&version); err != nil {
 		return "", err
@@ -124,7 +124,7 @@ func createBugReport(traefikConfiguration interface{}) (string, error) {
 		return "", err
 	}
 
-	config, err := anonymize.Do(&traefikConfiguration, true)
+	config, err := anonymize.Do(traefikConfiguration, true)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/traefik/bug_test.go
+++ b/cmd/traefik/bug_test.go
@@ -6,16 +6,27 @@ import (
 	"github.com/containous/traefik/cmd/traefik/anonymize"
 	"github.com/containous/traefik/configuration"
 	"github.com/containous/traefik/provider/file"
+	"github.com/containous/traefik/types"
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_createBugReport(t *testing.T) {
-	traefikConfiguration := TraefikConfiguration{
+	traefikConfiguration := &TraefikConfiguration{
 		ConfigFile: "FOO",
 		GlobalConfiguration: configuration.GlobalConfiguration{
 			EntryPoints: configuration.EntryPoints{
 				"goo": &configuration.EntryPoint{
 					Address: "hoo.bar",
+					Auth: &types.Auth{
+						Basic: &types.Basic{
+							UsersFile: "foo Basic UsersFile",
+							Users:     types.Users{"foo Basic Users 1", "foo Basic Users 2", "foo Basic Users 3"},
+						},
+						Digest: &types.Digest{
+							UsersFile: "foo Digest UsersFile",
+							Users:     types.Users{"foo Digest Users 1", "foo Digest Users 2", "foo Digest Users 3"},
+						},
+					},
 				},
 			},
 			File: &file.Provider{
@@ -27,6 +38,11 @@ func Test_createBugReport(t *testing.T) {
 
 	report, err := createBugReport(traefikConfiguration)
 	assert.NoError(t, err, report)
+
+	// exported anonymous configuration
+	assert.NotContains(t, "web Basic Users ", report)
+	assert.NotContains(t, "foo Digest Users ", report)
+	assert.NotContains(t, "hoo.bar", report)
 }
 
 func Test_anonymize_traefikConfiguration(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Remove the use of `interface{}` in the bug report command.

### Motivation

Fixes #2636

### More

- [x] Added/updated tests
