### PR TITLE
Frontend entry point redirect (implicit port)

### DIFF
--- a/middlewares/redirect/redirect_test.go
+++ b/middlewares/redirect/redirect_test.go
@@ -148,7 +148,7 @@ func TestNewRegexHandler(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			handler, err := NewRegexHandler(test.regex, test.replacement, test.permanent)
+			handler, err := NewRegexHandler(test.regex, test.replacement, Permanent(test.permanent))
 
 			if test.errorExpected {
 				require.Nil(t, handler)

--- a/server/server.go
+++ b/server/server.go
@@ -1292,7 +1292,7 @@ func (s *Server) buildRedirectHandler(srcEntryPointName string, opt *types.Redir
 	}
 
 	// regex redirect
-	redirection, err := redirect.NewRegexHandler(opt.Regex, opt.Replacement, opt.Permanent)
+	redirection, err := redirect.NewRegexHandler(opt.Regex, opt.Replacement, redirect.Permanent(opt.Permanent))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What does this PR do?

Turn implicit port to explicit port when evaluate the redirection.

### Motivation

Fixes #2925

### More

- [ ] Added/updated tests

### Additional Notes

The current behavior when a redirection is define from an entry point on port 80 to an entry point on 443:

```
http://foo:80 -> https://foo:433 -> https://foo -> https://foo:443 -> https://foo -> ...
```

The redirection cycle is due to the fact that 443 is an implicit port for TLS.
