### PR TITLE
Remote Address Masking

### DIFF
--- a/docs/configuration/commons.md
+++ b/docs/configuration/commons.md
@@ -223,18 +223,21 @@ Depending on your local jurisdiction you may be required to only store masked or
 Traefik partially masks IP addresses in its access log by default.
 This means the last octet of IPv4 addresses and the last 80 bytes of IPv6 addresses are set to 0 in the access log.
 Hostnames are set to `[REDACTED]` as they cannot be masked in a meaningful way:
+
 ```toml
 [accessLog]
 remoteIPMask = "partial"
 ```
 
 To log no addresses at all (IPv4: `0.0.0.0`, IPv6: `::`, hostname: `[REDACTED]`):
+
 ```toml
 [accessLog]
 remoteIPMask = "full"
 ```
 
 To keep the legacy behaviour of logging full addresses:
+
 ```toml
 [accessLog]
 remoteIPMask = "off"

--- a/docs/configuration/commons.md
+++ b/docs/configuration/commons.md
@@ -219,6 +219,26 @@ filePath = "/path/to/access.log"
 format = "json"
 ```
 
+Depending on your local jurisdiction you may be required to only store masked or fully anonymized IP addresses. Traefik partially masks IP addresses in its access log by default. This means the last octet of IPv4 addresses and the last 80 bytes of IPv6 addresses are set to 0 in the access log. Hostnames are set to `[REDACTED]` as they cannot be masked in a meaningful way:
+```toml
+[accessLog]
+remoteIPMask = "partial"
+```
+
+To log no addresses at all (IPv4: `0.0.0.0`, IPv6: `::`, hostname: `[REDACTED]`):
+```toml
+[accessLog]
+remoteIPMask = "full"
+```
+
+To keep the legacy behaviour of logging full addresses:
+```toml
+[accessLog]
+remoteIPMask = "off"
+```
+
+Note that your access log might still contain other personally identifiable information such as your user's information and IDs in URL parameters or usernames when using `Basic Auth`. These settings only affect the access log (which does not include e.g. headers passed). A thorough review of your logging and data storage practices is highly recommended.
+
 Deprecated way (before 1.4):
 ```toml
 # Access logs file

--- a/docs/configuration/commons.md
+++ b/docs/configuration/commons.md
@@ -219,7 +219,10 @@ filePath = "/path/to/access.log"
 format = "json"
 ```
 
-Depending on your local jurisdiction you may be required to only store masked or fully anonymized IP addresses. Traefik partially masks IP addresses in its access log by default. This means the last octet of IPv4 addresses and the last 80 bytes of IPv6 addresses are set to 0 in the access log. Hostnames are set to `[REDACTED]` as they cannot be masked in a meaningful way:
+Depending on your local jurisdiction you may be required to only store masked or fully anonymized IP addresses.
+Traefik partially masks IP addresses in its access log by default.
+This means the last octet of IPv4 addresses and the last 80 bytes of IPv6 addresses are set to 0 in the access log.
+Hostnames are set to `[REDACTED]` as they cannot be masked in a meaningful way:
 ```toml
 [accessLog]
 remoteIPMask = "partial"
@@ -237,7 +240,9 @@ To keep the legacy behaviour of logging full addresses:
 remoteIPMask = "off"
 ```
 
-Note that your access log might still contain other personally identifiable information such as your user's information and IDs in URL parameters or usernames when using `Basic Auth`. These settings only affect the access log (which does not include e.g. headers passed). A thorough review of your logging and data storage practices is highly recommended.
+Note that your access log might still contain other personally identifiable information such as your user's information and IDs in URL parameters or usernames when using `Basic Auth`.
+These settings only affect the access log (which does not include e.g. headers passed).
+A thorough review of your logging and data storage practices is highly recommended.
 
 Deprecated way (before 1.4):
 ```toml

--- a/middlewares/accesslog/logger.go
+++ b/middlewares/accesslog/logger.go
@@ -163,7 +163,7 @@ func (l *LogHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request, next h
 	// Mask host's address if necessary
 	isIPv6 := strings.Contains(host, ":")
 
-	if l.maskIPv4 != nil && l.maskIPv6 != nil {
+	if len(l.maskIPv4) > 0 && len(l.maskIPv6) > 0 {
 		host = maskHost(host, l.maskIPv4, l.maskIPv6, isIPv6)
 	}
 

--- a/middlewares/accesslog/logger.go
+++ b/middlewares/accesslog/logger.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -28,6 +29,15 @@ const (
 
 	// JSONFormat is the JSON logging format
 	JSONFormat = "json"
+
+	// NoMask does not apply a mask to logged IP addresses
+	NoMask = "off"
+
+	// PartialMask masks the last octet of IPv4 adresses and the last 80 bits of IPv6 addresses
+	PartialMask = "partial"
+
+	// FullMask completely anonymizes logged IP adresses
+	FullMask = "full"
 )
 
 // LogHandler will write each request and its response to the access log.
@@ -35,6 +45,8 @@ type LogHandler struct {
 	logger   *logrus.Logger
 	file     *os.File
 	filePath string
+	maskIPv4 *net.IPMask
+	maskIPv6 *net.IPMask
 	mu       sync.Mutex
 }
 
@@ -60,13 +72,42 @@ func NewLogHandler(config *types.AccessLog) (*LogHandler, error) {
 		return nil, fmt.Errorf("unsupported access log format: %s", config.Format)
 	}
 
+	// Enable masks for remote addresses
+	var maskIPv4 *net.IPMask
+	var maskIPv6 *net.IPMask
+
+	// Set default value if not set
+	if len(config.RemoteIPMask) == 0 {
+		config.RemoteIPMask = PartialMask
+	}
+
+	switch config.RemoteIPMask {
+	case NoMask:
+		maskIPv4 = nil
+		maskIPv6 = nil
+	case PartialMask:
+		v4 := net.CIDRMask(24, 32)
+		v6 := net.CIDRMask(48, 128)
+
+		maskIPv4 = &v4
+		maskIPv6 = &v6
+	case FullMask:
+		v4 := net.CIDRMask(0, 32)
+		v6 := net.CIDRMask(0, 128)
+
+		maskIPv4 = &v4
+		maskIPv6 = &v6
+	default:
+		return nil, fmt.Errorf("unsupported IP address mask setting for access log: %s", config.RemoteIPMask)
+	}
+
 	logger := &logrus.Logger{
 		Out:       file,
 		Formatter: formatter,
 		Hooks:     make(logrus.LevelHooks),
 		Level:     logrus.InfoLevel,
 	}
-	return &LogHandler{logger: logger, file: file, filePath: config.FilePath}, nil
+	return &LogHandler{logger: logger, file: file, filePath: config.FilePath, maskIPv4: maskIPv4, maskIPv6: maskIPv6}, nil
 }
 
 func openAccessLogFile(filePath string) (*os.File, error) {
@@ -125,8 +166,31 @@ func (l *LogHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request, next h
 	core[RequestProtocol] = req.Proto
 	core[RequestLine] = fmt.Sprintf("%s %s %s", req.Method, urlCopyString, req.Proto)
 
-	core[ClientAddr] = req.RemoteAddr
-	core[ClientHost], core[ClientPort] = silentSplitHostPort(req.RemoteAddr)
+	host, port := silentSplitHostPort(req.RemoteAddr)
+
+	// Mask host's address if necessary
+	var isIPv6 = false
+
+	if l.maskIPv4 != nil && l.maskIPv6 != nil {
+		host, isIPv6 = maskHost(host, l.maskIPv4, l.maskIPv6)
+	} else {
+		if strings.Contains(host, ":") {
+			isIPv6 = true
+		} else {
+			isIPv6 = false
+		}
+	}
+
+	core[ClientHost] = host
+	core[ClientPort] = port
+
+	if isIPv6 {
+		// IPv6 address
+		core[ClientAddr] = "[" + host + "]:" + port
+	} else {
+		// Ipv4 address or hostname
+		core[ClientAddr] = host + ":" + port
+	}
 
 	if forwardedFor := req.Header.Get("X-Forwarded-For"); forwardedFor != "" {
 		core[ClientHost] = forwardedFor
@@ -174,6 +238,25 @@ func silentSplitHostPort(value string) (host string, port string) {
 		return value, "-"
 	}
 	return host, port
+}
+
+func maskHost(address string, maskIPv4 *net.IPMask, maskIPv6 *net.IPMask) (maskedAddress string, isIPv6 bool) {
+	// Check if it is a hostname, an IPv4 or an IPv6 address
+	parsedAddress := net.ParseIP(address)
+
+	if parsedAddress == nil {
+		// Hostname
+		// As hostnames cannot be masked in a meaningful way, do not log them at all
+		return "[REDACTED]", false
+	}
+
+	if strings.Contains(address, ":") {
+		// IPv6
+		return parsedAddress.Mask(*maskIPv6).String(), true
+	}
+
+	// IPv4
+	return parsedAddress.Mask(*maskIPv4).String(), false
 }
 
 func usernameIfPresent(theURL *url.URL) string {

--- a/types/types.go
+++ b/types/types.go
@@ -456,8 +456,9 @@ type TraefikLog struct {
 
 // AccessLog holds the configuration settings for the access logger (middlewares/accesslog).
 type AccessLog struct {
-	FilePath string `json:"file,omitempty" description:"Access log file path. Stdout is used when omitted or empty" export:"true"`
-	Format   string `json:"format,omitempty" description:"Access log format: json | common" export:"true"`
+	FilePath     string `json:"file,omitempty" description:"Access log file path. Stdout is used when omitted or empty" export:"true"`
+	Format       string `json:"format,omitempty" description:"Access log format: json | common" export:"true"`
+	RemoteIPMask string `json:"remoteIPMask,omitempty" description:"Completely anonymize, partially mask (default) or do not mask IP addresses in the access log. Hostnames are only logged if this setting is set to off: full | partial | off"`
 }
 
 // ClientTLS holds TLS specific configurations as client


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

This PR adds the ability to mask or completely redact client's IP addresses and hostnames in the access log. Partial masking is enabled by default resulting in a private by default behaviour for traefik.

### Motivation

With the [GDPR](https://en.wikipedia.org/wiki/General_Data_Protection_Regulation) becoming enforceable soon and court rulings in countries such as Germany, logging and storage of (potentially) personally identifiable information needs to be reduced in many organizations.
This allows traefik's users to configure the access logger to mask/redact their client's IP addresses and hostnames.
There are three options for `remoteIPMask`:

1. `off` Log client's full adresses and hostnames like before
2. `partial` (default) Redact hostnames, [mask the last octet of IPv4 addresses and the last 80 bytes of IPv6 addreses](https://support.google.com/analytics/answer/2763052?hl=en)
3. `full` Redact hostnames and mask the whole IP address

Changing the default behaviour to `partial` may be a breaking change for some users now, however it is expected that many (future) users will operate traefik under EU jurisdiction and neither have the need nor the legal authorization to store this data. Thus it could be beneficial in the long term to adjust traefik's default behaviour in this case.

As I am not a lawyer I can not assess the legal compliance of this PR's changes, however I think it is useful to have these tools available vs. having to disable logging entirely.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

- Logging of usernames and passing addresses in HTTP headers should also be evaluated
