### PR TITLE
Challenge HTTP must ignore deprecated web.path option

### DIFF
--- a/integration/acme_test.go
+++ b/integration/acme_test.go
@@ -92,6 +92,16 @@ func (s *AcmeSuite) TestOnHostRuleRetrieveAcmeCertificateHTTP01(c *check.C) {
 	s.retrieveAcmeCertificate(c, testCase)
 }
 
+// Test OnHostRule option with none provided certificate and challenge HTTP-01 and web path
+func (s *AcmeSuite) TestOnHostRuleRetrieveAcmeCertificateHTTP01WithPath(c *check.C) {
+	testCase := AcmeTestCase{
+		traefikConfFilePath: "fixtures/acme/acme_http01_web.toml",
+		onDemand:            false,
+		domainToCheck:       acmeDomain}
+
+	s.retrieveAcmeCertificate(c, testCase)
+}
+
 // Test OnDemand option with a wildcard provided certificate
 func (s *AcmeSuite) TestOnDemandRetrieveAcmeCertificateWithWildcard(c *check.C) {
 	testCase := AcmeTestCase{

--- a/integration/fixtures/acme/acme_http01_web.toml
+++ b/integration/fixtures/acme/acme_http01_web.toml
@@ -1,0 +1,38 @@
+logLevel = "DEBUG"
+
+defaultEntryPoints = ["http", "https"]
+
+[entryPoints]
+  [entryPoints.http]
+  address = ":5002"
+  [entryPoints.https]
+  address = ":5001"
+    [entryPoints.https.tls]
+
+
+[web]
+path="/traefik"
+
+[acme]
+email = "test@traefik.io"
+storage = "/dev/null"
+entryPoint = "https"
+onDemand = {{.OnDemand}}
+OnHostRule = {{.OnHostRule}}
+caServer = "http://{{.BoulderHost}}:4000/directory"
+[acme.httpchallenge]
+entrypoint="http"
+
+[file]
+
+[backends]
+  [backends.backend]
+    [backends.backend.servers.server1]
+    url = "http://127.0.0.1:9010"
+
+
+[frontends]
+  [frontends.frontend]
+  backend = "backend"
+    [frontends.frontend.routes.test]
+    rule = "Host:traefik.acme.wtf"

--- a/server/server.go
+++ b/server/server.go
@@ -758,7 +758,9 @@ func (s *Server) addInternalPublicRoutes(entryPointName string, router *mux.Rout
 	if s.globalConfiguration.Ping != nil && s.globalConfiguration.Ping.EntryPoint != "" && s.globalConfiguration.Ping.EntryPoint == entryPointName {
 		s.globalConfiguration.Ping.AddRoutes(router)
 	}
+}
 
+func (s *Server) addACMERoutes(entryPointName string, router *mux.Router) {
 	if s.globalConfiguration.ACME != nil && s.globalConfiguration.ACME.HTTPChallenge != nil && s.globalConfiguration.ACME.HTTPChallenge.EntryPoint == entryPointName {
 		s.globalConfiguration.ACME.AddRoutes(router)
 	}
@@ -839,6 +841,9 @@ func (s *Server) buildInternalRouter(entryPointName, path string, internalMiddle
 	internalMuxRouter.Walk(wrapRoute(internalMiddlewares))
 
 	s.addInternalPublicRoutes(entryPointName, internalMuxSubrouter)
+
+	s.addACMERoutes(entryPointName, internalMuxRouter)
+
 	return internalMuxRouter
 }
 


### PR DESCRIPTION
### What does this PR do?
Ignore web.path when used with ACME HTTP-01 Challenge

### Motivation
Fix a bug in ACME HTTP-01 Challenge

### More
- [X] Added/updated tests
