### PR TITLE
Added SF to README.md and made links locale neutral

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Run it and forget it!
 
 - [Docker](https://www.docker.com/) / [Swarm mode](https://docs.docker.com/engine/swarm/)
 - [Kubernetes](https://kubernetes.io)
+- [Service Fabric](https://docs.microsoft.com/azure/service-fabric/)
 - [Mesos](https://github.com/apache/mesos) / [Marathon](https://mesosphere.github.io/marathon/)
 - [Rancher](https://rancher.com) (API, Metadata)
 - [Consul](https://www.consul.io/) / [Etcd](https://coreos.com/etcd/) / [Zookeeper](https://zookeeper.apache.org) / [BoltDB](https://github.com/boltdb/bolt)

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,7 @@ Run it and forget it!
 
 - [Docker](https://www.docker.com/) / [Swarm mode](https://docs.docker.com/engine/swarm/)
 - [Kubernetes](https://kubernetes.io)
-- [Service Fabric](https://docs.microsoft.com/en-gb/azure/service-fabric/)
+- [Service Fabric](https://docs.microsoft.com/azure/service-fabric/)
 - [Mesos](https://github.com/apache/mesos) / [Marathon](https://mesosphere.github.io/marathon/)
 - [Rancher](https://rancher.com) (API, Metadata)
 - [Consul](https://www.consul.io/) / [Etcd](https://coreos.com/etcd/) / [Zookeeper](https://zookeeper.apache.org) / [BoltDB](https://github.com/boltdb/bolt)


### PR DESCRIPTION
### What does this PR do?

Adds Service Fabric to the list of supported backends in the main README and makes the link locale neutral in the docs as updated here: #3033 

### Motivation

Service Fabric is supported from v1.5 and has docs but isn't included on the main README.md and the current link in the docs is `en-gb` locale specific.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation
