### PR TITLE
Fix breaking change in web metrics

### DIFF
--- a/cmd/traefik/configuration.go
+++ b/cmd/traefik/configuration.go
@@ -30,7 +30,7 @@ import (
 // TraefikConfiguration holds GlobalConfiguration and other stuff
 type TraefikConfiguration struct {
 	configuration.GlobalConfiguration `mapstructure:",squash" export:"true"`
-	ConfigFile                        string `short:"c" description:"Configuration file to use (TOML)." export:"true"`
+	ConfigFile string                 `short:"c" description:"Configuration file to use (TOML)." export:"true"`
 }
 
 // NewTraefikDefaultPointersConfiguration creates a TraefikConfiguration with pointers default values
@@ -61,7 +61,8 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 	// TODO: Deprecated - default Metrics
 	defaultWeb.Metrics = &types.Metrics{
 		Prometheus: &types.Prometheus{
-			Buckets: types.Buckets{0.1, 0.3, 1.2, 5},
+			Buckets:    types.Buckets{0.1, 0.3, 1.2, 5},
+			EntryPoint: configuration.DefaultInternalEntryPointName,
 		},
 		Datadog: &types.Datadog{
 			Address:      "localhost:8125",
@@ -220,7 +221,7 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 	defaultMetrics := types.Metrics{
 		Prometheus: &types.Prometheus{
 			Buckets:    types.Buckets{0.1, 0.3, 1.2, 5},
-			EntryPoint: "traefik",
+			EntryPoint: configuration.DefaultInternalEntryPointName,
 		},
 		Datadog: &types.Datadog{
 			Address:      "localhost:8125",

--- a/cmd/traefik/configuration.go
+++ b/cmd/traefik/configuration.go
@@ -30,7 +30,7 @@ import (
 // TraefikConfiguration holds GlobalConfiguration and other stuff
 type TraefikConfiguration struct {
 	configuration.GlobalConfiguration `mapstructure:",squash" export:"true"`
-	ConfigFile string                 `short:"c" description:"Configuration file to use (TOML)." export:"true"`
+	ConfigFile                        string `short:"c" description:"Configuration file to use (TOML)." export:"true"`
 }
 
 // NewTraefikDefaultPointersConfiguration creates a TraefikConfiguration with pointers default values

--- a/integration/basic_test.go
+++ b/integration/basic_test.go
@@ -336,3 +336,25 @@ func (s *SimpleSuite) TestWithUnexistingEntrypoint(c *check.C) {
 	err = try.GetRequest("http://127.0.0.1:8000/whoami", 1*time.Second, try.StatusCodeIs(http.StatusOK))
 	c.Assert(err, checker.IsNil)
 }
+
+func (s *SimpleSuite) TestMetricsPrometheusDefaultEntrypoint(c *check.C) {
+
+	s.createComposeProject(c, "base")
+	s.composeProject.Start(c)
+
+	cmd, output := s.traefikCmd("--defaultEntryPoints=http", "--entryPoints=Name:http Address::8000", "--web", "--web.metrics.prometheus.buckets=0.1,0.3,1.2,5.0", "--docker", "--debug")
+	defer output(c)
+
+	err := cmd.Start()
+	c.Assert(err, checker.IsNil)
+	defer cmd.Process.Kill()
+
+	err = try.GetRequest("http://127.0.0.1:8080/api/providers", 1*time.Second, try.BodyContains("PathPrefix"))
+	c.Assert(err, checker.IsNil)
+
+	err = try.GetRequest("http://127.0.0.1:8000/whoami", 1*time.Second, try.StatusCodeIs(http.StatusOK))
+	c.Assert(err, checker.IsNil)
+
+	err = try.GetRequest("http://127.0.0.1:8080/metrics", 1*time.Second, try.StatusCodeIs(http.StatusOK))
+	c.Assert(err, checker.IsNil)
+}


### PR DESCRIPTION
### What does this PR do?
Set a default value for web.metrics.prometheus.entrypoint when it's used in deprecated version

### Motivation
Fix a breaking change

### More
- [x] Added/updated tests