### PR TITLE
Fix support for macvlan driver in docker provider

### DIFF
--- a/provider/docker/builder_test.go
+++ b/provider/docker/builder_test.go
@@ -95,6 +95,25 @@ func taskSlot(slot int) func(*swarm.Task) {
 	}
 }
 
+func taskNetworkAttachment(id string, name string, driver string, addresses []string) func(*swarm.Task) {
+	return func(task *swarm.Task) {
+		task.NetworksAttachments = append(task.NetworksAttachments, swarm.NetworkAttachment{
+			Network: swarm.Network{
+				ID: id,
+				Spec: swarm.NetworkSpec{
+					Annotations: swarm.Annotations{
+						Name: name,
+					},
+					DriverConfiguration: &swarm.Driver{
+						Name: driver,
+					},
+				},
+			},
+			Addresses: addresses,
+		})
+	}
+}
+
 func taskStatus(ops ...func(*swarm.TaskStatus)) func(*swarm.Task) {
 	return func(task *swarm.Task) {
 		status := &swarm.TaskStatus{}
@@ -110,6 +129,14 @@ func taskStatus(ops ...func(*swarm.TaskStatus)) func(*swarm.Task) {
 func taskState(state swarm.TaskState) func(*swarm.TaskStatus) {
 	return func(status *swarm.TaskStatus) {
 		status.State = state
+	}
+}
+
+func taskContainerStatus(id string) func(*swarm.TaskStatus) {
+	return func(status *swarm.TaskStatus) {
+		status.ContainerStatus = swarm.ContainerStatus{
+			ContainerID: id,
+		}
 	}
 }
 

--- a/provider/docker/config_container_swarm_test.go
+++ b/provider/docker/config_container_swarm_test.go
@@ -1,7 +1,6 @@
 package docker
 
 import (
-	"reflect"
 	"strconv"
 	"testing"
 	"time"
@@ -468,70 +467,6 @@ func TestSwarmTraefikFilter(t *testing.T) {
 			actual := test.provider.containerFilter(dData)
 			if actual != test.expected {
 				t.Errorf("expected %v for %+v, got %+v", test.expected, test, actual)
-			}
-		})
-	}
-}
-
-func TestSwarmTaskParsing(t *testing.T) {
-	testCases := []struct {
-		service       swarm.Service
-		tasks         []swarm.Task
-		isGlobalSVC   bool
-		expectedNames map[string]string
-		networks      map[string]*docker.NetworkResource
-	}{
-		{
-			service: swarmService(serviceName("container")),
-			tasks: []swarm.Task{
-				swarmTask("id1", taskSlot(1)),
-				swarmTask("id2", taskSlot(2)),
-				swarmTask("id3", taskSlot(3)),
-			},
-			isGlobalSVC: false,
-			expectedNames: map[string]string{
-				"id1": "container.1",
-				"id2": "container.2",
-				"id3": "container.3",
-			},
-			networks: map[string]*docker.NetworkResource{
-				"1": {
-					Name: "foo",
-				},
-			},
-		},
-		{
-			service: swarmService(serviceName("container")),
-			tasks: []swarm.Task{
-				swarmTask("id1"),
-				swarmTask("id2"),
-				swarmTask("id3"),
-			},
-			isGlobalSVC: true,
-			expectedNames: map[string]string{
-				"id1": "container.id1",
-				"id2": "container.id2",
-				"id3": "container.id3",
-			},
-			networks: map[string]*docker.NetworkResource{
-				"1": {
-					Name: "foo",
-				},
-			},
-		},
-	}
-
-	for caseID, test := range testCases {
-		test := test
-		t.Run(strconv.Itoa(caseID), func(t *testing.T) {
-			t.Parallel()
-			dData := parseService(test.service, test.networks)
-
-			for _, task := range test.tasks {
-				taskDockerData := parseTasks(task, dData, map[string]*docker.NetworkResource{}, test.isGlobalSVC)
-				if !reflect.DeepEqual(taskDockerData.Name, test.expectedNames[task.ID]) {
-					t.Errorf("expect %v, got %v", test.expectedNames[task.ID], taskDockerData.Name)
-				}
 			}
 		})
 	}

--- a/provider/docker/swarm_test.go
+++ b/provider/docker/swarm_test.go
@@ -16,12 +16,17 @@ import (
 
 type fakeTasksClient struct {
 	dockerclient.APIClient
-	tasks []swarm.Task
-	err   error
+	tasks     []swarm.Task
+	container dockertypes.ContainerJSON
+	err       error
 }
 
 func (c *fakeTasksClient) TaskList(ctx context.Context, options dockertypes.TaskListOptions) ([]swarm.Task, error) {
 	return c.tasks, c.err
+}
+
+func (c *fakeTasksClient) ContainerInspect(ctx context.Context, container string) (dockertypes.ContainerJSON, error) {
+	return c.container, c.err
 }
 
 func TestListTasks(t *testing.T) {
@@ -35,11 +40,30 @@ func TestListTasks(t *testing.T) {
 		{
 			service: swarmService(serviceName("container")),
 			tasks: []swarm.Task{
-				swarmTask("id1", taskSlot(1), taskStatus(taskState(swarm.TaskStateRunning))),
-				swarmTask("id2", taskSlot(2), taskStatus(taskState(swarm.TaskStatePending))),
-				swarmTask("id3", taskSlot(3)),
-				swarmTask("id4", taskSlot(4), taskStatus(taskState(swarm.TaskStateRunning))),
-				swarmTask("id5", taskSlot(5), taskStatus(taskState(swarm.TaskStateFailed))),
+				swarmTask("id1",
+					taskSlot(1),
+					taskNetworkAttachment("1", "network1", "overlay", []string{"127.0.0.1"}),
+					taskStatus(taskState(swarm.TaskStateRunning)),
+				),
+				swarmTask("id2",
+					taskSlot(2),
+					taskNetworkAttachment("1", "network1", "overlay", []string{"127.0.0.2"}),
+					taskStatus(taskState(swarm.TaskStatePending)),
+				),
+				swarmTask("id3",
+					taskSlot(3),
+					taskNetworkAttachment("1", "network1", "overlay", []string{"127.0.0.3"}),
+				),
+				swarmTask("id4",
+					taskSlot(4),
+					taskNetworkAttachment("1", "network1", "overlay", []string{"127.0.0.4"}),
+					taskStatus(taskState(swarm.TaskStateRunning)),
+				),
+				swarmTask("id5",
+					taskSlot(5),
+					taskNetworkAttachment("1", "network1", "overlay", []string{"127.0.0.5"}),
+					taskStatus(taskState(swarm.TaskStateFailed)),
+				),
 			},
 			isGlobalSVC: false,
 			expectedTasks: []string{
@@ -60,7 +84,7 @@ func TestListTasks(t *testing.T) {
 			t.Parallel()
 			dockerData := parseService(test.service, test.networks)
 			dockerClient := &fakeTasksClient{tasks: test.tasks}
-			taskDockerData, _ := listTasks(context.Background(), dockerClient, test.service.ID, dockerData, map[string]*docker.NetworkResource{}, test.isGlobalSVC)
+			taskDockerData, _ := listTasks(context.Background(), dockerClient, test.service.ID, dockerData, test.networks, test.isGlobalSVC)
 
 			if len(test.expectedTasks) != len(taskDockerData) {
 				t.Errorf("expected tasks %v, got %v", spew.Sdump(test.expectedTasks), spew.Sdump(taskDockerData))
@@ -203,8 +227,14 @@ func TestListServices(t *testing.T) {
 					withEndpointSpec(modeDNSSR)),
 			},
 			tasks: []swarm.Task{
-				swarmTask("id1", taskStatus(taskState(swarm.TaskStateRunning))),
-				swarmTask("id2", taskStatus(taskState(swarm.TaskStateRunning))),
+				swarmTask("id1",
+					taskNetworkAttachment("yk6l57rfwizjzxxzftn4amaot", "network_name", "overlay", []string{"127.0.0.1"}),
+					taskStatus(taskState(swarm.TaskStateRunning)),
+				),
+				swarmTask("id2",
+					taskNetworkAttachment("yk6l57rfwizjzxxzftn4amaot", "network_name", "overlay", []string{"127.0.0.1"}),
+					taskStatus(taskState(swarm.TaskStateRunning)),
+				),
 			},
 			dockerVersion: "1.30",
 			networks: []dockertypes.NetworkResource{
@@ -248,6 +278,119 @@ func TestListServices(t *testing.T) {
 			assert.Equal(t, len(test.expectedServices), len(serviceDockerData))
 			for i, serviceName := range test.expectedServices {
 				assert.Equal(t, serviceName, serviceDockerData[i].Name)
+			}
+		})
+	}
+}
+
+func TestSwarmTaskParsing(t *testing.T) {
+	testCases := []struct {
+		service     swarm.Service
+		tasks       []swarm.Task
+		isGlobalSVC bool
+		expected    map[string]dockerData
+		networks    map[string]*docker.NetworkResource
+	}{
+		{
+			service: swarmService(serviceName("container")),
+			tasks: []swarm.Task{
+				swarmTask("id1", taskSlot(1)),
+				swarmTask("id2", taskSlot(2)),
+				swarmTask("id3", taskSlot(3)),
+			},
+			isGlobalSVC: false,
+			expected: map[string]dockerData{
+				"id1": {
+					Name: "container.1",
+				},
+				"id2": {
+					Name: "container.2",
+				},
+				"id3": {
+					Name: "container.3",
+				},
+			},
+			networks: map[string]*docker.NetworkResource{
+				"1": {
+					Name: "foo",
+				},
+			},
+		},
+		{
+			service: swarmService(serviceName("container")),
+			tasks: []swarm.Task{
+				swarmTask("id1"),
+				swarmTask("id2"),
+				swarmTask("id3"),
+			},
+			isGlobalSVC: true,
+			expected: map[string]dockerData{
+				"id1": {
+					Name: "container.id1",
+				},
+				"id2": {
+					Name: "container.id2",
+				},
+				"id3": {
+					Name: "container.id3",
+				},
+			},
+			networks: map[string]*docker.NetworkResource{
+				"1": {
+					Name: "foo",
+				},
+			},
+		},
+		{
+			service: swarmService(
+				serviceName("container"),
+				withEndpointSpec(modeVIP),
+				withEndpoint(
+					virtualIP("1", ""),
+				),
+			),
+			tasks: []swarm.Task{
+				swarmTask(
+					"id1",
+					taskNetworkAttachment("1", "vlan", "macvlan", []string{"127.0.0.1"}),
+					taskStatus(
+						taskState(swarm.TaskStateRunning),
+						taskContainerStatus("c1"),
+					),
+				),
+			},
+			isGlobalSVC: true,
+			expected: map[string]dockerData{
+				"id1": {
+					Name: "container.id1",
+					NetworkSettings: networkSettings{
+						Networks: map[string]*networkData{
+							"vlan": {
+								Name: "vlan",
+								Addr: "10.11.12.13",
+							},
+						},
+					},
+				},
+			},
+			networks: map[string]*docker.NetworkResource{
+				"1": {
+					Name: "vlan",
+				},
+			},
+		},
+	}
+
+	for caseID, test := range testCases {
+		test := test
+		t.Run(strconv.Itoa(caseID), func(t *testing.T) {
+			t.Parallel()
+			dData := parseService(test.service, test.networks)
+
+			for _, task := range test.tasks {
+				taskDockerData := parseTasks(task, dData, test.networks, test.isGlobalSVC)
+				expected := test.expected[task.ID]
+				assert.Equal(t, expected.Name, taskDockerData.Name)
 			}
 		})
 	}


### PR DESCRIPTION
### What does this PR do?

This PR fix support of macvlan driver in docker swarm mode.

Today it is impossible to support macvlan driver in swarm mode because we are not able to retrieve IP addresses of containers running on other host in the cluster

### Motivation

Fixes #2412 

### More

- [x] Added/updated tests
