### PR TITLE
Fix config duplication detection and throttle goroutine lifecycle.

### DIFF
--- a/server/throttler.go
+++ b/server/throttler.go
@@ -1,0 +1,102 @@
+package server
+
+import (
+	"encoding/json"
+	"reflect"
+	"time"
+
+	"github.com/containous/traefik/log"
+	"github.com/containous/traefik/safe"
+	"github.com/containous/traefik/types"
+	"github.com/eapache/channels"
+)
+
+// providerUpdateThrottler is responsible for throttling configuration updates
+// in order to prevent overloading the server.
+type providerUpdateThrottler struct {
+	server           *Server
+	throttleDuration time.Duration
+	// providerThrottledConfigUpdates manages per-provider channels to throttle
+	// configuration updates.
+	providerThrottledConfigUpdates map[string]chan types.ConfigMessage
+	// currentDirtyConfigurations represents configurations which have been
+	// accepted already but may still be dirty (i.e., not persisted into the
+	// server struct yet).
+	currentDirtyConfigurations types.Configurations
+}
+
+func newProviderUpdateThrottler(s *Server, throttleDuration time.Duration) *providerUpdateThrottler {
+	return &providerUpdateThrottler{
+		server:                         s,
+		throttleDuration:               throttleDuration,
+		providerThrottledConfigUpdates: make(map[string]chan types.ConfigMessage),
+		currentDirtyConfigurations:     make(types.Configurations),
+	}
+}
+
+func (t *providerUpdateThrottler) process(stop chan bool, configMsg types.ConfigMessage) {
+	t.server.defaultConfigurationValues(configMsg.Configuration)
+	provName := configMsg.ProviderName
+	jsonConf, _ := json.Marshal(configMsg.Configuration)
+	log.Debugf("Configuration received from provider %s: %s", provName, string(jsonConf))
+
+	currentConfig, ok := t.currentDirtyConfigurations[provName]
+	if !ok {
+		currentConfigurations := t.server.currentConfigurations.Get().(types.Configurations)
+		currentConfig = currentConfigurations[provName]
+		t.currentDirtyConfigurations[provName] = currentConfig
+	}
+
+	if configMsg.Configuration == nil ||
+		configMsg.Configuration.Backends == nil &&
+			configMsg.Configuration.Frontends == nil &&
+			configMsg.Configuration.TLSConfiguration == nil {
+		log.Infof("Skipping empty configuration for provider %s", provName)
+	} else if reflect.DeepEqual(currentConfig, configMsg.Configuration) {
+		log.Infof("Skipping same configuration for provider %s", provName)
+	} else {
+		t.currentDirtyConfigurations[provName] = configMsg.Configuration
+		providerConfigUpdateCh, ok := t.providerThrottledConfigUpdates[provName]
+		if !ok {
+			providerConfigUpdateCh = make(chan types.ConfigMessage)
+			t.providerThrottledConfigUpdates[provName] = providerConfigUpdateCh
+			safe.Go(func() {
+				t.throttleProviderConfigReload(t.server.configurationValidatedChan, providerConfigUpdateCh, stop)
+			})
+		}
+		providerConfigUpdateCh <- configMsg
+	}
+}
+
+// throttleProviderConfigReload throttles the configuration reload speed for a single provider.
+// It will immediately publish a new configuration and then only publish the next configuration after the throttle duration.
+// Note that in the case it receives N new configs in the timeframe of the throttle duration after publishing,
+// it will publish the last of the newly received configurations.
+func (t *providerUpdateThrottler) throttleProviderConfigReload(publish chan<- types.ConfigMessage, in <-chan types.ConfigMessage, stop chan bool) {
+	ring := channels.NewRingChannel(1)
+	defer ring.Close()
+
+	safe.Go(func() {
+		for {
+			select {
+			case <-stop:
+				return
+			case nextConfig, more := <-ring.Out():
+				if !more {
+					return
+				}
+				publish <- nextConfig.(types.ConfigMessage)
+				time.Sleep(t.throttleDuration)
+			}
+		}
+	})
+
+	for {
+		select {
+		case <-stop:
+			return
+		case nextConfig := <-in:
+			ring.In() <- nextConfig
+		}
+	}
+}

--- a/server/throttler_test.go
+++ b/server/throttler_test.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/containous/traefik/types"
+)
+
+func TestThrottleProviderConfigReload(t *testing.T) {
+	throttleDuration := 30 * time.Millisecond
+	publishConfig := make(chan types.ConfigMessage)
+	providerConfig := make(chan types.ConfigMessage)
+	stop := make(chan bool)
+	defer func() {
+		stop <- true
+	}()
+
+	throttler := newProviderUpdateThrottler(nil, throttleDuration)
+	go throttler.throttleProviderConfigReload(publishConfig, providerConfig, stop)
+
+	publishedConfigCount := 0
+	stopConsumeConfigs := make(chan bool)
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			case <-stopConsumeConfigs:
+				return
+			case <-publishConfig:
+				publishedConfigCount++
+			}
+		}
+	}()
+
+	// publish 5 new configs, one new config each 10 milliseconds
+	for i := 0; i < 5; i++ {
+		providerConfig <- types.ConfigMessage{}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// after 50 milliseconds 5 new configs were published
+	// with a throttle duration of 30 milliseconds this means, we should have received 2 new configs
+	wantPublishedConfigCount := 2
+	if publishedConfigCount != wantPublishedConfigCount {
+		t.Errorf("%d times configs were published, want %d times", publishedConfigCount, wantPublishedConfigCount)
+	}
+
+	stopConsumeConfigs <- true
+
+	select {
+	case <-publishConfig:
+		// There should be exactly one more message that we receive after ~60 milliseconds since the start of the test.
+		select {
+		case <-publishConfig:
+			t.Error("extra config publication found")
+		case <-time.After(100 * time.Millisecond):
+			return
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("Last config was not published in time")
+	}
+}


### PR DESCRIPTION
This change fixes two problems:

- Configurations were [compared against the persisted configuration](https://github.com/containous/traefik/blob/5140bbe99a79b45f98c27fbb8e9b6833194af4cb/server/server.go#L373), not the latest received; the two may deviate when throttling is active. We introduce a local configuration cache and compare against that.
- The variable managing throttling goroutines was only [scoped to the local method](https://github.com/containous/traefik/blob/5140bbe99a79b45f98c27fbb8e9b6833194af4cb/server/server.go#L365), effectively disabling goroutine cleanup and producing a leak. We properly hook up the goroutines to live as long as the server does.

We also refactor the throttling logic into a dedicated struct. While not completely separating the concerns of the server from the throttler (we still need to reference a number of server methods/values inside the throttler), it's a step forward.

Additional changes:

- Pass the stop signal from listenProviders through to the throttler eventually, avoiding the need to close the server for a proper shutdown. 
- Exit throttler if ring buffer is closed. (Could happen before stop signal is processed.)
- Test: Return published configs through channel to rule out race conditions.
- Test: Invoke stop channel function earlier to trigger goroutine shutdown.