### PR TITLE
Update docker-and-lets-encrypt example to show traefik:1.5.4

### DIFF
--- a/docs/user-guide/docker-and-lets-encrypt.md
+++ b/docs/user-guide/docker-and-lets-encrypt.md
@@ -50,7 +50,7 @@ version: '2'
 
 services:
   traefik:
-    image: traefik:1.3.5
+    image: traefik:1.5.4
     restart: always
     ports:
       - 80:80


### PR DESCRIPTION
### What does this PR do?

Update the docker-compose.yml example in this guide to the latest stable release of Traefik.

### Motivation

I was having issues using with Let's Encrypt due to #1832, 
https://community.letsencrypt.org/t/2018-01-11-update-regarding-acme-tls-sni-and-shared-hosting-infrastructure/50188.

Updating to a newer version of Traefik fixed the issue. This pull request should prevent others from having the same problem.

### More
- [x] Updated documentation


