### PR TITLE
fix: overflow on 32 bits arch.

### DIFF
--- a/provider/mesos/deprecated_config.go
+++ b/provider/mesos/deprecated_config.go
@@ -233,7 +233,7 @@ func getFuncApplicationIntValueV1(labelName string, defaultValue int) func(task 
 			return defaultValue
 		}
 
-		return getIntValueV1(task, labelName, defaultValue, math.MaxInt64)
+		return getIntValueV1(task, labelName, defaultValue, math.MaxInt32)
 	}
 }
 
@@ -254,7 +254,7 @@ func getFuncBoolValueV1(labelName string, defaultValue bool) func(task state.Tas
 // Deprecated
 func getFuncIntValueV1(labelName string, defaultValue int) func(task state.Task) int {
 	return func(task state.Task) int {
-		return getIntValueV1(task, labelName, defaultValue, math.MaxInt64)
+		return getIntValueV1(task, labelName, defaultValue, math.MaxInt32)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Use `math.MaxInt32` instead of `math.MaxInt64` for `int` max value.

### Motivation

```
# github.com/containous/traefik/provider/mesos
provider/mesos/deprecated_config.go:236:23: constant 9223372036854775807 overflows int
provider/mesos/deprecated_config.go:257:23: constant 9223372036854775807 overflows int
make[1]: *** [crossbinary-others] Error 2
```
