### PR TITLE
Allow overriding the log level in debug mode.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -62,7 +62,7 @@ Add more configuration information here.
 -->
 
 
-### If applicable, please paste the log output in debug mode (`--debug` switch)
+### If applicable, please paste the log output at DEBUG level (`--logLevel=DEBUG` switch)
 
 ```
 (paste your output here)

--- a/.github/ISSUE_TEMPLATE/bugs.md
+++ b/.github/ISSUE_TEMPLATE/bugs.md
@@ -61,7 +61,7 @@ Add more configuration information here.
 -->
 
 
-### If applicable, please paste the log output in debug mode (`--debug` switch)
+### If applicable, please paste the log output in DEBUG level (`--logLevel=DEBUG` switch)
 
 ```
 (paste your output here)

--- a/cmd/bug/bug.go
+++ b/cmd/bug/bug.go
@@ -76,7 +76,7 @@ HOW TO WRITE A GOOD ISSUE?
 Add more configuration information here.
 -->
 
-### If applicable, please paste the log output in debug mode (` + "`" + `--debug` + "`" + ` switch)
+### If applicable, please paste the log output at DEBUG level (` + "`" + `--logLevel=DEBUG` + "`" + ` switch)
 
 ` + "```" + `
 (paste your output here)

--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -305,7 +305,6 @@ func NewTraefikConfiguration() *TraefikConfiguration {
 		GlobalConfiguration: configuration.GlobalConfiguration{
 			AccessLogsFile:            "",
 			TraefikLogsFile:           "",
-			LogLevel:                  "ERROR",
 			EntryPoints:               map[string]*configuration.EntryPoint{},
 			Constraints:               types.Constraints{},
 			DefaultEntryPoints:        []string{"http"},

--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -217,12 +217,18 @@ func configureLogging(globalConfiguration *configuration.GlobalConfiguration) {
 	// configure default log flags
 	fmtlog.SetFlags(fmtlog.Lshortfile | fmtlog.LstdFlags)
 
-	if globalConfiguration.Debug {
-		globalConfiguration.LogLevel = "DEBUG"
-	}
-
 	// configure log level
-	level, err := logrus.ParseLevel(strings.ToLower(globalConfiguration.LogLevel))
+	// an explicitly defined log level always has precedence. if none is
+	// given and debug mode is disabled, the default is ERROR, and DEBUG
+	// otherwise.
+	levelStr := strings.ToLower(globalConfiguration.LogLevel)
+	if levelStr == "" {
+		levelStr = "error"
+		if globalConfiguration.Debug {
+			levelStr = "debug"
+		}
+	}
+	level, err := logrus.ParseLevel(levelStr)
 	if err != nil {
 		log.Error("Error getting level", err)
 	}

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -234,10 +234,6 @@ func (gc *GlobalConfiguration) SetEffectiveConfiguration(configFile string) {
 		gc.API.Debug = gc.Debug
 	}
 
-	if gc.Debug {
-		gc.LogLevel = "DEBUG"
-	}
-
 	if gc.Web != nil && (gc.Web.Path == "" || !strings.HasSuffix(gc.Web.Path, "/")) {
 		gc.Web.Path += "/"
 	}

--- a/docs/configuration/commons.md
+++ b/docs/configuration/commons.md
@@ -19,7 +19,7 @@
 # Enable debug mode.
 # This will install HTTP handlers to expose Go expvars under /debug/vars and
 # pprof profiling data under /debug/pprof.
-# Additionally, the log level will be set to DEBUG.
+# The log level will be set to DEBUG unless `logLevel` is specified.
 #
 # Optional
 # Default: false


### PR DESCRIPTION
### What does this PR do?

Allow overriding the log level in debug mode.

### Motivation

Enabling the debug mode caused the log level to be hard-wired to DEBUG. We change the behavior so that an explicitly defined log level always overrides.

One primary motivation is to allow pprof-based benchmarking without excessive DEBUG logging distorting the results.

### Additional Notes

We also remove a piece of code from `SetEffectiveConfiguration` which was never effective because the log level would already be set previously.

Fixes #2968.