### PR TITLE
remove unecessary mutex usage in healthchecks

### DIFF
--- a/healthcheck/healthcheck.go
+++ b/healthcheck/healthcheck.go
@@ -49,7 +49,6 @@ type BackendHealthCheck struct {
 
 //HealthCheck struct
 type HealthCheck struct {
-	mutex    sync.Mutex
 	Backends map[string]*BackendHealthCheck
 	cancel   context.CancelFunc
 }
@@ -78,14 +77,12 @@ func NewBackendHealthCheck(options Options, backendName string) *BackendHealthCh
 
 //SetBackendsConfiguration set backends configuration
 func (hc *HealthCheck) SetBackendsConfiguration(parentCtx context.Context, backends map[string]*BackendHealthCheck) {
-	hc.mutex.Lock()
 	hc.Backends = backends
 	if hc.cancel != nil {
 		hc.cancel()
 	}
 	ctx, cancel := context.WithCancel(parentCtx)
 	hc.cancel = cancel
-	hc.mutex.Unlock()
 
 	for _, backend := range backends {
 		currentBackend := backend


### PR DESCRIPTION
This mutex was introduced in https://github.com/containous/traefik/pull/2287 but it actually has no effect. Executing the health check tests with `go test -race ./...` does not yield any difference. In both cases, it does not report any race.