### PR TITLE
Change gzipwriter receiver to implement CloseNotifier

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -89,7 +89,7 @@
   branch = "master"
   name = "github.com/NYTimes/gziphandler"
   packages = ["."]
-  revision = "47ca22a0aeea4c9ceddfb935d818d636d934c312"
+  revision = "289a3b81f5aedc99f8d6eb0f67827c142f1310d8"
 
 [[projects]]
   name = "github.com/Nvveen/Gotty"

--- a/vendor/github.com/NYTimes/gziphandler/gzip.go
+++ b/vendor/github.com/NYTimes/gziphandler/gzip.go
@@ -88,7 +88,7 @@ type GzipResponseWriterWithCloseNotify struct {
 	*GzipResponseWriter
 }
 
-func (w *GzipResponseWriterWithCloseNotify) CloseNotify() <-chan bool {
+func (w GzipResponseWriterWithCloseNotify) CloseNotify() <-chan bool {
 	return w.ResponseWriter.(http.CloseNotifier).CloseNotify()
 }
 


### PR DESCRIPTION
### What does this PR do?
Change receiver for  `GzipResponseWriter` in order to implement `CloseNotifier`

### Motivation
Fixes #2760 

### More
Related to https://github.com/NYTimes/gziphandler/pull/63