### PR TITLE
Handle undefined entrypoint on ACME config and frontend config

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -142,6 +142,7 @@ func run(globalConfiguration *configuration.GlobalConfiguration, configFile stri
 	http.DefaultTransport.(*http.Transport).Proxy = http.ProxyFromEnvironment
 
 	globalConfiguration.SetEffectiveConfiguration(configFile)
+	globalConfiguration.ValidateConfiguration()
 
 	jsonConf, _ := json.Marshal(globalConfiguration)
 	log.Infof("Traefik version %s built on %s", version.Version, version.BuildDate)

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -259,6 +259,19 @@ func (gc *GlobalConfiguration) SetEffectiveConfiguration(configFile string) {
 	}
 }
 
+// ValidateConfiguration validate that configuration is coherent
+func (gc *GlobalConfiguration) ValidateConfiguration() {
+	if gc.ACME != nil {
+		if _, ok := gc.EntryPoints[gc.ACME.EntryPoint]; !ok {
+			log.Fatalf("Unknown entrypoint %q for ACME configuration", gc.ACME.EntryPoint)
+		} else {
+			if gc.EntryPoints[gc.ACME.EntryPoint].TLS == nil {
+				log.Fatalf("Entrypoint without TLS %q for ACME configuration", gc.ACME.EntryPoint)
+			}
+		}
+	}
+}
+
 // DefaultEntryPoints holds default entry points
 type DefaultEntryPoints []string
 

--- a/server/server.go
+++ b/server/server.go
@@ -673,31 +673,27 @@ func (s *Server) createTLSConfig(entryPointName string, tlsOption *traefikTls.TL
 	}
 
 	if s.globalConfiguration.ACME != nil {
-		if _, ok := s.serverEntryPoints[s.globalConfiguration.ACME.EntryPoint]; ok {
-			if entryPointName == s.globalConfiguration.ACME.EntryPoint {
-				checkOnDemandDomain := func(domain string) bool {
-					routeMatch := &mux.RouteMatch{}
-					router := router.GetHandler()
-					match := router.Match(&http.Request{URL: &url.URL{}, Host: domain}, routeMatch)
-					if match && routeMatch.Route != nil {
-						return true
-					}
-					return false
+		if entryPointName == s.globalConfiguration.ACME.EntryPoint {
+			checkOnDemandDomain := func(domain string) bool {
+				routeMatch := &mux.RouteMatch{}
+				router := router.GetHandler()
+				match := router.Match(&http.Request{URL: &url.URL{}, Host: domain}, routeMatch)
+				if match && routeMatch.Route != nil {
+					return true
 				}
-				if s.leadership == nil {
-					err := s.globalConfiguration.ACME.CreateLocalConfig(config, &s.serverEntryPoints[entryPointName].certs, checkOnDemandDomain)
-					if err != nil {
-						return nil, err
-					}
-				} else {
-					err := s.globalConfiguration.ACME.CreateClusterConfig(s.leadership, config, &s.serverEntryPoints[entryPointName].certs, checkOnDemandDomain)
-					if err != nil {
-						return nil, err
-					}
+				return false
+			}
+			if s.leadership == nil {
+				err := s.globalConfiguration.ACME.CreateLocalConfig(config, &s.serverEntryPoints[entryPointName].certs, checkOnDemandDomain)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				err := s.globalConfiguration.ACME.CreateClusterConfig(s.leadership, config, &s.serverEntryPoints[entryPointName].certs, checkOnDemandDomain)
+				if err != nil {
+					return nil, err
 				}
 			}
-		} else {
-			return nil, errors.New("Unknown entrypoint " + s.globalConfiguration.ACME.EntryPoint + " for ACME configuration")
 		}
 	} else {
 		config.GetCertificate = s.serverEntryPoints[entryPointName].getCertificate
@@ -925,23 +921,23 @@ func (s *Server) loadConfig(configurations types.Configurations, globalConfigura
 
 			log.Debugf("Creating frontend %s", frontendName)
 
+			var frontendEntryPoints []string
+			for _, entryPointName := range frontend.EntryPoints {
+				if _, ok := serverEntryPoints[entryPointName]; !ok {
+					log.Errorf("Undefined entrypoint '%s' for frontend %s", entryPointName, frontendName)
+				} else {
+					frontendEntryPoints = append(frontendEntryPoints, entryPointName)
+				}
+			}
+			frontend.EntryPoints = frontendEntryPoints
+
 			if len(frontend.EntryPoints) == 0 {
-				log.Errorf("No entrypoint defined for frontend %s, defaultEntryPoints:%s", frontendName, globalConfiguration.DefaultEntryPoints)
+				log.Errorf("No entrypoint defined for frontend %s", frontendName)
 				log.Errorf("Skipping frontend %s...", frontendName)
 				continue frontend
 			}
-			var failedEntrypoints int
 			for _, entryPointName := range frontend.EntryPoints {
 				log.Debugf("Wiring frontend %s to entryPoint %s", frontendName, entryPointName)
-				if _, ok := serverEntryPoints[entryPointName]; !ok {
-					log.Errorf("Undefined entrypoint '%s' for frontend %s", entryPointName, frontendName)
-					failedEntrypoints++
-					if failedEntrypoints == len(frontend.EntryPoints) {
-						log.Errorf("Skipping frontend %s...", frontendName)
-						continue frontend
-					}
-					continue
-				}
 
 				newServerRoute := &serverRoute{route: serverEntryPoints[entryPointName].httpRouter.GetHandler().NewRoute().Name(frontendName)}
 				for routeName, route := range frontend.Routes {


### PR DESCRIPTION
### What does this PR do?

Delete undefined entrypoints from `frontent.entrypoints`
Move Fatal if `ACME.Entrypoint` does not exists (from `createTLSConfig` to `ValidateConfiguration`)

### Motivation

Handle some weird errors (like panic in `postLoadConfiguration`)