### PR TITLE
Clarify how setting a frontend priority works

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -236,7 +236,7 @@ The following rules are both `Matchers` and `Modifiers`, so the `Matcher` portio
 By default, routes will be sorted (in descending order) using rules length (to avoid path overlap):
 `PathPrefix:/12345` will be matched before `PathPrefix:/1234` that will be matched before `PathPrefix:/1`.
 
-You can customize priority by frontend:
+You can customize priority by frontend. The priority value is added to the rule length during sorting:
 
 ```toml
   [frontends]
@@ -254,7 +254,7 @@ You can customize priority by frontend:
       rule = "PathPrefix:/toto"
 ```
 
-Here, `frontend1` will be matched before `frontend2` (`10 > 5`).
+Here, `frontend1` will be matched before `frontend2` (`(3 + 10 == 13) > (4 + 5 == 9)`).
 
 #### Custom headers
 


### PR DESCRIPTION
### What does this PR do?
Clarify how setting a frontend priority works.

See #1962 for discussion, and https://github.com/containous/traefik/blob/c0563f1a395d53edbbf1030b2387435077eeb871/server/server.go#L1338-L1347 for the now documented code.

### Motivation
I set the priority on a rule, and it wasn't effective the way I understood it from the documentation. This gave us trouble in routing in our test environment.

Reading #1962, I realized from the code snippet that setting the priority works more like an offset than an absolute ordering of frontends.

### More
Purely a documentation change.

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes
I would be _amazing_ to have a way to get the previously documented behavior, i.e. comparing priorities first, only using rule lengths to break ties.