### PR TITLE
fix: list entries parsing.

### DIFF
--- a/autogen/gentemplates/gen.go
+++ b/autogen/gentemplates/gen.go
@@ -572,7 +572,7 @@ var _templatesKvTmpl = []byte(`{{$frontends := List .Prefix "/frontends/" }}
 
 [frontends]{{range $frontends}}
     {{$frontend := Last .}}
-    {{$entryPoints := SplitGet . "/entrypoints"}}
+    {{$entryPoints := GetList . "/entrypoints"}}
     [frontends."{{$frontend}}"]
     backend = "{{Get "" . "/backend"}}"
     passHostHeader = {{Get "true" . "/passHostHeader"}}

--- a/templates/kv.tmpl
+++ b/templates/kv.tmpl
@@ -50,7 +50,7 @@
 
 [frontends]{{range $frontends}}
     {{$frontend := Last .}}
-    {{$entryPoints := SplitGet . "/entrypoints"}}
+    {{$entryPoints := GetList . "/entrypoints"}}
     [frontends."{{$frontend}}"]
     backend = "{{Get "" . "/backend"}}"
     passHostHeader = {{Get "true" . "/passHostHeader"}}


### PR DESCRIPTION
### What does this PR do?

Support list entries in KV.

ex:
```
foo/0: bar
foo/1: bir
foo/2: bur
```

### Motivation

Fixes #2667

### More

- [x] Added/updated tests (see #2661)

### Additional Notes

Fully compatible with the previous behavior.

  