### PR TITLE
Remove health check filter from Marathon tasks.

### DIFF
--- a/docs/user-guide/marathon.md
+++ b/docs/user-guide/marathon.md
@@ -130,7 +130,6 @@ As such, there is no way to handle this situation deterministically.
 Finally, Marathon health checks are not mandatory (the default is to use the task state as reported by Mesos), so requiring them for Traefik would raise the entry barrier for Marathon users.
 
 Traefik used to use the health check results as a strict requirement but moved away from it as [users reported the dramatic consequences](https://github.com/containous/traefik/issues/653).
-If health check results are known to exist, however, they will be used to signal task availability.
 
 #### Draining
 

--- a/provider/marathon/config.go
+++ b/provider/marathon/config.go
@@ -153,18 +153,6 @@ func (p *Provider) taskFilter(task marathon.Task, application marathon.Applicati
 		return false
 	}
 
-	// Filter task with existing, bad health check results.
-	if application.HasHealthChecks() {
-		if task.HasHealthCheckResults() {
-			for _, healthCheck := range task.HealthCheckResults {
-				if !healthCheck.Alive {
-					log.Debugf("Filtering Marathon task %s from application %s with bad health check", task.ID, application.ID)
-					return false
-				}
-			}
-		}
-	}
-
 	if ready := p.readyChecker.Do(task, application); !ready {
 		log.Infof("Filtering unready task %s from application %s", task.ID, application.ID)
 		return false

--- a/provider/marathon/config_test.go
+++ b/provider/marathon/config_test.go
@@ -936,51 +936,6 @@ func TestTaskFilter(t *testing.T) {
 			expected: true,
 		},
 		{
-			desc: "healthcheck available",
-			task: task(taskPorts(80)),
-			application: application(
-				appPorts(80),
-				healthChecks(marathon.NewDefaultHealthCheck()),
-			),
-			expected: true,
-		},
-		{
-			desc: "healthcheck result false",
-			task: task(
-				taskPorts(80),
-				healthCheckResultLiveness(false),
-			),
-			application: application(
-				appPorts(80),
-				healthChecks(marathon.NewDefaultHealthCheck()),
-			),
-			expected: false,
-		},
-		{
-			desc: "healthcheck results mixed",
-			task: task(
-				taskPorts(80),
-				healthCheckResultLiveness(true, false),
-			),
-			application: application(
-				appPorts(80),
-				healthChecks(marathon.NewDefaultHealthCheck()),
-			),
-			expected: false,
-		},
-		{
-			desc: "healthcheck result true",
-			task: task(
-				taskPorts(80),
-				healthCheckResultLiveness(true),
-			),
-			application: application(
-				appPorts(80),
-				healthChecks(marathon.NewDefaultHealthCheck()),
-			),
-			expected: true,
-		},
-		{
 			desc: "readiness check false",
 			task: task(taskPorts(80)),
 			application: application(


### PR DESCRIPTION
### What does this PR do?

Remove health check filter from Marathon tasks.

### Motivation

When available, Traefik uses the last Marathon health check result to decide whether a task should be filtered or not. This behavior is incorrect, however, as it ignores the failure threshold denoting the
number of failed health checks it would take for Marathon to actually consider a task as failing and trigger a restart. With Traefik not taking the threshold into account, a task is removed from the
configuration already while Marathon may still deem it healthy. 

Delaying the filtering until the moment when the failure threshold is exceeded would not buy us much: At that point, Marathon will decide to restart the unhealthy task anyway and cause a task state change that will lead to a Traefik configuration update excluding the task in question.

Consequently, we can remove the filter logic.

### More

- [x] Added/updated tests
- [x] Added/updated documentation