### PR TITLE
Fix typo in anonymous usage log message.

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -261,14 +261,14 @@ func stats(globalConfiguration *configuration.GlobalConfiguration) {
 Stats collection is enabled.
 Many thanks for contributing to Traefik's improvement by allowing us to receive anonymous information from your configuration.
 Help us improve Traefik by leaving this feature on :)
-More details on: https://docs.traefik.io/basic/#collected-data
+More details on: https://docs.traefik.io/basics/#collected-data
 `)
 		collect(globalConfiguration)
 	} else {
 		log.Info(`
 Stats collection is disabled.
 Help us improve Traefik by turning this feature on :)
-More details on: https://docs.traefik.io/basic/#collected-data
+More details on: https://docs.traefik.io/basics/#collected-data
 `)
 	}
 }


### PR DESCRIPTION
Matches link to docs in log message to actual URL.