### PR TITLE
Replace nginx by whoami in integration tests

### DIFF
--- a/integration/constraint_test.go
+++ b/integration/constraint_test.go
@@ -91,11 +91,11 @@ func (s *ConstraintSuite) TestMatchConstraintGlobal(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	defer cmd.Process.Kill()
 
-	nginx := s.composeProject.Container(c, "nginx")
+	whoami := s.composeProject.Container(c, "whoami")
 
-	err = s.registerService("test", nginx.NetworkSettings.IPAddress, 80, []string{"traefik.tags=api"})
+	err = s.registerService("test", whoami.NetworkSettings.IPAddress, 80, []string{"traefik.tags=api"})
 	c.Assert(err, checker.IsNil, check.Commentf("Error registering service"))
-	defer s.deregisterService("test", nginx.NetworkSettings.IPAddress)
+	defer s.deregisterService("test", whoami.NetworkSettings.IPAddress)
 
 	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8000/", nil)
 	c.Assert(err, checker.IsNil)
@@ -117,11 +117,11 @@ func (s *ConstraintSuite) TestDoesNotMatchConstraintGlobal(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	defer cmd.Process.Kill()
 
-	nginx := s.composeProject.Container(c, "nginx")
+	whoami := s.composeProject.Container(c, "whoami")
 
-	err = s.registerService("test", nginx.NetworkSettings.IPAddress, 80, []string{})
+	err = s.registerService("test", whoami.NetworkSettings.IPAddress, 80, []string{})
 	c.Assert(err, checker.IsNil, check.Commentf("Error registering service"))
-	defer s.deregisterService("test", nginx.NetworkSettings.IPAddress)
+	defer s.deregisterService("test", whoami.NetworkSettings.IPAddress)
 
 	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8000/", nil)
 	c.Assert(err, checker.IsNil)
@@ -143,11 +143,11 @@ func (s *ConstraintSuite) TestMatchConstraintProvider(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	defer cmd.Process.Kill()
 
-	nginx := s.composeProject.Container(c, "nginx")
+	whoami := s.composeProject.Container(c, "whoami")
 
-	err = s.registerService("test", nginx.NetworkSettings.IPAddress, 80, []string{"traefik.tags=api"})
+	err = s.registerService("test", whoami.NetworkSettings.IPAddress, 80, []string{"traefik.tags=api"})
 	c.Assert(err, checker.IsNil, check.Commentf("Error registering service"))
-	defer s.deregisterService("test", nginx.NetworkSettings.IPAddress)
+	defer s.deregisterService("test", whoami.NetworkSettings.IPAddress)
 
 	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8000/", nil)
 	c.Assert(err, checker.IsNil)
@@ -169,11 +169,11 @@ func (s *ConstraintSuite) TestDoesNotMatchConstraintProvider(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	defer cmd.Process.Kill()
 
-	nginx := s.composeProject.Container(c, "nginx")
+	whoami := s.composeProject.Container(c, "whoami")
 
-	err = s.registerService("test", nginx.NetworkSettings.IPAddress, 80, []string{})
+	err = s.registerService("test", whoami.NetworkSettings.IPAddress, 80, []string{})
 	c.Assert(err, checker.IsNil, check.Commentf("Error registering service"))
-	defer s.deregisterService("test", nginx.NetworkSettings.IPAddress)
+	defer s.deregisterService("test", whoami.NetworkSettings.IPAddress)
 
 	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8000/", nil)
 	c.Assert(err, checker.IsNil)
@@ -196,11 +196,11 @@ func (s *ConstraintSuite) TestMatchMultipleConstraint(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	defer cmd.Process.Kill()
 
-	nginx := s.composeProject.Container(c, "nginx")
+	whoami := s.composeProject.Container(c, "whoami")
 
-	err = s.registerService("test", nginx.NetworkSettings.IPAddress, 80, []string{"traefik.tags=api", "traefik.tags=eu-1"})
+	err = s.registerService("test", whoami.NetworkSettings.IPAddress, 80, []string{"traefik.tags=api", "traefik.tags=eu-1"})
 	c.Assert(err, checker.IsNil, check.Commentf("Error registering service"))
-	defer s.deregisterService("test", nginx.NetworkSettings.IPAddress)
+	defer s.deregisterService("test", whoami.NetworkSettings.IPAddress)
 
 	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8000/", nil)
 	c.Assert(err, checker.IsNil)
@@ -223,11 +223,11 @@ func (s *ConstraintSuite) TestDoesNotMatchMultipleConstraint(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	defer cmd.Process.Kill()
 
-	nginx := s.composeProject.Container(c, "nginx")
+	whoami := s.composeProject.Container(c, "whoami")
 
-	err = s.registerService("test", nginx.NetworkSettings.IPAddress, 80, []string{"traefik.tags=api", "traefik.tags=us-1"})
+	err = s.registerService("test", whoami.NetworkSettings.IPAddress, 80, []string{"traefik.tags=api", "traefik.tags=us-1"})
 	c.Assert(err, checker.IsNil, check.Commentf("Error registering service"))
-	defer s.deregisterService("test", nginx.NetworkSettings.IPAddress)
+	defer s.deregisterService("test", whoami.NetworkSettings.IPAddress)
 
 	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8000/", nil)
 	c.Assert(err, checker.IsNil)

--- a/integration/consul_catalog_test.go
+++ b/integration/consul_catalog_test.go
@@ -145,9 +145,9 @@ func (s *ConsulCatalogSuite) TestSingleService(c *check.C) {
 	err = try.GetRequest("http://127.0.0.1:8000/", 2*time.Second, try.StatusCodeIs(http.StatusNotFound))
 	c.Assert(err, checker.IsNil)
 
-	nginx := s.composeProject.Container(c, "nginx1")
+	whoami := s.composeProject.Container(c, "whoami1")
 
-	err = s.registerService("test", nginx.NetworkSettings.IPAddress, 80, []string{})
+	err = s.registerService("test", whoami.NetworkSettings.IPAddress, 80, []string{})
 	c.Assert(err, checker.IsNil, check.Commentf("Error registering service"))
 
 	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8000/", nil)
@@ -157,7 +157,7 @@ func (s *ConsulCatalogSuite) TestSingleService(c *check.C) {
 	err = try.Request(req, 10*time.Second, try.StatusCodeIs(http.StatusOK), try.HasBody())
 	c.Assert(err, checker.IsNil)
 
-	s.deregisterService("test", nginx.NetworkSettings.IPAddress)
+	s.deregisterService("test", whoami.NetworkSettings.IPAddress)
 	err = try.Request(req, 10*time.Second, try.StatusCodeIs(http.StatusNotFound), try.HasBody())
 	c.Assert(err, checker.IsNil)
 
@@ -175,11 +175,11 @@ func (s *ConsulCatalogSuite) TestExposedByDefaultFalseSingleService(c *check.C) 
 	c.Assert(err, checker.IsNil)
 	defer cmd.Process.Kill()
 
-	nginx := s.composeProject.Container(c, "nginx1")
+	whoami := s.composeProject.Container(c, "whoami1")
 
-	err = s.registerService("test", nginx.NetworkSettings.IPAddress, 80, []string{})
+	err = s.registerService("test", whoami.NetworkSettings.IPAddress, 80, []string{})
 	c.Assert(err, checker.IsNil, check.Commentf("Error registering service"))
-	defer s.deregisterService("test", nginx.NetworkSettings.IPAddress)
+	defer s.deregisterService("test", whoami.NetworkSettings.IPAddress)
 
 	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8000/", nil)
 	c.Assert(err, checker.IsNil)
@@ -201,16 +201,16 @@ func (s *ConsulCatalogSuite) TestExposedByDefaultFalseSimpleServiceMultipleNode(
 	c.Assert(err, checker.IsNil)
 	defer cmd.Process.Kill()
 
-	nginx := s.composeProject.Container(c, "nginx1")
-	nginx2 := s.composeProject.Container(c, "nginx2")
+	whoami := s.composeProject.Container(c, "whoami1")
+	whoami2 := s.composeProject.Container(c, "whoami2")
 
-	err = s.registerService("test", nginx.NetworkSettings.IPAddress, 80, []string{})
+	err = s.registerService("test", whoami.NetworkSettings.IPAddress, 80, []string{})
 	c.Assert(err, checker.IsNil, check.Commentf("Error registering service"))
-	defer s.deregisterService("test", nginx.NetworkSettings.IPAddress)
+	defer s.deregisterService("test", whoami.NetworkSettings.IPAddress)
 
-	err = s.registerService("test", nginx2.NetworkSettings.IPAddress, 80, []string{"traefik.enable=true"})
+	err = s.registerService("test", whoami2.NetworkSettings.IPAddress, 80, []string{"traefik.enable=true"})
 	c.Assert(err, checker.IsNil, check.Commentf("Error registering service"))
-	defer s.deregisterService("test", nginx2.NetworkSettings.IPAddress)
+	defer s.deregisterService("test", whoami2.NetworkSettings.IPAddress)
 
 	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8000/", nil)
 	c.Assert(err, checker.IsNil)
@@ -232,16 +232,16 @@ func (s *ConsulCatalogSuite) TestExposedByDefaultTrueSimpleServiceMultipleNode(c
 	c.Assert(err, checker.IsNil)
 	defer cmd.Process.Kill()
 
-	nginx := s.composeProject.Container(c, "nginx1")
-	nginx2 := s.composeProject.Container(c, "nginx2")
+	whoami := s.composeProject.Container(c, "whoami1")
+	whoami2 := s.composeProject.Container(c, "whoami2")
 
-	err = s.registerService("test", nginx.NetworkSettings.IPAddress, 80, []string{"name=nginx1"})
+	err = s.registerService("test", whoami.NetworkSettings.IPAddress, 80, []string{"name=whoami1"})
 	c.Assert(err, checker.IsNil, check.Commentf("Error registering service"))
-	defer s.deregisterService("test", nginx.NetworkSettings.IPAddress)
+	defer s.deregisterService("test", whoami.NetworkSettings.IPAddress)
 
-	err = s.registerService("test", nginx2.NetworkSettings.IPAddress, 80, []string{"name=nginx2"})
+	err = s.registerService("test", whoami2.NetworkSettings.IPAddress, 80, []string{"name=whoami2"})
 	c.Assert(err, checker.IsNil, check.Commentf("Error registering service"))
-	defer s.deregisterService("test", nginx2.NetworkSettings.IPAddress)
+	defer s.deregisterService("test", whoami2.NetworkSettings.IPAddress)
 
 	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8000/", nil)
 	c.Assert(err, checker.IsNil)
@@ -250,7 +250,7 @@ func (s *ConsulCatalogSuite) TestExposedByDefaultTrueSimpleServiceMultipleNode(c
 	err = try.Request(req, 5*time.Second, try.StatusCodeIs(http.StatusOK), try.HasBody())
 	c.Assert(err, checker.IsNil)
 
-	err = try.GetRequest("http://127.0.0.1:8080/api/providers/consul_catalog/backends", 60*time.Second, try.BodyContains("nginx1", "nginx2"))
+	err = try.GetRequest("http://127.0.0.1:8080/api/providers/consul_catalog/backends", 60*time.Second, try.BodyContains("whoami1", "whoami2"))
 	c.Assert(err, checker.IsNil)
 
 }
@@ -267,16 +267,16 @@ func (s *ConsulCatalogSuite) TestRefreshConfigWithMultipleNodeWithoutHealthCheck
 	c.Assert(err, checker.IsNil)
 	defer cmd.Process.Kill()
 
-	nginx := s.composeProject.Container(c, "nginx1")
-	nginx2 := s.composeProject.Container(c, "nginx2")
+	whoami := s.composeProject.Container(c, "whoami1")
+	whoami2 := s.composeProject.Container(c, "whoami2")
 
-	err = s.registerService("test", nginx.NetworkSettings.IPAddress, 80, []string{"name=nginx1"})
+	err = s.registerService("test", whoami.NetworkSettings.IPAddress, 80, []string{"name=whoami1"})
 	c.Assert(err, checker.IsNil, check.Commentf("Error registering service"))
-	defer s.deregisterService("test", nginx.NetworkSettings.IPAddress)
+	defer s.deregisterService("test", whoami.NetworkSettings.IPAddress)
 
-	err = s.registerAgentService("test", nginx.NetworkSettings.IPAddress, 80, []string{"name=nginx1"})
+	err = s.registerAgentService("test", whoami.NetworkSettings.IPAddress, 80, []string{"name=whoami1"})
 	c.Assert(err, checker.IsNil, check.Commentf("Error registering agent service"))
-	defer s.deregisterAgentService(nginx.NetworkSettings.IPAddress)
+	defer s.deregisterAgentService(whoami.NetworkSettings.IPAddress)
 
 	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8000/", nil)
 	c.Assert(err, checker.IsNil)
@@ -285,25 +285,25 @@ func (s *ConsulCatalogSuite) TestRefreshConfigWithMultipleNodeWithoutHealthCheck
 	err = try.Request(req, 5*time.Second, try.StatusCodeIs(http.StatusOK), try.HasBody())
 	c.Assert(err, checker.IsNil)
 
-	err = try.GetRequest("http://127.0.0.1:8080/api/providers/consul_catalog/backends", 60*time.Second, try.BodyContains("nginx1"))
+	err = try.GetRequest("http://127.0.0.1:8080/api/providers/consul_catalog/backends", 60*time.Second, try.BodyContains("whoami1"))
 	c.Assert(err, checker.IsNil)
 
-	err = s.registerService("test", nginx2.NetworkSettings.IPAddress, 80, []string{"name=nginx2"})
+	err = s.registerService("test", whoami2.NetworkSettings.IPAddress, 80, []string{"name=whoami2"})
 	c.Assert(err, checker.IsNil, check.Commentf("Error registering service"))
 
-	err = try.GetRequest("http://127.0.0.1:8080/api/providers/consul_catalog/backends", 60*time.Second, try.BodyContains("nginx1", "nginx2"))
+	err = try.GetRequest("http://127.0.0.1:8080/api/providers/consul_catalog/backends", 60*time.Second, try.BodyContains("whoami1", "whoami2"))
 	c.Assert(err, checker.IsNil)
 
-	s.deregisterService("test", nginx2.NetworkSettings.IPAddress)
+	s.deregisterService("test", whoami2.NetworkSettings.IPAddress)
 
-	err = try.GetRequest("http://127.0.0.1:8080/api/providers/consul_catalog/backends", 60*time.Second, try.BodyContains("nginx1"))
+	err = try.GetRequest("http://127.0.0.1:8080/api/providers/consul_catalog/backends", 60*time.Second, try.BodyContains("whoami1"))
 	c.Assert(err, checker.IsNil)
 
-	err = s.registerService("test", nginx2.NetworkSettings.IPAddress, 80, []string{"name=nginx2"})
+	err = s.registerService("test", whoami2.NetworkSettings.IPAddress, 80, []string{"name=whoami2"})
 	c.Assert(err, checker.IsNil, check.Commentf("Error registering service"))
-	defer s.deregisterService("test", nginx2.NetworkSettings.IPAddress)
+	defer s.deregisterService("test", whoami2.NetworkSettings.IPAddress)
 
-	err = try.GetRequest("http://127.0.0.1:8080/api/providers/consul_catalog/backends", 60*time.Second, try.BodyContains("nginx1", "nginx2"))
+	err = try.GetRequest("http://127.0.0.1:8080/api/providers/consul_catalog/backends", 60*time.Second, try.BodyContains("whoami1", "whoami2"))
 	c.Assert(err, checker.IsNil)
 
 }
@@ -320,13 +320,13 @@ func (s *ConsulCatalogSuite) TestBasicAuthSimpleService(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	defer cmd.Process.Kill()
 
-	nginx := s.composeProject.Container(c, "nginx1")
+	whoami := s.composeProject.Container(c, "whoami1")
 
-	err = s.registerService("test", nginx.NetworkSettings.IPAddress, 80, []string{
+	err = s.registerService("test", whoami.NetworkSettings.IPAddress, 80, []string{
 		"traefik.frontend.auth.basic=test:$2a$06$O5NksJPAcgrC9MuANkSoE.Xe9DSg7KcLLFYNr1Lj6hPcMmvgwxhme,test2:$2y$10$xP1SZ70QbZ4K2bTGKJOhpujkpcLxQcB3kEPF6XAV19IdcqsZTyDEe",
 	})
 	c.Assert(err, checker.IsNil, check.Commentf("Error registering service"))
-	defer s.deregisterService("test", nginx.NetworkSettings.IPAddress)
+	defer s.deregisterService("test", whoami.NetworkSettings.IPAddress)
 
 	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8000/", nil)
 	c.Assert(err, checker.IsNil)
@@ -357,16 +357,16 @@ func (s *ConsulCatalogSuite) TestRefreshConfigTagChange(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	defer cmd.Process.Kill()
 
-	nginx := s.composeProject.Container(c, "nginx1")
+	whoami := s.composeProject.Container(c, "whoami1")
 
-	err = s.registerService("test", nginx.NetworkSettings.IPAddress, 80, []string{"name=nginx1", "traefik.enable=false", "traefik.backend.circuitbreaker=NetworkErrorRatio() > 0.5"})
+	err = s.registerService("test", whoami.NetworkSettings.IPAddress, 80, []string{"name=whoami1", "traefik.enable=false", "traefik.backend.circuitbreaker=NetworkErrorRatio() > 0.5"})
 	c.Assert(err, checker.IsNil, check.Commentf("Error registering service"))
-	defer s.deregisterService("test", nginx.NetworkSettings.IPAddress)
+	defer s.deregisterService("test", whoami.NetworkSettings.IPAddress)
 
-	err = try.GetRequest("http://127.0.0.1:8080/api/providers/consul_catalog/backends", 5*time.Second, try.BodyContains("nginx1"))
+	err = try.GetRequest("http://127.0.0.1:8080/api/providers/consul_catalog/backends", 5*time.Second, try.BodyContains("whoami1"))
 	c.Assert(err, checker.NotNil)
 
-	err = s.registerService("test", nginx.NetworkSettings.IPAddress, 80, []string{"name=nginx1", "traefik.enable=true", "traefik.backend.circuitbreaker=ResponseCodeRatio(500, 600, 0, 600) > 0.5"})
+	err = s.registerService("test", whoami.NetworkSettings.IPAddress, 80, []string{"name=whoami1", "traefik.enable=true", "traefik.backend.circuitbreaker=ResponseCodeRatio(500, 600, 0, 600) > 0.5"})
 	c.Assert(err, checker.IsNil, check.Commentf("Error registering service"))
 
 	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8000/", nil)
@@ -376,7 +376,7 @@ func (s *ConsulCatalogSuite) TestRefreshConfigTagChange(c *check.C) {
 	err = try.Request(req, 20*time.Second, try.StatusCodeIs(http.StatusOK), try.HasBody())
 	c.Assert(err, checker.IsNil)
 
-	err = try.GetRequest("http://127.0.0.1:8080/api/providers/consul_catalog/backends", 60*time.Second, try.BodyContains("nginx1"))
+	err = try.GetRequest("http://127.0.0.1:8080/api/providers/consul_catalog/backends", 60*time.Second, try.BodyContains("whoami1"))
 	c.Assert(err, checker.IsNil)
 }
 
@@ -397,19 +397,19 @@ func (s *ConsulCatalogSuite) TestCircuitBreaker(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	defer cmd.Process.Kill()
 
-	nginx := s.composeProject.Container(c, "nginx1")
-	nginx2 := s.composeProject.Container(c, "nginx2")
-	nginx3 := s.composeProject.Container(c, "nginx3")
+	whoami := s.composeProject.Container(c, "whoami1")
+	whoami2 := s.composeProject.Container(c, "whoami2")
+	whoami3 := s.composeProject.Container(c, "whoami3")
 
-	err = s.registerService("test", nginx.NetworkSettings.IPAddress, 80, []string{"name=nginx1", "traefik.enable=true", "traefik.backend.circuitbreaker=NetworkErrorRatio() > 0.5"})
+	err = s.registerService("test", whoami.NetworkSettings.IPAddress, 80, []string{"name=whoami1", "traefik.enable=true", "traefik.backend.circuitbreaker=NetworkErrorRatio() > 0.5"})
 	c.Assert(err, checker.IsNil, check.Commentf("Error registering service"))
-	defer s.deregisterService("test", nginx.NetworkSettings.IPAddress)
-	err = s.registerService("test", nginx2.NetworkSettings.IPAddress, 42, []string{"name=nginx2", "traefik.enable=true", "traefik.backend.circuitbreaker=NetworkErrorRatio() > 0.5"})
+	defer s.deregisterService("test", whoami.NetworkSettings.IPAddress)
+	err = s.registerService("test", whoami2.NetworkSettings.IPAddress, 42, []string{"name=whoami2", "traefik.enable=true", "traefik.backend.circuitbreaker=NetworkErrorRatio() > 0.5"})
 	c.Assert(err, checker.IsNil, check.Commentf("Error registering service"))
-	defer s.deregisterService("test", nginx2.NetworkSettings.IPAddress)
-	err = s.registerService("test", nginx3.NetworkSettings.IPAddress, 42, []string{"name=nginx3", "traefik.enable=true", "traefik.backend.circuitbreaker=NetworkErrorRatio() > 0.5"})
+	defer s.deregisterService("test", whoami2.NetworkSettings.IPAddress)
+	err = s.registerService("test", whoami3.NetworkSettings.IPAddress, 42, []string{"name=whoami3", "traefik.enable=true", "traefik.backend.circuitbreaker=NetworkErrorRatio() > 0.5"})
 	c.Assert(err, checker.IsNil, check.Commentf("Error registering service"))
-	defer s.deregisterService("test", nginx3.NetworkSettings.IPAddress)
+	defer s.deregisterService("test", whoami3.NetworkSettings.IPAddress)
 
 	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8000/", nil)
 	c.Assert(err, checker.IsNil)
@@ -432,9 +432,9 @@ func (s *ConsulCatalogSuite) TestRefreshConfigPortChange(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	defer cmd.Process.Kill()
 
-	nginx := s.composeProject.Container(c, "nginx1")
+	whoami := s.composeProject.Container(c, "whoami1")
 
-	err = s.registerService("test", nginx.NetworkSettings.IPAddress, 81, []string{"name=nginx1", "traefik.enable=true"})
+	err = s.registerService("test", whoami.NetworkSettings.IPAddress, 81, []string{"name=whoami1", "traefik.enable=true"})
 	c.Assert(err, checker.IsNil, check.Commentf("Error registering service"))
 
 	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8000/", nil)
@@ -444,15 +444,15 @@ func (s *ConsulCatalogSuite) TestRefreshConfigPortChange(c *check.C) {
 	err = try.Request(req, 20*time.Second, try.StatusCodeIs(http.StatusBadGateway))
 	c.Assert(err, checker.IsNil)
 
-	err = try.GetRequest("http://127.0.0.1:8080/api/providers/consul_catalog/backends", 5*time.Second, try.BodyContains("nginx1"))
+	err = try.GetRequest("http://127.0.0.1:8080/api/providers/consul_catalog/backends", 5*time.Second, try.BodyContains("whoami1"))
 	c.Assert(err, checker.IsNil)
 
-	err = s.registerService("test", nginx.NetworkSettings.IPAddress, 80, []string{"name=nginx1", "traefik.enable=true"})
+	err = s.registerService("test", whoami.NetworkSettings.IPAddress, 80, []string{"name=whoami1", "traefik.enable=true"})
 	c.Assert(err, checker.IsNil, check.Commentf("Error registering service"))
 
-	defer s.deregisterService("test", nginx.NetworkSettings.IPAddress)
+	defer s.deregisterService("test", whoami.NetworkSettings.IPAddress)
 
-	err = try.GetRequest("http://127.0.0.1:8080/api/providers/consul_catalog/backends", 60*time.Second, try.BodyContains("nginx1"))
+	err = try.GetRequest("http://127.0.0.1:8080/api/providers/consul_catalog/backends", 60*time.Second, try.BodyContains("whoami1"))
 	c.Assert(err, checker.IsNil)
 
 	err = try.Request(req, 20*time.Second, try.StatusCodeIs(http.StatusOK), try.HasBody())
@@ -491,9 +491,9 @@ func (s *ConsulCatalogSuite) TestRetryWithConsulServer(c *check.C) {
 	s.composeProject.Scale(c, "consul", 1)
 	s.waitToElectConsulLeader()
 
-	nginx := s.composeProject.Container(c, "nginx1")
+	whoami := s.composeProject.Container(c, "whoami1")
 	// Register service
-	err = s.registerService("test", nginx.NetworkSettings.IPAddress, 80, []string{})
+	err = s.registerService("test", whoami.NetworkSettings.IPAddress, 80, []string{})
 	c.Assert(err, checker.IsNil, check.Commentf("Error registering service"))
 
 	// Provider consul catalog should be present

--- a/integration/docker_test.go
+++ b/integration/docker_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/docker/docker/pkg/namesgenerator"
 	"github.com/go-check/check"
 	d "github.com/libkermit/docker"
-	docker "github.com/libkermit/docker-check"
+	"github.com/libkermit/docker-check"
 	checker "github.com/vdemeester/shakers"
 )
 
@@ -25,8 +25,8 @@ var (
 	// Images to have or pull before the build in order to make it work
 	// FIXME handle this offline but loading them before build
 	RequiredImages = map[string]string{
-		"swarm": "1.0.0",
-		"nginx": "1",
+		"swarm":             "1.0.0",
+		"emilevauge/whoami": "latest",
 	}
 )
 

--- a/integration/ratelimit_test.go
+++ b/integration/ratelimit_test.go
@@ -19,7 +19,7 @@ func (s *RateLimitSuite) SetUpSuite(c *check.C) {
 	s.createComposeProject(c, "ratelimit")
 	s.composeProject.Start(c)
 
-	s.ServerIP = s.composeProject.Container(c, "nginx1").NetworkSettings.IPAddress
+	s.ServerIP = s.composeProject.Container(c, "whoami1").NetworkSettings.IPAddress
 }
 
 func (s *RateLimitSuite) TestSimpleConfiguration(c *check.C) {

--- a/integration/resources/compose/constraints.yml
+++ b/integration/resources/compose/constraints.yml
@@ -11,7 +11,7 @@ consul:
     - "8301/udp"
     - "8302"
     - "8302/udp"
-nginx:
-  image: nginx:alpine
+whoami:
+  image: emilevauge/whoami
   ports:
     - "8881:80"

--- a/integration/resources/compose/consul_catalog.yml
+++ b/integration/resources/compose/consul_catalog.yml
@@ -11,9 +11,9 @@ consul:
     - "8301/udp"
     - "8302"
     - "8302/udp"
-nginx1:
-  image: nginx:alpine
-nginx2:
-  image: nginx:alpine
-nginx3:
-  image: nginx:alpine
+whoami1:
+  image: emilevauge/whoami
+whoami2:
+  image: emilevauge/whoami
+whoami3:
+  image: emilevauge/whoami

--- a/integration/resources/compose/error_pages.yml
+++ b/integration/resources/compose/error_pages.yml
@@ -1,4 +1,4 @@
 nginx1:
-  image: nginx:alpine
+  image: nginx:1.13.8-alpine
 nginx2:
-  image: nginx:alpine
+  image: nginx:1.13.8-alpine

--- a/integration/resources/compose/file.yml
+++ b/integration/resources/compose/file.yml
@@ -1,20 +1,20 @@
-nginx1:
-  image: nginx:alpine
+whoami1:
+  image: emilevauge/whoami
   ports:
     - "8881:80"
-nginx2:
-  image: nginx:alpine
+whoami2:
+  image: emilevauge/whoami
   ports:
     - "8882:80"
-nginx3:
-  image: nginx:alpine
+whoami3:
+  image: emilevauge/whoami
   ports:
     - "8883:80"
-nginx4:
-  image: nginx:alpine
+whoami4:
+  image: emilevauge/whoami
   ports:
     - "8884:80"
-nginx5:
-  image: nginx:alpine
+whoami5:
+  image: emilevauge/whoami
   ports:
     - "8885:80"

--- a/integration/resources/compose/ratelimit.yml
+++ b/integration/resources/compose/ratelimit.yml
@@ -1,2 +1,2 @@
-nginx1:
-  image: nginx:alpine
+whoami1:
+  image: emilevauge/whoami


### PR DESCRIPTION
### What does this PR do?

This PR remove all nginx docker images in integration tests.

### Motivation

Avoid manifest issue when we pull images

![screenshot from 2018-02-21 14-45-05](https://user-images.githubusercontent.com/1776972/36483805-74225f74-1717-11e8-9294-02c151d262ba.png)

### More

- [x] Added/updated tests

