### PR TITLE
Add wildcard match to acme domains

### DIFF
--- a/acme/account.go
+++ b/acme/account.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"reflect"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -219,6 +220,12 @@ func (dc *DomainsCertificates) getCertificateForDomain(domainToFind string) (*Do
 
 	for _, domainsCertificate := range dc.Certs {
 		for _, domain := range domainsCertificate.Domains.ToStrArray() {
+			if strings.HasPrefix(domain, "*.") {
+				selector := "^" + strings.Replace(domain, "*.", "[^\\.]*\\.", -1) + "$"
+				if domainCheck, _ := regexp.MatchString(selector, domainToFind); domainCheck {
+					return domainsCertificate, true
+				}
+			}
 			if domain == domainToFind {
 				return domainsCertificate, true
 			}

--- a/acme/account.go
+++ b/acme/account.go
@@ -219,7 +219,7 @@ func (dc *DomainsCertificates) getCertificateForDomain(domainToFind string) (*Do
 
 	for _, domainsCertificate := range dc.Certs {
 		for _, domain := range domainsCertificate.Domains.ToStrArray() {
-			if strings.HasPrefix(domain, "*.") && searchProvidedCertificateForDomain(domainToFind, domain) {
+			if strings.HasPrefix(domain, "*.") && types.MatchDomain(domainToFind, domain) {
 				return domainsCertificate, true
 			}
 			if domain == domainToFind {

--- a/acme/account.go
+++ b/acme/account.go
@@ -8,7 +8,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"reflect"
-	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -220,11 +219,8 @@ func (dc *DomainsCertificates) getCertificateForDomain(domainToFind string) (*Do
 
 	for _, domainsCertificate := range dc.Certs {
 		for _, domain := range domainsCertificate.Domains.ToStrArray() {
-			if strings.HasPrefix(domain, "*.") {
-				selector := "^" + strings.Replace(domain, "*.", "[^\\.]*\\.", -1) + "$"
-				if domainCheck, _ := regexp.MatchString(selector, domainToFind); domainCheck {
-					return domainsCertificate, true
-				}
+			if strings.HasPrefix(domain, "*.") && searchProvidedCertificateForDomain(domainToFind, domain) {
+				return domainsCertificate, true
 			}
 			if domain == domainToFind {
 				return domainsCertificate, true

--- a/acme/acme_test.go
+++ b/acme/acme_test.go
@@ -444,3 +444,90 @@ func TestAcme_getValidDomain(t *testing.T) {
 		})
 	}
 }
+
+func TestAcme_getCertificateForDomain(t *testing.T) {
+	tests := []struct {
+		name          string
+		domain        string
+		dc            *DomainsCertificates
+		expected      *DomainsCertificate
+		expectedFound bool
+	}{
+		{
+			name:   "non-wildcard exact match",
+			domain: "foo.traefik.wtf",
+			dc: &DomainsCertificates{
+				Certs: []*DomainsCertificate{
+					{
+						Domains: types.Domain{
+							Main: "foo.traefik.wtf",
+						},
+					},
+				},
+			},
+			expected: &DomainsCertificate{
+				Domains: types.Domain{
+					Main: "foo.traefik.wtf",
+				},
+			},
+			expectedFound: true,
+		},
+		{
+			name:   "non-wildcard no match",
+			domain: "bar.traefik.wtf",
+			dc: &DomainsCertificates{
+				Certs: []*DomainsCertificate{
+					{
+						Domains: types.Domain{
+							Main: "foo.traefik.wtf",
+						},
+					},
+				},
+			},
+			expected:      nil,
+			expectedFound: false,
+		},
+		{
+			name:   "wildcard match",
+			domain: "foo.traefik.wtf",
+			dc: &DomainsCertificates{
+				Certs: []*DomainsCertificate{
+					{
+						Domains: types.Domain{
+							Main: "*.traefik.wtf",
+						},
+					},
+				},
+			},
+			expected: &DomainsCertificate{
+				Domains: types.Domain{
+					Main: "*.traefik.wtf",
+				},
+			},
+			expectedFound: true,
+		},
+		{
+			name:   "wildcard no match",
+			domain: "foo.traefik.wtf",
+			dc: &DomainsCertificates{
+				Certs: []*DomainsCertificate{
+					{
+						Domains: types.Domain{
+							Main: "*.bar.traefik.wtf",
+						},
+					},
+				},
+			},
+			expected:      nil,
+			expectedFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, found := tt.dc.getCertificateForDomain(tt.domain)
+			assert.Equal(t, tt.expectedFound, found)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/acme/acme_test.go
+++ b/acme/acme_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/containous/traefik/tls/generate"
 	"github.com/containous/traefik/types"
 	"github.com/stretchr/testify/assert"
-	acme "github.com/xenolf/lego/acmev2"
+	"github.com/xenolf/lego/acmev2"
 )
 
 func TestDomainsSet(t *testing.T) {
@@ -446,15 +446,15 @@ func TestAcme_getValidDomain(t *testing.T) {
 }
 
 func TestAcme_getCertificateForDomain(t *testing.T) {
-	tests := []struct {
-		name          string
+	testCases := []struct {
+		desc          string
 		domain        string
 		dc            *DomainsCertificates
 		expected      *DomainsCertificate
 		expectedFound bool
 	}{
 		{
-			name:   "non-wildcard exact match",
+			desc:   "non-wildcard exact match",
 			domain: "foo.traefik.wtf",
 			dc: &DomainsCertificates{
 				Certs: []*DomainsCertificate{
@@ -473,7 +473,7 @@ func TestAcme_getCertificateForDomain(t *testing.T) {
 			expectedFound: true,
 		},
 		{
-			name:   "non-wildcard no match",
+			desc:   "non-wildcard no match",
 			domain: "bar.traefik.wtf",
 			dc: &DomainsCertificates{
 				Certs: []*DomainsCertificate{
@@ -488,7 +488,7 @@ func TestAcme_getCertificateForDomain(t *testing.T) {
 			expectedFound: false,
 		},
 		{
-			name:   "wildcard match",
+			desc:   "wildcard match",
 			domain: "foo.traefik.wtf",
 			dc: &DomainsCertificates{
 				Certs: []*DomainsCertificate{
@@ -507,7 +507,7 @@ func TestAcme_getCertificateForDomain(t *testing.T) {
 			expectedFound: true,
 		},
 		{
-			name:   "wildcard no match",
+			desc:   "wildcard no match",
 			domain: "foo.traefik.wtf",
 			dc: &DomainsCertificates{
 				Certs: []*DomainsCertificate{
@@ -523,11 +523,14 @@ func TestAcme_getCertificateForDomain(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, found := tt.dc.getCertificateForDomain(tt.domain)
-			assert.Equal(t, tt.expectedFound, found)
-			assert.Equal(t, tt.expected, got)
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			got, found := test.dc.getCertificateForDomain(test.domain)
+			assert.Equal(t, test.expectedFound, found)
+			assert.Equal(t, test.expected, got)
 		})
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -15,7 +15,6 @@ import (
 	"os"
 	"os/signal"
 	"reflect"
-	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -517,15 +516,13 @@ func (s *Server) loadHTTPSConfiguration(configurations types.Configurations, def
 	return newEPCertificates, nil
 }
 
-// getCertificate allows to customize tlsConfig.Getcertificate behaviour to get the certificates inserted dynamically
+// getCertificate allows to customize tlsConfig.GetCertificate behaviour to get the certificates inserted dynamically
 func (s *serverEntryPoint) getCertificate(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 	domainToCheck := types.CanonicalDomain(clientHello.ServerName)
 	if s.certs.Get() != nil {
 		for domains, cert := range s.certs.Get().(map[string]*tls.Certificate) {
-			for _, domain := range strings.Split(domains, ",") {
-				selector := "^" + strings.Replace(domain, "*.", "[^\\.]*\\.?", -1) + "$"
-				domainCheck, _ := regexp.MatchString(selector, domainToCheck)
-				if domainCheck {
+			for _, certDomain := range strings.Split(domains, ",") {
+				if types.MatchDomain(domainToCheck, certDomain) {
 					return cert, nil
 				}
 			}

--- a/types/domain_test.go
+++ b/types/domain_test.go
@@ -88,3 +88,95 @@ func TestDomain_Set(t *testing.T) {
 		})
 	}
 }
+
+func TestMatchDomain(t *testing.T) {
+	testCases := []struct {
+		desc       string
+		certDomain string
+		domain     string
+		expected   bool
+	}{
+		{
+			desc:       "exact match",
+			certDomain: "traefik.wtf",
+			domain:     "traefik.wtf",
+			expected:   true,
+		},
+		{
+			desc:       "wildcard and root domain",
+			certDomain: "*.traefik.wtf",
+			domain:     "traefik.wtf",
+			expected:   false,
+		},
+		{
+			desc:       "wildcard and sub domain",
+			certDomain: "*.traefik.wtf",
+			domain:     "sub.traefik.wtf",
+			expected:   true,
+		},
+		{
+			desc:       "wildcard and sub sub domain",
+			certDomain: "*.traefik.wtf",
+			domain:     "sub.sub.traefik.wtf",
+			expected:   false,
+		},
+		{
+			desc:       "double wildcard and sub sub domain",
+			certDomain: "*.*.traefik.wtf",
+			domain:     "sub.sub.traefik.wtf",
+			expected:   true,
+		},
+		{
+			desc:       "sub sub domain and invalid wildcard",
+			certDomain: "sub.*.traefik.wtf",
+			domain:     "sub.sub.traefik.wtf",
+			expected:   false,
+		},
+		{
+			desc:       "sub sub domain and valid wildcard",
+			certDomain: "*.sub.traefik.wtf",
+			domain:     "sub.sub.traefik.wtf",
+			expected:   true,
+		},
+		{
+			desc:       "dot replaced by a cahr",
+			certDomain: "sub.sub.traefik.wtf",
+			domain:     "sub.sub.traefikiwtf",
+			expected:   false,
+		},
+		{
+			desc:       "*",
+			certDomain: "*",
+			domain:     "sub.sub.traefik.wtf",
+			expected:   false,
+		},
+		{
+			desc:       "?",
+			certDomain: "?",
+			domain:     "sub.sub.traefik.wtf",
+			expected:   false,
+		},
+		{
+			desc:       "...................",
+			certDomain: "...................",
+			domain:     "sub.sub.traefik.wtf",
+			expected:   false,
+		},
+		{
+			desc:       "wildcard and *",
+			certDomain: "*.traefik.wtf",
+			domain:     "*.*.traefik.wtf",
+			expected:   false,
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			domains := MatchDomain(test.domain, test.certDomain)
+			assert.Equal(t, test.expected, domains)
+		})
+	}
+}

--- a/types/domains.go
+++ b/types/domains.go
@@ -65,3 +65,24 @@ func (ds *Domains) String() string { return fmt.Sprintf("%+v", *ds) }
 func (ds *Domains) SetValue(val interface{}) {
 	*ds = val.([]Domain)
 }
+
+// MatchDomain return true if a domain match the cert domain
+func MatchDomain(domain string, certDomain string) bool {
+	if domain == certDomain {
+		return true
+	}
+
+	for len(certDomain) > 0 && certDomain[len(certDomain)-1] == '.' {
+		certDomain = certDomain[:len(certDomain)-1]
+	}
+
+	labels := strings.Split(domain, ".")
+	for i := range labels {
+		labels[i] = "*"
+		candidate := strings.Join(labels, ".")
+		if certDomain == candidate {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

- Allows matching of hosts like `x.traefik.wtf` to ACME wildcard
  certs `*.traefik.wtf`


### Motivation

- Tested wildcard acme v2 and noticed that it was not properly selecting my wildcard domains


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
