### PR TITLE
Use gorilla readMessage and writeMessage instead of just an io.Copy

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -520,7 +520,7 @@ imports:
 - name: github.com/VividCortex/gohistogram
   version: 51564d9861991fb0ad0f531c99ef602d0f9866e6
 - name: github.com/vulcand/oxy
-  version: 7b6e758ab449705195df638765c4ca472248908a
+  version: 812cebb8c764f2a78cb806267648b8728b4599ad
   repo: https://github.com/containous/oxy.git
   vcs: git
   subpackages:


### PR DESCRIPTION
### What does this PR do?
Fix a bug in websocket
related to: https://github.com/containous/oxy/pull/48
### Motivation
Fixes #2629

### More
Fix a bug with packet loss in websocket underlying connection. Instead of use this connection, we read messages with gorilla and write messages with gorilla
  