### PR TITLE
Fix missing configuration for jaeger reporter

### DIFF
--- a/cmd/traefik/configuration.go
+++ b/cmd/traefik/configuration.go
@@ -211,9 +211,10 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 		Backend:     "jaeger",
 		ServiceName: "traefik",
 		Jaeger: &jaeger.Config{
-			SamplingServerURL: "http://localhost:5778/sampling",
-			SamplingType:      "const",
-			SamplingParam:     1.0,
+			SamplingServerURL:  "http://localhost:5778/sampling",
+			SamplingType:       "const",
+			SamplingParam:      1.0,
+			LocalAgentHostPort: "127.0.0.1:6832",
 		},
 		Zipkin: &zipkin.Config{
 			HTTPEndpoint: "http://localhost:9411/api/v1/spans",

--- a/docs/configuration/tracing.md
+++ b/docs/configuration/tracing.md
@@ -45,6 +45,12 @@ Træfik supports two backends: Jaeger and Zipkin.
     # Default: 1.0
     #
     SamplingParam = 1.0
+
+    # LocalAgentHostPort instructs reporter to send spans to jaeger-agent at this address
+    #
+    # Default: "127.0.0.1:6832"
+    #
+    LocalAgentHostPort = "127.0.0.1:6832"
 ```
 
 ## Zipkin

--- a/middlewares/tracing/jaeger/jaeger.go
+++ b/middlewares/tracing/jaeger/jaeger.go
@@ -15,9 +15,10 @@ const Name = "jaeger"
 
 // Config provides configuration settings for a jaeger tracer
 type Config struct {
-	SamplingServerURL string  `description:"set the sampling server url." export:"false"`
-	SamplingType      string  `description:"set the sampling type." export:"true"`
-	SamplingParam     float64 `description:"set the sampling parameter." export:"true"`
+	SamplingServerURL  string  `description:"set the sampling server url." export:"false"`
+	SamplingType       string  `description:"set the sampling type." export:"true"`
+	SamplingParam      float64 `description:"set the sampling parameter." export:"true"`
+	LocalAgentHostPort string  `description:"set jaeger-agent's host:port that the reporter will used." export:"false"`
 }
 
 // Setup sets up the tracer
@@ -29,7 +30,8 @@ func (c *Config) Setup(componentName string) (opentracing.Tracer, io.Closer, err
 			Param:             c.SamplingParam,
 		},
 		Reporter: &jaegercfg.ReporterConfig{
-			LogSpans: true,
+			LogSpans:           true,
+			LocalAgentHostPort: c.LocalAgentHostPort,
 		},
 	}
 


### PR DESCRIPTION
### What does this PR do?

This PR fix a missing configuration for Jaeger. 
Add property `LocalAgentHostPort` to allow user to configure host and port where Jaeger reporter will send span

### More

- [x] Added/updated documentation

### Additional Notes
The configuration will be like that now :
```toml
[tracing]
    backend = "jaeger"
    servicename = "powpow"
    [tracing.jaeger]
    SamplingType = "const"
    LocalAgentHostPort = "jaeger:6832"
    SamplingServerURL = "http://jaeger:5778/sampling"
    SamplingParam = 1.0
```
