### PR TITLE
Drop capabilities in Kubernetes DaemonSet example

### DIFF
--- a/docs/user-guide/kubernetes.md
+++ b/docs/user-guide/kubernetes.md
@@ -121,6 +121,7 @@ spec:
         args:
         - --api
         - --kubernetes
+        - --logLevel=INFO
 ---
 kind: Service
 apiVersion: v1
@@ -182,7 +183,11 @@ spec:
         - name: admin
           containerPort: 8080
         securityContext:
-          privileged: true
+          capabilities:
+            drop:
+            - ALL
+            add:
+            - NET_BIND_SERVICE
         args:
         - --api
         - --kubernetes

--- a/examples/k8s/traefik-ds.yaml
+++ b/examples/k8s/traefik-ds.yaml
@@ -32,7 +32,11 @@ spec:
         - name: admin
           containerPort: 8080
         securityContext:
-          privileged: true
+          capabilities:
+            drop:
+            - ALL
+            add:
+            - NET_BIND_SERVICE
         args:
         - --api
         - --kubernetes


### PR DESCRIPTION
### What does this PR do?

Changes example of running DaemonSet on Kubernetes.
Makes Traefik run not in privileged mode but with only capability to bind to ports < 1024.

<!-- A brief description of the change being made with this pull request. -->


### Motivation

Reducing attack surface.

The motivation behind `privileged: true` was to have ability for Traefik to bind on privileged ports. Though there is a more fine-grained mechanism to restrict containers capabilities. This is unnecessary for the container to run in privileged mode.

### More

- [X] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Probably there was another rationale behind running in privileged. If there is it should be added explicitly to the capability list.
<!-- Anything else we should know when reviewing? -->
