### PR TITLE
Toggle /ping to artificially return unhealthy response on SIGTERM during requestAcceptGraceTimeout interval

### DIFF
--- a/docs/configuration/ping.md
+++ b/docs/configuration/ping.md
@@ -88,4 +88,4 @@ Otherwise, you are likely to expose _all_ services via this entry point.
 
 ### Using ping for external Load-balancer rotation health check
 
-If you are running traefik behind a external Load-balancer, and want to configure rotation health check on the Load-balancer to take a traefik instance out of rotation gracefully, you can configure [lifecycle.requestAcceptGraceTimeout](https://github.com/containous/traefik/blob/master/docs/configuration/commons.md#life-cycle) and the ping endpoint will return `503` response on traefik server termination, so that the Load-balancer can take the terminating traefik instance out of rotation, before it stops responding.
+If you are running traefik behind a external Load-balancer, and want to configure rotation health check on the Load-balancer to take a traefik instance out of rotation gracefully, you can configure [lifecycle.requestAcceptGraceTimeout](/configuration/commons.md#life-cycle) and the ping endpoint will return `503` response on traefik server termination, so that the Load-balancer can take the terminating traefik instance out of rotation, before it stops responding.

--- a/docs/configuration/ping.md
+++ b/docs/configuration/ping.md
@@ -85,3 +85,7 @@ Note the dedicated port `:8082` for `/ping`.
 
 In the above example, it is _very_ important to create a named dedicated entry point, and do **not** include it in `defaultEntryPoints`.
 Otherwise, you are likely to expose _all_ services via this entry point.
+
+### Using ping for external Load-balancer rotation health check
+
+If you are running traefik behind a external Load-balancer, and want to configure rotation health check on the Load-balancer to take a traefik instance out of rotation gracefully, you can configure [lifecycle.requestAcceptGraceTimeout](https://github.com/containous/traefik/blob/master/docs/configuration/commons.md#life-cycle) and the ping endpoint will return `503` response on traefik server termination, so that the Load-balancer can take the terminating traefik instance out of rotation, before it stops responding.

--- a/integration/fixtures/reqacceptgrace.toml
+++ b/integration/fixtures/reqacceptgrace.toml
@@ -6,6 +6,9 @@ logLevel = "DEBUG"
   [entryPoints.http]
   address = ":8000"
 
+  [entryPoints.traefik]
+  address = ":8001"
+
 [lifeCycle]
   requestAcceptGraceTimeout = "10s"
 
@@ -20,3 +23,5 @@ logLevel = "DEBUG"
   backend = "backend"
     [frontends.frontend.routes.service]
     rule = "Path:/service"
+
+[ping]

--- a/ping/ping.go
+++ b/ping/ping.go
@@ -3,19 +3,38 @@ package ping
 import (
 	"fmt"
 	"net/http"
+	"sync"
 
 	"github.com/containous/mux"
 )
 
 //Handler expose ping routes
 type Handler struct {
-	EntryPoint string `description:"Ping entryPoint" export:"true"`
+	EntryPoint  string `description:"Ping entryPoint" export:"true"`
+	terminating bool
+	termMutex   sync.RWMutex
+}
+
+// SetTerminating causes the ping endpoint to serve non 200 responses.
+func (g *Handler) SetTerminating() {
+	g.termMutex.Lock()
+	defer g.termMutex.Unlock()
+
+	g.terminating = true
 }
 
 // AddRoutes add ping routes on a router
-func (g Handler) AddRoutes(router *mux.Router) {
+func (g *Handler) AddRoutes(router *mux.Router) {
 	router.Methods(http.MethodGet, http.MethodHead).Path("/ping").
 		HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
-			fmt.Fprint(response, "OK")
+			g.termMutex.RLock()
+			defer g.termMutex.RUnlock()
+
+			statusCode := http.StatusOK
+			if g.terminating {
+				statusCode = http.StatusServiceUnavailable
+			}
+			response.WriteHeader(statusCode)
+			fmt.Fprint(response, http.StatusText(statusCode))
 		})
 }

--- a/ping/ping.go
+++ b/ping/ping.go
@@ -8,17 +8,17 @@ import (
 	"github.com/containous/mux"
 )
 
-//Handler expose ping routes
+// Handler expose ping routes
 type Handler struct {
 	EntryPoint  string `description:"Ping entryPoint" export:"true"`
 	terminating bool
-	termMutex   sync.RWMutex
+	lock        sync.RWMutex
 }
 
 // SetTerminating causes the ping endpoint to serve non 200 responses.
 func (g *Handler) SetTerminating() {
-	g.termMutex.Lock()
-	defer g.termMutex.Unlock()
+	g.lock.Lock()
+	defer g.lock.Unlock()
 
 	g.terminating = true
 }
@@ -27,8 +27,8 @@ func (g *Handler) SetTerminating() {
 func (g *Handler) AddRoutes(router *mux.Router) {
 	router.Methods(http.MethodGet, http.MethodHead).Path("/ping").
 		HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
-			g.termMutex.RLock()
-			defer g.termMutex.RUnlock()
+			g.lock.RLock()
+			defer g.lock.RUnlock()
 
 			statusCode := http.StatusOK
 			if g.terminating {

--- a/server/server.go
+++ b/server/server.go
@@ -212,6 +212,9 @@ func (s *Server) StartWithContext(ctx context.Context) {
 		<-ctx.Done()
 		log.Info("I have to go...")
 		reqAcceptGraceTimeOut := time.Duration(s.globalConfiguration.LifeCycle.RequestAcceptGraceTimeout)
+		if s.globalConfiguration.Ping != nil && reqAcceptGraceTimeOut > 0 {
+			s.globalConfiguration.Ping.SetTerminating()
+		}
 		if reqAcceptGraceTimeOut > 0 {
 			log.Infof("Waiting %s for incoming requests to cease", reqAcceptGraceTimeOut)
 			time.Sleep(reqAcceptGraceTimeOut)


### PR DESCRIPTION

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

Enhance /ping handler to return non-200 response upon requestAcceptGraceTimeout initiation, iff it is set.


### Motivation
Fixes #2969


### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

this is same as abandoned https://github.com/containous/traefik/pull/3031, but rebased against master branch.
