### PR TITLE
We need to flush the end of the body when retry is streamed

### DIFF
--- a/middlewares/retry.go
+++ b/middlewares/retry.go
@@ -56,6 +56,7 @@ func (retry *Retry) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		// It's a stream request and the body gets already sent to the client.
 		// Therefore we should not send the response a second time.
 		if recorder.streamingResponseStarted {
+			recorder.Flush()
 			break
 		}
 

--- a/middlewares/retry_test.go
+++ b/middlewares/retry_test.go
@@ -151,5 +151,4 @@ func TestRetryWithFlush(t *testing.T) {
 	if responseRecorder.Body.String() != "FULL DATA" {
 		t.Errorf("Wrong body %q want %q", responseRecorder.Body.String(), "FULL DATA")
 	}
-
 }

--- a/middlewares/retry_test.go
+++ b/middlewares/retry_test.go
@@ -134,3 +134,22 @@ type countingRetryListener struct {
 func (l *countingRetryListener) Retried(req *http.Request, attempt int) {
 	l.timesCalled++
 }
+
+func TestRetryWithFlush(t *testing.T) {
+	next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(200)
+		rw.Write([]byte("FULL "))
+		rw.(http.Flusher).Flush()
+		rw.Write([]byte("DATA"))
+	})
+
+	retry := NewRetry(1, next, &countingRetryListener{})
+	responseRecorder := httptest.NewRecorder()
+
+	retry.ServeHTTP(responseRecorder, &http.Request{})
+
+	if responseRecorder.Body.String() != "FULL DATA" {
+		t.Errorf("Wrong body %q want %q", responseRecorder.Body.String(), "FULL DATA")
+	}
+
+}


### PR DESCRIPTION
### What does this PR do?
Fix an issue in retry middleware

If we flush during the response and not at the end, the last part of the Body could be lost.

### Motivation
Fixes #2637

### More

- [X] Added/updated tests
