### PR TITLE
Add accesslog async writer

### DIFF
--- a/docs/configuration/logs.md
+++ b/docs/configuration/logs.md
@@ -120,12 +120,13 @@ filePath = "/path/to/access.log"
 To customize async log writer specify `asyncWriterChanSize`:
 ```toml
 [accessLog]
-# asyncWriterChanSize specify the size of async channel buffer
-#
-# Optional
-# Default: 1024
-#
-asyncWriterChanSize = 1024
+  [accessLog.async]
+  # asyncWriterChanSize specify the size of async channel buffer
+  #
+  # Optional
+  # Default: 1024
+  #
+  asyncWriterChanSize = 1024
 ```
 
 To write JSON format logs, specify `json` as the format:

--- a/docs/configuration/logs.md
+++ b/docs/configuration/logs.md
@@ -117,6 +117,17 @@ To write the logs into a log file specify the `filePath`:
 filePath = "/path/to/access.log"
 ```
 
+To customize async log writer specify `asyncWriterChanSize`:
+```toml
+[accessLog]
+# asyncWriterChanSize specify the size of async channel buffer
+#
+# Optional
+# Default: 1024
+#
+asyncWriterChanSize = 1024
+```
+
 To write JSON format logs, specify `json` as the format:
 ```toml
 [accessLog]

--- a/middlewares/accesslog/async_writer.go
+++ b/middlewares/accesslog/async_writer.go
@@ -34,18 +34,22 @@ func newAsyncWriter(chanSize int64, originalFile *os.File) *asyncWriter {
 		stopCh:       stopCh,
 	}
 
+	startedCh := make(chan interface{})
 	aWriter.Add(1)
 	go func() {
+		close(startedCh)
 		defer aWriter.Done()
 		for {
 			select {
 			case log := <-aWriter.writerStream:
 				printLog(aWriter, aWriter.originalFile, log)
-			case <-stopCh:
+			case <-aWriter.stopCh:
 				return
 			}
 		}
 	}()
+
+	<-startedCh
 
 	return aWriter
 

--- a/middlewares/accesslog/async_writer.go
+++ b/middlewares/accesslog/async_writer.go
@@ -1,0 +1,81 @@
+package accesslog
+
+import (
+	"io"
+	"os"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	defaultAsyncWriterSyncSize = 1024
+)
+
+type asyncWriter struct {
+	originalFile *os.File
+	stopCh       chan interface{}
+	writerStream chan []byte
+
+	sync.WaitGroup
+}
+
+func newAsyncWriter(chanSize int64, originalFile *os.File) *asyncWriter {
+	cSize := chanSize
+	if cSize == 0 {
+		cSize = defaultAsyncWriterSyncSize
+	}
+	stopCh := make(chan interface{}, 0)
+	w := make(chan []byte, cSize)
+	aWriter := &asyncWriter{
+		writerStream: w,
+		originalFile: originalFile,
+		stopCh:       stopCh,
+	}
+
+	aWriter.Add(1)
+	go func() {
+		defer aWriter.Done()
+		for {
+			select {
+			case log := <-aWriter.writerStream:
+				printLog(aWriter.originalFile, log)
+			case <-stopCh:
+				return
+			}
+		}
+	}()
+
+	return aWriter
+
+}
+
+func (w *asyncWriter) Write(p []byte) (n int, err error) {
+	size := len(p)
+	b := make([]byte, size)
+	copy(b, p)
+	w.writerStream <- b
+	return size, nil
+}
+
+func printLog(writer io.Writer, log []byte) {
+	_, err := writer.Write(log)
+	if err != nil {
+		logrus.Error(err)
+	}
+}
+
+func (w *asyncWriter) drainChannel() {
+	for log := range w.writerStream {
+		printLog(w.originalFile, log)
+	}
+}
+
+func (w *asyncWriter) Close() error {
+	close(w.stopCh)
+	w.Wait()
+	// drain channel before close file
+	close(w.writerStream)
+	w.drainChannel()
+	return w.originalFile.Close()
+}

--- a/middlewares/accesslog/async_writer_test.go
+++ b/middlewares/accesslog/async_writer_test.go
@@ -1,0 +1,44 @@
+package accesslog
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWriteAsync(t *testing.T) {
+	r, w, _ := os.Pipe()
+	aLog := newAsyncWriter(1024, w)
+	defer aLog.Close()
+	defer r.Close()
+	length, _ := aLog.Write([]byte("hello"))
+	assert.Equal(t, length, 5)
+}
+
+func TestDrainWriter(t *testing.T) {
+	r, w, _ := os.Pipe()
+	aLog := newAsyncWriter(1024, w)
+
+	close(aLog.stopCh)
+	aLog.Wait()
+
+	expected := 10
+	for i := 0; i < expected; i++ {
+		_, _ = aLog.Write([]byte(strconv.Itoa(i) + "|"))
+	}
+
+	close(aLog.writerStream)
+	aLog.drainChannel()
+	w.Close()
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	defer r.Close()
+
+	assert.Equal(t, strings.Count(buf.String(), "|"), expected)
+}

--- a/types/logs.go
+++ b/types/logs.go
@@ -22,11 +22,16 @@ type TraefikLog struct {
 
 // AccessLog holds the configuration settings for the access logger (middlewares/accesslog).
 type AccessLog struct {
-	FilePath            string            `json:"file,omitempty" description:"Access log file path. Stdout is used when omitted or empty" export:"true"`
-	Format              string            `json:"format,omitempty" description:"Access log format: json | common" export:"true"`
-	Filters             *AccessLogFilters `json:"filters,omitempty" description:"Access log filters, used to keep only specific access logs" export:"true"`
-	Fields              *AccessLogFields  `json:"fields,omitempty" description:"AccessLogFields" export:"true"`
-	AsyncWriterChanSize int64             `json:"asyncWriterChanSize,omitempty" description:"Async Writer chan size" export:"true"`
+	FilePath string            `json:"file,omitempty" description:"Access log file path. Stdout is used when omitted or empty" export:"true"`
+	Format   string            `json:"format,omitempty" description:"Access log format: json | common" export:"true"`
+	Filters  *AccessLogFilters `json:"filters,omitempty" description:"Access log filters, used to keep only specific access logs" export:"true"`
+	Fields   *AccessLogFields  `json:"fields,omitempty" description:"AccessLogFields" export:"true"`
+	Async    *AccessLogAsync   `json:"async,omitempty" description:"Async configuration" export:"true"`
+}
+
+// AccessLogAsync holds async log writer configuration for access log
+type AccessLogAsync struct {
+	AsyncWriterChanSize int64 `json:"asyncWriterChanSize,omitempty" description:"Async Writer chan size" export:"true"`
 }
 
 // StatusCodes holds status codes ranges to filter access log

--- a/types/logs.go
+++ b/types/logs.go
@@ -22,10 +22,11 @@ type TraefikLog struct {
 
 // AccessLog holds the configuration settings for the access logger (middlewares/accesslog).
 type AccessLog struct {
-	FilePath string            `json:"file,omitempty" description:"Access log file path. Stdout is used when omitted or empty" export:"true"`
-	Format   string            `json:"format,omitempty" description:"Access log format: json | common" export:"true"`
-	Filters  *AccessLogFilters `json:"filters,omitempty" description:"Access log filters, used to keep only specific access logs" export:"true"`
-	Fields   *AccessLogFields  `json:"fields,omitempty" description:"AccessLogFields" export:"true"`
+	FilePath            string            `json:"file,omitempty" description:"Access log file path. Stdout is used when omitted or empty" export:"true"`
+	Format              string            `json:"format,omitempty" description:"Access log format: json | common" export:"true"`
+	Filters             *AccessLogFilters `json:"filters,omitempty" description:"Access log filters, used to keep only specific access logs" export:"true"`
+	Fields              *AccessLogFields  `json:"fields,omitempty" description:"AccessLogFields" export:"true"`
+	AsyncWriterChanSize int64             `json:"asyncWriterChanSize,omitempty" description:"Async Writer chan size" export:"true"`
 }
 
 // StatusCodes holds status codes ranges to filter access log


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?
Add a async log writer for access logs.
<!-- A brief description of the change being made with this pull request. -->


### Motivation
On my current project, we use traefik and recently we activate access logs. When i checked the overhead this functionality, i realize that we lost a lot! So i tried to figure why and i found that we use sync io.Writer.

Small benchs:

Base configuration:
```toml
[entryPoints]
    [entryPoints.http]
       address = ":8080"
[accessLog]
filePath = 'test'
```

Without accesslogs from hey:
```console
$ hey -n 200000 http://127.0.0.1:8080/test
Summary:
  Total:	6.4238 secs
  Slowest:	0.0333 secs
  Fastest:	0.0002 secs
  Average:	0.0016 secs
  Requests/sec:	31134.0972
  
  Total data:	3800000 bytes
  Size/request:	19 bytes

Response time histogram:
  0.000 [1]	|
  0.003 [192996]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.007 [6398]	|∎
  0.010 [446]	|
  0.013 [107]	|
  0.017 [39]	|
  0.020 [9]	|
  0.023 [2]	|
  0.027 [0]	|
  0.030 [0]	|
  0.033 [2]	|


Latency distribution:
  10% in 0.0008 secs
  25% in 0.0011 secs
  50% in 0.0014 secs
  75% in 0.0018 secs
  90% in 0.0024 secs
  95% in 0.0030 secs
  99% in 0.0052 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0000 secs, 0.0002 secs, 0.0333 secs
  DNS-lookup:	0.0000 secs, 0.0000 secs, 0.0000 secs
  req write:	0.0000 secs, 0.0000 secs, 0.0191 secs
  resp wait:	0.0013 secs, 0.0001 secs, 0.0232 secs
  resp read:	0.0001 secs, 0.0000 secs, 0.0299 secs
```

With accesslogs:
```console
$ hey -n 200000 http://127.0.0.1:8080/test
Summary:
  Total:	20.0173 secs
  Slowest:	0.0261 secs
  Fastest:	0.0002 secs
  Average:	0.0050 secs
  Requests/sec:	9991.3647
  
  Total data:	3800000 bytes
  Size/request:	19 bytes

Response time histogram:
  0.000 [1]	|
  0.003 [2732]	|∎
  0.005 [154054]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.008 [32652]	|∎∎∎∎∎∎∎∎
  0.011 [7629]	|∎∎
  0.013 [2026]	|∎
  0.016 [556]	|
  0.018 [177]	|
  0.021 [148]	|
  0.024 [19]	|
  0.026 [6]	|


Latency distribution:
  10% in 0.0041 secs
  25% in 0.0042 secs
  50% in 0.0045 secs
  75% in 0.0053 secs
  90% in 0.0063 secs
  95% in 0.0081 secs
  99% in 0.0115 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0000 secs, 0.0002 secs, 0.0261 secs
  DNS-lookup:	0.0000 secs, 0.0000 secs, 0.0000 secs
  req write:	0.0000 secs, 0.0000 secs, 0.0023 secs
  resp wait:	0.0049 secs, 0.0002 secs, 0.0260 secs
  resp read:	0.0000 secs, 0.0000 secs, 0.0038 secs
```

With async log writer:
```console
$ hey -n 200000 http://127.0.0.1:8080/test
Summary:
  Total:	15.1209 secs
  Slowest:	0.0769 secs
  Fastest:	0.0002 secs
  Average:	0.0038 secs
  Requests/sec:	13226.7404
  
  Total data:	3800000 bytes
  Size/request:	19 bytes

Response time histogram:
  0.000 [1]	|
  0.008 [197458]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.016 [2258]	|
  0.023 [236]	|
  0.031 [22]	|
  0.039 [17]	|
  0.046 [6]	|
  0.054 [1]	|
  0.062 [0]	|
  0.069 [0]	|
  0.077 [1]	|


Latency distribution:
  10% in 0.0032 secs
  25% in 0.0033 secs
  50% in 0.0034 secs
  75% in 0.0042 secs
  90% in 0.0048 secs
  95% in 0.0053 secs
  99% in 0.0084 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0000 secs, 0.0002 secs, 0.0769 secs
  DNS-lookup:	0.0000 secs, 0.0000 secs, 0.0000 secs
  req write:	0.0000 secs, 0.0000 secs, 0.0205 secs
  resp wait:	0.0037 secs, 0.0002 secs, 0.0767 secs
  resp read:	0.0000 secs, 0.0000 secs, 0.0297 secs
```
<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [x] Added/updated documentation: Access Logs

### Additional Notes

<!-- Anything else we should know when reviewing? -->
I think that there is more to do to optimize access logs overhead but it's a first step.