### PR TITLE
Moved /api/cluster/leadership handler under public routes (requires no authentication)

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -744,15 +744,16 @@ func (s *Server) addInternalRoutes(entryPointName string, router *mux.Router) {
 
 	if s.globalConfiguration.API != nil && s.globalConfiguration.API.EntryPoint == entryPointName {
 		s.globalConfiguration.API.AddRoutes(router)
-		if s.leadership != nil {
-			s.leadership.AddRoutes(router)
-		}
 	}
 }
 
 func (s *Server) addInternalPublicRoutes(entryPointName string, router *mux.Router) {
 	if s.globalConfiguration.Ping != nil && s.globalConfiguration.Ping.EntryPoint != "" && s.globalConfiguration.Ping.EntryPoint == entryPointName {
 		s.globalConfiguration.Ping.AddRoutes(router)
+	}
+
+	if s.globalConfiguration.API != nil && s.globalConfiguration.API.EntryPoint == entryPointName && s.leadership != nil {
+		s.leadership.AddRoutes(router)
 	}
 }
 


### PR DESCRIPTION
As it was brought up in Slack, the `/cluster/leadership` URL is mostly being called from various load balancers and other sources that don't typically do authentication.  Having `/cluster` handler be under API endpoint, which otherwise might need to be guarded with authentication, prevents access to `/cluster/leadership` URL from load balancers.  Moving it under `Ping` endpoint, will solve this problem, and, as it seems from the intent of `/cluster/leadership` URL, it actually belongs under `Ping` to begin with, as it serves similar purpose.