### PR TITLE
Added cluster/leader endpoint

### DIFF
--- a/cluster/leadership.go
+++ b/cluster/leadership.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"net/http"
 	"time"
 
 	"github.com/cenk/backoff"
@@ -11,7 +12,6 @@ import (
 	"github.com/containous/traefik/types"
 	"github.com/docker/leadership"
 	"github.com/unrolled/render"
-	"net/http"
 )
 
 // Leadership allows leadership election using a KV store
@@ -132,5 +132,5 @@ func (l *Leadership) IsLeader() bool {
 // AddRoutes add dashboard routes on a router
 func (l *Leadership) AddRoutes(router *mux.Router) {
 	// Expose cluster leader
-	router.Methods(http.MethodGet).Path("/cluster/leader").HandlerFunc(l.getLeaderHandler)
+	router.Methods(http.MethodGet).Path("/api/cluster/leader").HandlerFunc(l.getLeaderHandler)
 }

--- a/cluster/leadership.go
+++ b/cluster/leadership.go
@@ -14,6 +14,10 @@ import (
 	"github.com/unrolled/render"
 )
 
+var templatesRenderer = render.New(render.Options{
+	Directory: "nowhere",
+})
+
 // Leadership allows leadership election using a KV store
 type Leadership struct {
 	*safe.Pool
@@ -101,23 +105,19 @@ func (l *Leadership) onElection(elected bool) {
 	}
 }
 
-var (
-	templatesRenderer = render.New(render.Options{
-		Directory: "nowhere",
-	})
-)
-
 type leaderResponse struct {
 	Leader bool `json:"leader"`
 }
 
 func (l *Leadership) getLeaderHandler(response http.ResponseWriter, request *http.Request) {
 	leader := &leaderResponse{Leader: l.IsLeader()}
+
 	status := http.StatusOK
 	if !leader.Leader {
 		// Set status to be `429`, as this will typically cause load balancers to stop sending requests to the instance without removing them from rotation.
 		status = http.StatusTooManyRequests
 	}
+
 	err := templatesRenderer.JSON(response, status, leader)
 	if err != nil {
 		log.Error(err)

--- a/docs/configuration/api.md
+++ b/docs/configuration/api.md
@@ -43,6 +43,7 @@ For more customization, see [entry points](/configuration/entrypoints/) document
 | Path                                                            | Method           | Description                               |
 |-----------------------------------------------------------------|------------------|-------------------------------------------|
 | `/`                                                             |     `GET`        | Provides a simple HTML frontend of Træfik |
+| `/cluster/leader`                                               |     `GET`        | JSON leader true/false response           |
 | `/health`                                                       |     `GET`        | JSON health metrics                       |
 | `/api`                                                          |     `GET`        | Configuration for all providers           |
 | `/api/providers`                                                |     `GET`        | Providers                                 |
@@ -219,6 +220,25 @@ curl -s "http://localhost:8080/api" | jq .
       }
     }
   }
+}
+```
+
+### Cluster Leadership
+
+```shell
+curl -s "http://localhost:8080/cluster/leader" | jq .
+```
+```shell
+< HTTP/1.1 200 OK
+< Content-Type: application/json; charset=UTF-8
+< Date: xxx
+< Content-Length: 15
+```
+If the given node is not a cluster leader, an HTTP status of `429-Too-Many-Requests` will be returned.
+```json
+{
+  // current leadership status of the queried node
+  "leader": true
 }
 ```
 

--- a/server/server.go
+++ b/server/server.go
@@ -740,6 +740,10 @@ func (s *Server) addInternalRoutes(entryPointName string, router *mux.Router) {
 	if s.globalConfiguration.API != nil && s.globalConfiguration.API.EntryPoint == entryPointName {
 		s.globalConfiguration.API.AddRoutes(router)
 	}
+
+	if s.leadership != nil {
+		s.leadership.AddRoutes(router)
+	}
 }
 
 func (s *Server) addInternalPublicRoutes(entryPointName string, router *mux.Router) {

--- a/server/server.go
+++ b/server/server.go
@@ -739,10 +739,9 @@ func (s *Server) addInternalRoutes(entryPointName string, router *mux.Router) {
 
 	if s.globalConfiguration.API != nil && s.globalConfiguration.API.EntryPoint == entryPointName {
 		s.globalConfiguration.API.AddRoutes(router)
-	}
-
-	if s.leadership != nil {
-		s.leadership.AddRoutes(router)
+		if s.leadership != nil {
+			s.leadership.AddRoutes(router)
+		}
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR introduces a `/cluster/leader` endpoint, which will return `200-OK` or `429-Too-Many-Requests` status, depending on if the particular node is a leader or not.  The corresponding json payload will also be returned with `{"leader":"true"}` in case the node is a leader and `{"leader":"false"}` if it is not.

### Motivation

This will enable creating various Load Balancers on top of a Traefik cluster, which will only route API requests to the current leader, instead of randomly to any instance in the cluster.  The return of `429` status code will make most load balancers (like Netscalar or ELB, etc) to keep the instances in the pool, but "temporarily" not send any requests to them.
