### PR TITLE
Disable websocket compression

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1027,7 +1027,7 @@
     "roundrobin",
     "utils"
   ]
-  revision = "fd0f370c961f6aa304379f4106e76ffe5ed7e97a"
+  revision = "fd6f71c694e2ab8b584c50b98ab4825027feb315"
   source = "https://github.com/containous/oxy.git"
 
 [[projects]]

--- a/vendor/github.com/vulcand/oxy/forward/fwd.go
+++ b/vendor/github.com/vulcand/oxy/forward/fwd.go
@@ -283,8 +283,6 @@ func (f *httpForwarder) serveWebSocket(w http.ResponseWriter, req *http.Request,
 
 	dialer := websocket.DefaultDialer
 
-	dialer.EnableCompression = strings.Contains(req.Header.Get("Sec-Websocket-Extensions"), "permessage-deflate")
-
 	if outReq.URL.Scheme == "wss" && f.tlsClientConfig != nil {
 		dialer.TLSClientConfig = f.tlsClientConfig.Clone()
 		// WebSocket is only in http/1.1
@@ -325,8 +323,6 @@ func (f *httpForwarder) serveWebSocket(w http.ResponseWriter, req *http.Request,
 	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool {
 		return true
 	}}
-
-	upgrader.EnableCompression = strings.Contains(resp.Header.Get("Sec-Websocket-Extensions"), "permessage-deflate")
 
 	utils.RemoveHeaders(resp.Header, WebsocketUpgradeHeaders...)
 


### PR DESCRIPTION
### What does this PR do?
Disable websocket compression

### Motivation
WebSocket compression with gorilla failed if server do not manage server_no_context_takeover and client_no_context_takeover.
That's why for now we will disable compression
fixes: #2714
related to: containous/oxy#51
### More

- [X] Updated tests