### PR TITLE
Missing annotation prefix support.

### DIFF
--- a/docs/configuration/backends/kubernetes.md
+++ b/docs/configuration/backends/kubernetes.md
@@ -127,7 +127,7 @@ The following general annotations are applicable on the Ingress object:
 | `traefik.ingress.kubernetes.io/rewrite-target: /users`                          | Replaces each matched Ingress path with the specified one, and adds the old path to the `X-Replaced-Path` header.                               |
 | `traefik.ingress.kubernetes.io/rule-type: PathPrefixStrip`                      | Override the default frontend rule type. Default: `PathPrefix`.                                                                                 |
 | `traefik.ingress.kubernetes.io/whitelist-source-range: "1.2.3.0/24, fe80::/16"` | A comma-separated list of IP ranges permitted for access. all source IPs are permitted if the list is empty or a single range is ill-formatted. |
-| `traefik.ingress.kubernetes.io/app-root: "/index.html"` | Redirects all requests for `/` to the defined path. Non-root paths will not be affected by this annotation and handled normally. This annotation may not be combined with the `ReplacePath` rule type or any other annotation leveraging that rule type. Trying to do so leads to an error and the corresponding Ingress object being ignored. |
+| `traefik.ingress.kubernetes.io/app-root: "/index.html"`                         | Redirects all requests for `/` to the defined path. (4)                                                                                         |
 
 <1> `traefik.ingress.kubernetes.io/error-pages` example:
 
@@ -169,6 +169,11 @@ maxresponsebodybytes: 10485761
 memresponsebodybytes: 2097152
 retryexpression: IsNetworkError() && Attempts() <= 2
 ```
+
+<4> `traefik.ingress.kubernetes.io/app-root`:
+Non-root paths will not be affected by this annotation and handled normally.
+This annotation may not be combined with the `ReplacePath` rule type or any other annotation leveraging that rule type.
+Trying to do so leads to an error and the corresponding Ingress object being ignored.
 
 !!! note
     Please note that `traefik.ingress.kubernetes.io/redirect-regex` and `traefik.ingress.kubernetes.io/redirect-replacement` do not have to be set if `traefik.ingress.kubernetes.io/redirect-entry-point` is defined for the redirection (they will not be used in this case).

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -340,7 +340,7 @@ func getRuleForPath(pa extensionsv1beta1.HTTPIngressPath, i *extensionsv1beta1.I
 		pathReplaceAnnotation = annotationKubernetesRewriteTarget
 	}
 
-	if rootPath := label.GetStringValue(i.Annotations, annotationKubernetesAppRoot, ""); rootPath != "" && pa.Path == "/" {
+	if rootPath := getStringValue(i.Annotations, annotationKubernetesAppRoot, ""); rootPath != "" && pa.Path == "/" {
 		if pathReplaceAnnotation != "" {
 			return "", fmt.Errorf("app-root must not be used together with annotation %q", pathReplaceAnnotation)
 		}


### PR DESCRIPTION
### What does this PR do?

Missing annotation prefix support: `ingress.kubernetes.io/app-root`

### Motivation

Have consistent behavior.

### More

- [x] Added/updated documentation

### Additional Notes

Related to #2522
