### PR TITLE
Use gorilla readMessage and writeMessage instead of just an io.Copy

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -481,7 +481,7 @@ imports:
 - name: github.com/urfave/negroni
   version: 490e6a555d47ca891a89a150d0c1ef3922dfffe9
 - name: github.com/vulcand/oxy
-  version: 7e9763c4dc71b9758379da3581e6495c145caaab
+  version: bf0e6bab094f7b909a8d94ba9d7b74aaf7cc3025
   repo: https://github.com/containous/oxy.git
   vcs: git
   subpackages:

--- a/vendor/github.com/vulcand/oxy/utils/netutils.go
+++ b/vendor/github.com/vulcand/oxy/utils/netutils.go
@@ -132,7 +132,7 @@ func RemoveHeaders(headers http.Header, names ...string) {
 }
 
 // Parse the MIME media type value of a header.
-func GetHeaderMediaType(headers http.Header, name string) (string, error)  {
+func GetHeaderMediaType(headers http.Header, name string) (string, error) {
 	mediatype, _, err := mime.ParseMediaType(headers.Get(name))
 	return mediatype, err
 }


### PR DESCRIPTION
### What does this PR do?
Fix a bug in websocket
related to: https://github.com/containous/oxy/pull/48
### Motivation
Fixes #2629

### More
Fix a bug with packet loss in websocket underlying connection. Instead of use this connection, we read messages with gorilla and write messages with gorilla