### PR TITLE
doc: option not available in 1.5.

### DIFF
--- a/docs/configuration/entrypoints.md
+++ b/docs/configuration/entrypoints.md
@@ -27,7 +27,6 @@
       entryPoint = "https"
       regex = "^http://localhost/(.*)"
       replacement = "http://mydomain/$1"
-      permanent = true
 
     [entryPoints.http.auth]
       headerField = "X-WebAuth-User"


### PR DESCRIPTION
### What does this PR do?

Remove an option (`redirect.permanent`) not available in 1.5.

### Motivation

Have a good documentation

### More

- [x] Added/updated documentation
