### PR TITLE
Handle quoted strings in UnmarshalJSON

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -214,8 +214,8 @@
     ".",
     "parse"
   ]
-  revision = "963366c29a7acc2d6e02f4f9bcf260d5a1cf4968"
-  version = "v1.1.1"
+  revision = "b4c2f060875361c070ed2bc300c5929b82f5fa2e"
+  version = "v1.1.2"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/containous/flaeg/parse/parse.go
+++ b/vendor/github.com/containous/flaeg/parse/parse.go
@@ -1,6 +1,7 @@
 package parse
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"reflect"
@@ -203,6 +204,11 @@ func (d *Duration) UnmarshalText(text []byte) error {
 	return d.Set(string(text))
 }
 
+// MarshalJSON serializes the given duration value.
+func (d *Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Duration(*d))
+}
+
 // UnmarshalJSON deserializes the given text into a duration value.
 func (d *Duration) UnmarshalJSON(text []byte) error {
 	if v, err := strconv.Atoi(string(text)); err == nil {
@@ -210,7 +216,13 @@ func (d *Duration) UnmarshalJSON(text []byte) error {
 		return nil
 	}
 
-	v, err := time.ParseDuration(string(text))
+	// We use json unmarshal on value because we have the quoted version
+	var value string
+	err := json.Unmarshal(text, &value)
+	if err != nil {
+		return err
+	}
+	v, err := time.ParseDuration(value)
 	*d = Duration(v)
 	return err
 }


### PR DESCRIPTION
### What does this PR do?

`MarshalJSON` use `int` value of `time.Duration`
`UnmarshalJSON` handle `int` value and `string` (go duration format)

### Motivation

Fix a bug when Marshalling / Unmarshalling JSON