### PR TITLE
Support multi-port services.

### DIFF
--- a/provider/kubernetes/builder_endpoint_test.go
+++ b/provider/kubernetes/builder_endpoint_test.go
@@ -47,11 +47,11 @@ func subset(opts ...func(*corev1.EndpointSubset)) func(*corev1.Endpoints) {
 
 func eAddresses(opts ...func(*corev1.EndpointAddress)) func(*corev1.EndpointSubset) {
 	return func(subset *corev1.EndpointSubset) {
-		a := &corev1.EndpointAddress{}
 		for _, opt := range opts {
+			a := &corev1.EndpointAddress{}
 			opt(a)
+			subset.Addresses = append(subset.Addresses, *a)
 		}
-		subset.Addresses = append(subset.Addresses, *a)
 	}
 }
 

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -470,7 +470,7 @@ retryexpression: IsNetworkError() && Attempts() <= 2
 `),
 			sSpec(
 				clusterIP("10.0.0.3"),
-				sPorts(sPort(803, ""))),
+				sPorts(sPort(803, "http"))),
 		),
 		buildService(
 			sName("service4"),
@@ -480,7 +480,7 @@ retryexpression: IsNetworkError() && Attempts() <= 2
 			sAnnotation(annotationKubernetesMaxConnAmount, "6"),
 			sSpec(
 				clusterIP("10.0.0.4"),
-				sPorts(sPort(804, ""))),
+				sPorts(sPort(804, "http"))),
 		),
 	}
 
@@ -502,10 +502,10 @@ retryexpression: IsNetworkError() && Attempts() <= 2
 			eUID("2"),
 			subset(
 				eAddresses(eAddress("10.15.0.1")),
-				ePorts(ePort(8080, "http"))),
+				ePorts(ePort(8080, ""))),
 			subset(
 				eAddresses(eAddress("10.15.0.2")),
-				ePorts(ePort(8080, "http"))),
+				ePorts(ePort(8080, ""))),
 		),
 		buildEndpoint(
 			eNamespace("testing"),


### PR DESCRIPTION
### What does this PR do?

Support Kubernetes services with multiple defined ports.

### Motivation

- enable more compact port definitions
- be aligned with the existing Service routing behavior

### More

- [x] Added/updated tests
- ~[ ] Added/updated documentation~ (not needed as we simply match what upstream Kubernetes already does on Service objects)

Fixes #3118.