### PR TITLE
Change the default host prefix to container name

### DIFF
--- a/provider/ecs/ecs.go
+++ b/provider/ecs/ecs.go
@@ -314,7 +314,7 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 				}
 
 				instances = append(instances, ecsInstance{
-					fmt.Sprintf("%s-%s", strings.Replace(*task.Group, ":", "-", 1), *container.Name),
+					*container.Name,
 					(*task.TaskArn)[len(*task.TaskArn)-12:],
 					task,
 					taskDefinition,


### PR DESCRIPTION
### What does this PR do?

The container name is likely what you want to call the service. Instead
of having a prefix of the target/cluster.

If you had a cluster called `service` and a service called `x`, the hostname would be `service-x.{domain}`.

What you likely want is to have `x.{domain}`.

### Motivation

Better service naming

### Additional Notes

This service is not backward compatible. If you have traefik running with ECS, it will change the host names under the hood.

I definitely welcome ideas on how to make this change backward compatible. One way I thought about was to get the hostname from a label on the service. There is already a pretty good label support for other things.
