### PR TITLE
Add SF to supported backends in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,7 @@ Run it and forget it!
 
 - [Docker](https://www.docker.com/) / [Swarm mode](https://docs.docker.com/engine/swarm/)
 - [Kubernetes](https://kubernetes.io)
+- [Service Fabric](https://docs.microsoft.com/en-gb/azure/service-fabric/)
 - [Mesos](https://github.com/apache/mesos) / [Marathon](https://mesosphere.github.io/marathon/)
 - [Rancher](https://rancher.com) (API, Metadata)
 - [Consul](https://www.consul.io/) / [Etcd](https://coreos.com/etcd/) / [Zookeeper](https://zookeeper.apache.org) / [BoltDB](https://github.com/boltdb/bolt)


### PR DESCRIPTION
### What does this PR do?

Adds Service Fabric to the list of supported backends in docs.

I'm not 100% on which branch this PR should be made against, considered v1.5 as it's relevant for that release but have gone for master to play it safe. Let me know if you want me to update. 

### Motivation

Service Fabric is supported from v1.5 and has docs but isn't liked in the `index.md` of the docs. 

### More

- [ ] Added/updated tests
- [x] Added/updated documentation
