### PR TITLE
Default value for lifecycle

### DIFF
--- a/cmd/traefik/configuration.go
+++ b/cmd/traefik/configuration.go
@@ -287,6 +287,9 @@ func NewTraefikConfiguration() *TraefikConfiguration {
 			HealthCheck: &configuration.HealthCheckConfig{
 				Interval: flaeg.Duration(configuration.DefaultHealthCheckInterval),
 			},
+			LifeCycle: &configuration.LifeCycle{
+				GraceTimeOut: flaeg.Duration(configuration.DefaultGraceTimeout),
+			},
 			CheckNewVersion: true,
 		},
 		ConfigFile: "",


### PR DESCRIPTION
### What does this PR do?

Fix the life cycle default value

### Motivation

Fix a bug with no default value on `Lifecycle` and his child (`GracefulTimeout`)

### More

`Lifecycle` is a pointer and the default value in the `NewTraefikPointerConfiguration` is not enough.