### PR TITLE
Check all the C/N and SANs of provided certificates before to generat…

### DIFF
--- a/acme/account.go
+++ b/acme/account.go
@@ -222,6 +222,24 @@ func (dc *DomainsCertificates) exists(domainToFind Domain) (*DomainsCertificate,
 	return nil, false
 }
 
+func (dc *DomainsCertificates) toDomainsMap() map[string]*tls.Certificate {
+	domainsCertificatesMap := make(map[string]*tls.Certificate)
+	for _, domainCertificate := range dc.Certs {
+		certKey := domainCertificate.Domains.Main
+		if domainCertificate.Domains.SANs != nil {
+			sort.Strings(domainCertificate.Domains.SANs)
+			for _, dnsName := range domainCertificate.Domains.SANs {
+				if dnsName != domainCertificate.Domains.Main {
+					certKey += fmt.Sprintf(",%s", dnsName)
+				}
+			}
+
+		}
+		domainsCertificatesMap[certKey] = domainCertificate.tlsCert
+	}
+	return domainsCertificatesMap
+}
+
 // DomainsCertificate contains a certificate for multiple domains
 type DomainsCertificate struct {
 	Domains     Domain


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This PR fixes ACME certificates generation.
So far, only C/N of provided certificates was checked before to generate ACME certificate.

This PR adds a check on the SANs and generates ACME certificates only for domains which need it.

### Motivation

<!-- What inspired you to submit this pull request? -->

Only generate ACME certificates for domains which need it.
Fixes #473 

### More

- [x] Added/updated tests