### PR TITLE
Added missing metrics to registry for DataDog and StatsD

### DIFF
--- a/metrics/datadog.go
+++ b/metrics/datadog.go
@@ -19,9 +19,18 @@ var datadogTicker *time.Ticker
 
 // Metric names consistent with https://github.com/DataDog/integrations-extras/pull/64
 const (
-	ddMetricsReqsName    = "requests.total"
-	ddMetricsLatencyName = "request.duration"
-	ddRetriesTotalName   = "backend.retries.total"
+	ddMetricsBackendReqsName      = "backend.request.total"
+	ddMetricsBackendLatencyName   = "backend.request.duration"
+	ddRetriesTotalName            = "backend.retries.total"
+	ddConfigReloadsName           = "config.reload.total"
+	ddConfigReloadsFailureTagName = "failure"
+	ddLastConfigReloadSuccessName = "config.reload.lastSuccessTimestamp"
+	ddLastConfigReloadFailureName = "config.reload.lastFailureTimestamp"
+	ddEntrypointReqsName          = "entrypoint.request.total"
+	ddEntrypointReqDurationName   = "entrypoint.request.duration"
+	ddEntrypointOpenConnsName     = "entrypoint.connections.open"
+	ddOpenConnsName               = "backend.connections.open"
+	ddServerUpName                = "backend.server.up"
 )
 
 // RegisterDatadog registers the metrics pusher if this didn't happen yet and creates a datadog Registry instance.
@@ -31,10 +40,19 @@ func RegisterDatadog(config *types.Datadog) Registry {
 	}
 
 	registry := &standardRegistry{
-		enabled:                     true,
-		backendReqsCounter:          datadogClient.NewCounter(ddMetricsReqsName, 1.0),
-		backendReqDurationHistogram: datadogClient.NewHistogram(ddMetricsLatencyName, 1.0),
-		backendRetriesCounter:       datadogClient.NewCounter(ddRetriesTotalName, 1.0),
+		enabled:                        true,
+		configReloadsCounter:           datadogClient.NewCounter(ddConfigReloadsName, 1.0),
+		configReloadsFailureCounter:    datadogClient.NewCounter(ddConfigReloadsName, 1.0).With(ddConfigReloadsFailureTagName, "true"),
+		lastConfigReloadSuccessGauge:   datadogClient.NewGauge(ddLastConfigReloadSuccessName),
+		lastConfigReloadFailureGauge:   datadogClient.NewGauge(ddLastConfigReloadFailureName),
+		entrypointReqsCounter:          datadogClient.NewCounter(ddEntrypointReqsName, 1.0),
+		entrypointReqDurationHistogram: datadogClient.NewHistogram(ddEntrypointReqDurationName, 1.0),
+		entrypointOpenConnsGauge:       datadogClient.NewGauge(ddEntrypointOpenConnsName),
+		backendReqsCounter:             datadogClient.NewCounter(ddMetricsBackendReqsName, 1.0),
+		backendReqDurationHistogram:    datadogClient.NewHistogram(ddMetricsBackendLatencyName, 1.0),
+		backendRetriesCounter:          datadogClient.NewCounter(ddRetriesTotalName, 1.0),
+		backendOpenConnsGauge:          datadogClient.NewGauge(ddOpenConnsName),
+		backendServerUpGauge:           datadogClient.NewGauge(ddServerUpName),
 	}
 
 	return registry

--- a/metrics/datadog_test.go
+++ b/metrics/datadog_test.go
@@ -24,10 +24,16 @@ func TestDatadog(t *testing.T) {
 
 	expected := []string{
 		// We are only validating counts, as it is nearly impossible to validate latency, since it varies every run
-		"traefik.requests.total:1.000000|c|#service:test,code:404,method:GET\n",
-		"traefik.requests.total:1.000000|c|#service:test,code:200,method:GET\n",
+		"traefik.backend.request.total:1.000000|c|#service:test,code:404,method:GET\n",
+		"traefik.backend.request.total:1.000000|c|#service:test,code:200,method:GET\n",
 		"traefik.backend.retries.total:2.000000|c|#service:test\n",
-		"traefik.request.duration:10000.000000|h|#service:test,code:200",
+		"traefik.backend.request.duration:10000.000000|h|#service:test,code:200\n",
+		"traefik.config.reload.total:1.000000|c\n",
+		"traefik.config.reload.total:1.000000|c|#failure:true\n",
+		"traefik.entrypoint.request.total:1.000000|c|#entrypoint:test\n",
+		"traefik.entrypoint.request.duration:10000.000000|h|#entrypoint:test\n",
+		"traefik.entrypoint.connections.open:1.000000|g|#entrypoint:test\n",
+		"traefik.backend.server.up:1.000000|g|#backend:test,url:http://127.0.0.1,one:two\n",
 	}
 
 	udp.ShouldReceiveAll(t, expected, func() {
@@ -36,5 +42,11 @@ func TestDatadog(t *testing.T) {
 		datadogRegistry.BackendReqDurationHistogram().With("service", "test", "code", strconv.Itoa(http.StatusOK)).Observe(10000)
 		datadogRegistry.BackendRetriesCounter().With("service", "test").Add(1)
 		datadogRegistry.BackendRetriesCounter().With("service", "test").Add(1)
+		datadogRegistry.ConfigReloadsCounter().Add(1)
+		datadogRegistry.ConfigReloadsFailureCounter().Add(1)
+		datadogRegistry.EntrypointReqsCounter().With("entrypoint", "test").Add(1)
+		datadogRegistry.EntrypointReqDurationHistogram().With("entrypoint", "test").Observe(10000)
+		datadogRegistry.EntrypointOpenConnsGauge().With("entrypoint", "test").Set(1)
+		datadogRegistry.BackendServerUpGauge().With("backend", "test", "url", "http://127.0.0.1", "one", "two").Set(1)
 	})
 }

--- a/metrics/statsd.go
+++ b/metrics/statsd.go
@@ -18,9 +18,18 @@ var statsdClient = statsd.New("traefik.", kitlog.LoggerFunc(func(keyvals ...inte
 var statsdTicker *time.Ticker
 
 const (
-	statsdMetricsReqsName    = "requests.total"
-	statsdMetricsLatencyName = "request.duration"
-	statsdRetriesTotalName   = "backend.retries.total"
+	statsdMetricsBackendReqsName      = "backend.request.total"
+	statsdMetricsBackendLatencyName   = "backend.request.duration"
+	statsdRetriesTotalName            = "backend.retries.total"
+	statsdConfigReloadsName           = "config.reload.total"
+	statsdConfigReloadsFailureName    = statsdConfigReloadsName + ".failure"
+	statsdLastConfigReloadSuccessName = "config.reload.lastSuccessTimestamp"
+	statsdLastConfigReloadFailureName = "config.reload.lastFailureTimestamp"
+	statsdEntrypointReqsName          = "entrypoint.request.total"
+	statsdEntrypointReqDurationName   = "entrypoint.request.duration"
+	statsdEntrypointOpenConnsName     = "entrypoint.connections.open"
+	statsdOpenConnsName               = "backend.connections.open"
+	statsdServerUpName                = "backend.server.up"
 )
 
 // RegisterStatsd registers the metrics pusher if this didn't happen yet and creates a statsd Registry instance.
@@ -30,10 +39,19 @@ func RegisterStatsd(config *types.Statsd) Registry {
 	}
 
 	return &standardRegistry{
-		enabled:                     true,
-		backendReqsCounter:          statsdClient.NewCounter(statsdMetricsReqsName, 1.0),
-		backendReqDurationHistogram: statsdClient.NewTiming(statsdMetricsLatencyName, 1.0),
-		backendRetriesCounter:       statsdClient.NewCounter(statsdRetriesTotalName, 1.0),
+		enabled:                        true,
+		configReloadsCounter:           statsdClient.NewCounter(statsdConfigReloadsName, 1.0),
+		configReloadsFailureCounter:    statsdClient.NewCounter(statsdConfigReloadsFailureName, 1.0),
+		lastConfigReloadSuccessGauge:   statsdClient.NewGauge(statsdLastConfigReloadSuccessName),
+		lastConfigReloadFailureGauge:   statsdClient.NewGauge(statsdLastConfigReloadFailureName),
+		entrypointReqsCounter:          statsdClient.NewCounter(statsdEntrypointReqsName, 1.0),
+		entrypointReqDurationHistogram: statsdClient.NewTiming(statsdEntrypointReqDurationName, 1.0),
+		entrypointOpenConnsGauge:       statsdClient.NewGauge(statsdEntrypointOpenConnsName),
+		backendReqsCounter:             statsdClient.NewCounter(statsdMetricsBackendReqsName, 1.0),
+		backendReqDurationHistogram:    statsdClient.NewTiming(statsdMetricsBackendLatencyName, 1.0),
+		backendRetriesCounter:          statsdClient.NewCounter(statsdRetriesTotalName, 1.0),
+		backendOpenConnsGauge:          statsdClient.NewGauge(statsdOpenConnsName),
+		backendServerUpGauge:           statsdClient.NewGauge(statsdServerUpName),
 	}
 }
 

--- a/metrics/statsd_test.go
+++ b/metrics/statsd_test.go
@@ -23,9 +23,15 @@ func TestStatsD(t *testing.T) {
 
 	expected := []string{
 		// We are only validating counts, as it is nearly impossible to validate latency, since it varies every run
-		"traefik.requests.total:2.000000|c\n",
+		"traefik.backend.request.total:2.000000|c\n",
 		"traefik.backend.retries.total:2.000000|c\n",
-		"traefik.request.duration:10000.000000|ms",
+		"traefik.backend.request.duration:10000.000000|ms",
+		"traefik.config.reload.total:1.000000|c\n",
+		"traefik.config.reload.total:1.000000|c\n",
+		"traefik.entrypoint.request.total:1.000000|c\n",
+		"traefik.entrypoint.request.duration:10000.000000|ms",
+		"traefik.entrypoint.connections.open:1.000000|g\n",
+		"traefik.backend.server.up:1.000000|g\n",
 	}
 
 	udp.ShouldReceiveAll(t, expected, func() {
@@ -34,5 +40,11 @@ func TestStatsD(t *testing.T) {
 		statsdRegistry.BackendRetriesCounter().With("service", "test").Add(1)
 		statsdRegistry.BackendRetriesCounter().With("service", "test").Add(1)
 		statsdRegistry.BackendReqDurationHistogram().With("service", "test", "code", string(http.StatusOK)).Observe(10000)
+		statsdRegistry.ConfigReloadsCounter().Add(1)
+		statsdRegistry.ConfigReloadsFailureCounter().Add(1)
+		statsdRegistry.EntrypointReqsCounter().With("entrypoint", "test").Add(1)
+		statsdRegistry.EntrypointReqDurationHistogram().With("entrypoint", "test").Observe(10000)
+		statsdRegistry.EntrypointOpenConnsGauge().With("entrypoint", "test").Set(1)
+		statsdRegistry.BackendServerUpGauge().With("backend:test", "url", "http://127.0.0.1").Set(1)
 	})
 }


### PR DESCRIPTION
This is to add the missing metrics to the registry for DataDog and StatsD, following #2567