### PR TITLE
Rename TLSConfigurations to TLS.

### DIFF
--- a/autogen/gentemplates/gen.go
+++ b/autogen/gentemplates/gen.go
@@ -522,7 +522,7 @@ func templatesKubernetesTmpl() (*asset, error) {
 
 var _templatesKvTmpl = []byte(`{{$frontends := List .Prefix "/frontends/" }}
 {{$backends :=  List .Prefix "/backends/"}}
-{{$tlsconfiguration := List .Prefix "/tlsconfiguration/"}}
+{{$tls := List .Prefix "/tls/"}}
 
 [backends]{{range $backends}}
 {{$backend := .}}
@@ -587,13 +587,13 @@ var _templatesKvTmpl = []byte(`{{$frontends := List .Prefix "/frontends/" }}
         {{end}}
 {{end}}
 
-{{range $tlsconfiguration}}
+{{range $tls}}
 {{$entryPoints := SplitGet . "/entrypoints"}}
-[[tlsConfiguration]]
+[[tls]]
     entryPoints = [{{range $entryPoints}}
       "{{.}}",
     {{end}}]
-    [tlsConfiguration.certificate]
+    [tls.certificate]
         certFile = """{{Get "" . "/certificate" "/certfile"}}"""
         keyFile = """{{Get "" . "/certificate" "/keyfile"}}"""
 {{end}}

--- a/docs/configuration/backends/file.md
+++ b/docs/configuration/backends/file.md
@@ -84,15 +84,15 @@ defaultEntryPoints = ["http", "https"]
   rule = "Path:/test"
 
 # HTTPS certificate
-[[tlsConfiguration]]
+[[tls]]
   entryPoints = ["https"]
-  [tlsConfiguration.certificate]
+  [tls.certificate]
     certFile = "path/to/my.cert"
     keyFile = "path/to/my.key"
     
-[[tlsConfiguration]]
+[[tls]]
   entryPoints = ["https"]
-  [tlsConfiguration.certificate]
+  [tls.certificate]
     certFile = "path/to/my/other.cert"
     keyFile = "path/to/my/other.key"
 ```
@@ -163,15 +163,15 @@ filename = "rules.toml"
   rule = "Path:/test"
   
 # HTTPS certificate
-[[tlsConfiguration]]
+[[tls]]
   entryPoints = ["https"]
-  [tlsConfiguration.certificate]
+  [tls.certificate]
     certFile = "path/to/my.cert"
     keyFile = "path/to/my.key"
     
-[[tlsConfiguration]]
+[[tls]]
   entryPoints = ["https"]
-  [tlsConfiguration.certificate]
+  [tls.certificate]
     certFile = "path/to/my/other.cert"
     keyFile = "path/to/my/other.key"
 

--- a/docs/user-guide/kv-config.md
+++ b/docs/user-guide/kv-config.md
@@ -274,14 +274,14 @@ Here is the toml configuration we would like to store in the store :
   backend = "backend2"
   rule = "Path:/test"
 
-[[tlsConfiguration]]
+[[tls]]
 entryPoints = ["https"]
-  [tlsConfiguration.certificate]
+  [tls.certificate]
     certFile = "path/to/your.cert"
     keyFile = "path/to/your.key"
-[[tlsConfiguration]]
+[[tls]]
 entryPoints = ["https","other-https"]
-  [tlsConfiguration.certificate]
+  [tls.certificate]
     certFile = """-----BEGIN CERTIFICATE-----
                       <cert file content>
                       -----END CERTIFICATE-----"""
@@ -335,19 +335,19 @@ And there, the same dynamic configuration in a KV Store (using `prefix = "traefi
 
 - certificate 1
 
-| Key                                                | Value              |
-|----------------------------------------------------|--------------------|
-| `/traefik/tlsconfiguration/1/entrypoints`          | `https`            |
-| `/traefik/tlsconfiguration/1/certificate/certfile` | `path/to/your.cert`|
-| `/traefik/tlsconfiguration/1/certificate/keyfile`  | `path/to/your.key` |
+| Key                                   | Value              |
+|---------------------------------------|--------------------|
+| `/traefik/tls/1/entrypoints`          | `https`            |
+| `/traefik/tls/1/certificate/certfile` | `path/to/your.cert`|
+| `/traefik/tls/1/certificate/keyfile`  | `path/to/your.key` |
 
 - certificate 2
 
-| Key                                                | Value                 |
-|----------------------------------------------------|-----------------------|
-| `/traefik/tlsconfiguration/2/entrypoints`          | `https,other-https`   |
-| `/traefik/tlsconfiguration/2/certificate/certfile` | `<cert file content>` |
-| `/traefik/tlsconfiguration/2/certificate/certfile` | `<key file content>`  |
+| Key                                   | Value                 |
+|---------------------------------------|-----------------------|
+| `/traefik/tls/2/entrypoints`          | `https,other-https`   |
+| `/traefik/tls/2/certificate/certfile` | `<cert file content>` |
+| `/traefik/tls/2/certificate/certfile` | `<key file content>`  |
 
 ### Atomic configuration changes
 

--- a/examples/consul-config.sh
+++ b/examples/consul-config.sh
@@ -26,11 +26,11 @@ curl -i -H "Accept: application/json" -X PUT -d "Path:/test"                  ht
 
 
 # certificate 1
-curl -i -H "Accept: application/json" -X PUT -d "https"                  http://localhost:8500/v1/kv/traefik/tlsconfiguration/pair1/entrypoints
-curl -i -H "Accept: application/json" -X PUT -d "/tmp/test1.crt"                  http://localhost:8500/v1/kv/traefik/tlsconfiguration/pair1/certificate/certfile
-curl -i -H "Accept: application/json" -X PUT -d "/tmp/test1.key"                  http://localhost:8500/v1/kv/traefik/tlsconfiguration/pair1/certificate/keyfile
+curl -i -H "Accept: application/json" -X PUT -d "https"                  http://localhost:8500/v1/kv/traefik/tls/pair1/entrypoints
+curl -i -H "Accept: application/json" -X PUT -d "/tmp/test1.crt"                  http://localhost:8500/v1/kv/traefik/tls/pair1/certificate/certfile
+curl -i -H "Accept: application/json" -X PUT -d "/tmp/test1.key"                  http://localhost:8500/v1/kv/traefik/tls/pair1/certificate/keyfile
 
 # certificate 2
-curl -i -H "Accept: application/json" -X PUT -d "http,https"                  http://localhost:8500/v1/kv/traefik/tlsconfiguration/pair2/entrypoints
-curl -i -H "Accept: application/json" -X PUT -d "/tmp/test2.crt"                  http://localhost:8500/v1/kv/traefik/tlsconfiguration/pair2/certificate/certfile
-curl -i -H "Accept: application/json" -X PUT -d "/tmp/test2.key"                  http://localhost:8500/v1/kv/traefik/tlsconfiguration/pair2/certificate/keyfile
+curl -i -H "Accept: application/json" -X PUT -d "http,https"                  http://localhost:8500/v1/kv/traefik/tls/pair2/entrypoints
+curl -i -H "Accept: application/json" -X PUT -d "/tmp/test2.crt"                  http://localhost:8500/v1/kv/traefik/tls/pair2/certificate/certfile
+curl -i -H "Accept: application/json" -X PUT -d "/tmp/test2.key"                  http://localhost:8500/v1/kv/traefik/tls/pair2/certificate/keyfile

--- a/examples/etcd-config.sh
+++ b/examples/etcd-config.sh
@@ -28,14 +28,14 @@ function insert_etcd2_data() {
     curl -i -H "Accept: application/json" -X PUT -d value="Path:/test"                  http://localhost:2379/v2/keys/traefik/frontends/frontend2/routes/test_2/rule
 
     # certificate 1
-    curl -i -H "Accept: application/json" -X PUT -d value="https"                       http://localhost:2379/v2/keys/traefik/tlsconfiguration/pair1/entrypoints
-    curl -i -H "Accept: application/json" -X PUT -d value="/tmp/test1.crt"              http://localhost:2379/v2/keys/traefik/tlsconfiguration/pair1/certificate/certfile
-    curl -i -H "Accept: application/json" -X PUT -d value="/tmp/test1.key"              http://localhost:2379/v2/keys/traefik/tlsconfiguration/pair1/certificate/keyfile
+    curl -i -H "Accept: application/json" -X PUT -d value="https"                       http://localhost:2379/v2/keys/traefik/tls/pair1/entrypoints
+    curl -i -H "Accept: application/json" -X PUT -d value="/tmp/test1.crt"              http://localhost:2379/v2/keys/traefik/tls/pair1/certificate/certfile
+    curl -i -H "Accept: application/json" -X PUT -d value="/tmp/test1.key"              http://localhost:2379/v2/keys/traefik/tls/pair1/certificate/keyfile
 
     # certificate 2
-    curl -i -H "Accept: application/json" -X PUT -d value="http,https"                  http://localhost:2379/v2/keys/traefik/tlsconfiguration/pair2/entrypoints
-    curl -i -H "Accept: application/json" -X PUT -d value="/tmp/test2.crt"              http://localhost:2379/v2/keys/traefik/tlsconfiguration/pair2/certificate/certfile
-    curl -i -H "Accept: application/json" -X PUT -d value="/tmp/test2.key"              http://localhost:2379/v2/keys/traefik/tlsconfiguration/pair2/certificate/keyfile
+    curl -i -H "Accept: application/json" -X PUT -d value="http,https"                  http://localhost:2379/v2/keys/traefik/tls/pair2/entrypoints
+    curl -i -H "Accept: application/json" -X PUT -d value="/tmp/test2.crt"              http://localhost:2379/v2/keys/traefik/tls/pair2/certificate/certfile
+    curl -i -H "Accept: application/json" -X PUT -d value="/tmp/test2.key"              http://localhost:2379/v2/keys/traefik/tls/pair2/certificate/keyfile
 }
 
 #
@@ -71,14 +71,14 @@ function insert_etcd3_data() {
     docker container run --rm -ti -e ETCDCTL_DIAL_="TIMEOUT 10s" -e ETCDCTL_API="3" tenstartups/etcdctl --endpoints=[$etcd_ip:2379] put "/traefik/frontends/frontend2/routes/test_2/rule" "Path:/test"
 
     # certificate 1
-    docker container run --rm -ti -e ETCDCTL_DIAL_="TIMEOUT 10s" -e ETCDCTL_API="3" tenstartups/etcdctl --endpoints=[$etcd_ip:2379] put "/traefik/tlsconfiguration/pair1/entrypoints" "https"
-    docker container run --rm -ti -e ETCDCTL_DIAL_="TIMEOUT 10s" -e ETCDCTL_API="3" tenstartups/etcdctl --endpoints=[$etcd_ip:2379] put "/traefik/tlsconfiguration/pair1/certificate/certfile" "/tmp/test1.crt"
-    docker container run --rm -ti -e ETCDCTL_DIAL_="TIMEOUT 10s" -e ETCDCTL_API="3" tenstartups/etcdctl --endpoints=[$etcd_ip:2379] put "/traefik/tlsconfiguration/pair1/certificate/keyfile" "/tmp/test1.key"
+    docker container run --rm -ti -e ETCDCTL_DIAL_="TIMEOUT 10s" -e ETCDCTL_API="3" tenstartups/etcdctl --endpoints=[$etcd_ip:2379] put "/traefik/tls/pair1/entrypoints" "https"
+    docker container run --rm -ti -e ETCDCTL_DIAL_="TIMEOUT 10s" -e ETCDCTL_API="3" tenstartups/etcdctl --endpoints=[$etcd_ip:2379] put "/traefik/tls/pair1/certificate/certfile" "/tmp/test1.crt"
+    docker container run --rm -ti -e ETCDCTL_DIAL_="TIMEOUT 10s" -e ETCDCTL_API="3" tenstartups/etcdctl --endpoints=[$etcd_ip:2379] put "/traefik/tls/pair1/certificate/keyfile" "/tmp/test1.key"
 
     # certificate 2
-    docker container run --rm -ti -e ETCDCTL_DIAL_="TIMEOUT 10s" -e ETCDCTL_API="3" tenstartups/etcdctl --endpoints=[$etcd_ip:2379] put "/traefik/tlsconfiguration/pair2/entrypoints" "https"
-    docker container run --rm -ti -e ETCDCTL_DIAL_="TIMEOUT 10s" -e ETCDCTL_API="3" tenstartups/etcdctl --endpoints=[$etcd_ip:2379] put "/traefik/tlsconfiguration/pair2/certificate/certfile" "/tmp/test2.crt"
-    docker container run --rm -ti -e ETCDCTL_DIAL_="TIMEOUT 10s" -e ETCDCTL_API="3" tenstartups/etcdctl --endpoints=[$etcd_ip:2379] put "/traefik/tlsconfiguration/pair2/certificate/keyfile" "/tmp/test2.key"
+    docker container run --rm -ti -e ETCDCTL_DIAL_="TIMEOUT 10s" -e ETCDCTL_API="3" tenstartups/etcdctl --endpoints=[$etcd_ip:2379] put "/traefik/tls/pair2/entrypoints" "https"
+    docker container run --rm -ti -e ETCDCTL_DIAL_="TIMEOUT 10s" -e ETCDCTL_API="3" tenstartups/etcdctl --endpoints=[$etcd_ip:2379] put "/traefik/tls/pair2/certificate/certfile" "/tmp/test2.crt"
+    docker container run --rm -ti -e ETCDCTL_DIAL_="TIMEOUT 10s" -e ETCDCTL_API="3" tenstartups/etcdctl --endpoints=[$etcd_ip:2379] put "/traefik/tls/pair2/certificate/keyfile" "/tmp/test2.key"
 }
 
 function show_usage() {

--- a/integration/consul_test.go
+++ b/integration/consul_test.go
@@ -564,15 +564,15 @@ func (s *ConsulSuite) TestSNIDynamicTlsConfig(c *check.C) {
 	}
 
 	tlsconfigure1 := map[string]string{
-		"traefik/tlsconfiguration/snitestcom/entrypoints":          "https",
-		"traefik/tlsconfiguration/snitestcom/certificate/keyfile":  string(snitestComKey),
-		"traefik/tlsconfiguration/snitestcom/certificate/certfile": string(snitestComCert),
+		"traefik/tls/snitestcom/entrypoints":          "https",
+		"traefik/tls/snitestcom/certificate/keyfile":  string(snitestComKey),
+		"traefik/tls/snitestcom/certificate/certfile": string(snitestComCert),
 	}
 
 	tlsconfigure2 := map[string]string{
-		"traefik/tlsconfiguration/snitestorg/entrypoints":          "https",
-		"traefik/tlsconfiguration/snitestorg/certificate/keyfile":  string(snitestOrgKey),
-		"traefik/tlsconfiguration/snitestorg/certificate/certfile": string(snitestOrgCert),
+		"traefik/tls/snitestorg/entrypoints":          "https",
+		"traefik/tls/snitestorg/certificate/keyfile":  string(snitestOrgKey),
+		"traefik/tls/snitestorg/certificate/certfile": string(snitestOrgCert),
 	}
 
 	// config backends,frontends and first tls keypair
@@ -613,7 +613,7 @@ func (s *ConsulSuite) TestSNIDynamicTlsConfig(c *check.C) {
 
 	// wait for consul
 	err = try.Do(60*time.Second, func() error {
-		_, err := s.kv.Get("traefik/tlsconfiguration/snitestcom/certificate/keyfile", nil)
+		_, err := s.kv.Get("traefik/tls/snitestcom/certificate/keyfile", nil)
 		return err
 	})
 	c.Assert(err, checker.IsNil)
@@ -642,7 +642,7 @@ func (s *ConsulSuite) TestSNIDynamicTlsConfig(c *check.C) {
 
 	// wait for consul
 	err = try.Do(60*time.Second, func() error {
-		_, err := s.kv.Get("traefik/tlsconfiguration/snitestorg/certificate/keyfile", nil)
+		_, err := s.kv.Get("traefik/tls/snitestorg/certificate/keyfile", nil)
 		return err
 	})
 	c.Assert(err, checker.IsNil)

--- a/integration/etcd3_test.go
+++ b/integration/etcd3_test.go
@@ -474,15 +474,15 @@ func (s *Etcd3Suite) TestSNIDynamicTlsConfig(c *check.C) {
 	}
 
 	tlsconfigure1 := map[string]string{
-		"/traefik/tlsconfiguration/snitestcom/entrypoints":          "https",
-		"/traefik/tlsconfiguration/snitestcom/certificate/keyfile":  string(snitestComKey),
-		"/traefik/tlsconfiguration/snitestcom/certificate/certfile": string(snitestComCert),
+		"/traefik/tls/snitestcom/entrypoints":          "https",
+		"/traefik/tls/snitestcom/certificate/keyfile":  string(snitestComKey),
+		"/traefik/tls/snitestcom/certificate/certfile": string(snitestComCert),
 	}
 
 	tlsconfigure2 := map[string]string{
-		"/traefik/tlsconfiguration/snitestorg/entrypoints":          "https",
-		"/traefik/tlsconfiguration/snitestorg/certificate/keyfile":  string(snitestOrgKey),
-		"/traefik/tlsconfiguration/snitestorg/certificate/certfile": string(snitestOrgCert),
+		"/traefik/tls/snitestorg/entrypoints":          "https",
+		"/traefik/tls/snitestorg/certificate/keyfile":  string(snitestOrgKey),
+		"/traefik/tls/snitestorg/certificate/certfile": string(snitestOrgCert),
 	}
 
 	// config backends,frontends and first tls keypair
@@ -523,7 +523,7 @@ func (s *Etcd3Suite) TestSNIDynamicTlsConfig(c *check.C) {
 
 	// wait for etcd
 	err = try.Do(60*time.Second, func() error {
-		_, err := s.kv.Get("/traefik/tlsconfiguration/snitestcom/certificate/keyfile", nil)
+		_, err := s.kv.Get("/traefik/tls/snitestcom/certificate/keyfile", nil)
 		return err
 	})
 	c.Assert(err, checker.IsNil)
@@ -557,7 +557,7 @@ func (s *Etcd3Suite) TestSNIDynamicTlsConfig(c *check.C) {
 
 	// wait for etcd
 	err = try.Do(60*time.Second, func() error {
-		_, err := s.kv.Get("/traefik/tlsconfiguration/snitestorg/certificate/keyfile", nil)
+		_, err := s.kv.Get("/traefik/tls/snitestorg/certificate/keyfile", nil)
 		return err
 	})
 	c.Assert(err, checker.IsNil)
@@ -609,9 +609,9 @@ func (s *Etcd3Suite) TestDeleteSNIDynamicTlsConfig(c *check.C) {
 	}
 
 	tlsconfigure1 := map[string]string{
-		"/traefik/tlsconfiguration/snitestcom/entrypoints":          "https",
-		"/traefik/tlsconfiguration/snitestcom/certificate/keyfile":  string(snitestComKey),
-		"/traefik/tlsconfiguration/snitestcom/certificate/certfile": string(snitestComCert),
+		"/traefik/tls/snitestcom/entrypoints":          "https",
+		"/traefik/tls/snitestcom/certificate/keyfile":  string(snitestComKey),
+		"/traefik/tls/snitestcom/certificate/certfile": string(snitestComCert),
 	}
 
 	// config backends,frontends and first tls keypair
@@ -637,7 +637,7 @@ func (s *Etcd3Suite) TestDeleteSNIDynamicTlsConfig(c *check.C) {
 
 	// wait for etcd
 	err = try.Do(60*time.Second, func() error {
-		_, err := s.kv.Get("/traefik/tlsconfiguration/snitestcom/certificate/keyfile", nil)
+		_, err := s.kv.Get("/traefik/tls/snitestcom/certificate/keyfile", nil)
 		return err
 	})
 	c.Assert(err, checker.IsNil)

--- a/integration/etcd_test.go
+++ b/integration/etcd_test.go
@@ -490,15 +490,15 @@ func (s *EtcdSuite) TestSNIDynamicTlsConfig(c *check.C) {
 	}
 
 	tlsconfigure1 := map[string]string{
-		"/traefik/tlsconfiguration/snitestcom/entrypoints":          "https",
-		"/traefik/tlsconfiguration/snitestcom/certificate/keyfile":  string(snitestComKey),
-		"/traefik/tlsconfiguration/snitestcom/certificate/certfile": string(snitestComCert),
+		"/traefik/tls/snitestcom/entrypoints":          "https",
+		"/traefik/tls/snitestcom/certificate/keyfile":  string(snitestComKey),
+		"/traefik/tls/snitestcom/certificate/certfile": string(snitestComCert),
 	}
 
 	tlsconfigure2 := map[string]string{
-		"/traefik/tlsconfiguration/snitestorg/entrypoints":          "https",
-		"/traefik/tlsconfiguration/snitestorg/certificate/keyfile":  string(snitestOrgKey),
-		"/traefik/tlsconfiguration/snitestorg/certificate/certfile": string(snitestOrgCert),
+		"/traefik/tls/snitestorg/entrypoints":          "https",
+		"/traefik/tls/snitestorg/certificate/keyfile":  string(snitestOrgKey),
+		"/traefik/tls/snitestorg/certificate/certfile": string(snitestOrgCert),
 	}
 
 	// config backends,frontends and first tls keypair
@@ -539,7 +539,7 @@ func (s *EtcdSuite) TestSNIDynamicTlsConfig(c *check.C) {
 
 	// wait for etcd
 	err = try.Do(60*time.Second, func() error {
-		_, err := s.kv.Get("/traefik/tlsconfiguration/snitestcom/certificate/keyfile", nil)
+		_, err := s.kv.Get("/traefik/tls/snitestcom/certificate/keyfile", nil)
 		return err
 	})
 	c.Assert(err, checker.IsNil)
@@ -573,7 +573,7 @@ func (s *EtcdSuite) TestSNIDynamicTlsConfig(c *check.C) {
 
 	// wait for etcd
 	err = try.Do(60*time.Second, func() error {
-		_, err := s.kv.Get("/traefik/tlsconfiguration/snitestorg/certificate/keyfile", nil)
+		_, err := s.kv.Get("/traefik/tls/snitestorg/certificate/keyfile", nil)
 		return err
 	})
 	c.Assert(err, checker.IsNil)

--- a/integration/fixtures/acme/certificates.toml
+++ b/integration/fixtures/acme/certificates.toml
@@ -9,8 +9,8 @@
     [frontends.frontend.routes.test]
     rule = "Host:traefik.acme.wtf"
 
-[[tlsConfiguration]]
+[[tls]]
 entryPoints = ["https"]
-    [tlsConfiguration.certificate]
+    [tls.certificate]
      certFile = "fixtures/acme/ssl/wildcard.crt"
      keyFile = "fixtures/acme/ssl/wildcard.key"

--- a/integration/fixtures/https/dynamic_https.toml
+++ b/integration/fixtures/https/dynamic_https.toml
@@ -16,9 +16,9 @@
     [frontends.frontend2.routes.test_2]
     rule = "Host:snitest.org"
 
-[[tlsConfiguration]]
+[[tls]]
 entryPoints = ["https"]
-  [tlsConfiguration.certificate]
+  [tls.certificate]
     certFile = """-----BEGIN CERTIFICATE-----
 MIIC/zCCAeegAwIBAgIJALAYHG/vGqWEMA0GCSqGSIb3DQEBBQUAMBYxFDASBgNV
 BAMMC3NuaXRlc3Qub3JnMB4XDTE1MTEyMzIyMDU0NFoXDTI1MTEyMDIyMDU0NFow

--- a/integration/https_test.go
+++ b/integration/https_test.go
@@ -624,7 +624,7 @@ func modifyCertificateConfFileContent(c *check.C, certFileName, confFileName, en
 	// If certificate file is not provided, just truncate the configuration file
 	if len(certFileName) > 0 {
 		tlsConf := types.Configuration{
-			TLSConfiguration: []*traefikTls.Configuration{
+			TLS: []*traefikTls.Configuration{
 				{
 					Certificate: &traefikTls.Certificate{
 						CertFile: traefikTls.FileOrContent("fixtures/https/" + certFileName + ".cert"),

--- a/provider/file/file.go
+++ b/provider/file/file.go
@@ -186,7 +186,7 @@ func loadFileConfigFromDirectory(directory string, configuration *types.Configur
 			}
 		}
 
-		for _, conf := range c.TLSConfiguration {
+		for _, conf := range c.TLS {
 			if _, exists := configTLSMaps[conf]; exists {
 				log.Warnf("TLS Configuration %v already configured, skipping", conf)
 			} else {
@@ -196,7 +196,7 @@ func loadFileConfigFromDirectory(directory string, configuration *types.Configur
 
 	}
 	for conf := range configTLSMaps {
-		configuration.TLSConfiguration = append(configuration.TLSConfiguration, conf)
+		configuration.TLS = append(configuration.TLS, conf)
 	}
 	return configuration, nil
 }

--- a/provider/file/file_test.go
+++ b/provider/file/file_test.go
@@ -26,7 +26,7 @@ func TestProvideSingleFileAndWatch(t *testing.T) {
 		tempDir, "simple.toml",
 		createFrontendConfiguration(expectedNumFrontends),
 		createBackendConfiguration(expectedNumBackends),
-		createTLSConfiguration(expectedNumTLSConf))
+		createTLS(expectedNumTLSConf))
 
 	configurationChan, signal := createConfigurationRoutine(t, &expectedNumFrontends, &expectedNumBackends, &expectedNumTLSConf)
 
@@ -45,7 +45,7 @@ func TestProvideSingleFileAndWatch(t *testing.T) {
 		tempDir, "simple.toml",
 		createFrontendConfiguration(expectedNumFrontends),
 		createBackendConfiguration(expectedNumBackends),
-		createTLSConfiguration(expectedNumTLSConf))
+		createTLS(expectedNumTLSConf))
 
 	err = waitForSignal(signal, 2*time.Second, "single frontend, backend, TLS configuration")
 	assert.NoError(t, err)
@@ -63,7 +63,7 @@ func TestProvideSingleFileAndNotWatch(t *testing.T) {
 		tempDir, "simple.toml",
 		createFrontendConfiguration(expectedNumFrontends),
 		createBackendConfiguration(expectedNumBackends),
-		createTLSConfiguration(expectedNumTLSConf))
+		createTLS(expectedNumTLSConf))
 
 	configurationChan, signal := createConfigurationRoutine(t, &expectedNumFrontends, &expectedNumBackends, &expectedNumTLSConf)
 
@@ -82,7 +82,7 @@ func TestProvideSingleFileAndNotWatch(t *testing.T) {
 		tempDir, "simple.toml",
 		createFrontendConfiguration(expectedNumFrontends),
 		createBackendConfiguration(expectedNumBackends),
-		createTLSConfiguration(expectedNumTLSConf))
+		createTLS(expectedNumTLSConf))
 
 	// Must fail because we don't watch the changes
 	err = waitForSignal(signal, 2*time.Second, "single frontend, backend and TLS configuration")
@@ -99,7 +99,7 @@ func TestProvideDirectoryAndWatch(t *testing.T) {
 
 	tempFile1 := createRandomFile(t, tempDir, createFrontendConfiguration(expectedNumFrontends))
 	tempFile2 := createRandomFile(t, tempDir, createBackendConfiguration(expectedNumBackends))
-	tempFile3 := createRandomFile(t, tempDir, createTLSConfiguration(expectedNumTLSConf))
+	tempFile3 := createRandomFile(t, tempDir, createTLS(expectedNumTLSConf))
 
 	configurationChan, signal := createConfigurationRoutine(t, &expectedNumFrontends, &expectedNumBackends, &expectedNumTLSConf)
 
@@ -145,7 +145,7 @@ func TestProvideDirectoryAndNotWatch(t *testing.T) {
 
 	createRandomFile(t, tempDir, createFrontendConfiguration(expectedNumFrontends))
 	tempFile2 := createRandomFile(t, tempDir, createBackendConfiguration(expectedNumBackends))
-	createRandomFile(t, tempTLSDir, createTLSConfiguration(expectedNumTLSConf))
+	createRandomFile(t, tempTLSDir, createTLS(expectedNumTLSConf))
 
 	configurationChan, signal := createConfigurationRoutine(t, &expectedNumFrontends, &expectedNumBackends, &expectedNumTLSConf)
 
@@ -167,7 +167,7 @@ func TestProvideDirectoryAndNotWatch(t *testing.T) {
 
 }
 
-func createConfigurationRoutine(t *testing.T, expectedNumFrontends *int, expectedNumBackends *int, expectedNumTLSConfigurations *int) (chan types.ConfigMessage, chan interface{}) {
+func createConfigurationRoutine(t *testing.T, expectedNumFrontends *int, expectedNumBackends *int, expectedNumTLSes *int) (chan types.ConfigMessage, chan interface{}) {
 	configurationChan := make(chan types.ConfigMessage)
 	signal := make(chan interface{})
 
@@ -177,7 +177,7 @@ func createConfigurationRoutine(t *testing.T, expectedNumFrontends *int, expecte
 			assert.Equal(t, "file", data.ProviderName)
 			assert.Len(t, data.Configuration.Frontends, *expectedNumFrontends)
 			assert.Len(t, data.Configuration.Backends, *expectedNumBackends)
-			assert.Len(t, data.Configuration.TLSConfiguration, *expectedNumTLSConfigurations)
+			assert.Len(t, data.Configuration.TLS, *expectedNumTLSes)
 			signal <- nil
 		}
 	})
@@ -297,13 +297,13 @@ func createBackendConfiguration(n int) string {
 	return conf
 }
 
-// createTLSConfiguration Helper
-func createTLSConfiguration(n int) string {
+// createTLS Helper
+func createTLS(n int) string {
 	var conf string
 	for i := 1; i <= n; i++ {
-		conf += fmt.Sprintf(`[[TLSConfiguration]]
+		conf += fmt.Sprintf(`[[TLS]]
 	EntryPoints = ["https"]
-	[TLSConfiguration.Certificate]
+	[TLS.Certificate]
 	CertFile = "integration/fixtures/https/snitest%[1]d.com.cert"
 	KeyFile = "integration/fixtures/https/snitest%[1]d.com.key"
 `, i)

--- a/server/server.go
+++ b/server/server.go
@@ -357,7 +357,7 @@ func (s *Server) preLoadConfiguration(configMsg types.ConfigMessage) {
 	currentConfigurations := s.currentConfigurations.Get().(types.Configurations)
 	jsonConf, _ := json.Marshal(configMsg.Configuration)
 	log.Debugf("Configuration received from provider %s: %s", configMsg.ProviderName, string(jsonConf))
-	if configMsg.Configuration == nil || configMsg.Configuration.Backends == nil && configMsg.Configuration.Frontends == nil && configMsg.Configuration.TLSConfiguration == nil {
+	if configMsg.Configuration == nil || configMsg.Configuration.Backends == nil && configMsg.Configuration.Frontends == nil && configMsg.Configuration.TLS == nil {
 		log.Infof("Skipping empty Configuration for provider %s", configMsg.ProviderName)
 	} else if reflect.DeepEqual(currentConfigurations[configMsg.ProviderName], configMsg.Configuration) {
 		log.Infof("Skipping same configuration for provider %s", configMsg.ProviderName)
@@ -462,8 +462,8 @@ func (s *Server) loadHTTPSConfiguration(configurations types.Configurations) (ma
 	newEPCertificates := make(map[string]*traefikTls.DomainsCertificates)
 	// Get all certificates
 	for _, configuration := range configurations {
-		if configuration.TLSConfiguration != nil && len(configuration.TLSConfiguration) > 0 {
-			if err := traefikTls.SortTLSConfigurationPerEntryPoints(configuration.TLSConfiguration, newEPCertificates); err != nil {
+		if configuration.TLS != nil && len(configuration.TLS) > 0 {
+			if err := traefikTls.SortTLSPerEntryPoints(configuration.TLS, newEPCertificates); err != nil {
 				return nil, err
 			}
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -463,7 +463,7 @@ func TestServerLoadConfigHealthCheckOptions(t *testing.T) {
 								HealthCheck: healthCheck,
 							},
 						},
-						TLSConfiguration: []*tls.Configuration{
+						TLS: []*tls.Configuration{
 							{
 								Certificate: &tls.Certificate{
 									CertFile: localhostCert,
@@ -644,7 +644,7 @@ func TestServerLoadConfigEmptyBasicAuth(t *testing.T) {
 					},
 				},
 			},
-			TLSConfiguration: []*tls.Configuration{
+			TLS: []*tls.Configuration{
 				{
 					Certificate: &tls.Certificate{
 						CertFile: localhostCert,

--- a/templates/kv.tmpl
+++ b/templates/kv.tmpl
@@ -1,6 +1,6 @@
 {{$frontends := List .Prefix "/frontends/" }}
 {{$backends :=  List .Prefix "/backends/"}}
-{{$tlsconfiguration := List .Prefix "/tlsconfiguration/"}}
+{{$tls := List .Prefix "/tls/"}}
 
 [backends]{{range $backends}}
 {{$backend := .}}
@@ -65,13 +65,13 @@
         {{end}}
 {{end}}
 
-{{range $tlsconfiguration}}
+{{range $tls}}
 {{$entryPoints := SplitGet . "/entrypoints"}}
-[[tlsConfiguration]]
+[[tls]]
     entryPoints = [{{range $entryPoints}}
       "{{.}}",
     {{end}}]
-    [tlsConfiguration.certificate]
+    [tls.certificate]
         certFile = """{{Get "" . "/certificate" "/certfile"}}"""
         keyFile = """{{Get "" . "/certificate" "/keyfile"}}"""
 {{end}}

--- a/tls/tls.go
+++ b/tls/tls.go
@@ -86,8 +86,8 @@ func (r *RootCAs) Type() string {
 	return "rootcas"
 }
 
-// SortTLSConfigurationPerEntryPoints converts TLS configuration sorted by Certificates into TLS configuration sorted by EntryPoints
-func SortTLSConfigurationPerEntryPoints(configurations []*Configuration, epConfiguration map[string]*DomainsCertificates) error {
+// SortTLSPerEntryPoints converts TLS configuration sorted by Certificates into TLS configuration sorted by EntryPoints
+func SortTLSPerEntryPoints(configurations []*Configuration, epConfiguration map[string]*DomainsCertificates) error {
 	if epConfiguration == nil {
 		epConfiguration = make(map[string]*DomainsCertificates)
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -197,9 +197,9 @@ type Configurations map[string]*Configuration
 
 // Configuration of a provider.
 type Configuration struct {
-	Backends         map[string]*Backend         `json:"backends,omitempty"`
-	Frontends        map[string]*Frontend        `json:"frontends,omitempty"`
-	TLSConfiguration []*traefikTls.Configuration `json:"tlsConfiguration,omitempty"`
+	Backends  map[string]*Backend         `json:"backends,omitempty"`
+	Frontends map[string]*Frontend        `json:"frontends,omitempty"`
+	TLS       []*traefikTls.Configuration `json:"tls,omitempty"`
 }
 
 // ConfigMessage hold configuration information exchanged between parts of traefik.


### PR DESCRIPTION
### What does this PR do?

Rename `TLSConfigurations` to `TLS`.

### Motivation

More readable configuration.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

