### PR TITLE
Add warning that PUT to API only works with rest and web

### DIFF
--- a/docs/configuration/api.md
+++ b/docs/configuration/api.md
@@ -56,6 +56,9 @@
     For compatibility reason, when you activate the rest provider, you can use `web` or `rest` as `provider` value.
     But be careful, in the configuration for all providers the key is still `web`.
 
+!!! warning
+    Updating providers with `PUT /api/providers/{provider}` can only be used with `web` or `rest`
+
 ### Provider configurations
 
 ```shell


### PR DESCRIPTION
### What does this PR do?

Adds a warning to API documentation about updating providers

### Motivation

The API documentation seems to state that you can invoke PUT for updating providers for any provider, though in fact it only works for `rest` or `web`:

https://github.com/containous/traefik/blob/395b1702dee610107e3690afef0490bc0beca282/provider/rest/rest.go#L35


### More

- [x] Added/updated documentation

