### PR TITLE
Add lower-case passHostHeader key support.

### DIFF
--- a/autogen/gentemplates/gen.go
+++ b/autogen/gentemplates/gen.go
@@ -575,7 +575,13 @@ var _templatesKvTmpl = []byte(`{{$frontends := List .Prefix "/frontends/" }}
     {{$entryPoints := GetList . "/entrypoints"}}
     [frontends."{{$frontend}}"]
     backend = "{{Get "" . "/backend"}}"
+    {{ $passHostHeader := Get "" . "/passhostheader"}}
+    {{if $passHostHeader}}
+    passHostHeader = {{ $passHostHeader }}
+    {{else}}
+    # keep for compatibility reason
     passHostHeader = {{Get "true" . "/passHostHeader"}}
+    {{end}}
     priority = {{Get "0" . "/priority"}}
     entryPoints = [{{range $entryPoints}}
       "{{.}}",

--- a/docs/user-guide/kv-config.md
+++ b/docs/user-guide/kv-config.md
@@ -328,7 +328,7 @@ And there, the same dynamic configuration in a KV Store (using `prefix = "traefi
 | Key                                                | Value              |
 |----------------------------------------------------|--------------------|
 | `/traefik/frontends/frontend2/backend`             | `backend1`         |
-| `/traefik/frontends/frontend2/passHostHeader`      | `true`             |
+| `/traefik/frontends/frontend2/passhostheader`      | `true`             |
 | `/traefik/frontends/frontend2/priority`            | `10`               |
 | `/traefik/frontends/frontend2/entrypoints`         | `http,https`       |
 | `/traefik/frontends/frontend2/routes/test_2/rule`  | `PathPrefix:/test` |

--- a/templates/kv.tmpl
+++ b/templates/kv.tmpl
@@ -53,7 +53,13 @@
     {{$entryPoints := GetList . "/entrypoints"}}
     [frontends."{{$frontend}}"]
     backend = "{{Get "" . "/backend"}}"
+    {{ $passHostHeader := Get "" . "/passhostheader"}}
+    {{if $passHostHeader}}
+    passHostHeader = {{ $passHostHeader }}
+    {{else}}
+    # keep for compatibility reason
     passHostHeader = {{Get "true" . "/passHostHeader"}}
+    {{end}}
     priority = {{Get "0" . "/priority"}}
     entryPoints = [{{range $entryPoints}}
       "{{.}}",


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

`passHostHeader` is the only key in camel-case.
`storeconfig` command store keys in lower-case.

Add support for `passhostheader`, fallback on `passHostHeader` is needed.

### Motivation

Fixes #2103

### More

- [x] Added/updated documentation

### Additional Notes

Tests will be added on the master branch.
