### PR TITLE
Isolate backend with same name on different provider

### DIFF
--- a/integration/fixtures/multiple_provider.toml
+++ b/integration/fixtures/multiple_provider.toml
@@ -1,0 +1,25 @@
+defaultEntryPoints = ["http"]
+
+debug=true
+
+[entryPoints]
+  [entryPoints.http]
+  address = ":8000"
+
+[api]
+
+[docker]
+endpoint = "unix:///var/run/docker.sock"
+watch = true
+exposedbydefault = false
+
+[file]
+  [frontends]
+  [frontends.frontend-1]
+    backend = "backend-test"
+  [frontends.frontend-1.routes.test_1]
+  rule = "PathPrefix:/file"
+  [backends]
+    [backends.backend-test]
+        [backends.backend-test.servers.website]
+            url = "http://{{ .IP }}"

--- a/integration/resources/compose/base.yml
+++ b/integration/resources/compose/base.yml
@@ -3,3 +3,9 @@ whoami1:
   labels:
     - traefik.enable=true
     - traefik.frontend.rule=PathPrefix:/whoami
+    - traefik.backend="test"
+
+whoami2:
+  image: emilevauge/whoami
+  labels:
+    - traefik.enable=false

--- a/server/server.go
+++ b/server/server.go
@@ -913,7 +913,7 @@ func (s *Server) loadConfig(configurations types.Configurations, globalConfigura
 	backendsHealthCheck := map[string]*healthcheck.BackendHealthCheck{}
 	errorHandler := NewRecordingErrorHandler(middlewares.DefaultNetErrorRecorder{})
 
-	for _, config := range configurations {
+	for providerName, config := range configurations {
 		frontendNames := sortedFrontendNamesForConfig(config)
 	frontend:
 		for _, frontendName := range frontendNames {
@@ -970,7 +970,7 @@ func (s *Server) loadConfig(configurations types.Configurations, globalConfigura
 						}
 					}
 				}
-				if backends[entryPointName+frontend.Backend] == nil {
+				if backends[entryPointName+providerName+frontend.Backend] == nil {
 					log.Debugf("Creating backend %s", frontend.Backend)
 
 					roundTripper, err := s.getRoundTripper(entryPointName, globalConfiguration, frontend.PassTLSCert, entryPoint.TLS)
@@ -1191,14 +1191,14 @@ func (s *Server) loadConfig(configurations types.Configurations, globalConfigura
 					} else {
 						n.UseHandler(lb)
 					}
-					backends[entryPointName+frontend.Backend] = n
+					backends[entryPointName+providerName+frontend.Backend] = n
 				} else {
 					log.Debugf("Reusing backend %s", frontend.Backend)
 				}
 				if frontend.Priority > 0 {
 					newServerRoute.route.Priority(frontend.Priority)
 				}
-				s.wireFrontendBackend(newServerRoute, backends[entryPointName+frontend.Backend])
+				s.wireFrontendBackend(newServerRoute, backends[entryPointName+providerName+frontend.Backend])
 
 				err := newServerRoute.route.GetError()
 				if err != nil {


### PR DESCRIPTION
### What does this PR do?
Isolate each backend on different provider

### Motivation
If you had two backends with same name on different provider, only one backend was used. This PR fix this bug by isolate the backends on each provider.

### More

- [X] Added/updated tests