### PR TITLE
Support TLS MinVersion and CipherSuite as CLI option.

### DIFF
--- a/configuration/entrypoints.go
+++ b/configuration/entrypoints.go
@@ -224,12 +224,22 @@ func makeEntryPointTLS(result map[string]string) (*tls.TLS, error) {
 		}
 	}
 
-	if len(result["ca"]) > 0 {
-		files := strings.Split(result["ca"], ",")
-		optional := toBool(result, "ca_optional")
-		configTLS.ClientCA = tls.ClientCA{
-			Files:    files,
-			Optional: optional,
+	if configTLS != nil {
+		if len(result["ca"]) > 0 {
+			files := strings.Split(result["ca"], ",")
+			optional := toBool(result, "ca_optional")
+			configTLS.ClientCA = tls.ClientCA{
+				Files:    files,
+				Optional: optional,
+			}
+		}
+
+		if len(result["tls_minversion"]) > 0 {
+			configTLS.MinVersion = result["tls_minversion"]
+		}
+
+		if len(result["tls_ciphersuites"]) > 0 {
+			configTLS.CipherSuites = strings.Split(result["tls_ciphersuites"], ",")
 		}
 	}
 

--- a/configuration/entrypoints_test.go
+++ b/configuration/entrypoints_test.go
@@ -21,6 +21,8 @@ func Test_parseEntryPointsConfiguration(t *testing.T) {
 				"Address::8000 " +
 				"TLS:goo,gii " +
 				"TLS " +
+				"TLS.MinVersion:VersionTLS11 " +
+				"TLS.CipherSuites:TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA " +
 				"CA:car " +
 				"CA.Optional:true " +
 				"Redirect.EntryPoint:https " +
@@ -67,6 +69,8 @@ func Test_parseEntryPointsConfiguration(t *testing.T) {
 				"redirect_replacement":     "http://mydomain/$1",
 				"tls":                        "goo,gii",
 				"tls_acme":                   "TLS",
+				"tls_ciphersuites":           "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+				"tls_minversion":             "VersionTLS11",
 				"whitelistsourcerange":       "10.42.0.0/16,152.89.1.33/32,afed:be44::/16",
 				"whitelist_sourcerange":      "10.42.0.0/16,152.89.1.33/32,afed:be44::/16",
 				"whitelist_usexforwardedfor": "true",
@@ -172,6 +176,8 @@ func TestEntryPoints_Set(t *testing.T) {
 				"Address::8000 " +
 				"TLS:goo,gii " +
 				"TLS " +
+				"TLS.MinVersion:VersionTLS11 " +
+				"TLS.CipherSuites:TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA " +
 				"CA:car " +
 				"CA.Optional:true " +
 				"Redirect.EntryPoint:https " +
@@ -198,6 +204,8 @@ func TestEntryPoints_Set(t *testing.T) {
 			expectedEntryPoint: &EntryPoint{
 				Address: ":8000",
 				TLS: &tls.TLS{
+					MinVersion:   "VersionTLS11",
+					CipherSuites: []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA384", "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"},
 					Certificates: tls.Certificates{
 						{
 							CertFile: tls.FileOrContent("goo"),
@@ -274,6 +282,8 @@ func TestEntryPoints_Set(t *testing.T) {
 				"address::8000 " +
 				"tls:goo,gii " +
 				"tls " +
+				"tls.minversion:VersionTLS11 " +
+				"tls.ciphersuites:TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA " +
 				"ca:car " +
 				"ca.Optional:true " +
 				"redirect.entryPoint:https " +
@@ -298,6 +308,8 @@ func TestEntryPoints_Set(t *testing.T) {
 			expectedEntryPoint: &EntryPoint{
 				Address: ":8000",
 				TLS: &tls.TLS{
+					MinVersion:   "VersionTLS11",
+					CipherSuites: []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA384", "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"},
 					Certificates: tls.Certificates{
 						{
 							CertFile: tls.FileOrContent("goo"),

--- a/docs/configuration/entrypoints.md
+++ b/docs/configuration/entrypoints.md
@@ -108,6 +108,8 @@ Name:foo
 Address::80
 TLS:goo,gii
 TLS
+TLS.MinVersion:VersionTLS11
+TLS.CipherSuites:TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA384
 CA:car
 CA.Optional:true
 Redirect.EntryPoint:https


### PR DESCRIPTION
### What does this PR do?

Support TLS MinVersion and CipherSuite as CLI option.

### Motivation

Fixes #3103

### More

- [x] Added/updated tests
- [x] Added/updated documentation
