### PR TITLE
Check for endpoints while detecting Consul service changes

### DIFF
--- a/provider/consulcatalog/consul_catalog_test.go
+++ b/provider/consulcatalog/consul_catalog_test.go
@@ -638,6 +638,24 @@ func TestHasServiceChanged(t *testing.T) {
 			expected: true,
 		},
 		{
+			desc: "Change detected on addresses",
+			current: map[string]Service{
+				"foo-service": {
+					Name:      "foo",
+					Nodes:     []string{"node1"},
+					Addresses: []string{"127.0.0.1"},
+				},
+			},
+			previous: map[string]Service{
+				"foo-service": {
+					Name:      "foo",
+					Nodes:     []string{"node1"},
+					Addresses: []string{"127.0.0.2"},
+				},
+			},
+			expected: true,
+		},
+		{
 			desc: "No Change detected",
 			current: map[string]Service{
 				"foo-service": {


### PR DESCRIPTION
### What does this PR do?

Check for endpoint ip address while detecting Consul catalog changes

### Motivation

I'm experimenting with Docker Swarm, Registrator and Consul to implement service discovery in my project, and turned out, that scaling or updating an image for  a service does not trigger Traefik to refresh back-ends.  

After some investigation I figured out, that it's looking only on diff of unique node ids (that's why scaling a service on the same node never trigger update) and does not check for endpoint ip changes at all.

### More

- [x] Added/updated tests

### Additional Notes

Nothing else to mention.