### PR TITLE
Explain how to write entrypoints definition in a compose file

### DIFF
--- a/docs/configuration/entrypoints.md
+++ b/docs/configuration/entrypoints.md
@@ -78,7 +78,23 @@ For more information about the CLI, see the documentation about [Traefik command
     Whitespace is used as option separator and `,` is used as value separator for the list.  
     The names of the options are case-insensitive.
 
-All available options:
+In compose file the entrypoint syntax is different:
+
+```yaml
+traefik:
+    image: traefik
+    command:
+        - --defaultentrypoints=powpow
+        - "--entryPoints=Name:powpow Address::42 Compress:true"
+```
+or
+```yaml
+traefik:
+    image: traefik
+    command: --defaultentrypoints=powpow --entryPoints='Name:powpow Address::42 Compress:true'
+```
+
+#### All available options:
 
 ```ini
 Name:foo

--- a/docs/user-guide/cluster-docker-consul.md
+++ b/docs/user-guide/cluster-docker-consul.md
@@ -94,8 +94,8 @@ services:
     image: traefik:1.5
     command:
       - "--api"
-      - "--entrypoints='Name:http Address::80 Redirect.EntryPoint:https'"
-      - "--entrypoints='Name:https Address::443 TLS'"
+      - "--entrypoints=Name:http Address::80 Redirect.EntryPoint:https"
+      - "--entrypoints=Name:https Address::443 TLS"
       - "--defaultentrypoints=http,https"
       - "--acme"
       - "--acme.storage=/etc/traefik/acme/acme.json"
@@ -204,8 +204,8 @@ services:
     command:
       - "storeconfig"
       - "--api"
-      - "--entrypoints='Name:http Address::80 Redirect.EntryPoint:https'"
-      - "--entrypoints='Name:https Address::443 TLS'"
+      - "--entrypoints=Name:http Address::80 Redirect.EntryPoint:https"
+      - "--entrypoints=Name:https Address::443 TLS"
       - "--defaultentrypoints=http,https"
       - "--acme"
       - "--acme.storage=traefik/acme/account"


### PR DESCRIPTION
### What does this PR do?

This PR add an explanation on how to write entrypoint definition with CLI in a compose file.

Træfik CLI binary:
```shell
--entryPoints='Name:http Address::80'
--entryPoints='Name:https Address::443 TLS'
```

Træfik CLI compose file
```yaml
traefik:
    image: traefik
    command:
        - --defaultentrypoints=powpow
        - "--entryPoints=Name:powpow Address::42 Compress:true"
```

### Motivation

Better documentation :book:

### More

- [x] Added/updated documentation
