### PR TITLE
Change port of traefik for error pages integration test

### DIFF
--- a/integration/error_pages_test.go
+++ b/integration/error_pages_test.go
@@ -39,7 +39,7 @@ func (s *ErrorPagesSuite) TestSimpleConfiguration(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	defer cmd.Process.Kill()
 
-	frontendReq, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:80", nil)
+	frontendReq, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8080", nil)
 	c.Assert(err, checker.IsNil)
 	frontendReq.Host = "test.local"
 
@@ -62,7 +62,7 @@ func (s *ErrorPagesSuite) TestErrorPage(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	defer cmd.Process.Kill()
 
-	frontendReq, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:80", nil)
+	frontendReq, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8080", nil)
 	c.Assert(err, checker.IsNil)
 	frontendReq.Host = "test.local"
 

--- a/integration/fixtures/error_pages/error.toml
+++ b/integration/fixtures/error_pages/error.toml
@@ -4,7 +4,7 @@ logLevel = "DEBUG"
 
 [entryPoints]
   [entryPoints.http]
-  address = ":80"
+  address = ":8080"
 
 [file]
 [backends]

--- a/integration/fixtures/error_pages/simple.toml
+++ b/integration/fixtures/error_pages/simple.toml
@@ -4,7 +4,7 @@ logLevel = "DEBUG"
 
 [entryPoints]
   [entryPoints.http]
-  address = ":80"
+  address = ":8080"
 
 [file]
 [backends]


### PR DESCRIPTION
### What does this PR do?

This PR change Træfik port in error page integration test

### Motivation

Be able to run integration test with Goland without to be sudo

### More

- [x] Added/updated tests
