### PR TITLE
Traefik still start when Let's encrypt is down

### DIFF
--- a/acme/acme.go
+++ b/acme/acme.go
@@ -295,6 +295,7 @@ func (a *ACME) leadershipListener(elected bool) error {
 
 // CreateLocalConfig creates a tls.config using local ACME configuration
 func (a *ACME) CreateLocalConfig(tlsConfig *tls.Config, certs *safe.Safe, checkOnDemandDomain func(domain string) bool) error {
+	defer a.runJobs()
 	err := a.init()
 	if err != nil {
 		return err
@@ -333,7 +334,8 @@ func (a *ACME) CreateLocalConfig(tlsConfig *tls.Config, certs *safe.Safe, checkO
 
 	a.client, err = a.buildACMEClient(account)
 	if err != nil {
-		return err
+		log.Errorf("Failed to build ACME Client: %s", err)
+		return nil
 	}
 
 	if needRegister {
@@ -374,7 +376,6 @@ func (a *ACME) CreateLocalConfig(tlsConfig *tls.Config, certs *safe.Safe, checkO
 
 	a.retrieveCertificates()
 	a.renewCertificates()
-	a.runJobs()
 
 	ticker := time.NewTicker(24 * time.Hour)
 	safe.Go(func() {

--- a/acme/acme.go
+++ b/acme/acme.go
@@ -334,7 +334,8 @@ func (a *ACME) CreateLocalConfig(tlsConfig *tls.Config, certs *safe.Safe, checkO
 
 	a.client, err = a.buildACMEClient(account)
 	if err != nil {
-		log.Errorf("Failed to build ACME Client: %s", err)
+		log.Errorf(`Failed to build ACME client: %s
+Let's Encrypt functionality will be limited until traefik is restarted.`, err)
 		return nil
 	}
 

--- a/docs/configuration/acme.md
+++ b/docs/configuration/acme.md
@@ -149,9 +149,9 @@ entryPoint = "https"
 Let's Encrypt functionality will be limited until Træfik is restarted.
 
 If Let's Encrypt is not reachable, these certificates will be used :
-  - ACME certificates already generated before downtime,
-  - Expired ACME certificates,
-  - Provided certificates,
+  - ACME certificates already generated before downtime
+  - Expired ACME certificates
+  - Provided certificates
 
 !!! note
  Default Træfik certificate will be used instead of ACME certificates for new (sub)domains (which need Let's Encrypt challenge).

--- a/docs/configuration/acme.md
+++ b/docs/configuration/acme.md
@@ -144,10 +144,17 @@ entryPoint = "https"
     If `HTTP-01` challenge is used, `acme.httpChallenge.entryPoint` has to be defined and reachable by Let's Encrypt through the port 80.
     These are Let's Encrypt limitations as described on the [community forum](https://community.letsencrypt.org/t/support-for-ports-other-than-80-and-443/3419/72).
 
-!!! note
-    If Let's Encrypt is down when Træfik is started, already generated certificates will be used, but certificates will not be renewed, and no new certificate will be generated.
-    Træfik needs to be restarted when Let's Encrypt is back.
+### Let's Encrypt downtime
 
+Let's Encrypt functionality will be limited until Træfik is restarted.
+
+If Let's Encrypt is not reachable, these certificates will be used :
+  - ACME certificates already generated before downtime,
+  - Expired ACME certificates,
+  - Provided certificates,
+
+!!! note
+ Default Træfik certificate will be used instead of ACME certificates for new (sub)domains (which need Let's Encrypt challenge).
 
 ### `storage`
 

--- a/docs/configuration/acme.md
+++ b/docs/configuration/acme.md
@@ -144,6 +144,11 @@ entryPoint = "https"
     If `HTTP-01` challenge is used, `acme.httpChallenge.entryPoint` has to be defined and reachable by Let's Encrypt through the port 80.
     These are Let's Encrypt limitations as described on the [community forum](https://community.letsencrypt.org/t/support-for-ports-other-than-80-and-443/3419/72).
 
+!!! note
+    If Let's Encrypt is down when Træfik is started, already generated certificates will be used, but certificates will not be renewed, and no new certificate will be generated.
+    Træfik needs to be restarted when Let's Encrypt is back.
+
+
 ### `storage`
 
 ```toml

--- a/integration/acme_test.go
+++ b/integration/acme_test.go
@@ -142,6 +142,19 @@ func (s *AcmeSuite) TestOnHostRuleRetrieveAcmeCertificateWithDynamicWildcard(c *
 	s.retrieveAcmeCertificate(c, testCase)
 }
 
+// Test Let's encrypt down
+func (s *AcmeSuite) TestNoValidLetsEncryptServer(c *check.C) {
+	cmd, display := s.traefikCmd(withConfigFile("fixtures/acme/wrong_acme.toml"))
+	defer display(c)
+	err := cmd.Start()
+	c.Assert(err, checker.IsNil)
+	defer cmd.Process.Kill()
+
+	// Expected traefik works
+	err = try.GetRequest("http://127.0.0.1:8080/api/providers", 10*time.Second, try.StatusCodeIs(http.StatusOK))
+	c.Assert(err, checker.IsNil)
+}
+
 // Doing an HTTPS request and test the response certificate
 func (s *AcmeSuite) retrieveAcmeCertificate(c *check.C, testCase AcmeTestCase) {
 	file := s.adaptFile(c, testCase.traefikConfFilePath, struct {

--- a/integration/fixtures/acme/wrong_acme.toml
+++ b/integration/fixtures/acme/wrong_acme.toml
@@ -1,0 +1,33 @@
+logLevel = "DEBUG"
+
+defaultEntryPoints = ["http", "https"]
+
+[entryPoints]
+  [entryPoints.http]
+  address = ":8080"
+  [entryPoints.https]
+  address = ":5001"
+    [entryPoints.https.tls]
+
+
+[acme]
+email = "test@traefik.io"
+storage = "/dev/null"
+entryPoint = "https"
+onDemand = {{.OnDemand}}
+OnHostRule = {{.OnHostRule}}
+caServer = "http://{{.BoulderHost}}:4000/directory"
+
+[file]
+
+[backends]
+  [backends.backend]
+    [backends.backend.servers.server1]
+    url = "http://127.0.0.1:9010"
+
+
+[frontends]
+  [frontends.frontend]
+  backend = "backend"
+    [frontends.frontend.routes.test]
+    rule = "Host:traefik.acme.wtf"

--- a/integration/fixtures/acme/wrong_acme.toml
+++ b/integration/fixtures/acme/wrong_acme.toml
@@ -2,9 +2,11 @@ logLevel = "DEBUG"
 
 defaultEntryPoints = ["http", "https"]
 
+[api]
+
 [entryPoints]
   [entryPoints.http]
-  address = ":8080"
+  address = ":8081"
   [entryPoints.https]
   address = ":5001"
     [entryPoints.https.tls]
@@ -14,9 +16,8 @@ defaultEntryPoints = ["http", "https"]
 email = "test@traefik.io"
 storage = "/dev/null"
 entryPoint = "https"
-onDemand = {{.OnDemand}}
-OnHostRule = {{.OnHostRule}}
-caServer = "http://{{.BoulderHost}}:4000/directory"
+OnHostRule = true
+caServer = "http://wrongurl:4000/directory"
 
 [file]
 


### PR DESCRIPTION
### What does this PR do?
Fix traefik crash when Let's Encrypt is down

### Motivation
Be able to start traefik even if LE is down.
Fixes #791

### More
The already generated certificates are still used.
If Traefik starts with LE down, you will need to restart Traefik in order to reconnect to LE and onHostRule certificates will generate error logs
In order to have this fix in 1.5.2 we don't change ACME too deeply, more deeply changes may come in 1.6.

- [X] Added/updated tests
- [X] Added/updated documentation
