### PR TITLE
Return errors from Docker client.Events

### DIFF
--- a/provider/docker/docker.go
+++ b/provider/docker/docker.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"context"
+	"io"
 	"math"
 	"net"
 	"net/http"

--- a/provider/docker/docker.go
+++ b/provider/docker/docker.go
@@ -237,15 +237,21 @@ func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *s
 					}
 
 					eventsc, errc := dockerClient.Events(ctx, options)
-					for event := range eventsc {
-						if event.Action == "start" ||
-							event.Action == "die" ||
-							strings.HasPrefix(event.Action, "health_status") {
-							startStopHandle(event)
+					for {
+						select {
+						case event := <-eventsc:
+							if event.Action == "start" ||
+								event.Action == "die" ||
+								strings.HasPrefix(event.Action, "health_status") {
+								startStopHandle(event)
+							}
+						case err := <-errc:
+							if err == io.EOF {
+								log.Debug("Provider event stream closed")
+							}
+
+							return err
 						}
-					}
-					if err := <-errc; err != nil {
-						return err
 					}
 				}
 			}


### PR DESCRIPTION
### What does this PR do?

Logs Errors from the Docker `client.Events` channel and prevents hangs when the event stream will no longer be pushed into.

### Motivation

Backends getting out of sync during intermittent connection issues to the Docker daemon, and not being able to force them to refresh.

### More

- [ ] Added/updated tests

### Additional Notes

All errors in the Docker `client.Events` method cause events to stop being processed, leaving the messages channel open (https://github.com/moby/moby/blob/master/client/events.go#L20-L71). Since events are used as a notification mechanism it's save to reconnect if we lose one or more events.

This area of the codebase is untested. You can test/verify behaviours with a PoC I wrote here: 
``` golang
package main

import (
	"context"
	"fmt"

	"github.com/docker/docker/api/types"
	"github.com/docker/docker/api/types/filters"
	"github.com/docker/docker/client"
)

func main() {
	var err error

	cli, err := client.NewEnvClient()
	if err != nil {
		panic(err)
	}

	f := filters.NewArgs()
	f.Add("type", "container")

	options := types.EventsOptions{
		Filters: f,
	}

	ctx := context.Background()
	// ctx, cancel := context.WithCancel(ctx)

	eventsc, errc := cli.Events(ctx, options)
	for {
		select {
		case event := <-eventsc:
			fmt.Println("Received event: ", event)
		case err := <-errc:
			if err == nil {
				continue
			}

			fmt.Println("Received error: ", err)
			return
		}
	}
}
```
