### PR TITLE
Adding priority to backend server properties

### DIFF
--- a/autogen/gentemplates/gen.go
+++ b/autogen/gentemplates/gen.go
@@ -504,6 +504,7 @@ var _templatesDockerTmpl = []byte(`{{$backendServers := .Servers}}
   {{range $serverName, $server := getServers $servers }}
   [backends."backend-{{ $backendName }}".servers."{{ $serverName }}"]
     url = "{{ $server.URL }}"
+    priority = {{ $server.Priority }}
     weight = {{ $server.Weight }}
   {{end}}
 

--- a/autogen/gentemplates/gen.go
+++ b/autogen/gentemplates/gen.go
@@ -1505,6 +1505,7 @@ var _templatesMesosTmpl = []byte(`[backends]
   {{range $serverName, $server := getServers $tasks }}
   [backends."backend-{{ $backendName }}".servers."{{ $serverName }}"]
     url = "{{ $server.URL }}"
+    priority = {{ $server.Priority }}
     weight = {{ $server.Weight }}
   {{end}}
 {{end}}

--- a/autogen/gentemplates/gen.go
+++ b/autogen/gentemplates/gen.go
@@ -695,6 +695,7 @@ var _templatesEcsTmpl = []byte(`[backends]
   {{range $serverName, $server := getServers $instances }}
   [backends."backend-{{ $serviceName }}".servers."{{ $serverName }}"]
     url = "{{ $server.URL }}"
+    priority = {{ $server.Priority }}
     weight = {{ $server.Weight }}
   {{end}}
 

--- a/provider/docker/config.go
+++ b/provider/docker/config.go
@@ -475,8 +475,9 @@ func (p *Provider) getServers(containers []dockerData) map[string]types.Server {
 		}
 
 		servers[provider.Normalize(serverName)] = types.Server{
-			URL:    fmt.Sprintf("%s://%s:%s", protocol, ip, port),
-			Weight: label.GetIntValue(container.SegmentLabels, label.TraefikWeight, label.DefaultWeightInt),
+			URL:      fmt.Sprintf("%s://%s:%s", protocol, ip, port),
+			Priority: label.GetIntValue(container.SegmentLabels, label.TraefikPriority, label.DefaultPriority),
+			Weight:   label.GetIntValue(container.SegmentLabels, label.TraefikWeight, label.DefaultWeightInt),
 		}
 	}
 

--- a/provider/docker/config_container_docker_test.go
+++ b/provider/docker/config_container_docker_test.go
@@ -93,6 +93,7 @@ func TestDockerBuildConfiguration(t *testing.T) {
 					labels(map[string]string{
 						label.TraefikPort:     "666",
 						label.TraefikProtocol: "https",
+						label.TraefikPriority: "99",
 						label.TraefikWeight:   "12",
 
 						label.TraefikBackend: "foobar",
@@ -269,8 +270,9 @@ func TestDockerBuildConfiguration(t *testing.T) {
 				"backend-foobar": {
 					Servers: map[string]types.Server{
 						"server-test1": {
-							URL:    "https://127.0.0.1:666",
-							Weight: 12,
+							URL:      "https://127.0.0.1:666",
+							Priority: 99,
+							Weight:   12,
 						},
 					},
 					CircuitBreaker: &types.CircuitBreaker{

--- a/provider/docker/config_container_swarm_test.go
+++ b/provider/docker/config_container_swarm_test.go
@@ -102,6 +102,7 @@ func TestSwarmBuildConfiguration(t *testing.T) {
 					serviceLabels(map[string]string{
 						label.TraefikPort:     "666",
 						label.TraefikProtocol: "https",
+						label.TraefikPriority: "99",
 						label.TraefikWeight:   "12",
 
 						label.TraefikBackend: "foobar",
@@ -275,8 +276,9 @@ func TestSwarmBuildConfiguration(t *testing.T) {
 				"backend-foobar": {
 					Servers: map[string]types.Server{
 						"server-test1": {
-							URL:    "https://127.0.0.1:666",
-							Weight: 12,
+							URL:      "https://127.0.0.1:666",
+							Priority: 99,
+							Weight:   12,
 						},
 					},
 					CircuitBreaker: &types.CircuitBreaker{

--- a/provider/ecs/config.go
+++ b/provider/ecs/config.go
@@ -203,8 +203,9 @@ func getServers(instances []ecsInstance) map[string]types.Server {
 
 		serverName := provider.Normalize(fmt.Sprintf("server-%s-%s", instance.Name, instance.ID))
 		servers[serverName] = types.Server{
-			URL:    fmt.Sprintf("%s://%s:%s", protocol, host, port),
-			Weight: getIntValue(instance, label.TraefikWeight, 0),
+			URL:      fmt.Sprintf("%s://%s:%s", protocol, host, port),
+			Priority: getIntValue(instance, label.TraefikPriority, 0),
+			Weight:   getIntValue(instance, label.TraefikWeight, 0),
 		}
 	}
 

--- a/provider/ecs/config_test.go
+++ b/provider/ecs/config_test.go
@@ -122,6 +122,7 @@ func TestBuildConfiguration(t *testing.T) {
 						DockerLabels: map[string]*string{
 							label.TraefikPort:     aws.String("666"),
 							label.TraefikProtocol: aws.String("https"),
+							label.TraefikPriority: aws.String("99"),
 							label.TraefikWeight:   aws.String("12"),
 
 							label.TraefikBackend: aws.String("foobar"),
@@ -206,8 +207,9 @@ func TestBuildConfiguration(t *testing.T) {
 					"backend-testing-instance": {
 						Servers: map[string]types.Server{
 							"server-testing-instance-6": {
-								URL:    "https://10.0.0.1:666",
-								Weight: 12,
+								URL:      "https://10.0.0.1:666",
+								Priority: 99,
+								Weight:   12,
 							},
 						},
 						CircuitBreaker: &types.CircuitBreaker{

--- a/provider/label/label.go
+++ b/provider/label/label.go
@@ -21,6 +21,7 @@ const (
 const (
 	DefaultWeight                                  = "0" // TODO [breaking] use int value
 	DefaultWeightInt                               = 0   // TODO rename to DefaultWeight
+	DefaultPriority                                = 0
 	DefaultProtocol                                = "http"
 	DefaultPassHostHeader                          = "true" // TODO [breaking] use bool value
 	DefaultPassHostHeaderBool                      = true   // TODO rename to DefaultPassHostHeader

--- a/provider/label/names.go
+++ b/provider/label/names.go
@@ -8,6 +8,7 @@ const (
 	SuffixEnable                                   = "enable"
 	SuffixPort                                     = "port"
 	SuffixPortIndex                                = "portIndex"
+	SuffixPriority                                 = "priority"
 	SuffixProtocol                                 = "protocol"
 	SuffixTags                                     = "tags"
 	SuffixWeight                                   = "weight"
@@ -70,6 +71,7 @@ const (
 	TraefikEnable                                  = Prefix + SuffixEnable
 	TraefikPort                                    = Prefix + SuffixPort
 	TraefikPortIndex                               = Prefix + SuffixPortIndex
+	TraefikPriority                                = Prefix + SuffixPriority
 	TraefikProtocol                                = Prefix + SuffixProtocol
 	TraefikTags                                    = Prefix + SuffixTags
 	TraefikWeight                                  = Prefix + SuffixWeight

--- a/provider/mesos/config.go
+++ b/provider/mesos/config.go
@@ -329,8 +329,9 @@ func (p *Provider) getServers(tasks []state.Task) map[string]types.Server {
 
 		serverName := "server-" + getID(task)
 		servers[serverName] = types.Server{
-			URL:    fmt.Sprintf("%s://%s:%s", protocol, host, port),
-			Weight: getIntValue(task, label.TraefikWeight, label.DefaultWeightInt, math.MaxInt32),
+			URL:      fmt.Sprintf("%s://%s:%s", protocol, host, port),
+			Priority: getIntValue(task, label.TraefikPriority, label.DefaultPriority, math.MaxInt64),
+			Weight:   getIntValue(task, label.TraefikWeight, label.DefaultWeightInt, math.MaxInt32),
 		}
 	}
 

--- a/provider/mesos/config_test.go
+++ b/provider/mesos/config_test.go
@@ -119,6 +119,7 @@ func TestBuildConfiguration(t *testing.T) {
 				aTask("ID1",
 					withLabel(label.TraefikPort, "666"),
 					withLabel(label.TraefikProtocol, "https"),
+					withLabel(label.TraefikPriority, "99"),
 					withLabel(label.TraefikWeight, "12"),
 
 					withLabel(label.TraefikBackend, "foobar"),
@@ -294,8 +295,9 @@ func TestBuildConfiguration(t *testing.T) {
 				"backend-foobar": {
 					Servers: map[string]types.Server{
 						"server-ID1": {
-							URL:    "https://10.10.10.10:666",
-							Weight: 12,
+							URL:      "https://10.10.10.10:666",
+							Priority: 99,
+							Weight:   12,
 						},
 					},
 					CircuitBreaker: &types.CircuitBreaker{

--- a/server/server.go
+++ b/server/server.go
@@ -1246,8 +1246,8 @@ func (s *Server) configureLBServers(lb healthcheck.LoadBalancer, config *types.C
 			log.Errorf("Error parsing server URL %s: %v", srv.URL, err)
 			return err
 		}
-		log.Debugf("Creating server %s at %s with weight %d", name, u, srv.Weight)
-		if err := lb.UpsertServer(u, roundrobin.Weight(srv.Weight)); err != nil {
+		log.Debugf("Creating server %s at %s with priority %d, weight %d", name, u, srv.Priority, srv.Weight)
+		if err := lb.UpsertServer(u, roundrobin.Priority(srv.Priority), roundrobin.Weight(srv.Weight)); err != nil {
 			log.Errorf("Error adding server %s to load balancer: %v", srv.URL, err)
 			return err
 		}

--- a/templates/docker.tmpl
+++ b/templates/docker.tmpl
@@ -48,6 +48,7 @@
   {{range $serverName, $server := getServers $servers }}
   [backends."backend-{{ $backendName }}".servers."{{ $serverName }}"]
     url = "{{ $server.URL }}"
+    priority = {{ $server.Priority }}
     weight = {{ $server.Weight }}
   {{end}}
 

--- a/templates/ecs.tmpl
+++ b/templates/ecs.tmpl
@@ -47,6 +47,7 @@
   {{range $serverName, $server := getServers $instances }}
   [backends."backend-{{ $serviceName }}".servers."{{ $serverName }}"]
     url = "{{ $server.URL }}"
+    priority = {{ $server.Priority }}
     weight = {{ $server.Weight }}
   {{end}}
 

--- a/templates/mesos.tmpl
+++ b/templates/mesos.tmpl
@@ -50,6 +50,7 @@
   {{range $serverName, $server := getServers $tasks }}
   [backends."backend-{{ $backendName }}".servers."{{ $serverName }}"]
     url = "{{ $server.URL }}"
+    priority = {{ $server.Priority }}
     weight = {{ $server.Weight }}
   {{end}}
 {{end}}

--- a/types/types.go
+++ b/types/types.go
@@ -70,8 +70,9 @@ type HealthCheck struct {
 
 // Server holds server configuration.
 type Server struct {
-	URL    string `json:"url,omitempty"`
-	Weight int    `json:"weight"`
+	URL      string `json:"url,omitempty"`
+	Weight   int    `json:"weight"`
+	Priority int    `json:"priority"`
 }
 
 // Route holds route configuration.


### PR DESCRIPTION
### What does this PR do?

The PR adds a new field `priority` to backend servers. Only servers with the highest priority are considered when selecting a server while all servers are available for serving existing users. Weight can still be used to balance requests across servers (of the same priority). 

### Motivation

Iimplementing zero downtime upgrades on applications making use of HTTP sessions is a bit more complex than simply replacing the servers with the new version. Replicating sessions across servers is not necessarily an option (due to, for example, cross-version incompatibility or performance) and sticky sessions are often used to avoid the need for replication.

Using weight has been offered as a solution to implement session draining. The problem with weight, however, is that you need to update existing configuration. With providers such as AWS ECS this may be impossible without recreating the containers (which defeats the purpose).

This PR makes it possible to properly implement session draining: existing users keep using the current version while new users are directed to the latest version. For example, assume you have version 1.0 deployed with backend servers having priority 1. When version 2.0 is deployed, priority 2 can be used on the new backend servers. If the version 1.0 still has active users, they may keep using the old servers (with priority 1). New users, however, are sent to the 2.0 version due to its higher priority on the new backend servers.

The priority is an integer and can be anything from build number to timestamp.  

### More

- [x] Docker
- [ ]  Rancher
- [ ]  Marathon
- [ ]  k8s
- [x]  Mesos
- [x]  ECS
- [ ]  Consul Catalog
- [ ]  KV (bold, consul, etcd, zk)
- [ ] Updated documentation
