### PR TITLE
Added initial support for request mirroring

### DIFF
--- a/middlewares/mirror.go
+++ b/middlewares/mirror.go
@@ -1,0 +1,149 @@
+package middlewares
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"sync/atomic"
+
+	"github.com/containous/traefik/log"
+	"github.com/containous/traefik/safe"
+	"github.com/containous/traefik/types"
+	"github.com/vulcand/oxy/forward"
+	"github.com/vulcand/oxy/utils"
+	"net/url"
+)
+
+//Mirror is a middleware that provides the request mirroring capabilities
+type Mirror struct {
+	BackendURL     *url.URL
+	RequestHeaders map[string]string
+	SampleRate     uint64
+	mirror         *forward.Forwarder
+	counter        uint64
+}
+
+//NewMirrorMiddleware initializes the Mirror for the request mirroring
+func NewMirrorMiddleware(frontend *types.Frontend, backend *types.Backend) (*Mirror, error) {
+	mirror := frontend.Mirror
+	// Default sample rate is every request.
+	var sampleRate uint64 = 1
+	if mirror.SampleRate > 0 {
+		sampleRate = uint64(mirror.SampleRate)
+	}
+	mirrorURL, err := url.Parse(backend.Servers["mirror"].URL)
+	if err != nil {
+		return nil, err
+	}
+
+	forwarder, err := forward.New(
+	//forward.Stream(true),
+	//forward.PassHostHeader(frontend.PassHostHeader),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &Mirror{BackendURL: mirrorURL,
+			RequestHeaders: mirror.RequestHeaders,
+			SampleRate:     sampleRate,
+			mirror:         forwarder},
+		nil
+}
+
+func (m *Mirror) ServeHTTP(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
+	if m.counter%m.SampleRate == 0 {
+		atomic.AddUint64(&m.counter, 1)
+		// Copy the request and forward to 'next' and to 'mirror'
+		mReq, err := m.copyRequest(req)
+		if err != nil {
+			log.Errorf("Encountered an error while cloning the request: %v", err)
+		}
+
+		// We don't care about the response from the mirror, so we can just launch it in a safe go routine
+		// In case of failure, will log the error
+		safe.GoWithRecover(func() {
+			mRw := createDummyResponseWriter()
+			m.mirror.ServeHTTP(mRw, mReq)
+		}, func(err interface{}) {
+			log.Errorf("Error in request mirroring routine: %s", err)
+		})
+
+		next.ServeHTTP(w, req)
+	} else {
+		// no mirroring
+		next.ServeHTTP(w, req)
+	}
+}
+
+func (m *Mirror) copyRequest(req *http.Request) (*http.Request, error) {
+	var body []byte
+	o := *req
+
+	if req.Body != nil {
+		b, err := ioutil.ReadAll(req.Body)
+		body = b
+
+		if err != nil {
+			return nil, err
+		}
+
+		// Create a new reader for the body of the original request
+		req.Body = ioutil.NopCloser(bytes.NewReader(body))
+	}
+
+	// TODO - Is this way better than doing `o := *req` copy?
+	//o, err := http.NewRequest(req.Method, utils.CopyURL(req.URL).String(), ioutil.NopCloser(bytes.NewReader(body)))
+	//if err != nil {
+	//	return nil, err
+	//}
+
+	o.ContentLength = int64(len(body))
+	// remove TransferEncoding that could have been previously set because we have transformed the request from chunked encoding
+	o.TransferEncoding = []string{}
+	// http.Transport will close the request body on any error, we are controlling the close process ourselves, so we override the closer here
+	if body == nil {
+		o.Body = nil
+	} else {
+		o.Body = ioutil.NopCloser(bytes.NewReader(body))
+	}
+
+	o.URL = utils.CopyURL(m.BackendURL)
+	o.Header = make(http.Header)
+	utils.CopyHeaders(o.Header, req.Header)
+
+	return &o, nil
+}
+
+// dummyResponseWriter captures information from the response and preserves it for
+// later analysis.
+type dummyResponseWriter struct {
+	header      http.Header
+	closeNotify chan bool
+}
+
+// Header returns empty header
+func (rw *dummyResponseWriter) Header() http.Header {
+
+	if rw.header == nil {
+		rw.header = make(http.Header)
+	}
+
+	return rw.header
+}
+
+// WriteHeader does nothing...
+func (rw *dummyResponseWriter) WriteHeader(status int) {
+}
+
+// Flush does nothing
+func (rw *dummyResponseWriter) Write(bytes []byte) (int, error) {
+	return len(bytes), nil
+}
+
+func (rw *dummyResponseWriter) CloseNotify() <-chan bool {
+	return rw.closeNotify
+}
+
+func createDummyResponseWriter() http.ResponseWriter {
+	return &dummyResponseWriter{closeNotify: make(chan bool, 1)}
+}

--- a/middlewares/mirror_test.go
+++ b/middlewares/mirror_test.go
@@ -1,0 +1,98 @@
+package middlewares
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	//"strconv"
+	"testing"
+
+	"github.com/containous/traefik/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/negroni"
+	"github.com/vulcand/oxy/forward"
+	"io/ioutil"
+	"strings"
+	"time"
+)
+
+func TestMirror(t *testing.T) {
+	t1 := false
+	t2 := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Test Server")
+		if r.Body != nil {
+			body, _ := ioutil.ReadAll(r.Body)
+			fmt.Fprintln(w, string(body))
+		}
+		fmt.Println("Test server request")
+		t1 = true
+	}))
+	defer ts.Close()
+
+	tsMirror := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Test Mirror Server")
+		fmt.Println("Mirror server request")
+		t2 = true
+	}))
+	defer tsMirror.Close()
+
+	testMirror := &types.Mirror{Backend: "mirror"}
+	testFrontend := &types.Frontend{Mirror: testMirror}
+	//testMirror := &types.Backend{Servers: map[string]types.Server{
+	//	testMirror.Backend: {URL: ts.URL},
+	//}}
+	testMirrorBackend := &types.Backend{Servers: map[string]types.Server{
+		testMirror.Backend: {URL: tsMirror.URL},
+	}}
+
+	testMirrorHandler, err := NewMirrorMiddleware(testFrontend, testMirrorBackend)
+	require.NoError(t, err)
+
+	assert.Equal(t, testMirrorHandler.BackendURL.String(), tsMirror.URL, "Should be equal")
+
+	recorder := httptest.NewRecorder()
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/test", nil)
+	// Make sure this is set, otherwise the mirror forwarding will use the req.URL instead of req.RequestURI for the path.
+	req.RequestURI = req.URL.RequestURI()
+	require.NoError(t, err)
+
+	//handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	//	fmt.Fprintln(w, "traefik")
+	//})
+
+	handler, _ := forward.New()
+	n := negroni.New()
+	n.Use(testMirrorHandler)
+	n.UseHandler(handler)
+
+	n.ServeHTTP(recorder, req)
+
+	time.Sleep(5 * time.Second)
+
+	assert.Equal(t, http.StatusOK, recorder.Code, "HTTP status")
+	assert.Contains(t, recorder.Body.String(), "Test Server")
+
+	assert.True(t, t1, "Test server should be called")
+	assert.True(t, t2, "Mirror server should be called")
+
+	// ----
+
+	body := strings.NewReader("Test Body")
+	req, err = http.NewRequest(http.MethodPost, ts.URL+"/test", body)
+
+	req.RequestURI = req.URL.RequestURI()
+	require.NoError(t, err)
+
+	n.ServeHTTP(recorder, req)
+
+	time.Sleep(5 * time.Second)
+
+	assert.Equal(t, http.StatusOK, recorder.Code, "HTTP status")
+	assert.Contains(t, recorder.Body.String(), "Test Server")
+	assert.Contains(t, recorder.Body.String(), "Test Body")
+
+	assert.True(t, t1, "Test server should be called")
+	assert.True(t, t2, "Mirror server should be called")
+}

--- a/middlewares/mirror_test.go
+++ b/middlewares/mirror_test.go
@@ -50,7 +50,7 @@ func TestMirror(t *testing.T) {
 	testMirrorHandler, err := NewMirrorMiddleware(testFrontend, testMirrorBackend)
 	require.NoError(t, err)
 
-	assert.Equal(t, testMirrorHandler.BackendURL.String(), tsMirror.URL, "Should be equal")
+	assert.Equal(t, testMirrorHandler.backendURL.String(), tsMirror.URL, "Should be equal")
 
 	recorder := httptest.NewRecorder()
 	req, err := http.NewRequest(http.MethodGet, ts.URL+"/test", nil)

--- a/provider/consulcatalog/consul_catalog_config.go
+++ b/provider/consulcatalog/consul_catalog_config.go
@@ -54,6 +54,7 @@ func (p *Provider) buildConfiguration(catalog []catalogUpdate) *types.Configurat
 		"getRedirect":            p.getRedirect,
 		"hasErrorPages":          p.getFuncHasAttributePrefix(label.BaseFrontendErrorPage),
 		"getErrorPages":          p.getErrorPages,
+		"getMirror":              p.getMirror,
 		"hasRateLimit":           p.getFuncHasAttributePrefix(label.BaseFrontendRateLimit),
 		"getRateLimit":           p.getRateLimit,
 		"getHeaders":             p.getHeaders,
@@ -350,6 +351,18 @@ func (p *Provider) getErrorPages(tags []string) map[string]*types.ErrorPage {
 
 	prefix := label.Prefix + label.BaseFrontendErrorPage
 	return label.ParseErrorPages(labels, prefix, label.RegexpFrontendErrorPage)
+}
+
+func (p *Provider) getMirror(tags []string) *types.Mirror {
+	backend := p.getAttribute(label.TraefikFrontendMirrorBackend, tags, "")
+	sampleRate := p.getIntAttribute(label.TraefikFrontendMirrorSampleRate, tags, 0)
+	requestHeaders := p.getMapAttribute(label.TraefikFrontendMirrorRequestHeaders, tags)
+
+	return &types.Mirror{
+		Backend:        backend,
+		SampleRate:     sampleRate,
+		RequestHeaders: requestHeaders,
+	}
 }
 
 func (p *Provider) getRateLimit(tags []string) *types.RateLimit {

--- a/provider/docker/config.go
+++ b/provider/docker/config.go
@@ -49,6 +49,7 @@ func (p *Provider) buildConfigurationV2(containersInspected []dockerData) *types
 		"getFrontendRule":   p.getFrontendRule,
 		"getRedirect":       getRedirect,
 		"getErrorPages":     getErrorPages,
+		"getMirror":         getMirror,
 		"getRateLimit":      getRateLimit,
 		"getHeaders":        getHeaders,
 		"getWhiteList":      getWhiteList,
@@ -326,6 +327,12 @@ func getRedirect(labels map[string]string) *types.Redirect {
 func getErrorPages(labels map[string]string) map[string]*types.ErrorPage {
 	prefix := label.Prefix + label.BaseFrontendErrorPage
 	return label.ParseErrorPages(labels, prefix, label.RegexpFrontendErrorPage)
+}
+
+func getMirror(labels map[string]string) *types.Mirror {
+	prefix := label.Prefix + label.BaseFrontendErrorPage
+
+	return label.ParseMirror(labels, prefix)
 }
 
 func getRateLimit(labels map[string]string) *types.RateLimit {

--- a/provider/ecs/config.go
+++ b/provider/ecs/config.go
@@ -57,6 +57,7 @@ func (p *Provider) buildConfiguration(services map[string][]ecsInstance) (*types
 		"getEntryPoints":    getFuncSliceString(label.TraefikFrontendEntryPoints),
 		"getRedirect":       getRedirect,
 		"getErrorPages":     getErrorPages,
+		"getMirror":         getMirror,
 		"getRateLimit":      getRateLimit,
 		"getHeaders":        getHeaders,
 		"getWhiteList":      getWhiteList,
@@ -253,6 +254,16 @@ func getErrorPages(instance ecsInstance) map[string]*types.ErrorPage {
 
 	prefix := label.Prefix + label.BaseFrontendErrorPage
 	return label.ParseErrorPages(labels, prefix, label.RegexpFrontendErrorPage)
+}
+
+func getMirror(instance ecsInstance) *types.Mirror {
+	labels := mapPToMap(instance.containerDefinition.DockerLabels)
+	if len(labels) == 0 {
+		return nil
+	}
+
+	prefix := label.Prefix + label.BaseFrontendErrorPage
+	return label.ParseMirror(labels, prefix)
 }
 
 func getRateLimit(instance ecsInstance) *types.RateLimit {

--- a/provider/label/label.go
+++ b/provider/label/label.go
@@ -229,6 +229,19 @@ func HasPrefixP(labels *map[string]string, prefix string) bool {
 	return HasPrefix(*labels, prefix)
 }
 
+// ParseMirror parse mirror to create Mirror struct
+func ParseMirror(labels map[string]string, labelPrefix string) *types.Mirror {
+	backend := GetStringValue(labels, labelPrefix+SuffixMirrorBackend, "")
+	sampleRate := GetIntValue(labels, labelPrefix+SuffixMirrorSampleRate, 0)
+	requestHeaders := GetMapValue(labels, labelPrefix+SuffixMirrorRequestHeaders)
+
+	return &types.Mirror{
+		Backend:        backend,
+		SampleRate:     sampleRate,
+		RequestHeaders: requestHeaders,
+	}
+}
+
 // ParseErrorPages parse error pages to create ErrorPage struct
 func ParseErrorPages(labels map[string]string, labelPrefix string, labelRegex *regexp.Regexp) map[string]*types.ErrorPage {
 	var errorPages map[string]*types.ErrorPage

--- a/provider/label/names.go
+++ b/provider/label/names.go
@@ -6,6 +6,7 @@ const (
 	SuffixBackend                                  = "backend"
 	SuffixDomain                                   = "domain"
 	SuffixEnable                                   = "enable"
+	SuffixMirror                                   = "mirror"
 	SuffixPort                                     = "port"
 	SuffixPortIndex                                = "portIndex"
 	SuffixProtocol                                 = "protocol"
@@ -141,4 +142,11 @@ const (
 	SuffixRateLimitPeriod                          = "period"
 	SuffixRateLimitAverage                         = "average"
 	SuffixRateLimitBurst                           = "burst"
+	BaseFrontendMirror                             = "frontend." + SuffixMirror + "."
+	SuffixMirrorBackend                            = "backend"
+	SuffixMirrorSampleRate                         = "sampleRate"
+	SuffixMirrorRequestHeaders                     = "requestHeaders"
+	TraefikFrontendMirrorBackend                   = Prefix + BaseFrontendMirror + SuffixMirrorBackend
+	TraefikFrontendMirrorSampleRate                = Prefix + BaseFrontendMirror + SuffixMirrorSampleRate
+	TraefikFrontendMirrorRequestHeaders            = Prefix + BaseFrontendMirror + SuffixMirrorRequestHeaders
 )

--- a/provider/marathon/config.go
+++ b/provider/marathon/config.go
@@ -78,6 +78,7 @@ func (p *Provider) buildConfiguration() *types.Configuration {
 		"getBasicAuth":         getFuncSliceStringService(label.SuffixFrontendAuthBasic),
 		"getRedirect":          getRedirect,
 		"getErrorPages":        getErrorPages,
+		"getMirror":            getMirror,
 		"getRateLimit":         getRateLimit,
 		"getHeaders":           getHeaders,
 		"getWhiteList":         getWhiteList,
@@ -535,6 +536,13 @@ func getErrorPages(application marathon.Application, serviceName string) map[str
 		return label.ParseErrorPages(labels, prefix, label.RegexpBaseFrontendErrorPage)
 	}
 	return label.ParseErrorPages(labels, prefix, label.RegexpFrontendErrorPage)
+}
+
+func getMirror(application marathon.Application, serviceName string) *types.Mirror {
+	labels := getLabels(application, serviceName)
+	prefix := getLabelName(serviceName, label.BaseFrontendErrorPage)
+
+	return label.ParseMirror(labels, prefix)
 }
 
 func getRateLimit(application marathon.Application, serviceName string) *types.RateLimit {

--- a/provider/mesos/config.go
+++ b/provider/mesos/config.go
@@ -50,6 +50,7 @@ func (p *Provider) buildConfiguration(tasks []state.Task) *types.Configuration {
 		"getFrontendRule":   p.getFrontendRule,
 		"getRedirect":       getRedirect,
 		"getErrorPages":     getErrorPages,
+		"getMirror":         getMirror,
 		"getRateLimit":      getRateLimit,
 		"getHeaders":        getHeaders,
 		"getWhiteList":      getWhiteList,
@@ -369,6 +370,13 @@ func getRedirect(task state.Task) *types.Redirect {
 	}
 
 	return nil
+}
+
+func getMirror(task state.Task) *types.Mirror {
+	prefix := label.Prefix + label.BaseFrontendErrorPage
+	labels := taskLabelsToMap(task)
+
+	return label.ParseMirror(labels, prefix)
 }
 
 func getErrorPages(task state.Task) map[string]*types.ErrorPage {

--- a/provider/rancher/config.go
+++ b/provider/rancher/config.go
@@ -64,6 +64,7 @@ func (p *Provider) buildConfiguration(services []rancherData) *types.Configurati
 		"getEntryPoints":    getFuncSliceString(label.TraefikFrontendEntryPoints),
 		"getBasicAuth":      getFuncSliceString(label.TraefikFrontendAuthBasic),
 		"getErrorPages":     getErrorPages,
+		"getMirror":         getMirror,
 		"getRateLimit":      getRateLimit,
 		"getRedirect":       getRedirect,
 		"getHeaders":        getHeaders,
@@ -311,6 +312,11 @@ func getRedirect(service rancherData) *types.Redirect {
 func getErrorPages(service rancherData) map[string]*types.ErrorPage {
 	prefix := label.Prefix + label.BaseFrontendErrorPage
 	return label.ParseErrorPages(service.Labels, prefix, label.RegexpFrontendErrorPage)
+}
+
+func getMirror(service rancherData) *types.Mirror {
+	prefix := label.Prefix + label.BaseFrontendErrorPage
+	return label.ParseMirror(service.Labels, prefix)
 }
 
 func getRateLimit(service rancherData) *types.RateLimit {

--- a/types/types.go
+++ b/types/types.go
@@ -102,6 +102,13 @@ type ErrorPage struct {
 	Query   string   `json:"query,omitempty"`
 }
 
+//Mirror holds request mirroring configuration
+type Mirror struct {
+	Backend        string            `json:"backend,omitempty"`
+	RequestHeaders map[string]string `json:"requestHeaders,omitempty"`
+	SampleRate     int               `json:"sampleRate,omitempty"`
+}
+
 // Rate holds a rate limiting configuration for a specific time period
 type Rate struct {
 	Period  flaeg.Duration `json:"period,omitempty"`
@@ -184,6 +191,7 @@ type Frontend struct {
 	Errors               map[string]*ErrorPage `json:"errors,omitempty"`
 	RateLimit            *RateLimit            `json:"ratelimit,omitempty"`
 	Redirect             *Redirect             `json:"redirect,omitempty"`
+	Mirror               *Mirror               `json:"mirror,omitempty"`
 }
 
 // Redirect configures a redirection of an entry point to another, or to an URL


### PR DESCRIPTION
### What does this PR do?

This PR adds initial support for request mirroring, similar to the capabilities offered by some other proxies, like Istio (https://dzone.com/articles/traffic-shadowing-with-istio-reducing-the-risk-of)

### Motivation

Provide ability to do request shadowing, which is very useful in various testing scenarios


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes
Fixes #2989 