### PR TITLE
Use goroutine pool in throttleProvider

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -367,7 +367,7 @@ func (s *Server) preLoadConfiguration(configMsg types.ConfigMessage) {
 			providerConfigUpdateCh = make(chan types.ConfigMessage)
 			s.providerConfigUpdateMap[configMsg.ProviderName] = providerConfigUpdateCh
 			s.routinesPool.Go(func(stop chan bool) {
-				throttleProviderConfigReload(providersThrottleDuration, s.configurationValidatedChan, providerConfigUpdateCh, stop)
+				s.throttleProviderConfigReload(providersThrottleDuration, s.configurationValidatedChan, providerConfigUpdateCh, stop)
 			})
 		}
 		providerConfigUpdateCh <- configMsg
@@ -378,11 +378,11 @@ func (s *Server) preLoadConfiguration(configMsg types.ConfigMessage) {
 // It will immediately publish a new configuration and then only publish the next configuration after the throttle duration.
 // Note that in the case it receives N new configs in the timeframe of the throttle duration after publishing,
 // it will publish the last of the newly received configurations.
-func throttleProviderConfigReload(throttle time.Duration, publish chan<- types.ConfigMessage, in <-chan types.ConfigMessage, stop chan bool) {
+func (s *Server) throttleProviderConfigReload(throttle time.Duration, publish chan<- types.ConfigMessage, in <-chan types.ConfigMessage, stop chan bool) {
 	ring := channels.NewRingChannel(1)
 	defer ring.Close()
 
-	safe.Go(func() {
+	s.routinesPool.Go(func(stop chan bool) {
 		for {
 			select {
 			case <-stop:

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -297,7 +297,10 @@ func TestThrottleProviderConfigReload(t *testing.T) {
 		stop <- true
 	}()
 
-	go throttleProviderConfigReload(throttleDuration, publishConfig, providerConfig, stop)
+	globalConfig := configuration.GlobalConfiguration{}
+	server := NewServer(globalConfig)
+
+	go server.throttleProviderConfigReload(throttleDuration, publishConfig, providerConfig, stop)
 
 	publishedConfigCount := 0
 	stopConsumeConfigs := make(chan bool)


### PR DESCRIPTION
### What does this PR do?
The new goroutine in `throttleProviderConfigReload` use the same stop channel as the current goroutine.
(it can be a problem because it doesn't block the goroutine cleanup)
It's better to use a new goroutines in the pool.