### PR TITLE
Tracing statusCodeTracker need to implement CloseNotify

### DIFF
--- a/middlewares/tracing/entrypoint.go
+++ b/middlewares/tracing/entrypoint.go
@@ -37,6 +37,6 @@ func (e *entryPointMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request,
 	recorder := newStatusCodeRecoder(w, 200)
 	next(recorder, r)
 
-	LogResponseCode(span, recorder.GetStatus())
+	LogResponseCode(span, recorder.Status())
 	span.Finish()
 }

--- a/middlewares/tracing/entrypoint.go
+++ b/middlewares/tracing/entrypoint.go
@@ -32,11 +32,11 @@ func (e *entryPointMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request,
 	LogRequest(span, r)
 	ext.SpanKindRPCServer.Set(span)
 
-	w = &statusCodeTracker{w, 200}
 	r = r.WithContext(opentracing.ContextWithSpan(r.Context(), span))
 
-	next(w, r)
+	recorder := newStatusCodeRecoder(w, 200)
+	next(recorder, r)
 
-	LogResponseCode(span, w.(*statusCodeTracker).status)
+	LogResponseCode(span, recorder.GetStatus())
 	span.Finish()
 }

--- a/middlewares/tracing/forwarder.go
+++ b/middlewares/tracing/forwarder.go
@@ -42,5 +42,5 @@ func (f *forwarderMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, 
 
 	next(recorder, r)
 
-	LogResponseCode(span, recorder.GetStatus())
+	LogResponseCode(span, recorder.Status())
 }

--- a/middlewares/tracing/forwarder.go
+++ b/middlewares/tracing/forwarder.go
@@ -38,9 +38,9 @@ func (f *forwarderMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, 
 
 	InjectRequestHeaders(r)
 
-	w = &statusCodeTracker{w, 200}
+	recorder := newStatusCodeRecoder(w, 200)
 
-	next(w, r)
+	next(recorder, r)
 
-	LogResponseCode(span, w.(*statusCodeTracker).status)
+	LogResponseCode(span, recorder.GetStatus())
 }

--- a/middlewares/tracing/status_code.go
+++ b/middlewares/tracing/status_code.go
@@ -8,7 +8,7 @@ import (
 
 type statusCodeRecoder interface {
 	http.ResponseWriter
-	GetStatus() int
+	Status() int
 }
 
 type statusCodeWithoutCloseNotify struct {
@@ -22,8 +22,8 @@ func (s *statusCodeWithoutCloseNotify) WriteHeader(status int) {
 	s.ResponseWriter.WriteHeader(status)
 }
 
-// GetStatus get response status
-func (s *statusCodeWithoutCloseNotify) GetStatus() int {
+// Status get response status
+func (s *statusCodeWithoutCloseNotify) Status() int {
 	return s.status
 }
 
@@ -34,7 +34,9 @@ func (s *statusCodeWithoutCloseNotify) Hijack() (net.Conn, *bufio.ReadWriter, er
 
 // Flush sends any buffered data to the client.
 func (s *statusCodeWithoutCloseNotify) Flush() {
-	s.ResponseWriter.(http.Flusher).Flush()
+	if flusher, ok := s.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
 }
 
 type statusCodeWithCloseNotify struct {

--- a/middlewares/tracing/status_code.go
+++ b/middlewares/tracing/status_code.go
@@ -1,0 +1,55 @@
+package tracing
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+)
+
+type statusCodeRecoder interface {
+	http.ResponseWriter
+	GetStatus() int
+}
+
+type statusCodeWithoutCloseNotify struct {
+	http.ResponseWriter
+	status int
+}
+
+// WriteHeader captures the status code for later retrieval.
+func (s *statusCodeWithoutCloseNotify) WriteHeader(status int) {
+	s.status = status
+	s.ResponseWriter.WriteHeader(status)
+}
+
+// GetStatus get response status
+func (s *statusCodeWithoutCloseNotify) GetStatus() int {
+	return s.status
+}
+
+// Hijack hijacks the connection
+func (s *statusCodeWithoutCloseNotify) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return s.ResponseWriter.(http.Hijacker).Hijack()
+}
+
+// Flush sends any buffered data to the client.
+func (s *statusCodeWithoutCloseNotify) Flush() {
+	s.ResponseWriter.(http.Flusher).Flush()
+}
+
+type statusCodeWithCloseNotify struct {
+	*statusCodeWithoutCloseNotify
+}
+
+func (s *statusCodeWithCloseNotify) CloseNotify() <-chan bool {
+	return s.ResponseWriter.(http.CloseNotifier).CloseNotify()
+}
+
+// newStatusCodeRecoder returns an initialized statusCodeRecoder.
+func newStatusCodeRecoder(rw http.ResponseWriter, status int) statusCodeRecoder {
+	recorder := &statusCodeWithoutCloseNotify{rw, status}
+	if _, ok := rw.(http.CloseNotifier); ok {
+		return &statusCodeWithCloseNotify{recorder}
+	}
+	return recorder
+}

--- a/middlewares/tracing/tracing.go
+++ b/middlewares/tracing/tracing.go
@@ -28,16 +28,6 @@ type Backend interface {
 	Setup(serviceName string) (opentracing.Tracer, io.Closer, error)
 }
 
-type statusCodeTracker struct {
-	http.ResponseWriter
-	status int
-}
-
-func (s *statusCodeTracker) WriteHeader(status int) {
-	s.status = status
-	s.ResponseWriter.WriteHeader(status)
-}
-
 // Setup Tracing middleware
 func (t *Tracing) Setup() {
 	var err error


### PR DESCRIPTION
### What does this PR do?

statucCodeTracker does not implement CloseNotify

### Motivation
 Avoid noise in logs:
```console
time="2018-01-19T16:11:56Z" level=warning msg="Upstream ResponseWriter of type *tracing.statusCodeTracker does not implement http.CloseNotifier. Returning dummy channel."
```
