### PR TITLE
Dependency fsnotify organization has been renamed

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1241,6 +1241,7 @@
   name = "gopkg.in/fsnotify.v1"
   packages = ["."]
   revision = "629574ca2a5df945712d3079857300b5e4da0236"
+  source = "github.com/fsnotify/fsnotify"
   version = "v1.4.2"
 
 [[projects]]
@@ -1399,6 +1400,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "bda37c8b43334917a61fd0b22facf044a35a9b822f709603a8cb58464d738d12"
+  inputs-digest = "7994872ae2ae128f087243191120faabaac8a738140a5ca664422a8f709827ec"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -162,6 +162,7 @@ ignored = ["github.com/sirupsen/logrus"]
 
 [[constraint]]
   name = "gopkg.in/fsnotify.v1"
+  source = "github.com/fsnotify/fsnotify"
   version = "1.4.2"
 
 [[constraint]]


### PR DESCRIPTION
### What does this PR do?

This PR fix an issue when we do a `make validate`

```console
(129/186) Failed to write github.com/docker/docker@7848b8beb9d38a98a78b75f78e05f8d2255f9dfe
grouped write of manifest, lock and vendor: error while writing out vendor tree: failed to write dep tree: failed to export gopkg.in/fsnotify.v1: fatal: failed to unpack tree object 629574ca2a5df945712d3079857300b5e4da0236
: exit status 128
make: *** [Makefile:77: validate] Error 1
```
`gopkg.in/fsnotify.v1` is no more available due to a organization renaming. Explanation available [here](https://github.com/go-fsnotify/fsnotify)

The project organization `go-fsnotify` was renamed to `fsnotify`

### Motivation

Building issue
