### PR TITLE
Replace Delay by RefreshSecond in Eureka

### DIFF
--- a/anonymize/anonymize_config_test.go
+++ b/anonymize/anonymize_config_test.go
@@ -432,8 +432,9 @@ func TestDo_globalConfiguration(t *testing.T) {
 			Trace: true,
 			DebugLogGeneratedTemplate: true,
 		},
-		Endpoint: "eureka Endpoint",
-		Delay:    flaeg.Duration(30 * time.Second),
+		Endpoint:       "eureka Endpoint",
+		Delay:          flaeg.Duration(30 * time.Second),
+		RefreshSeconds: flaeg.Duration(30 * time.Second),
 	}
 	config.ECS = &ecs.Provider{
 		BaseProvider: provider.BaseProvider{

--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -166,7 +166,7 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 
 	// default Eureka
 	var defaultEureka eureka.Provider
-	defaultEureka.Delay = flaeg.Duration(30 * time.Second)
+	defaultEureka.RefreshSeconds = flaeg.Duration(30 * time.Second)
 
 	// default ServiceFabric
 	var defaultServiceFabric servicefabric.Provider

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -201,6 +201,13 @@ func (gc *GlobalConfiguration) SetEffectiveConfiguration(configFile string) {
 		gc.LifeCycle.GraceTimeOut = gc.GraceTimeOut
 	}
 
+	if gc.Eureka != nil {
+		if gc.Eureka.Delay != 0 {
+			log.Warn("Delay has been deprecated -- please use RefreshSeconds")
+			gc.Eureka.RefreshSeconds = gc.Eureka.Delay
+		}
+	}
+
 	if gc.Rancher != nil {
 		// Ensure backwards compatibility for now
 		if len(gc.Rancher.AccessKey) > 0 ||

--- a/docs/configuration/backends/eureka.md
+++ b/docs/configuration/backends/eureka.md
@@ -21,7 +21,7 @@ endpoint = "http://my.eureka.server/eureka"
 # Optional
 # Default: 30s
 #
-delay = "1m"
+refreshSeconds = "1m"
 
 # Override default configuration template.
 # For advanced users :)

--- a/provider/eureka/eureka.go
+++ b/provider/eureka/eureka.go
@@ -18,7 +18,8 @@ import (
 type Provider struct {
 	provider.BaseProvider `mapstructure:",squash" export:"true"`
 	Endpoint              string         `description:"Eureka server endpoint"`
-	Delay                 flaeg.Duration `description:"Override default configuration time between refresh" export:"true"`
+	Delay                 flaeg.Duration `description:"Override default configuration time between refresh (Deprecated)" export:"true"` // Deprecated
+	RefreshSeconds        flaeg.Duration `description:"Override default configuration time between refresh" export:"true"`
 }
 
 // Provide allows the eureka provider to provide configurations to traefik
@@ -46,7 +47,11 @@ func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *s
 			Configuration: configuration,
 		}
 
-		ticker := time.NewTicker(time.Duration(p.Delay))
+		if p.Delay != 0 {
+			p.RefreshSeconds = p.Delay
+		}
+
+		ticker := time.NewTicker(time.Duration(p.RefreshSeconds))
 		safe.Go(func() {
 			for t := range ticker.C {
 				log.Debugf("Refreshing Provider %s", t.String())


### PR DESCRIPTION
### What does this PR do?

add a new option `RefreshSecond`, it replace `Delay`.

### Motivation

Have the same option's name between provider.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

