### PR TITLE
Remove hardcoded frontend prefix in Kubernetes template

### DIFF
--- a/autogen/gentemplates/gen.go
+++ b/autogen/gentemplates/gen.go
@@ -865,9 +865,9 @@ var _templatesKubernetesTmpl = []byte(`[backends]
     {{end}}
 
     {{if $frontend.Errors }}
-    [frontends."frontend-{{ $frontendName }}".errors]
+    [frontends."{{ $frontendName }}".errors]
       {{range $pageName, $page := $frontend.Errors }}
-      [frontends."frontend-{{ $frontendName }}".errors.{{ $pageName }}]
+      [frontends."{{ $frontendName }}".errors.{{ $pageName }}]
         status = [{{range $page.Status }}
           "{{.}}",
           {{end}}]
@@ -877,11 +877,11 @@ var _templatesKubernetesTmpl = []byte(`[backends]
     {{end}}
 
     {{if $frontend.RateLimit }}
-    [frontends."frontend-{{ $frontendName }}".rateLimit]
+    [frontends."{{ $frontendName }}".rateLimit]
       extractorFunc = "{{ $frontend.RateLimit.ExtractorFunc }}"
-      [frontends."frontend-{{ $frontendName }}".rateLimit.rateSet]
+      [frontends."{{ $frontendName }}".rateLimit.rateSet]
         {{range $limitName, $limit := $frontend.RateLimit.RateSet }}
-        [frontends."frontend-{{ $frontendName }}".rateLimit.rateSet.{{ $limitName }}]
+        [frontends."{{ $frontendName }}".rateLimit.rateSet.{{ $limitName }}]
           period = "{{ $limit.Period }}"
           average = {{ $limit.Average }}
           burst = {{ $limit.Burst }}

--- a/templates/kubernetes.tmpl
+++ b/templates/kubernetes.tmpl
@@ -68,7 +68,7 @@
     {{end}}
 
     {{if $frontend.Errors }}
-    [frontends."frontend-{{ $frontendName }}".errors]
+    [frontends."{{ $frontendName }}".errors]
       {{range $pageName, $page := $frontend.Errors }}
       [frontends."frontend-{{ $frontendName }}".errors.{{ $pageName }}]
         status = [{{range $page.Status }}
@@ -80,11 +80,11 @@
     {{end}}
 
     {{if $frontend.RateLimit }}
-    [frontends."frontend-{{ $frontendName }}".rateLimit]
+    [frontends."{{ $frontendName }}".rateLimit]
       extractorFunc = "{{ $frontend.RateLimit.ExtractorFunc }}"
-      [frontends."frontend-{{ $frontendName }}".rateLimit.rateSet]
+      [frontends."{{ $frontendName }}".rateLimit.rateSet]
         {{range $limitName, $limit := $frontend.RateLimit.RateSet }}
-        [frontends."frontend-{{ $frontendName }}".rateLimit.rateSet.{{ $limitName }}]
+        [frontends."{{ $frontendName }}".rateLimit.rateSet.{{ $limitName }}]
           period = "{{ $limit.Period }}"
           average = {{ $limit.Average }}
           burst = {{ $limit.Burst }}

--- a/templates/kubernetes.tmpl
+++ b/templates/kubernetes.tmpl
@@ -70,7 +70,7 @@
     {{if $frontend.Errors }}
     [frontends."{{ $frontendName }}".errors]
       {{range $pageName, $page := $frontend.Errors }}
-      [frontends."frontend-{{ $frontendName }}".errors.{{ $pageName }}]
+      [frontends."{{ $frontendName }}".errors.{{ $pageName }}]
         status = [{{range $page.Status }}
           "{{.}}",
           {{end}}]


### PR DESCRIPTION
### What does this PR do?

Fixes a bug related to k8 annotations and template generation.

The hardcoded `frontend` prefix forces the generation of new frontends instead of adding the rate limiting or errors into the existing frontend.


### Motivation

I am trying to run the latest version from master in GKE, and rate limiting was not working.

### Additional Notes

Was there any specific reason for adding the `frontend` prefix @ldez ?
