### PR TITLE
Unable to generate documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_deploy:
       fi;
       curl -sI https://github.com/containous/structor/releases/latest | grep -Fi Location  | tr -d '\r' | sed "s/tag/download/g" | awk -F " " '{ print $2 "/structor_linux-amd64"}' | wget --output-document=$GOPATH/bin/structor -i -;
       chmod +x $GOPATH/bin/structor;
-      structor -o containous -r traefik --dockerfile-url="https://raw.githubusercontent.com/containous/traefik/master/docs.Dockerfile" --menu.js-url="https://raw.githubusercontent.com/containous/structor/master/traefik-menu.js.gotmpl" --exp-branch=master --debug;
+      structor -o containous -r traefik --dockerfile-url="https://raw.githubusercontent.com/containous/traefik/master/docs.Dockerfile" --menu.js-url="https://raw.githubusercontent.com/containous/structor/master/traefik-menu.js.gotmpl" --rqts-url="https://raw.githubusercontent.com/containous/structor/master/requirements-override.txt" --exp-branch=master --debug;
     fi
 deploy:
   - provider: releases

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ mkdocs>=0.17.2
 pymdown-extensions>=1.4
 mkdocs-bootswatch>=0.4.0
 mkdocs-material>=2.2.6
+tornado<5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-mkdocs>=0.17.2
+mkdocs>=0.17.3
 pymdown-extensions>=1.4
 mkdocs-bootswatch>=0.4.0
 mkdocs-material>=2.2.6
-tornado<5


### PR DESCRIPTION
### What does this PR do?

This PR 

- Force mkdocs to use `tornado` version `<5`
- Change [structor](https://github.com/containous/structor) :ant: command to be able to use new parameter that override `requirements.txt`

### Motivation

Fix errors when the documentation is building.
<details>

```console
make docs 
docker build -t traefik-docs -f docs.Dockerfile .
Sending build context to Docker daemon  139.4MB
Step 1/5 : FROM alpine
 ---> 3fd9065eaf02
Step 2/5 : ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.local/bin
 ---> Using cache
 ---> a8ec7bbe4f5d
Step 3/5 : COPY requirements.txt /mkdocs/
 ---> Using cache
 ---> 7fedefbd2f74
Step 4/5 : WORKDIR /mkdocs
 ---> Using cache
 ---> 5b8b5d465777
Step 5/5 : RUN apk --update upgrade && apk --no-cache --no-progress add py-pip && rm -rf /var/cache/apk/* && pip install --user -r requirements.txt
 ---> Using cache
 ---> 32160b0e963f
Successfully built 32160b0e963f
Successfully tagged traefik-docs:latest
docker run  --rm -v /home/michael/sources/go/src/github.com/containous/traefik:/mkdocs -p 8000:8000 traefik-docs mkdocs serve
INFO    -  Building documentation... 
Traceback (most recent call last):
  File "/root/.local/bin/mkdocs", line 11, in <module>
    sys.exit(cli())
  File "/root/.local/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/root/.local/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/root/.local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/root/.local/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/root/.local/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/root/.local/lib/python2.7/site-packages/mkdocs/__main__.py", line 127, in serve_command
    livereload=livereload
  File "/root/.local/lib/python2.7/site-packages/mkdocs/commands/serve.py", line 117, in serve
    config = builder()
  File "/root/.local/lib/python2.7/site-packages/mkdocs/commands/serve.py", line 104, in builder
    theme_dir=theme_dir
  File "/root/.local/lib/python2.7/site-packages/mkdocs/config/base.py", line 181, in load_config
    errors, warnings = cfg.validate()
  File "/root/.local/lib/python2.7/site-packages/mkdocs/config/base.py", line 105, in validate
    post_failed, post_warnings = self._post_validate()
  File "/root/.local/lib/python2.7/site-packages/mkdocs/config/base.py", line 85, in _post_validate
    config_option.post_validation(self, key_name=key)
  File "/root/.local/lib/python2.7/site-packages/mkdocs/config/config_options.py", line 433, in post_validation
    config[key_name] = theme.Theme(**theme_config)
  File "/root/.local/lib/python2.7/site-packages/mkdocs/theme.py", line 47, in __init__
    self._load_theme_config(name)
  File "/root/.local/lib/python2.7/site-packages/mkdocs/theme.py", line 77, in _load_theme_config
    theme_dir = utils.get_theme_dir(name)
  File "/root/.local/lib/python2.7/site-packages/mkdocs/utils/__init__.py", line 373, in get_theme_dir
    return os.path.dirname(os.path.abspath(theme.load().__file__))
  File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2290, in load
    self.require(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2307, in require
    items = working_set.resolve(reqs, env, installer)
  File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 854, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.VersionConflict: (tornado 5.0 (/root/.local/lib/python2.7/site-packages), Requirement.parse('tornado<5'))
Makefile:98: recipe for target 'docs' failed
make: *** [docs] Error 1
```
</details>

### Additional Notes

A PR is open [here](https://github.com/mkdocs/mkdocs/pull/1427) and should fix the issue with new mkdocs version
