### PR TITLE
Update traefik-ds.yaml with --api command line parameter

### DIFF
--- a/examples/k8s/traefik-ds.yaml
+++ b/examples/k8s/traefik-ds.yaml
@@ -35,7 +35,7 @@ spec:
           privileged: true
         args:
         - -d
-        - --web
+        - --api
         - --kubernetes
 ---
 kind: Service


### PR DESCRIPTION
--web is deprecated, this was updated in the document, but not here.

### What does this PR do?

traffic *--web* command line parameter is deprecated. 
The documentation is fixed with --api but not the example file itself.

### Motivation

Good will ;)

### More

- [x] Added/updated documentation

### Additional Notes

nil