### PR TITLE
Check all the C/N and SANs of provided certificates before generating ACME certificates in ACME provider

### DIFF
--- a/acme/acme.go
+++ b/acme/acme.go
@@ -23,7 +23,6 @@ import (
 	"github.com/containous/traefik/log"
 	acmeprovider "github.com/containous/traefik/provider/acme"
 	"github.com/containous/traefik/safe"
-	traefikTls "github.com/containous/traefik/tls"
 	"github.com/containous/traefik/tls/generate"
 	"github.com/containous/traefik/types"
 	"github.com/eapache/channels"
@@ -582,7 +581,7 @@ func (a *ACME) getUncheckedDomains(domains []string, account *Account) []string 
 
 	// Get dynamic certificates
 	if a.dynamicCerts != nil && a.dynamicCerts.Get() != nil {
-		for domains, certificate := range a.dynamicCerts.Get().(*traefikTls.DomainsCertificates).Get().(map[string]*tls.Certificate) {
+		for domains, certificate := range a.dynamicCerts.Get().(map[string]*tls.Certificate) {
 			allCerts[domains] = certificate
 		}
 	}

--- a/anonymize/anonymize_config_test.go
+++ b/anonymize/anonymize_config_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/containous/traefik/provider/mesos"
 	"github.com/containous/traefik/provider/rancher"
 	"github.com/containous/traefik/provider/zk"
-	traefikTls "github.com/containous/traefik/tls"
+	traefiktls "github.com/containous/traefik/tls"
 	"github.com/containous/traefik/types"
 )
 
@@ -46,14 +46,14 @@ func TestDo_globalConfiguration(t *testing.T) {
 	config.EntryPoints = configuration.EntryPoints{
 		"foo": {
 			Address: "foo Address",
-			TLS: &traefikTls.TLS{
+			TLS: &traefiktls.TLS{
 				MinVersion:   "foo MinVersion",
 				CipherSuites: []string{"foo CipherSuites 1", "foo CipherSuites 2", "foo CipherSuites 3"},
-				Certificates: traefikTls.Certificates{
+				Certificates: traefiktls.Certificates{
 					{CertFile: "CertFile 1", KeyFile: "KeyFile 1"},
 					{CertFile: "CertFile 2", KeyFile: "KeyFile 2"},
 				},
-				ClientCA: traefikTls.ClientCA{
+				ClientCA: traefiktls.ClientCA{
 					Files:    []string{"foo ClientCAFiles 1", "foo ClientCAFiles 2", "foo ClientCAFiles 3"},
 					Optional: false,
 				},
@@ -91,14 +91,14 @@ func TestDo_globalConfiguration(t *testing.T) {
 		},
 		"fii": {
 			Address: "fii Address",
-			TLS: &traefikTls.TLS{
+			TLS: &traefiktls.TLS{
 				MinVersion:   "fii MinVersion",
 				CipherSuites: []string{"fii CipherSuites 1", "fii CipherSuites 2", "fii CipherSuites 3"},
-				Certificates: traefikTls.Certificates{
+				Certificates: traefiktls.Certificates{
 					{CertFile: "CertFile 1", KeyFile: "KeyFile 1"},
 					{CertFile: "CertFile 2", KeyFile: "KeyFile 2"},
 				},
-				ClientCA: traefikTls.ClientCA{
+				ClientCA: traefiktls.ClientCA{
 					Files:    []string{"fii ClientCAFiles 1", "fii ClientCAFiles 2", "fii ClientCAFiles 3"},
 					Optional: false,
 				},
@@ -181,7 +181,7 @@ func TestDo_globalConfiguration(t *testing.T) {
 	config.MaxIdleConnsPerHost = 666
 	config.IdleTimeout = flaeg.Duration(666 * time.Second)
 	config.InsecureSkipVerify = true
-	config.RootCAs = traefikTls.RootCAs{"RootCAs 1", "RootCAs 2", "RootCAs 3"}
+	config.RootCAs = traefiktls.RootCAs{"RootCAs 1", "RootCAs 2", "RootCAs 3"}
 	config.Retry = &configuration.Retry{
 		Attempts: 666,
 	}

--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -28,7 +28,7 @@ import (
 	"github.com/containous/traefik/safe"
 	"github.com/containous/traefik/server"
 	"github.com/containous/traefik/server/uuid"
-	traefikTls "github.com/containous/traefik/tls"
+	traefiktls "github.com/containous/traefik/tls"
 	"github.com/containous/traefik/types"
 	"github.com/containous/traefik/version"
 	"github.com/coreos/go-systemd/daemon"
@@ -62,7 +62,7 @@ Complete documentation is available at https://traefik.io`,
 	// add custom parsers
 	f.AddParser(reflect.TypeOf(configuration.EntryPoints{}), &configuration.EntryPoints{})
 	f.AddParser(reflect.TypeOf(configuration.DefaultEntryPoints{}), &configuration.DefaultEntryPoints{})
-	f.AddParser(reflect.TypeOf(traefikTls.RootCAs{}), &traefikTls.RootCAs{})
+	f.AddParser(reflect.TypeOf(traefiktls.RootCAs{}), &traefiktls.RootCAs{})
 	f.AddParser(reflect.TypeOf(types.Constraints{}), &types.Constraints{})
 	f.AddParser(reflect.TypeOf(kubernetes.Namespaces{}), &kubernetes.Namespaces{})
 	f.AddParser(reflect.TypeOf(ecs.Clusters{}), &ecs.Clusters{})

--- a/integration/https_test.go
+++ b/integration/https_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/containous/traefik/integration/try"
-	traefikTls "github.com/containous/traefik/tls"
+	traefiktls "github.com/containous/traefik/tls"
 	"github.com/containous/traefik/types"
 	"github.com/go-check/check"
 	checker "github.com/vdemeester/shakers"
@@ -624,11 +624,11 @@ func modifyCertificateConfFileContent(c *check.C, certFileName, confFileName, en
 	// If certificate file is not provided, just truncate the configuration file
 	if len(certFileName) > 0 {
 		tlsConf := types.Configuration{
-			TLS: []*traefikTls.Configuration{
+			TLS: []*traefiktls.Configuration{
 				{
-					Certificate: &traefikTls.Certificate{
-						CertFile: traefikTls.FileOrContent("fixtures/https/" + certFileName + ".cert"),
-						KeyFile:  traefikTls.FileOrContent("fixtures/https/" + certFileName + ".key"),
+					Certificate: &traefiktls.Certificate{
+						CertFile: traefiktls.FileOrContent("fixtures/https/" + certFileName + ".cert"),
+						KeyFile:  traefiktls.FileOrContent("fixtures/https/" + certFileName + ".key"),
 					},
 					EntryPoints: []string{entryPoint},
 				},

--- a/server/server.go
+++ b/server/server.go
@@ -38,7 +38,7 @@ import (
 	"github.com/containous/traefik/rules"
 	"github.com/containous/traefik/safe"
 	"github.com/containous/traefik/server/cookie"
-	traefikTls "github.com/containous/traefik/tls"
+	traefiktls "github.com/containous/traefik/tls"
 	"github.com/containous/traefik/types"
 	"github.com/containous/traefik/whitelist"
 	"github.com/eapache/channels"
@@ -176,7 +176,7 @@ func createHTTPTransport(globalConfiguration configuration.GlobalConfiguration) 
 	return transport
 }
 
-func createRootCACertPool(rootCAs traefikTls.RootCAs) *x509.CertPool {
+func createRootCACertPool(rootCAs traefiktls.RootCAs) *x509.CertPool {
 	roots := x509.NewCertPool()
 
 	for _, cert := range rootCAs {
@@ -485,7 +485,7 @@ func (s *Server) loadHTTPSConfiguration(configurations types.Configurations, def
 	// Get all certificates
 	for _, configuration := range configurations {
 		if configuration.TLS != nil && len(configuration.TLS) > 0 {
-			if err := traefikTls.SortTLSPerEntryPoints(configuration.TLS, newEPCertificates, defaultEntryPoints); err != nil {
+			if err := traefiktls.SortTLSPerEntryPoints(configuration.TLS, newEPCertificates, defaultEntryPoints); err != nil {
 				return nil, err
 			}
 		}
@@ -569,7 +569,7 @@ func (s *Server) startProvider() {
 	})
 }
 
-func createClientTLSConfig(entryPointName string, tlsOption *traefikTls.TLS) (*tls.Config, error) {
+func createClientTLSConfig(entryPointName string, tlsOption *traefiktls.TLS) (*tls.Config, error) {
 	if tlsOption == nil {
 		return nil, errors.New("no TLS provided")
 	}
@@ -602,7 +602,7 @@ func createClientTLSConfig(entryPointName string, tlsOption *traefikTls.TLS) (*t
 }
 
 // creates a TLS config that allows terminating HTTPS for multiple domains using SNI
-func (s *Server) createTLSConfig(entryPointName string, tlsOption *traefikTls.TLS, router *middlewares.HandlerSwitcher) (*tls.Config, error) {
+func (s *Server) createTLSConfig(entryPointName string, tlsOption *traefiktls.TLS, router *middlewares.HandlerSwitcher) (*tls.Config, error) {
 	if tlsOption == nil {
 		return nil, nil
 	}
@@ -679,7 +679,7 @@ func (s *Server) createTLSConfig(entryPointName string, tlsOption *traefikTls.TL
 	}
 
 	// Set the minimum TLS version if set in the config TOML
-	if minConst, exists := traefikTls.MinVersion[s.globalConfiguration.EntryPoints[entryPointName].TLS.MinVersion]; exists {
+	if minConst, exists := traefiktls.MinVersion[s.globalConfiguration.EntryPoints[entryPointName].TLS.MinVersion]; exists {
 		config.PreferServerCipherSuites = true
 		config.MinVersion = minConst
 	}
@@ -688,7 +688,7 @@ func (s *Server) createTLSConfig(entryPointName string, tlsOption *traefikTls.TL
 		// if our list of CipherSuites is defined in the entrypoint config, we can re-initilize the suites list as empty
 		config.CipherSuites = make([]uint16, 0)
 		for _, cipher := range s.globalConfiguration.EntryPoints[entryPointName].TLS.CipherSuites {
-			if cipherConst, exists := traefikTls.CipherSuites[cipher]; exists {
+			if cipherConst, exists := traefiktls.CipherSuites[cipher]; exists {
 				config.CipherSuites = append(config.CipherSuites, cipherConst)
 			} else {
 				// CipherSuite listed in the toml does not exist in our listed
@@ -864,7 +864,7 @@ func (s *Server) buildEntryPoints(globalConfiguration configuration.GlobalConfig
 
 // getRoundTripper will either use server.defaultForwardingRoundTripper or create a new one
 // given a custom TLS configuration is passed and the passTLSCert option is set to true.
-func (s *Server) getRoundTripper(entryPointName string, globalConfiguration configuration.GlobalConfiguration, passTLSCert bool, tls *traefikTls.TLS) (http.RoundTripper, error) {
+func (s *Server) getRoundTripper(entryPointName string, globalConfiguration configuration.GlobalConfiguration, passTLSCert bool, tls *traefiktls.TLS) (http.RoundTripper, error) {
 	if passTLSCert {
 		tlsConfig, err := createClientTLSConfig(entryPointName, tls)
 		if err != nil {

--- a/tls/tls.go
+++ b/tls/tls.go
@@ -32,26 +32,10 @@ type TLS struct {
 // RootCAs hold the CA we want to have in root
 type RootCAs []FileOrContent
 
-// DomainsCertificates allows mapping TLS certificates to a list of domains
-type DomainsCertificates map[string]*tls.Certificate
-
 // Configuration allows mapping a TLS certificate to a list of entrypoints
 type Configuration struct {
 	EntryPoints []string
 	Certificate *Certificate
-}
-
-// Set is the method to set the flag value, part of the flag.Value interface.
-// Set's argument is a string to be parsed to set the flag.
-// It's a comma-separated list, so we split it.
-func (dc *DomainsCertificates) add(domain string, cert *tls.Certificate) error {
-	dc.Get().(map[string]*tls.Certificate)[domain] = cert
-	return nil
-}
-
-// Get method allow getting the map stored into the DomainsCertificates
-func (dc *DomainsCertificates) Get() interface{} {
-	return map[string]*tls.Certificate(*dc)
 }
 
 // String is the method to format the flag's value, part of the flag.Value interface.
@@ -94,9 +78,9 @@ func (r *RootCAs) Type() string {
 }
 
 // SortTLSPerEntryPoints converts TLS configuration sorted by Certificates into TLS configuration sorted by EntryPoints
-func SortTLSPerEntryPoints(configurations []*Configuration, epConfiguration map[string]*DomainsCertificates, defaultEntryPoints []string) error {
+func SortTLSPerEntryPoints(configurations []*Configuration, epConfiguration map[string]map[string]*tls.Certificate, defaultEntryPoints []string) error {
 	if epConfiguration == nil {
-		epConfiguration = make(map[string]*DomainsCertificates)
+		epConfiguration = make(map[string]map[string]*tls.Certificate)
 	}
 	for _, conf := range configurations {
 		if conf.EntryPoints == nil || len(conf.EntryPoints) == 0 {

--- a/types/types.go
+++ b/types/types.go
@@ -15,7 +15,7 @@ import (
 	"github.com/containous/flaeg"
 	"github.com/containous/mux"
 	"github.com/containous/traefik/log"
-	traefikTls "github.com/containous/traefik/tls"
+	traefiktls "github.com/containous/traefik/tls"
 	"github.com/ryanuber/go-glob"
 )
 
@@ -223,7 +223,7 @@ type Configurations map[string]*Configuration
 type Configuration struct {
 	Backends  map[string]*Backend         `json:"backends,omitempty"`
 	Frontends map[string]*Frontend        `json:"frontends,omitempty"`
-	TLS       []*traefikTls.Configuration `json:"tls,omitempty"`
+	TLS       []*traefiktls.Configuration `json:"tls,omitempty"`
 }
 
 // ConfigMessage hold configuration information exchanged between parts of traefik.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

This PR fixes ACME certificates generation in ACME provider.
So far, only C/N of provided certificates was checked before to generate ACME certificate in ACME provider.

This PR adds a check on the SANs and generates ACME certificates only for domains which need it in ACME provider.

### Motivation

<!-- What inspired you to submit this pull request? -->
Report #2913 modifications in the new ACME provider.

### Additional Notes

<!-- Anything else we should know when reviewing? -->
* This PR allows deleting the overkill type `tls.DomainsCertificate` by using directly `maps`.
* This PR allows renaming the `traefik.tls` alias.