### PR TITLE
Add TLS Docs

### DIFF
--- a/docs/configuration/backends/kubernetes.md
+++ b/docs/configuration/backends/kubernetes.md
@@ -94,6 +94,13 @@ A label selector can be defined to filter on specific Ingress objects only.
 
 See [label-selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) for details.
 
+### TLS communication between Traefik and backend pods
+
+Traefik automatically requests endpoint information based on the service provided in the ingress spec. Although traefik will connect directly to the endpoints (pods), it still checks the service port to see if TLS communication is required. If the service port defined in the ingress spec is 443, then the backend communication protocol is assumed to be TLS, and will connect via TLS automatically.
+
+!!! note
+    Please note that by enabling TLS communication between traefik and your pods, you will have to have trusted certificates that have the proper trust chain and IP subject name. If this is not an option, you may need to skip TLS certificate verification. See the [InsecureSkipVerify](configuration/commons/#main-section) setting for more details.
+    
 ## Annotations
 
 ### General annotations

--- a/docs/configuration/backends/kubernetes.md
+++ b/docs/configuration/backends/kubernetes.md
@@ -96,10 +96,14 @@ See [label-selectors](https://kubernetes.io/docs/concepts/overview/working-with-
 
 ### TLS communication between Traefik and backend pods
 
-Traefik automatically requests endpoint information based on the service provided in the ingress spec. Although traefik will connect directly to the endpoints (pods), it still checks the service port to see if TLS communication is required. If the service port defined in the ingress spec is 443, then the backend communication protocol is assumed to be TLS, and will connect via TLS automatically.
+Traefik automatically requests endpoint information based on the service provided in the ingress spec.
+Although traefik will connect directly to the endpoints (pods), it still checks the service port to see if TLS communication is required.
+If the service port defined in the ingress spec is 443, then the backend communication protocol is assumed to be TLS, and will connect via TLS automatically.
 
 !!! note
-    Please note that by enabling TLS communication between traefik and your pods, you will have to have trusted certificates that have the proper trust chain and IP subject name. If this is not an option, you may need to skip TLS certificate verification. See the [InsecureSkipVerify](configuration/commons/#main-section) setting for more details.
+    Please note that by enabling TLS communication between traefik and your pods, you will have to have trusted certificates that have the proper trust chain and IP subject name. 
+    If this is not an option, you may need to skip TLS certificate verification.
+    See the [InsecureSkipVerify](configuration/commons/#main-section) setting for more details.
     
 ## Annotations
 


### PR DESCRIPTION
### What does this PR do?

Adds a note about how to enable TLS communication in k8s to backend pods.


### Motivation

Resolves #3008


### More

- [x] Added/updated documentation
