### PR TITLE
Infinite entry point redirection.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -952,7 +952,7 @@ func (s *Server) loadConfig(configurations types.Configurations, globalConfigura
 
 				entryPoint := globalConfiguration.EntryPoints[entryPointName]
 				n := negroni.New()
-				if entryPoint.Redirect != nil {
+				if entryPoint.Redirect != nil && entryPointName != entryPoint.Redirect.EntryPoint {
 					if redirectHandlers[entryPointName] != nil {
 						n.Use(redirectHandlers[entryPointName])
 					} else if handler, err := s.buildRedirectHandler(entryPointName, entryPoint.Redirect); err != nil {
@@ -1141,7 +1141,7 @@ func (s *Server) loadConfig(configurations types.Configurations, globalConfigura
 						log.Infof("Configured IP Whitelists: %s", frontend.WhitelistSourceRange)
 					}
 
-					if frontend.Redirect != nil {
+					if frontend.Redirect != nil && entryPointName != frontend.Redirect.EntryPoint {
 						rewrite, err := s.buildRedirectHandler(entryPointName, frontend.Redirect)
 						if err != nil {
 							log.Errorf("Error creating Frontend Redirect: %v", err)
@@ -1347,7 +1347,7 @@ func (s *Server) buildRedirect(entryPointName string) (string, string, error) {
 		protocol = "https"
 	}
 
-	replacement := protocol + "://$1" + match[0] + "$2"
+	replacement := protocol + "://${1}" + match[0] + "${2}"
 	return defaultRedirectRegex, replacement, nil
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1071,7 +1071,7 @@ func TestServerBuildRedirect(t *testing.T) {
 					"https": &configuration.EntryPoint{Address: ":443", TLS: &tls.TLS{}},
 				},
 			},
-			expectedReplacement: "https://$1:443$2",
+			expectedReplacement: "https://${1}:443${2}",
 		},
 		{
 			desc: "Redirect endpoint http to http02 with HTTP protocol",
@@ -1082,7 +1082,7 @@ func TestServerBuildRedirect(t *testing.T) {
 					"http02": &configuration.EntryPoint{Address: ":88"},
 				},
 			},
-			expectedReplacement: "http://$1:88$2",
+			expectedReplacement: "http://${1}:88${2}",
 		},
 		{
 			desc: "Redirect endpoint to non-existent entry point",


### PR DESCRIPTION
### What does this PR do?

Prevent the creation of a redirection on the same entry point.

### Motivation

Fixes #2925

### Additional Notes

With those labels:
```ini
traefik.frontend.entryPoints=http,https
traefik.frontend.redirect.entryPoint=https
```

The current behavior;

```
http://foo:80 -> https://foo:433 -> https://foo -> https://foo:443 -> https://foo -> ...
```

Due to:
```shell
Creating frontend frontend-PathPrefix-foo-0  
Wiring frontend frontend-PathPrefix-foo-0 to entryPoint http 
Creating route route-frontend-PathPrefix-foo-0 PathPrefix:/foo 
Creating entry point redirect http -> https   # <-----------------------------------
Frontend frontend-PathPrefix-foo-0 redirect created 
Creating backend backend-whoami1             
Creating load-balancer wrr                   
Creating server server-upbeat_goldberg at http://172.17.0.2:80 with weight 0 
Wiring frontend frontend-PathPrefix-foo-0 to entryPoint https 
Creating route route-frontend-PathPrefix-foo-0 PathPrefix:/foo 
Creating entry point redirect https -> https   # <----------------------------------- 
Frontend frontend-PathPrefix-foo-0 redirect created 
```
