### PR TITLE
Starting Træfik even if TLS certificates are in error

### DIFF
--- a/tls/certificate.go
+++ b/tls/certificate.go
@@ -95,7 +95,8 @@ func (c *Certificates) CreateTLSConfig(entryPointName string) (*tls.Config, map[
 		for _, certificate := range *c {
 			err := certificate.AppendCertificates(domainsCertificates, entryPointName)
 			if err != nil {
-				return nil, nil, err
+				log.Errorf("Unable to add a certificate to the entryPoint %q : %v", entryPointName, err)
+				continue
 			}
 			for _, certDom := range domainsCertificates {
 				for _, cert := range certDom.Get().(map[string]*tls.Certificate) {
@@ -127,16 +128,16 @@ func (c *Certificate) AppendCertificates(certs map[string]*DomainsCertificates, 
 
 	certContent, err := c.CertFile.Read()
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to read CertFile : %v", err)
 	}
 
 	keyContent, err := c.KeyFile.Read()
 	if err != nil {
-		return err
+		return fmt.Errorf("uUnable to read KeyFile : %v", err)
 	}
 	tlsCert, err := tls.X509KeyPair(certContent, keyContent)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to generate TLS certificate : %v", err)
 	}
 
 	parsedCert, _ := x509.ParseCertificate(tlsCert.Certificate[0])


### PR DESCRIPTION


<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This PR allows starting Træfik even if one of the TLS certificate is in error.

A `fatal` message was created when certificates were missing and Træfik was stopped, now it's just an `error` message.

### Motivation

<!-- What inspired you to submit this pull request? -->

Fixes #2897 

### Additional Notes

<!-- Anything else we should know when reviewing? -->
The error messages will be improved in V1.6.