### PR TITLE
Set INFO log level in Kubernetes guide and examples.

### DIFF
--- a/docs/user-guide/kubernetes.md
+++ b/docs/user-guide/kubernetes.md
@@ -184,9 +184,9 @@ spec:
         securityContext:
           privileged: true
         args:
-        - -d
         - --api
         - --kubernetes
+        - --logLevel=INFO
 ---
 kind: Service
 apiVersion: v1

--- a/examples/k8s/traefik-deployment.yaml
+++ b/examples/k8s/traefik-deployment.yaml
@@ -31,6 +31,7 @@ spec:
         args:
         - --api
         - --kubernetes
+        - --logLevel=INFO
 ---
 kind: Service
 apiVersion: v1

--- a/examples/k8s/traefik-ds.yaml
+++ b/examples/k8s/traefik-ds.yaml
@@ -34,9 +34,9 @@ spec:
         securityContext:
           privileged: true
         args:
-        - -d
         - --api
         - --kubernetes
+        - --logLevel=INFO
 ---
 kind: Service
 apiVersion: v1


### PR DESCRIPTION
### What does this PR do?

Lower the log level for the Kubernetes manifests from DEBUG to INFO.

### Motivation

Less logging noise.

### Additional Notes

We previously enabled DEBUG log level implicitly by means of the `-d` parameter. Apart from being fairly intransparent to the regular user that debug mode hard-wires the DEBUG log level, it also produces an overwhelming amount of logs.

INFO seems much more sensible while still allowing to observe that Traefik has started, even in the absence of warnings and errors.

Finally, we also align the parameter usage across all examples we offer.