### PR TITLE
Server weight zero

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -263,8 +263,8 @@
 [[projects]]
   name = "github.com/containous/traefik-extra-service-fabric"
   packages = ["."]
-  revision = "29a6d70ad0f15175efbaa5fd93d8afdd8b373b93"
-  version = "v1.1.1"
+  revision = "503022efdc178146d598911092af75690510a80c"
+  version = "v1.1.3"
 
 [[projects]]
   name = "github.com/coreos/bbolt"
@@ -761,6 +761,7 @@
   version = "v1.3.7"
 
 [[projects]]
+  branch = "master"
   name = "github.com/jjcollinge/servicefabric"
   packages = ["."]
   revision = "8eebe170fa1ba25d3dfb928b3f86a7313b13b9fe"
@@ -1674,6 +1675,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "37f92cc9416b1449e9fe4fd1b02d999af8d9887617424db7cb334060cd362e5c"
+  inputs-digest = "c441208e9bf330e85e2939b383515f58a4957286960b43c444e6f512d1ff94ee"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -66,7 +66,7 @@
 
 [[constraint]]
   name = "github.com/containous/traefik-extra-service-fabric"
-  version = "1.1.1"
+  version = "1.1.3"
 
 [[constraint]]
   name = "github.com/coreos/go-systemd"

--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -35,6 +35,7 @@ import (
 	"github.com/coreos/go-systemd/daemon"
 	"github.com/ogier/pflag"
 	"github.com/sirupsen/logrus"
+	"github.com/vulcand/oxy/roundrobin"
 )
 
 func main() {
@@ -154,6 +155,10 @@ func runCmd(globalConfiguration *configuration.GlobalConfiguration, configFile s
 	}
 
 	http.DefaultTransport.(*http.Transport).Proxy = http.ProxyFromEnvironment
+
+	if globalConfiguration.AllowMinWeightZero {
+		roundrobin.SetDefaultWeight(0)
+	}
 
 	globalConfiguration.SetEffectiveConfiguration(configFile)
 	globalConfiguration.ValidateConfiguration()

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -78,6 +78,7 @@ type GlobalConfiguration struct {
 	HealthCheck               *HealthCheckConfig      `description:"Health check parameters" export:"true"`
 	RespondingTimeouts        *RespondingTimeouts     `description:"Timeouts for incoming requests to the Traefik instance" export:"true"`
 	ForwardingTimeouts        *ForwardingTimeouts     `description:"Timeouts for requests forwarded to the backend servers" export:"true"`
+	AllowMinWeightZero        bool                    `description:"Allow weight to take 0 as minimum real value." export:"true"`         // Deprecated
 	Web                       *WebCompatibility       `description:"(Deprecated) Enable Web backend with default settings" export:"true"` // Deprecated
 	Docker                    *docker.Provider        `description:"Enable Docker backend with default settings" export:"true"`
 	File                      *file.Provider          `description:"Enable File backend with default settings" export:"true"`

--- a/docs/configuration/commons.md
+++ b/docs/configuration/commons.md
@@ -69,6 +69,15 @@
 # Default: ["http"]
 #
 # defaultEntryPoints = ["http", "https"]
+
+# Allow the use of 0 as server weight.
+# - false: a weight 0 means internally a weight of 1.
+# - true: a weight 0 means internally a weight of 0 (a server with a weight of 0 is removed from the available servers).
+#
+# Optional
+# Default: false
+#
+# AllowMinWeightZero = true
 ```
 
 - `graceTimeOut`: Duration to give active requests a chance to finish before Traefik stops.  

--- a/examples/accessLog/traefik.ab.toml
+++ b/examples/accessLog/traefik.ab.toml
@@ -29,10 +29,13 @@ entryPoint = "api"
       method = "drr"
       [backends.backend.servers.server1]
       url = "http://127.0.0.1:8081"
+      weight = 1
       [backends.backend.servers.server2]
       url = "http://127.0.0.1:8082"
+      weight = 1
       [backends.backend.servers.server3]
       url = "http://127.0.0.1:8083"
+      weight = 1
   [frontends]
     [frontends.frontend]
     backend = "backend"

--- a/examples/accessLog/traefik.example.toml
+++ b/examples/accessLog/traefik.example.toml
@@ -27,18 +27,24 @@ entryPoint = "api"
     [backends.backend1]
       [backends.backend1.servers.server1]
       url = "http://127.0.0.1:8081"
+      weight = 1
+
     [backends.backend2]
       [backends.backend2.LoadBalancer]
       method = "drr"
       [backends.backend2.servers.server1]
       url = "http://127.0.0.1:8082"
+      weight = 1
       [backends.backend2.servers.server2]
       url = "http://127.0.0.1:8083"
+      weight = 1
+
   [frontends]
     [frontends.frontend1]
     backend = "backend1"
       [frontends.frontend1.routes.test_1]
       rule = "Path: /test1"
+
     [frontends.frontend2]
     backend = "backend2"
     passHostHeader = true

--- a/integration/fixtures/acme/acme_http01.toml
+++ b/integration/fixtures/acme/acme_http01.toml
@@ -26,6 +26,7 @@ caServer = "http://{{.BoulderHost}}:4001/directory"
   [backends.backend]
     [backends.backend.servers.server1]
     url = "http://127.0.0.1:9010"
+    weight = 1
 
 
 [frontends]

--- a/integration/fixtures/acme/acme_http01_web.toml
+++ b/integration/fixtures/acme/acme_http01_web.toml
@@ -28,6 +28,7 @@ path="/traefik"
   [backends.backend]
     [backends.backend.servers.server1]
     url = "http://127.0.0.1:9010"
+    weight = 1
 
 [frontends]
   [frontends.frontend]

--- a/integration/fixtures/acme/acme_provided.toml
+++ b/integration/fixtures/acme/acme_provided.toml
@@ -28,6 +28,7 @@ entryPoint="http"
   [backends.backend]
     [backends.backend.servers.server1]
     url = "http://127.0.0.1:9010"
+    weight = 1
 
 
 [frontends]

--- a/integration/fixtures/acme/certificates.toml
+++ b/integration/fixtures/acme/certificates.toml
@@ -2,6 +2,7 @@
   [backends.backend]
     [backends.backend.servers.server1]
     url = "http://127.0.0.1:9010"
+    weight = 1
 
 [frontends]
   [frontends.frontend]

--- a/integration/fixtures/acme/no_challenge_acme.toml
+++ b/integration/fixtures/acme/no_challenge_acme.toml
@@ -26,6 +26,7 @@ caServer = "http://{{.BoulderHost}}:4001/directory"
   [backends.backend]
     [backends.backend.servers.server1]
     url = "http://127.0.0.1:9010"
+    weight = 1
 
 
 [frontends]

--- a/integration/fixtures/acme/wrong_acme.toml
+++ b/integration/fixtures/acme/wrong_acme.toml
@@ -25,6 +25,7 @@ caServer = "http://wrongurl:4001/directory"
   [backends.backend]
     [backends.backend.servers.server1]
     url = "http://127.0.0.1:9010"
+    weight = 1
 
 
 [frontends]

--- a/integration/fixtures/error_pages/error.toml
+++ b/integration/fixtures/error_pages/error.toml
@@ -11,17 +11,20 @@ logLevel = "DEBUG"
   [backends.backend1]
     [backends.backend1.servers.server1]
     url = "http://{{.Server1}}:8989474"
+    weight = 1
   [backends.error]
     [backends.error.servers.error]
     url = "http://{{.Server2}}:80"
+    weight = 1
+
 [frontends]
-    [frontends.frontend1]
-    passHostHeader = true
-    backend = "backend1"
-    [frontends.frontend1.routes.test_1]
-    rule = "Host:test.local"
-    [frontends.frontend1.errors]
-        [frontends.frontend1.errors.networks]
-        status = ["500-502", "503-599"]
-        backend = "error"
-        query = "/50x.html"
+  [frontends.frontend1]
+  passHostHeader = true
+  backend = "backend1"
+  [frontends.frontend1.routes.test_1]
+  rule = "Host:test.local"
+  [frontends.frontend1.errors]
+    [frontends.frontend1.errors.networks]
+    status = ["500-502", "503-599"]
+    backend = "error"
+    query = "/50x.html"

--- a/integration/fixtures/error_pages/simple.toml
+++ b/integration/fixtures/error_pages/simple.toml
@@ -11,17 +11,20 @@ logLevel = "DEBUG"
   [backends.backend1]
     [backends.backend1.servers.server1]
     url = "http://{{.Server1}}:80"
+    weight = 1
   [backends.error]
     [backends.error.servers.error]
     url = "http://{{.Server2}}:80"
+    weight = 1
+
 [frontends]
-    [frontends.frontend1]
-    passHostHeader = true
-    backend = "backend1"
+  [frontends.frontend1]
+  passHostHeader = true
+  backend = "backend1"
     [frontends.frontend1.routes.test_1]
     rule = "Host:test.local"
     [frontends.frontend1.errors]
-        [frontends.frontend1.errors.networks]
-        status = ["500-502", "503-599"]
-        backend = "error"
-        query = "/50x.html"
+      [frontends.frontend1.errors.networks]
+      status = ["500-502", "503-599"]
+      backend = "error"
+      query = "/50x.html"

--- a/integration/fixtures/file/dir/simple1.toml
+++ b/integration/fixtures/file/dir/simple1.toml
@@ -3,6 +3,7 @@
   [backends.backend1]
     [backends.backend1.servers.server1]
     url = "http://172.17.0.2:80"
+    weight = 1
 
 [frontends]
   [frontends.frontend1]

--- a/integration/fixtures/file/dir/simple2.toml
+++ b/integration/fixtures/file/dir/simple2.toml
@@ -3,6 +3,7 @@
   [backends.backend2]
     [backends.backend2.servers.server1]
     url = "http://172.17.0.2:80"
+    weight = 1
 
 [frontends]
   [frontends.frontend2]

--- a/integration/fixtures/grpc/config.toml
+++ b/integration/fixtures/grpc/config.toml
@@ -19,6 +19,7 @@ rootCAs = [ """{{ .CertContent }}""" ]
   [backends.backend1]
     [backends.backend1.servers.server1]
     url = "https://127.0.0.1:{{ .GRPCServerPort }}"
+    weight = 1
 
 
 [frontends]

--- a/integration/fixtures/grpc/config_insecure.toml
+++ b/integration/fixtures/grpc/config_insecure.toml
@@ -19,6 +19,7 @@ insecureSkipVerify = true
   [backends.backend1]
     [backends.backend1.servers.server1]
     url = "https://127.0.0.1:{{ .GRPCServerPort }}"
+    weight = 1
 
 
 [frontends]

--- a/integration/fixtures/healthcheck/multiple-entrypoints-drr.toml
+++ b/integration/fixtures/healthcheck/multiple-entrypoints-drr.toml
@@ -20,8 +20,10 @@ logLevel = "DEBUG"
     interval = "1s"
     [backends.backend1.servers.server1]
     url = "http://{{.Server1}}:80"
+    weight = 1
     [backends.backend1.servers.server2]
     url = "http://{{.Server2}}:80"
+    weight = 1
 
 [frontends]
   [frontends.frontend1]

--- a/integration/fixtures/healthcheck/multiple-entrypoints-wrr.toml
+++ b/integration/fixtures/healthcheck/multiple-entrypoints-wrr.toml
@@ -20,8 +20,10 @@ logLevel = "DEBUG"
     interval = "1s"
     [backends.backend1.servers.server1]
     url = "http://{{.Server1}}:80"
+    weight = 1
     [backends.backend1.servers.server2]
     url = "http://{{.Server2}}:80"
+    weight = 1
 
 [frontends]
   [frontends.frontend1]

--- a/integration/fixtures/healthcheck/port_overload.toml
+++ b/integration/fixtures/healthcheck/port_overload.toml
@@ -17,6 +17,7 @@ logLevel = "DEBUG"
     interval = "1s"
     [backends.backend1.servers.server1]
     url = "http://{{.Server1}}:81"
+    weight = 1
 
 [frontends]
   [frontends.frontend1]

--- a/integration/fixtures/healthcheck/simple.toml
+++ b/integration/fixtures/healthcheck/simple.toml
@@ -16,8 +16,10 @@ logLevel = "DEBUG"
     interval = "1s"
     [backends.backend1.servers.server1]
     url = "http://{{.Server1}}:80"
+    weight = 1
     [backends.backend1.servers.server2]
     url = "http://{{.Server2}}:80"
+    weight = 1
 
 [frontends]
   [frontends.frontend1]

--- a/integration/fixtures/https/clientca/https_1ca1config.toml
+++ b/integration/fixtures/https/clientca/https_1ca1config.toml
@@ -24,9 +24,11 @@ defaultEntryPoints = ["https"]
   [backends.backend1]
     [backends.backend1.servers.server1]
     url = "http://127.0.0.1:9010"
+    weight = 1
   [backends.backend2]
     [backends.backend2.servers.server1]
     url = "http://127.0.0.1:9020"
+    weight = 1
 
 [frontends]
   [frontends.frontend1]

--- a/integration/fixtures/https/clientca/https_2ca1config.toml
+++ b/integration/fixtures/https/clientca/https_2ca1config.toml
@@ -23,9 +23,11 @@ defaultEntryPoints = ["https"]
   [backends.backend1]
     [backends.backend1.servers.server1]
     url = "http://127.0.0.1:9010"
+    weight = 1
   [backends.backend2]
     [backends.backend2.servers.server1]
     url = "http://127.0.0.1:9020"
+    weight = 1
 
 [frontends]
   [frontends.frontend1]

--- a/integration/fixtures/https/clientca/https_2ca2config.toml
+++ b/integration/fixtures/https/clientca/https_2ca2config.toml
@@ -24,9 +24,11 @@ defaultEntryPoints = ["https"]
   [backends.backend1]
     [backends.backend1.servers.server1]
     url = "http://127.0.0.1:9010"
+    weight = 1
   [backends.backend2]
     [backends.backend2.servers.server1]
     url = "http://127.0.0.1:9020"
+    weight = 1
 
 [frontends]
   [frontends.frontend1]

--- a/integration/fixtures/https/dynamic_https.toml
+++ b/integration/fixtures/https/dynamic_https.toml
@@ -2,9 +2,11 @@
   [backends.backend1]
     [backends.backend1.servers.server1]
     url = "http://127.0.0.1:9010"
+    weight = 1
   [backends.backend2]
     [backends.backend2.servers.server1]
     url = "http://127.0.0.1:9020"
+    weight = 1
 
 [frontends]
   [frontends.frontend1]

--- a/integration/fixtures/https/https_sni.toml
+++ b/integration/fixtures/https/https_sni.toml
@@ -21,9 +21,11 @@ defaultEntryPoints = ["https"]
   [backends.backend1]
     [backends.backend1.servers.server1]
     url = "http://127.0.0.1:9010"
+    weight = 1
   [backends.backend2]
     [backends.backend2.servers.server1]
     url = "http://127.0.0.1:9020"
+    weight = 1
 
 [frontends]
   [frontends.frontend1]

--- a/integration/fixtures/https/rootcas/https.toml
+++ b/integration/fixtures/https/rootcas/https.toml
@@ -32,6 +32,7 @@ fblo6RBxUQ==
   [backends.backend1]
     [backends.backend1.servers.server1]
     url = "{{ .BackendHost }}"
+    weight = 1
 
 [frontends]
   [frontends.frontend1]

--- a/integration/fixtures/https/rootcas/https_with_file.toml
+++ b/integration/fixtures/https/rootcas/https_with_file.toml
@@ -17,6 +17,8 @@ rootCAs =  [ "fixtures/https/rootcas/local.crt"]
   [backends.backend1]
     [backends.backend1.servers.server1]
     url = "{{ .BackendHost }}"
+    weight = 1
+
 [frontends]
   [frontends.frontend1]
   backend = "backend1"

--- a/integration/fixtures/log_rotation_config.toml
+++ b/integration/fixtures/log_rotation_config.toml
@@ -27,12 +27,14 @@ entryPoint = "api"
 ################################################################
 # rules
 ################################################################
- [backends]
-   [backends.backend1]
-     [backends.backend1.servers.server1]
-       url = "http://127.0.0.1:8081"
-  [frontends]
-   [frontends.frontend1]
-   backend = "backend1"
-     [frontends.frontend1.routes.test_1]
-     rule = "Path: /test1"
+[backends]
+  [backends.backend1]
+    [backends.backend1.servers.server1]
+    url = "http://127.0.0.1:8081"
+    weight = 1
+
+[frontends]
+  [frontends.frontend1]
+  backend = "backend1"
+   [frontends.frontend1.routes.test_1]
+   rule = "Path: /test1"

--- a/integration/fixtures/multiple_provider.toml
+++ b/integration/fixtures/multiple_provider.toml
@@ -19,7 +19,9 @@ exposedByDefault = false
     backend = "backend-test"
   [frontends.frontend-1.routes.test_1]
   rule = "PathPrefix:/file"
+
   [backends]
     [backends.backend-test]
         [backends.backend-test.servers.website]
-            url = "http://{{ .IP }}"
+        url = "http://{{ .IP }}"
+        weight = 1

--- a/integration/fixtures/provideracme/acme.toml
+++ b/integration/fixtures/provideracme/acme.toml
@@ -11,16 +11,16 @@ defaultEntryPoints = ["http", "https"]
 
 
 [acme]
-email = "test@traefik.io"
-storage = "/tmp/acme.json"
-entryPoint = "https"
-onDemand = {{.OnDemand}}
-onHostRule = {{.OnHostRule}}
-caServer = "http://{{.BoulderHost}}:4001/directory"
-[acme.httpChallenge]
-entryPoint="http"
-[[acme.domains]]
-main = "traefik.acme.wtf"
+  email = "test@traefik.io"
+  storage = "/tmp/acme.json"
+  entryPoint = "https"
+  onDemand = {{.OnDemand}}
+  onHostRule = {{.OnHostRule}}
+  caServer = "http://{{.BoulderHost}}:4001/directory"
+  [acme.httpChallenge]
+  entryPoint="http"
+  [[acme.domains]]
+  main = "traefik.acme.wtf"
 
 
 [api]
@@ -31,6 +31,7 @@ main = "traefik.acme.wtf"
   [backends.backend]
     [backends.backend.servers.server1]
     url = "http://127.0.0.1:9010"
+    weight = 1
 
 [frontends]
   [frontends.frontend]

--- a/integration/fixtures/provideracme/acme_insan.toml
+++ b/integration/fixtures/provideracme/acme_insan.toml
@@ -11,17 +11,17 @@ defaultEntryPoints = ["http", "https"]
 
 
 [acme]
-email = "test@traefik.io"
-storage = "/tmp/acme.json"
-entryPoint = "https"
-onDemand = false
-onHostRule = false
-caServer = "http://{{.BoulderHost}}:4001/directory"
-[acme.httpChallenge]
-entryPoint="http"
-[[acme.domains]]
-main = "acme.wtf"
-sans = [ "traefik.acme.wtf" ]
+  email = "test@traefik.io"
+  storage = "/tmp/acme.json"
+  entryPoint = "https"
+  onDemand = false
+  onHostRule = false
+  caServer = "http://{{.BoulderHost}}:4001/directory"
+  [acme.httpChallenge]
+  entryPoint="http"
+  [[acme.domains]]
+  main = "acme.wtf"
+  sans = [ "traefik.acme.wtf" ]
 
 
 [api]
@@ -32,6 +32,7 @@ sans = [ "traefik.acme.wtf" ]
   [backends.backend]
     [backends.backend.servers.server1]
     url = "http://127.0.0.1:9010"
+    weight = 1
 
 [frontends]
   [frontends.frontend]

--- a/integration/fixtures/provideracme/acme_onhost.toml
+++ b/integration/fixtures/provideracme/acme_onhost.toml
@@ -11,14 +11,14 @@ defaultEntryPoints = ["http", "https"]
 
 
 [acme]
-email = "test@traefik.io"
-storage = "/tmp/acme.json"
-entryPoint = "https"
-onDemand = {{.OnDemand}}
-onHostRule = {{.OnHostRule}}
-caServer = "http://{{.BoulderHost}}:4001/directory"
-[acme.httpChallenge]
-entryPoint="http"
+  email = "test@traefik.io"
+  storage = "/tmp/acme.jsonl"
+  entryPoint = "https"
+  onDemand = {{.OnDemand}}
+  onHostRule = {{.OnHostRule}}
+  caServer = "http://{{.BoulderHost}}:4001/directory"
+  [acme.httpChallenge]
+  entryPoint="http"
 
 [api]
 
@@ -28,6 +28,7 @@ entryPoint="http"
   [backends.backend]
     [backends.backend.servers.server1]
     url = "http://127.0.0.1:9010"
+    weight = 1
 
 [frontends]
   [frontends.frontend]

--- a/integration/fixtures/proxy-protocol/with.toml
+++ b/integration/fixtures/proxy-protocol/with.toml
@@ -2,22 +2,23 @@ logLevel = "DEBUG"
 defaultEntryPoints = ["http"]
 
 [entryPoints]
-[entryPoints.http]
-address = ":8000"
-[entryPoints.http.proxyProtocol]
-trustedIPs = ["{{.HaproxyIP}}"]
+  [entryPoints.http]
+  address = ":8000"
+    [entryPoints.http.proxyProtocol]
+    trustedIPs = ["{{.HaproxyIP}}"]
 
 [api]
 
 [file]
 
 [backends]
-[backends.backend1]
-[backends.backend1.servers.server1]
-url = "http://{{.WhoamiIP}}"
+  [backends.backend1]
+    [backends.backend1.servers.server1]
+    url = "http://{{.WhoamiIP}}"
+    weight = 1
 
 [frontends]
-[frontends.frontend1]
-backend = "backend1"
-[frontends.frontend1.routes.test_1]
-rule = "Path:/whoami"
+  [frontends.frontend1]
+  backend = "backend1"
+    [frontends.frontend1.routes.test_1]
+    rule = "Path:/whoami"

--- a/integration/fixtures/proxy-protocol/without.toml
+++ b/integration/fixtures/proxy-protocol/without.toml
@@ -2,22 +2,23 @@ logLevel = "DEBUG"
 defaultEntryPoints = ["http"]
 
 [entryPoints]
-[entryPoints.http]
-address = ":8000"
-[entryPoints.http.proxyProtocol]
-trustedIPs = ["1.2.3.4"]
+  [entryPoints.http]
+  address = ":8000"
+    [entryPoints.http.proxyProtocol]
+    trustedIPs = ["1.2.3.4"]
 
 [api]
 
 [file]
 
 [backends]
-[backends.backend1]
-[backends.backend1.servers.server1]
-url = "http://{{.WhoamiIP}}"
+  [backends.backend1]
+    [backends.backend1.servers.server1]
+    url = "http://{{.WhoamiIP}}"
+    weight = 1
 
 [frontends]
-[frontends.frontend1]
-backend = "backend1"
-[frontends.frontend1.routes.test_1]
-rule = "Path:/whoami"
+  [frontends.frontend1]
+  backend = "backend1"
+    [frontends.frontend1.routes.test_1]
+    rule = "Path:/whoami"

--- a/integration/fixtures/ratelimit/simple.toml
+++ b/integration/fixtures/ratelimit/simple.toml
@@ -12,19 +12,21 @@ logLevel = "DEBUG"
   [backends.backend1]
     [backends.backend1.servers.server1]
     url = "http://{{.Server1}}:80"
+    weight = 1
+
 [frontends]
-    [frontends.frontend1]
-    passHostHeader = true
-    backend = "backend1"
+  [frontends.frontend1]
+  passHostHeader = true
+  backend = "backend1"
     [frontends.frontend1.routes.test_1]
     rule = "Path:/"
     [frontends.frontend1.ratelimit]
     extractorfunc = "client.ip"
-        [frontends.frontend1.ratelimit.rateset.rateset1]
-        period = "60s"
-        average = 4
-        burst = 5
-        [frontends.frontend1.ratelimit.rateset.rateset2]
-        period = "3s"
-        average = 1
-        burst = 2
+      [frontends.frontend1.ratelimit.rateset.rateset1]
+      period = "60s"
+      average = 4
+      burst = 5
+      [frontends.frontend1.ratelimit.rateset.rateset2]
+      period = "3s"
+      average = 1
+      burst = 2

--- a/integration/fixtures/reqacceptgrace.toml
+++ b/integration/fixtures/reqacceptgrace.toml
@@ -17,6 +17,7 @@ logLevel = "DEBUG"
   [backends.backend]
     [backends.backend.servers.server]
     url = "{{.Server}}"
+    weight = 1
 
 [frontends]
   [frontends.frontend]

--- a/integration/fixtures/retry/simple.toml
+++ b/integration/fixtures/retry/simple.toml
@@ -15,8 +15,10 @@ logLevel = "DEBUG"
   [backends.backend1]
     [backends.backend1.servers.server1]
     url = "http://{{.WhoamiEndpoint}}:8080" # not valid
+    weight = 1
     [backends.backend1.servers.server2]
     url = "http://{{.WhoamiEndpoint}}:80"
+    weight = 1
 
 [frontends]
   [frontends.frontend1]

--- a/integration/fixtures/simple_stats.toml
+++ b/integration/fixtures/simple_stats.toml
@@ -5,26 +5,29 @@ debug=true
   address = ":8000"
 
 [api]
+
 [file]
-   [backends]
-     [backends.backend1]
-       [backends.backend1.servers.server1]
-       url = "{{ .Server1 }}"
+
+  [backends]
+    [backends.backend1]
+      [backends.backend1.servers.server1]
+      url = "{{ .Server1 }}"
+      weight = 1
+
     [backends.backend2]
-       [backends.backend2.servers.server1]
-       url = "{{ .Server2 }}"
+      [backends.backend2.servers.server1]
+      url = "{{ .Server2 }}"
+      weight = 1
 
-   [frontends]
-     [frontends.frontend1]
-            entrypoints=["http"]
+  [frontends]
+    [frontends.frontend1]
+      entrypoints=["http"]
+      backend = "backend1"
+      [frontends.frontend1.routes.test_1]
+      rule = "PathPrefix:/whoami"
 
-     backend = "backend1"
-       [frontends.frontend1.routes.test_1]
-       rule = "PathPrefix:/whoami"
-
-   [frontends.frontend2]
-     backend = "backend2"
-            entrypoints=["traefik"]
-
-       [frontends.frontend2.routes.test_1]
-       rule = "PathPrefix:/whoami"
+  [frontends.frontend2]
+    backend = "backend2"
+    entrypoints=["traefik"]
+    [frontends.frontend2.routes.test_1]
+    rule = "PathPrefix:/whoami"

--- a/integration/fixtures/timeout/forwarding_timeouts.toml
+++ b/integration/fixtures/timeout/forwarding_timeouts.toml
@@ -22,9 +22,11 @@ responseHeaderTimeout = "300ms"
     # Non-routable IP address that should always deliver a dial timeout.
     # See: https://stackoverflow.com/questions/100841/artificially-create-a-connection-timeout-error#answer-904609
     url = "http://50.255.255.1"
+    weight = 1
   [backends.backend2]
     [backends.backend2.servers.server2]
     url = "http://{{.TimeoutEndpoint}}:9000"
+    weight = 1
 
 [frontends]
   [frontends.frontend1]

--- a/integration/fixtures/tracing/simple.toml
+++ b/integration/fixtures/tracing/simple.toml
@@ -6,32 +6,38 @@ debug = true
 [api]
 
 [entryPoints]
-    [entryPoints.http]
+  [entryPoints.http]
     address = ":8000"
 
 [tracing]
-    backend = "{{.TracingBackend}}"
-    servicename = "tracing"
+  backend = "{{.TracingBackend}}"
+  servicename = "tracing"
     [tracing.zipkin]
-        httpEndpoint = "http://{{.ZipkinIP}}:9411/api/v1/spans"
-        debug = true
+      httpEndpoint = "http://{{.ZipkinIP}}:9411/api/v1/spans"
+      debug = true
     [tracing.jaeger]
-        samplingType = "const"
-        samplingParam = 1.0
+      samplingType = "const"
+      samplingParam = 1.0
+
 [retry]
-    attempts = 3
+  attempts = 3
+
 [file]
 
 [backends]
   [backends.backend1]
     [backends.backend1.servers.server-ratelimit]
       url = "http://{{.WhoAmiIP}}:{{.WhoAmiPort}}"
+      weight = 1
   [backends.backend2]
     [backends.backend2.servers.server-retry]
       url = "http://{{.WhoAmiIP}}:{{.WhoAmiPort}}"
+      weight = 1
   [backends.backend3]
     [backends.backend3.servers.server-auth]
       url = "http://{{.WhoAmiIP}}:{{.WhoAmiPort}}"
+      weight = 1
+
 [frontends]
   [frontends.frontend1]
     passHostHeader = true

--- a/integration/fixtures/websocket/config.toml
+++ b/integration/fixtures/websocket/config.toml
@@ -6,7 +6,6 @@ logLevel = "DEBUG"
   [entryPoints.http]
   address = ":8000"
 
-
 [api]
 
 [file]
@@ -15,6 +14,7 @@ logLevel = "DEBUG"
   [backends.backend1]
     [backends.backend1.servers.server1]
     url = "{{ .WebsocketServer }}"
+    weight = 1
 
 [frontends]
   [frontends.frontend1]

--- a/integration/fixtures/websocket/config_https.toml
+++ b/integration/fixtures/websocket/config_https.toml
@@ -19,6 +19,7 @@ insecureSkipVerify=true
   [backends.backend1]
     [backends.backend1.servers.server1]
     url = "{{ .WebsocketServer }}"
+    weight = 1
 
 [frontends]
   [frontends.frontend1]

--- a/provider/consulcatalog/config.go
+++ b/provider/consulcatalog/config.go
@@ -39,8 +39,8 @@ func (p *Provider) buildConfigurationV2(catalog []catalogUpdate) *types.Configur
 		"getFrontendRule":        p.getFrontendRule,
 		"getBasicAuth":           label.GetFuncSliceString(label.TraefikFrontendAuthBasic),
 		"getFrontEndEntryPoints": label.GetFuncSliceString(label.TraefikFrontendEntryPoints),
-		"getPriority":            label.GetFuncInt(label.TraefikFrontendPriority, label.DefaultFrontendPriorityInt),
-		"getPassHostHeader":      label.GetFuncBool(label.TraefikFrontendPassHostHeader, label.DefaultPassHostHeaderBool),
+		"getPriority":            label.GetFuncInt(label.TraefikFrontendPriority, label.DefaultFrontendPriority),
+		"getPassHostHeader":      label.GetFuncBool(label.TraefikFrontendPassHostHeader, label.DefaultPassHostHeader),
 		"getPassTLSCert":         label.GetFuncBool(label.TraefikFrontendPassTLSCert, label.DefaultPassTLSCert),
 		"getWhiteList":           label.GetWhiteList,
 		"getRedirect":            label.GetRedirect,
@@ -192,7 +192,7 @@ func getServerName(node *api.ServiceEntry, index int) string {
 }
 
 func (p *Provider) getWeight(tags []string) int {
-	weight := p.getIntAttribute(label.SuffixWeight, tags, label.DefaultWeightInt)
+	weight := p.getIntAttribute(label.SuffixWeight, tags, label.DefaultWeight)
 
 	// Deprecated
 	deprecatedWeightTag := "backend." + label.SuffixWeight
@@ -200,7 +200,7 @@ func (p *Provider) getWeight(tags []string) int {
 		log.Warnf("Deprecated configuration found: %s. Please use %s.",
 			p.getPrefixedName(deprecatedWeightTag), p.getPrefixedName(label.SuffixWeight))
 
-		weight = p.getIntAttribute(deprecatedWeightTag, tags, label.DefaultWeightInt)
+		weight = p.getIntAttribute(deprecatedWeightTag, tags, label.DefaultWeight)
 	}
 
 	return weight

--- a/provider/consulcatalog/deprecated_config.go
+++ b/provider/consulcatalog/deprecated_config.go
@@ -36,8 +36,8 @@ func (p *Provider) buildConfigurationV1(catalog []catalogUpdate) *types.Configur
 		"getFrontendRule":   p.getFrontendRuleV1,
 		"getBasicAuth":      p.getFuncSliceAttribute(label.SuffixFrontendAuthBasic),
 		"getEntryPoints":    getEntryPointsV1,
-		"getPriority":       p.getFuncIntAttribute(label.SuffixFrontendPriority, label.DefaultFrontendPriorityInt),
-		"getPassHostHeader": p.getFuncBoolAttribute(label.SuffixFrontendPassHostHeader, label.DefaultPassHostHeaderBool),
+		"getPriority":       p.getFuncIntAttribute(label.SuffixFrontendPriority, label.DefaultFrontendPriority),
+		"getPassHostHeader": p.getFuncBoolAttribute(label.SuffixFrontendPassHostHeader, label.DefaultPassHostHeader),
 		"getPassTLSCert":    p.getFuncBoolAttribute(label.SuffixFrontendPassTLSCert, label.DefaultPassTLSCert),
 	}
 

--- a/provider/docker/config.go
+++ b/provider/docker/config.go
@@ -40,8 +40,8 @@ func (p *Provider) buildConfigurationV2(containersInspected []dockerData) *types
 
 		// Frontend functions
 		"getBackendName":    getBackendName,
-		"getPriority":       label.GetFuncInt(label.TraefikFrontendPriority, label.DefaultFrontendPriorityInt),
-		"getPassHostHeader": label.GetFuncBool(label.TraefikFrontendPassHostHeader, label.DefaultPassHostHeaderBool),
+		"getPriority":       label.GetFuncInt(label.TraefikFrontendPriority, label.DefaultFrontendPriority),
+		"getPassHostHeader": label.GetFuncBool(label.TraefikFrontendPassHostHeader, label.DefaultPassHostHeader),
 		"getPassTLSCert":    label.GetFuncBool(label.TraefikFrontendPassTLSCert, label.DefaultPassTLSCert),
 		"getEntryPoints":    label.GetFuncSliceString(label.TraefikFrontendEntryPoints),
 		"getBasicAuth":      label.GetFuncSliceString(label.TraefikFrontendAuthBasic),
@@ -318,7 +318,7 @@ func (p *Provider) getServers(containers []dockerData) map[string]types.Server {
 
 		servers[provider.Normalize(serverName)] = types.Server{
 			URL:    fmt.Sprintf("%s://%s:%s", protocol, ip, port),
-			Weight: label.GetIntValue(container.SegmentLabels, label.TraefikWeight, label.DefaultWeightInt),
+			Weight: label.GetIntValue(container.SegmentLabels, label.TraefikWeight, label.DefaultWeight),
 		}
 	}
 

--- a/provider/docker/config_container_docker_test.go
+++ b/provider/docker/config_container_docker_test.go
@@ -57,7 +57,7 @@ func TestDockerBuildConfiguration(t *testing.T) {
 					Servers: map[string]types.Server{
 						"server-test": {
 							URL:    "http://127.0.0.1:80",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 					},
 					CircuitBreaker: nil,

--- a/provider/docker/config_container_swarm_test.go
+++ b/provider/docker/config_container_swarm_test.go
@@ -59,7 +59,7 @@ func TestSwarmBuildConfiguration(t *testing.T) {
 					Servers: map[string]types.Server{
 						"server-test": {
 							URL:    "http://127.0.0.1:80",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 					},
 				},

--- a/provider/docker/config_segment_test.go
+++ b/provider/docker/config_segment_test.go
@@ -59,7 +59,7 @@ func TestSegmentBuildConfiguration(t *testing.T) {
 					Servers: map[string]types.Server{
 						"server-sauternes-foo-0": {
 							URL:    "http://127.0.0.1:2503",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 					},
 					CircuitBreaker: nil,

--- a/provider/docker/deprecated_config.go
+++ b/provider/docker/deprecated_config.go
@@ -21,7 +21,7 @@ func (p *Provider) buildConfigurationV1(containersInspected []dockerData) *types
 		// Backend functions
 		"getIPAddress": p.getIPAddress,
 		"getPort":      getPortV1,
-		"getWeight":    getFuncIntLabelV1(label.TraefikWeight, label.DefaultWeightInt),
+		"getWeight":    getFuncIntLabelV1(label.TraefikWeight, label.DefaultWeight),
 		"getProtocol":  getFuncStringLabelV1(label.TraefikProtocol, label.DefaultProtocol),
 
 		"hasCircuitBreakerLabel":      hasFuncV1(label.TraefikBackendCircuitBreakerExpression),
@@ -38,8 +38,8 @@ func (p *Provider) buildConfigurationV1(containersInspected []dockerData) *types
 		// Frontend functions
 		"getBackend":              getBackendNameV1,
 		"getBackendName":          getBackendNameV1,
-		"getPriority":             getFuncIntLabelV1(label.TraefikFrontendPriority, label.DefaultFrontendPriorityInt),
-		"getPassHostHeader":       getFuncBoolLabelV1(label.TraefikFrontendPassHostHeader, label.DefaultPassHostHeaderBool),
+		"getPriority":             getFuncIntLabelV1(label.TraefikFrontendPriority, label.DefaultFrontendPriority),
+		"getPassHostHeader":       getFuncBoolLabelV1(label.TraefikFrontendPassHostHeader, label.DefaultPassHostHeader),
 		"getPassTLSCert":          getFuncBoolLabelV1(label.TraefikFrontendPassTLSCert, label.DefaultPassTLSCert),
 		"getEntryPoints":          getFuncSliceStringLabelV1(label.TraefikFrontendEntryPoints),
 		"getBasicAuth":            getFuncSliceStringLabelV1(label.TraefikFrontendAuthBasic),
@@ -100,15 +100,15 @@ func (p *Provider) buildConfigurationV1(containersInspected []dockerData) *types
 		// Services - Backend server functions
 		"getServicePort":     getServicePortV1,
 		"getServiceProtocol": getFuncServiceStringLabelV1(label.SuffixProtocol, label.DefaultProtocol),
-		"getServiceWeight":   getFuncServiceStringLabelV1(label.SuffixWeight, label.DefaultWeight),
+		"getServiceWeight":   getFuncServiceIntLabelV1(label.SuffixWeight, label.DefaultWeight),
 		// Services - Frontend functions
 		"getServiceEntryPoints":          getFuncServiceSliceStringLabelV1(label.SuffixFrontendEntryPoints),
 		"getServiceWhitelistSourceRange": getFuncServiceSliceStringLabelV1(label.SuffixFrontendWhiteListSourceRange),
 		"getServiceBasicAuth":            getFuncServiceSliceStringLabelV1(label.SuffixFrontendAuthBasic),
 		"getServiceFrontendRule":         p.getServiceFrontendRuleV1,
-		"getServicePassHostHeader":       getFuncServiceBoolLabelV1(label.SuffixFrontendPassHostHeader, label.DefaultPassHostHeaderBool),
+		"getServicePassHostHeader":       getFuncServiceBoolLabelV1(label.SuffixFrontendPassHostHeader, label.DefaultPassHostHeader),
 		"getServicePassTLSCert":          getFuncServiceBoolLabelV1(label.SuffixFrontendPassTLSCert, label.DefaultPassTLSCert),
-		"getServicePriority":             getFuncServiceIntLabelV1(label.SuffixFrontendPriority, label.DefaultFrontendPriorityInt),
+		"getServicePriority":             getFuncServiceIntLabelV1(label.SuffixFrontendPriority, label.DefaultFrontendPriority),
 		"hasServiceRedirect":             hasServiceRedirectV1,
 		"getServiceRedirectEntryPoint":   getFuncServiceStringLabelV1(label.SuffixFrontendRedirectEntryPoint, ""),
 		"getServiceRedirectReplacement":  getFuncServiceStringLabelV1(label.SuffixFrontendRedirectReplacement, ""),

--- a/provider/docker/deprecated_container_docker_test.go
+++ b/provider/docker/deprecated_container_docker_test.go
@@ -584,17 +584,17 @@ func TestDockerGetFuncStringLabelV1(t *testing.T) {
 	}{
 		{
 			container:    containerJSON(),
-			labelName:    label.TraefikWeight,
-			defaultValue: label.DefaultWeight,
-			expected:     "0",
+			labelName:    label.TraefikProtocol,
+			defaultValue: label.DefaultProtocol,
+			expected:     "http",
 		},
 		{
 			container: containerJSON(labels(map[string]string{
-				label.TraefikWeight: "10",
+				label.TraefikProtocol: "https",
 			})),
-			labelName:    label.TraefikWeight,
-			defaultValue: label.DefaultWeight,
-			expected:     "10",
+			labelName:    label.TraefikProtocol,
+			defaultValue: label.DefaultProtocol,
+			expected:     "https",
 		},
 	}
 

--- a/provider/docker/deprecated_container_docker_test.go
+++ b/provider/docker/deprecated_container_docker_test.go
@@ -56,7 +56,7 @@ func TestDockerBuildConfigurationV1(t *testing.T) {
 					Servers: map[string]types.Server{
 						"server-test": {
 							URL:    "http://127.0.0.1:80",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 					},
 					CircuitBreaker: nil,

--- a/provider/docker/deprecated_container_swarm_test.go
+++ b/provider/docker/deprecated_container_swarm_test.go
@@ -57,7 +57,7 @@ func TestSwarmBuildConfigurationV1(t *testing.T) {
 					Servers: map[string]types.Server{
 						"server-test": {
 							URL:    "http://127.0.0.1:80",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 					},
 				},

--- a/provider/docker/deprecated_container_swarm_test.go
+++ b/provider/docker/deprecated_container_swarm_test.go
@@ -420,19 +420,19 @@ func TestSwarmGetFuncStringLabelV1(t *testing.T) {
 	}{
 		{
 			service:      swarmService(),
-			labelName:    label.TraefikWeight,
-			defaultValue: label.DefaultWeight,
+			labelName:    label.TraefikProtocol,
+			defaultValue: label.DefaultProtocol,
 			networks:     map[string]*docker.NetworkResource{},
-			expected:     "0",
+			expected:     "http",
 		},
 		{
 			service: swarmService(serviceLabels(map[string]string{
-				label.TraefikWeight: "10",
+				label.TraefikProtocol: "https",
 			})),
-			labelName:    label.TraefikWeight,
-			defaultValue: label.DefaultWeight,
+			labelName:    label.TraefikProtocol,
+			defaultValue: label.DefaultProtocol,
 			networks:     map[string]*docker.NetworkResource{},
-			expected:     "10",
+			expected:     "https",
 		},
 	}
 

--- a/provider/docker/deprecated_service_test.go
+++ b/provider/docker/deprecated_service_test.go
@@ -272,25 +272,25 @@ func TestDockerGetFuncServiceStringLabelV1(t *testing.T) {
 	}{
 		{
 			container:    containerJSON(),
-			suffixLabel:  label.SuffixWeight,
-			defaultValue: label.DefaultWeight,
-			expected:     "0",
+			suffixLabel:  label.SuffixProtocol,
+			defaultValue: label.DefaultProtocol,
+			expected:     "http",
 		},
 		{
 			container: containerJSON(labels(map[string]string{
-				label.TraefikWeight: "200",
+				label.TraefikProtocol: "https",
 			})),
-			suffixLabel:  label.SuffixWeight,
-			defaultValue: label.DefaultWeight,
-			expected:     "200",
+			suffixLabel:  label.SuffixProtocol,
+			defaultValue: label.DefaultProtocol,
+			expected:     "https",
 		},
 		{
 			container: containerJSON(labels(map[string]string{
-				"traefik.myservice.weight": "31337",
+				label.Prefix + "myservice." + label.SuffixProtocol: "https",
 			})),
-			suffixLabel:  label.SuffixWeight,
-			defaultValue: label.DefaultWeight,
-			expected:     "31337",
+			suffixLabel:  label.SuffixProtocol,
+			defaultValue: label.DefaultProtocol,
+			expected:     "https",
 		},
 	}
 

--- a/provider/docker/deprecated_service_test.go
+++ b/provider/docker/deprecated_service_test.go
@@ -59,7 +59,7 @@ func TestDockerServiceBuildConfigurationV1(t *testing.T) {
 					Servers: map[string]types.Server{
 						"service-0": {
 							URL:    "http://127.0.0.1:2503",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 					},
 					CircuitBreaker: nil,

--- a/provider/ecs/config.go
+++ b/provider/ecs/config.go
@@ -42,9 +42,9 @@ func (p *Provider) buildConfigurationV2(instances []ecsInstance) (*types.Configu
 		// Frontend functions
 		"filterFrontends":   filterFrontends,
 		"getFrontendRule":   p.getFrontendRule,
-		"getPassHostHeader": label.GetFuncBool(label.TraefikFrontendPassHostHeader, label.DefaultPassHostHeaderBool),
+		"getPassHostHeader": label.GetFuncBool(label.TraefikFrontendPassHostHeader, label.DefaultPassHostHeader),
 		"getPassTLSCert":    label.GetFuncBool(label.TraefikFrontendPassTLSCert, label.DefaultPassTLSCert),
-		"getPriority":       label.GetFuncInt(label.TraefikFrontendPriority, label.DefaultFrontendPriorityInt),
+		"getPriority":       label.GetFuncInt(label.TraefikFrontendPriority, label.DefaultFrontendPriority),
 		"getBasicAuth":      label.GetFuncSliceString(label.TraefikFrontendAuthBasic),
 		"getEntryPoints":    label.GetFuncSliceString(label.TraefikFrontendEntryPoints),
 		"getRedirect":       label.GetRedirect,
@@ -133,7 +133,7 @@ func getServers(instances []ecsInstance) map[string]types.Server {
 		serverName := provider.Normalize(fmt.Sprintf("server-%s-%s", instance.Name, instance.ID))
 		servers[serverName] = types.Server{
 			URL:    fmt.Sprintf("%s://%s:%s", protocol, host, port),
-			Weight: label.GetIntValue(instance.TraefikLabels, label.TraefikWeight, 0),
+			Weight: label.GetIntValue(instance.TraefikLabels, label.TraefikWeight, label.DefaultWeight),
 		}
 	}
 

--- a/provider/ecs/config_test.go
+++ b/provider/ecs/config_test.go
@@ -47,7 +47,8 @@ func TestBuildConfiguration(t *testing.T) {
 					"backend-instance": {
 						Servers: map[string]types.Server{
 							"server-instance-1": {
-								URL: "http://10.0.0.1:1337",
+								URL:    "http://10.0.0.1:1337",
+								Weight: label.DefaultWeight,
 							}},
 					},
 				},
@@ -99,7 +100,8 @@ func TestBuildConfiguration(t *testing.T) {
 						},
 						Servers: map[string]types.Server{
 							"server-instance-1": {
-								URL: "http://10.0.0.1:1337",
+								URL:    "http://10.0.0.1:1337",
+								Weight: label.DefaultWeight,
 							}},
 					},
 				},

--- a/provider/ecs/deprecated_config.go
+++ b/provider/ecs/deprecated_config.go
@@ -31,7 +31,7 @@ func (p *Provider) buildConfigurationV1(instances []ecsInstance) (*types.Configu
 		"getPort": getPort,
 
 		"getProtocol":             getFuncStringValueV1(label.TraefikProtocol, label.DefaultProtocol),
-		"getWeight":               getFuncIntValueV1(label.TraefikWeight, label.DefaultWeightInt),
+		"getWeight":               getFuncIntValueV1(label.TraefikWeight, label.DefaultWeight),
 		"getLoadBalancerMethod":   getFuncFirstStringValueV1(label.TraefikBackendLoadBalancerMethod, label.DefaultBackendLoadBalancerMethod),
 		"getLoadBalancerSticky":   getStickyV1,
 		"hasStickinessLabel":      getFuncFirstBoolValueV1(label.TraefikBackendLoadBalancerStickiness, false),
@@ -43,9 +43,9 @@ func (p *Provider) buildConfigurationV1(instances []ecsInstance) (*types.Configu
 		// Frontend functions
 		"filterFrontends":   filterFrontends,
 		"getFrontendRule":   p.getFrontendRule,
-		"getPassHostHeader": getFuncBoolValueV1(label.TraefikFrontendPassHostHeader, label.DefaultPassHostHeaderBool),
+		"getPassHostHeader": getFuncBoolValueV1(label.TraefikFrontendPassHostHeader, label.DefaultPassHostHeader),
 		"getPassTLSCert":    getFuncBoolValueV1(label.TraefikFrontendPassTLSCert, label.DefaultPassTLSCert),
-		"getPriority":       getFuncIntValueV1(label.TraefikFrontendPriority, label.DefaultFrontendPriorityInt),
+		"getPriority":       getFuncIntValueV1(label.TraefikFrontendPriority, label.DefaultFrontendPriority),
 		"getBasicAuth":      getFuncSliceStringV1(label.TraefikFrontendAuthBasic),
 		"getEntryPoints":    getFuncSliceStringV1(label.TraefikFrontendEntryPoints),
 	}

--- a/provider/ecs/deprecated_config_test.go
+++ b/provider/ecs/deprecated_config_test.go
@@ -45,7 +45,8 @@ func TestBuildConfigurationV1(t *testing.T) {
 					"backend-testing": {
 						Servers: map[string]types.Server{
 							"server-testing1": {
-								URL: "http://10.0.0.1:1337",
+								URL:    "http://10.0.0.1:1337",
+								Weight: label.DefaultWeight,
 							}},
 						LoadBalancer: &types.LoadBalancer{
 							Method: "wrr",
@@ -100,7 +101,8 @@ func TestBuildConfigurationV1(t *testing.T) {
 						},
 						Servers: map[string]types.Server{
 							"server-testing1": {
-								URL: "http://10.0.0.1:1337",
+								URL:    "http://10.0.0.1:1337",
+								Weight: label.DefaultWeight,
 							}},
 						LoadBalancer: &types.LoadBalancer{
 							Method: "wrr",

--- a/provider/eureka/config.go
+++ b/provider/eureka/config.go
@@ -52,6 +52,6 @@ func getProtocol(instance eureka.InstanceInfo) string {
 	return label.DefaultProtocol
 }
 
-func getWeight(instance eureka.InstanceInfo) string {
-	return label.GetStringValue(instance.Metadata.Map, label.TraefikWeight, label.DefaultWeight)
+func getWeight(instance eureka.InstanceInfo) int {
+	return label.GetIntValue(instance.Metadata.Map, label.TraefikWeight, label.DefaultWeight)
 }

--- a/provider/eureka/config_test.go
+++ b/provider/eureka/config_test.go
@@ -95,7 +95,7 @@ func TestGetWeight(t *testing.T) {
 		instanceInfo   eureka.InstanceInfo
 	}{
 		{
-			expectedWeight: 1,
+			expectedWeight: label.DefaultWeight,
 			instanceInfo: eureka.InstanceInfo{
 				Port: &eureka.Port{
 					Port: 80, Enabled: true,

--- a/provider/eureka/config_test.go
+++ b/provider/eureka/config_test.go
@@ -91,11 +91,11 @@ func TestGetProtocol(t *testing.T) {
 
 func TestGetWeight(t *testing.T) {
 	testCases := []struct {
-		expectedWeight string
+		expectedWeight int
 		instanceInfo   eureka.InstanceInfo
 	}{
 		{
-			expectedWeight: "0",
+			expectedWeight: 1,
 			instanceInfo: eureka.InstanceInfo{
 				Port: &eureka.Port{
 					Port: 80, Enabled: true,
@@ -106,7 +106,7 @@ func TestGetWeight(t *testing.T) {
 			},
 		},
 		{
-			expectedWeight: "10",
+			expectedWeight: 10,
 			instanceInfo: eureka.InstanceInfo{
 				Port: &eureka.Port{
 					Port: 80, Enabled: true,

--- a/provider/kubernetes/builder_configuration_test.go
+++ b/provider/kubernetes/builder_configuration_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/containous/flaeg"
+	"github.com/containous/traefik/provider/label"
 	"github.com/containous/traefik/tls"
 	"github.com/containous/traefik/types"
 	"github.com/stretchr/testify/assert"
@@ -448,11 +449,11 @@ func sampleConfiguration() *types.Configuration {
 				Servers: map[string]types.Server{
 					"http://10.10.0.1:8080": {
 						URL:    "http://10.10.0.1:8080",
-						Weight: 1,
+						Weight: label.DefaultWeight,
 					},
 					"http://10.21.0.1:8080": {
 						URL:    "http://10.21.0.1:8080",
-						Weight: 1,
+						Weight: label.DefaultWeight,
 					},
 				},
 				CircuitBreaker: nil,
@@ -464,7 +465,7 @@ func sampleConfiguration() *types.Configuration {
 				Servers: map[string]types.Server{
 					"https://example.com": {
 						URL:    "https://example.com",
-						Weight: 1,
+						Weight: label.DefaultWeight,
 					},
 				},
 				CircuitBreaker: nil,
@@ -476,11 +477,11 @@ func sampleConfiguration() *types.Configuration {
 				Servers: map[string]types.Server{
 					"https://10.15.0.1:8443": {
 						URL:    "https://10.15.0.1:8443",
-						Weight: 1,
+						Weight: label.DefaultWeight,
 					},
 					"https://10.15.0.2:9443": {
 						URL:    "https://10.15.0.2:9443",
-						Weight: 1,
+						Weight: label.DefaultWeight,
 					},
 				},
 				CircuitBreaker: nil,

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -267,7 +267,7 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 
 							templateObjects.Backends[baseName].Servers[name] = types.Server{
 								URL:    url,
-								Weight: 1,
+								Weight: label.DefaultWeight,
 							}
 						} else {
 							endpoints, exists, err := k8sClient.GetEndpoints(service.Namespace, service.Name)
@@ -295,7 +295,7 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 									}
 									templateObjects.Backends[baseName].Servers[name] = types.Server{
 										URL:    url,
-										Weight: 1,
+										Weight: label.DefaultWeight,
 									}
 								}
 							}

--- a/provider/kv/filler_test.go
+++ b/provider/kv/filler_test.go
@@ -116,9 +116,9 @@ func TestFiller(t *testing.T) {
 		{Key: "traefik/backends/backend.with.dot.too/servers", Value: []byte("")},
 		{Key: "traefik/backends/backend.with.dot.too/servers/server.with.dot", Value: []byte("")},
 		{Key: "traefik/backends/backend.with.dot.too/servers/server.with.dot.without.url", Value: []byte("")},
-		{Key: "traefik/backends/backend.with.dot.too/servers/server.with.dot.without.url/weight", Value: []byte("0")},
+		{Key: "traefik/backends/backend.with.dot.too/servers/server.with.dot.without.url/weight", Value: []byte("1")},
 		{Key: "traefik/backends/backend.with.dot.too/servers/server.with.dot/url", Value: []byte("http://172.17.0.2:80")},
-		{Key: "traefik/backends/backend.with.dot.too/servers/server.with.dot/weight", Value: []byte("0")},
+		{Key: "traefik/backends/backend.with.dot.too/servers/server.with.dot/weight", Value: []byte("1")},
 		{Key: "traefik/frontends/frontend.with.dot", Value: []byte("")},
 		{Key: "traefik/frontends/frontend.with.dot/backend", Value: []byte("backend.with.dot.too")},
 		{Key: "traefik/frontends/frontend.with.dot/errors", Value: []byte("")},
@@ -157,8 +157,8 @@ func TestFiller(t *testing.T) {
 				withLimit("bar", "3", "6", "9"))),
 		backend("backend.with.dot.too",
 			withPair("servers/server.with.dot/url", "http://172.17.0.2:80"),
-			withPair("servers/server.with.dot/weight", "0"),
-			withPair("servers/server.with.dot.without.url/weight", "0")),
+			withPair("servers/server.with.dot/weight", "1"),
+			withPair("servers/server.with.dot.without.url/weight", "1")),
 	)
 	assert.EqualValues(t, expected, pairs1)
 
@@ -181,8 +181,8 @@ func TestFiller(t *testing.T) {
 			withPair("ratelimit/rateset/bar/period", "9")),
 		entry("backends/backend.with.dot.too",
 			withPair("servers/server.with.dot/url", "http://172.17.0.2:80"),
-			withPair("servers/server.with.dot/weight", "0"),
-			withPair("servers/server.with.dot.without.url/weight", "0")),
+			withPair("servers/server.with.dot/weight", "1"),
+			withPair("servers/server.with.dot.without.url/weight", "1")),
 	)
 	assert.EqualValues(t, expected, pairs2)
 }

--- a/provider/kv/kv_config.go
+++ b/provider/kv/kv_config.go
@@ -42,7 +42,7 @@ func (p *Provider) buildConfiguration() *types.Configuration {
 
 		// Frontend functions
 		"getBackendName":    p.getFuncString(pathFrontendBackend, ""),
-		"getPriority":       p.getFuncInt(pathFrontendPriority, label.DefaultFrontendPriorityInt),
+		"getPriority":       p.getFuncInt(pathFrontendPriority, label.DefaultFrontendPriority),
 		"getPassHostHeader": p.getPassHostHeader(),
 		"getPassTLSCert":    p.getFuncBool(pathFrontendPassTLSCert, label.DefaultPassTLSCert),
 		"getEntryPoints":    p.getFuncList(pathFrontendEntryPoints),
@@ -89,12 +89,12 @@ func (p *Provider) getPassHostHeader() func(rootPath string) bool {
 			value, err := strconv.ParseBool(rawValue)
 			if err != nil {
 				log.Errorf("Invalid value for %s %s: %s", rootPath, pathFrontendPassHostHeader, rawValue)
-				return label.DefaultPassHostHeaderBool
+				return label.DefaultPassHostHeader
 			}
 			return value
 		}
 
-		return p.getBool(label.DefaultPassHostHeaderBool, rootPath, pathFrontendPassHostHeaderDeprecated)
+		return p.getBool(label.DefaultPassHostHeader, rootPath, pathFrontendPassHostHeaderDeprecated)
 	}
 }
 
@@ -402,7 +402,7 @@ func (p *Provider) getServers(rootPath string) map[string]types.Server {
 		serverName := p.last(serverKey)
 		servers[serverName] = types.Server{
 			URL:    serverURL,
-			Weight: p.getInt(0, serverKey, pathBackendServerWeight),
+			Weight: p.getInt(label.DefaultWeight, serverKey, pathBackendServerWeight),
 		}
 	}
 

--- a/provider/kv/kv_config_test.go
+++ b/provider/kv/kv_config_test.go
@@ -32,8 +32,8 @@ func TestProviderBuildConfiguration(t *testing.T) {
 					withPair("routes/route.with.dot/rule", "Host:test.localhost")),
 				backend("backend.with.dot.too",
 					withPair("servers/server.with.dot/url", "http://172.17.0.2:80"),
-					withPair("servers/server.with.dot/weight", "0"),
-					withPair("servers/server.with.dot.without.url/weight", "0")),
+					withPair("servers/server.with.dot/weight", strconv.Itoa(label.DefaultWeight)),
+					withPair("servers/server.with.dot.without.url/weight", strconv.Itoa(label.DefaultWeight))),
 			),
 			expected: &types.Configuration{
 				Backends: map[string]*types.Backend{
@@ -42,7 +42,7 @@ func TestProviderBuildConfiguration(t *testing.T) {
 						Servers: map[string]types.Server{
 							"server.with.dot": {
 								URL:    "http://172.17.0.2:80",
-								Weight: 0,
+								Weight: label.DefaultWeight,
 							},
 						},
 					},
@@ -82,8 +82,8 @@ func TestProviderBuildConfiguration(t *testing.T) {
 					withPair(pathBackendBufferingMemRequestBodyBytes, "2097152"),
 					withPair(pathBackendBufferingRetryExpression, "IsNetworkError() && Attempts() <= 2"),
 					withPair("servers/server1/url", "http://172.17.0.2:80"),
-					withPair("servers/server1/weight", "0"),
-					withPair("servers/server2/weight", "0")),
+					withPair("servers/server1/weight", strconv.Itoa(label.DefaultWeight)),
+					withPair("servers/server2/weight", strconv.Itoa(label.DefaultWeight))),
 				frontend("frontend1",
 					withPair(pathFrontendBackend, "backend1"),
 					withPair(pathFrontendPriority, "6"),
@@ -148,7 +148,7 @@ func TestProviderBuildConfiguration(t *testing.T) {
 						Servers: map[string]types.Server{
 							"server1": {
 								URL:    "http://172.17.0.2:80",
-								Weight: 0,
+								Weight: label.DefaultWeight,
 							},
 						},
 						CircuitBreaker: &types.CircuitBreaker{
@@ -2012,7 +2012,7 @@ func TestProviderGetServers(t *testing.T) {
 			expected: map[string]types.Server{
 				"server1": {
 					URL:    "http://172.17.0.2:80",
-					Weight: 0,
+					Weight: label.DefaultWeight,
 				},
 			},
 		},
@@ -2027,7 +2027,7 @@ func TestProviderGetServers(t *testing.T) {
 			expected: map[string]types.Server{
 				"server1": {
 					URL:    "http://172.17.0.2:80",
-					Weight: 0,
+					Weight: label.DefaultWeight,
 				},
 				"server2": {
 					URL:    "http://172.17.0.3:80",

--- a/provider/label/label.go
+++ b/provider/label/label.go
@@ -17,19 +17,21 @@ const (
 
 // Default values
 const (
-	DefaultWeight                                  = "0" // TODO [breaking] use int value
-	DefaultWeightInt                               = 0   // TODO rename to DefaultWeight
+	DefaultWeight                                  = 0
 	DefaultProtocol                                = "http"
-	DefaultPassHostHeader                          = "true" // TODO [breaking] use bool value
-	DefaultPassHostHeaderBool                      = true   // TODO rename to DefaultPassHostHeader
+	DefaultPassHostHeader                          = true
 	DefaultPassTLSCert                             = false
-	DefaultFrontendPriority                        = "0" // TODO [breaking] int value
-	DefaultFrontendPriorityInt                     = 0   // TODO rename to DefaultFrontendPriority
+	DefaultFrontendPriority                        = 0
 	DefaultCircuitBreakerExpression                = "NetworkErrorRatio() > 1"
 	DefaultBackendLoadBalancerMethod               = "wrr"
 	DefaultBackendMaxconnExtractorFunc             = "request.host"
 	DefaultBackendLoadbalancerStickinessCookieName = ""
 	DefaultBackendHealthCheckPort                  = 0
+
+	// TODO need to be remove in extra-service-fabric
+	DefaultWeightInt           = 0    // Deprecated
+	DefaultPassHostHeaderBool  = true // Deprecated
+	DefaultFrontendPriorityInt = 0    // Deprecated
 )
 
 var (

--- a/provider/label/label.go
+++ b/provider/label/label.go
@@ -17,7 +17,7 @@ const (
 
 // Default values
 const (
-	DefaultWeight                                  = 0
+	DefaultWeight                                  = 1
 	DefaultProtocol                                = "http"
 	DefaultPassHostHeader                          = true
 	DefaultPassTLSCert                             = false
@@ -29,7 +29,7 @@ const (
 	DefaultBackendHealthCheckPort                  = 0
 
 	// TODO need to be remove in extra-service-fabric
-	DefaultWeightInt           = 0    // Deprecated
+	DefaultWeightInt           = 1    // Deprecated
 	DefaultPassHostHeaderBool  = true // Deprecated
 	DefaultFrontendPriorityInt = 0    // Deprecated
 )

--- a/provider/label/label_test.go
+++ b/provider/label/label_test.go
@@ -602,17 +602,17 @@ func TestGetFuncString(t *testing.T) {
 	}{
 		{
 			labels:       nil,
-			labelName:    TraefikWeight,
-			defaultValue: DefaultWeight,
-			expected:     "0",
+			labelName:    TraefikProtocol,
+			defaultValue: DefaultProtocol,
+			expected:     "http",
 		},
 		{
 			labels: map[string]string{
-				TraefikWeight: "10",
+				TraefikProtocol: "https",
 			},
-			labelName:    TraefikWeight,
-			defaultValue: DefaultWeight,
-			expected:     "10",
+			labelName:    TraefikProtocol,
+			defaultValue: DefaultProtocol,
+			expected:     "https",
 		},
 	}
 

--- a/provider/marathon/config.go
+++ b/provider/marathon/config.go
@@ -43,9 +43,9 @@ func (p *Provider) buildConfigurationV2(applications *marathon.Applications) *ty
 		"getSegmentNameSuffix": getSegmentNameSuffix,
 		"getFrontendRule":      p.getFrontendRule,
 		"getFrontendName":      p.getFrontendName,
-		"getPassHostHeader":    label.GetFuncBool(label.TraefikFrontendPassHostHeader, label.DefaultPassHostHeaderBool),
+		"getPassHostHeader":    label.GetFuncBool(label.TraefikFrontendPassHostHeader, label.DefaultPassHostHeader),
 		"getPassTLSCert":       label.GetFuncBool(label.TraefikFrontendPassTLSCert, label.DefaultPassTLSCert),
-		"getPriority":          label.GetFuncInt(label.TraefikFrontendPriority, label.DefaultFrontendPriorityInt),
+		"getPriority":          label.GetFuncInt(label.TraefikFrontendPriority, label.DefaultFrontendPriority),
 		"getEntryPoints":       label.GetFuncSliceString(label.TraefikFrontendEntryPoints),
 		"getBasicAuth":         label.GetFuncSliceString(label.TraefikFrontendAuthBasic),
 		"getRedirect":          label.GetRedirect,
@@ -339,7 +339,7 @@ func (p *Provider) getServer(app appData, task marathon.Task) (string, *types.Se
 
 	return serverName, &types.Server{
 		URL:    fmt.Sprintf("%s://%s:%v", protocol, host, port),
-		Weight: label.GetIntValue(app.SegmentLabels, label.TraefikWeight, label.DefaultWeightInt),
+		Weight: label.GetIntValue(app.SegmentLabels, label.TraefikWeight, label.DefaultWeight),
 	}, nil
 }
 

--- a/provider/marathon/config_test.go
+++ b/provider/marathon/config_test.go
@@ -60,7 +60,7 @@ func TestBuildConfiguration(t *testing.T) {
 					Servers: map[string]types.Server{
 						"server-app-taskID": {
 							URL:    "http://localhost:80",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 					},
 					CircuitBreaker: nil,
@@ -119,7 +119,7 @@ func TestBuildConfiguration(t *testing.T) {
 					Servers: map[string]types.Server{
 						"server-app-taskID": {
 							URL:    "http://localhost:80",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 					},
 					MaxConn: nil,
@@ -152,7 +152,7 @@ func TestBuildConfiguration(t *testing.T) {
 					Servers: map[string]types.Server{
 						"server-app-taskID": {
 							URL:    "http://localhost:80",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 					},
 				},
@@ -420,11 +420,11 @@ func TestBuildConfiguration(t *testing.T) {
 					Servers: map[string]types.Server{
 						"server-foo-v000-taskID-service-main": {
 							URL:    "http://localhost:8080",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 						"server-foo-v001-taskID-service-main": {
 							URL:    "http://localhost:8081",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 					},
 				},
@@ -503,7 +503,7 @@ func TestBuildConfigurationSegments(t *testing.T) {
 					Servers: map[string]types.Server{
 						"server-app-taskID-service-web": {
 							URL:    "http://localhost:80",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 					},
 					MaxConn: &types.MaxConn{
@@ -515,7 +515,7 @@ func TestBuildConfigurationSegments(t *testing.T) {
 					Servers: map[string]types.Server{
 						"server-app-taskID-service-admin": {
 							URL:    "http://localhost:81",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 					},
 					MaxConn: &types.MaxConn{
@@ -1278,15 +1278,15 @@ func TestGetServers(t *testing.T) {
 			expected: map[string]types.Server{
 				"server-A": {
 					URL:    "http://1.1.1.1:80",
-					Weight: 0,
+					Weight: label.DefaultWeight,
 				},
 				"server-B": {
 					URL:    "http://1.1.1.2:80",
-					Weight: 0,
+					Weight: label.DefaultWeight,
 				},
 				"server-C": {
 					URL:    "http://1.1.1.3:80",
-					Weight: 0,
+					Weight: label.DefaultWeight,
 				},
 			},
 		},

--- a/provider/marathon/deprecated_config.go
+++ b/provider/marathon/deprecated_config.go
@@ -27,7 +27,7 @@ func (p *Provider) buildConfigurationV1(applications *marathon.Applications) *ty
 		"getPort":          getPortV1,
 		"getServers":       p.getServersV1,
 
-		"getWeight":                   getFuncIntServiceV1(label.SuffixWeight, label.DefaultWeightInt),
+		"getWeight":                   getFuncIntServiceV1(label.SuffixWeight, label.DefaultWeight),
 		"getProtocol":                 getFuncStringServiceV1(label.SuffixProtocol, label.DefaultProtocol),
 		"hasCircuitBreakerLabels":     hasFuncV1(label.TraefikBackendCircuitBreakerExpression),
 		"getCircuitBreakerExpression": getFuncStringV1(label.TraefikBackendCircuitBreakerExpression, label.DefaultCircuitBreakerExpression),
@@ -46,9 +46,9 @@ func (p *Provider) buildConfigurationV1(applications *marathon.Applications) *ty
 		// Frontend functions
 		"getServiceNames":         getServiceNamesV1,
 		"getServiceNameSuffix":    getSegmentNameSuffix,
-		"getPassHostHeader":       getFuncBoolServiceV1(label.SuffixFrontendPassHostHeader, label.DefaultPassHostHeaderBool),
+		"getPassHostHeader":       getFuncBoolServiceV1(label.SuffixFrontendPassHostHeader, label.DefaultPassHostHeader),
 		"getPassTLSCert":          getFuncBoolServiceV1(label.SuffixFrontendPassTLSCert, label.DefaultPassTLSCert),
-		"getPriority":             getFuncIntServiceV1(label.SuffixFrontendPriority, label.DefaultFrontendPriorityInt),
+		"getPriority":             getFuncIntServiceV1(label.SuffixFrontendPriority, label.DefaultFrontendPriority),
 		"getEntryPoints":          getFuncSliceStringServiceV1(label.SuffixFrontendEntryPoints),
 		"getFrontendRule":         p.getFrontendRuleV1,
 		"getFrontendName":         p.getFrontendNameV1,
@@ -323,7 +323,7 @@ func (p *Provider) getServersV1(application marathon.Application, serviceName st
 		serverName := provider.Normalize("server-" + task.ID + getSegmentNameSuffix(serviceName))
 		servers[serverName] = types.Server{
 			URL:    fmt.Sprintf("%s://%s:%v", protocol, host, port),
-			Weight: label.GetIntValue(labels, getLabelNameV1(serviceName, label.SuffixWeight), label.DefaultWeightInt),
+			Weight: label.GetIntValue(labels, getLabelNameV1(serviceName, label.SuffixWeight), label.DefaultWeight),
 		}
 	}
 

--- a/provider/marathon/deprecated_config_test.go
+++ b/provider/marathon/deprecated_config_test.go
@@ -56,7 +56,7 @@ func TestBuildConfigurationV1(t *testing.T) {
 					Servers: map[string]types.Server{
 						"server-task": {
 							URL:    "http://localhost:80",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 					},
 					CircuitBreaker: nil,
@@ -112,7 +112,7 @@ func TestBuildConfigurationV1(t *testing.T) {
 					Servers: map[string]types.Server{
 						"server-task": {
 							URL:    "http://localhost:80",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 					},
 					MaxConn: nil,
@@ -143,7 +143,7 @@ func TestBuildConfigurationV1(t *testing.T) {
 					Servers: map[string]types.Server{
 						"server-task": {
 							URL:    "http://localhost:80",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 					},
 				},
@@ -306,7 +306,7 @@ func TestBuildConfigurationServicesV1(t *testing.T) {
 					Servers: map[string]types.Server{
 						"server-task-service-web": {
 							URL:    "http://localhost:80",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 					},
 					MaxConn: &types.MaxConn{
@@ -318,7 +318,7 @@ func TestBuildConfigurationServicesV1(t *testing.T) {
 					Servers: map[string]types.Server{
 						"server-task-service-admin": {
 							URL:    "http://localhost:81",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 					},
 					MaxConn: &types.MaxConn{

--- a/provider/mesos/config.go
+++ b/provider/mesos/config.go
@@ -39,8 +39,8 @@ func (p *Provider) buildConfigurationV2(tasks []state.Task) *types.Configuration
 		"getFrontEndName":   getFrontendName,
 		"getEntryPoints":    label.GetFuncSliceString(label.TraefikFrontendEntryPoints),
 		"getBasicAuth":      label.GetFuncSliceString(label.TraefikFrontendAuthBasic),
-		"getPriority":       label.GetFuncInt(label.TraefikFrontendPriority, label.DefaultFrontendPriorityInt),
-		"getPassHostHeader": label.GetFuncBool(label.TraefikFrontendPassHostHeader, label.DefaultPassHostHeaderBool),
+		"getPriority":       label.GetFuncInt(label.TraefikFrontendPriority, label.DefaultFrontendPriority),
+		"getPassHostHeader": label.GetFuncBool(label.TraefikFrontendPassHostHeader, label.DefaultPassHostHeader),
 		"getPassTLSCert":    label.GetFuncBool(label.TraefikFrontendPassTLSCert, label.DefaultPassTLSCert),
 		"getFrontendRule":   p.getFrontendRule,
 		"getRedirect":       label.GetRedirect,
@@ -184,7 +184,7 @@ func (p *Provider) getServers(tasks []taskData) map[string]types.Server {
 		serverName := "server-" + getID(task)
 		servers[serverName] = types.Server{
 			URL:    fmt.Sprintf("%s://%s:%s", protocol, host, port),
-			Weight: getIntValue(task.TraefikLabels, label.TraefikWeight, label.DefaultWeightInt, math.MaxInt32),
+			Weight: getIntValue(task.TraefikLabels, label.TraefikWeight, label.DefaultWeight, math.MaxInt32),
 		}
 	}
 

--- a/provider/mesos/config_test.go
+++ b/provider/mesos/config_test.go
@@ -90,11 +90,11 @@ func TestBuildConfiguration(t *testing.T) {
 					Servers: map[string]types.Server{
 						"server-ID1": {
 							URL:    "http://10.10.10.10:80",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 						"server-ID2": {
 							URL:    "http://10.10.10.11:81",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 					},
 				},
@@ -102,11 +102,11 @@ func TestBuildConfiguration(t *testing.T) {
 					Servers: map[string]types.Server{
 						"server-ID3": {
 							URL:    "http://20.10.10.10:80",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 						"server-ID4": {
 							URL:    "http://20.10.10.11:81",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 					},
 				},
@@ -617,7 +617,7 @@ func TestGetServers(t *testing.T) {
 			expected: map[string]types.Server{
 				"server-ID1": {
 					URL:    "http://10.10.10.10:80",
-					Weight: 0,
+					Weight: label.DefaultWeight,
 				},
 				"server-ID2": {
 					URL:    "http://10.10.10.11:81",

--- a/provider/mesos/deprecated_config.go
+++ b/provider/mesos/deprecated_config.go
@@ -24,7 +24,7 @@ func (p *Provider) buildConfigurationV1(tasks []state.Task) *types.Configuration
 		"getBackendName": getBackendNameV1,
 		"getHost":        p.getHostV1,
 		"getProtocol":    getFuncApplicationStringValueV1(label.TraefikProtocol, label.DefaultProtocol),
-		"getWeight":      getFuncApplicationIntValueV1(label.TraefikWeight, label.DefaultWeightInt),
+		"getWeight":      getFuncApplicationIntValueV1(label.TraefikWeight, label.DefaultWeight),
 		"getBackend":     getBackendV1,
 		"getPort":        p.getPort,
 
@@ -33,8 +33,8 @@ func (p *Provider) buildConfigurationV1(tasks []state.Task) *types.Configuration
 		"getFrontEndName":    getFrontendNameV1,
 		"getEntryPoints":     getFuncSliceStringValueV1(label.TraefikFrontendEntryPoints),
 		"getBasicAuth":       getFuncSliceStringValueV1(label.TraefikFrontendAuthBasic),
-		"getPriority":        getFuncIntValueV1(label.TraefikFrontendPriority, label.DefaultFrontendPriorityInt),
-		"getPassHostHeader":  getFuncBoolValueV1(label.TraefikFrontendPassHostHeader, label.DefaultPassHostHeaderBool),
+		"getPriority":        getFuncIntValueV1(label.TraefikFrontendPriority, label.DefaultFrontendPriority),
+		"getPassHostHeader":  getFuncBoolValueV1(label.TraefikFrontendPassHostHeader, label.DefaultPassHostHeader),
 		"getFrontendRule":    p.getFrontendRuleV1,
 	}
 

--- a/provider/mesos/deprecated_config_test.go
+++ b/provider/mesos/deprecated_config_test.go
@@ -86,11 +86,11 @@ func TestBuildConfigurationV1(t *testing.T) {
 					Servers: map[string]types.Server{
 						"server-ID1": {
 							URL:    "http://10.10.10.10:80",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 						"server-ID2": {
 							URL:    "http://10.10.10.11:81",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 					},
 				},
@@ -98,11 +98,11 @@ func TestBuildConfigurationV1(t *testing.T) {
 					Servers: map[string]types.Server{
 						"server-ID3": {
 							URL:    "http://20.10.10.10:80",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 						"server-ID4": {
 							URL:    "http://20.10.10.11:81",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 					},
 				},

--- a/provider/rancher/config.go
+++ b/provider/rancher/config.go
@@ -29,8 +29,8 @@ func (p *Provider) buildConfigurationV2(services []rancherData) *types.Configura
 		// Frontend functions
 		"getBackendName":    getBackendName,
 		"getFrontendRule":   p.getFrontendRule,
-		"getPriority":       label.GetFuncInt(label.TraefikFrontendPriority, label.DefaultFrontendPriorityInt),
-		"getPassHostHeader": label.GetFuncBool(label.TraefikFrontendPassHostHeader, label.DefaultPassHostHeaderBool),
+		"getPriority":       label.GetFuncInt(label.TraefikFrontendPriority, label.DefaultFrontendPriority),
+		"getPassHostHeader": label.GetFuncBool(label.TraefikFrontendPassHostHeader, label.DefaultPassHostHeader),
 		"getPassTLSCert":    label.GetFuncBool(label.TraefikFrontendPassTLSCert, label.DefaultPassTLSCert),
 		"getEntryPoints":    label.GetFuncSliceString(label.TraefikFrontendEntryPoints),
 		"getBasicAuth":      label.GetFuncSliceString(label.TraefikFrontendAuthBasic),
@@ -170,7 +170,7 @@ func getServers(service rancherData) map[string]types.Server {
 
 		protocol := label.GetStringValue(service.SegmentLabels, label.TraefikProtocol, label.DefaultProtocol)
 		port := label.GetStringValue(service.SegmentLabels, label.TraefikPort, "")
-		weight := label.GetIntValue(service.SegmentLabels, label.TraefikWeight, label.DefaultWeightInt)
+		weight := label.GetIntValue(service.SegmentLabels, label.TraefikWeight, label.DefaultWeight)
 
 		serverName := "server-" + strconv.Itoa(index)
 		servers[serverName] = types.Server{

--- a/provider/rancher/config_test.go
+++ b/provider/rancher/config_test.go
@@ -454,7 +454,7 @@ func TestProviderBuildConfiguration(t *testing.T) {
 					Servers: map[string]types.Server{
 						"server-0": {
 							URL:    "http://127.0.0.1:80",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 					},
 					CircuitBreaker: nil,
@@ -855,7 +855,7 @@ func TestGetServers(t *testing.T) {
 			expected: map[string]types.Server{
 				"server-0": {
 					URL:    "http://10.10.10.0:",
-					Weight: 0,
+					Weight: label.DefaultWeight,
 				},
 			},
 		},

--- a/provider/rancher/deprecated_config.go
+++ b/provider/rancher/deprecated_config.go
@@ -18,7 +18,7 @@ func (p *Provider) buildConfigurationV1(services []rancherData) *types.Configura
 		// Backend functions
 		"getPort":                     getFuncStringV1(label.TraefikPort, ""),
 		"getProtocol":                 getFuncStringV1(label.TraefikProtocol, label.DefaultProtocol),
-		"getWeight":                   getFuncIntV1(label.TraefikWeight, label.DefaultWeightInt),
+		"getWeight":                   getFuncIntV1(label.TraefikWeight, label.DefaultWeight),
 		"hasCircuitBreakerLabel":      hasFuncV1(label.TraefikBackendCircuitBreakerExpression),
 		"getCircuitBreakerExpression": getFuncStringV1(label.TraefikBackendCircuitBreakerExpression, label.DefaultCircuitBreakerExpression),
 		"hasLoadBalancerLabel":        hasLoadBalancerLabel,
@@ -33,8 +33,8 @@ func (p *Provider) buildConfigurationV1(services []rancherData) *types.Configura
 		// Frontend functions
 		"getBackend":             getBackendNameV1,
 		"getFrontendRule":        p.getFrontendRuleV1,
-		"getPriority":            getFuncIntV1(label.TraefikFrontendPriority, label.DefaultFrontendPriorityInt),
-		"getPassHostHeader":      getFuncBoolV1(label.TraefikFrontendPassHostHeader, label.DefaultPassHostHeaderBool),
+		"getPriority":            getFuncIntV1(label.TraefikFrontendPriority, label.DefaultFrontendPriority),
+		"getPassHostHeader":      getFuncBoolV1(label.TraefikFrontendPassHostHeader, label.DefaultPassHostHeader),
 		"getEntryPoints":         getFuncSliceStringV1(label.TraefikFrontendEntryPoints),
 		"getBasicAuth":           getFuncSliceStringV1(label.TraefikFrontendAuthBasic),
 		"hasRedirect":            hasRedirect,

--- a/provider/rancher/deprecated_config_test.go
+++ b/provider/rancher/deprecated_config_test.go
@@ -149,7 +149,7 @@ func TestProviderBuildConfigurationV1(t *testing.T) {
 					Servers: map[string]types.Server{
 						"server-0": {
 							URL:    "http://127.0.0.1:80",
-							Weight: 0,
+							Weight: label.DefaultWeight,
 						},
 					},
 					CircuitBreaker: nil,

--- a/server/server.go
+++ b/server/server.go
@@ -55,9 +55,11 @@ import (
 	"golang.org/x/net/http2"
 )
 
-var (
-	httpServerLogger = stdlog.New(log.WriterLevel(logrus.DebugLevel), "", 0)
-)
+var httpServerLogger = stdlog.New(log.WriterLevel(logrus.DebugLevel), "", 0)
+
+func init() {
+	roundrobin.SetDefaultWeight(0)
+}
 
 // Server is the reverse-proxy/load-balancer engine
 type Server struct {

--- a/server/server.go
+++ b/server/server.go
@@ -57,10 +57,6 @@ import (
 
 var httpServerLogger = stdlog.New(log.WriterLevel(logrus.DebugLevel), "", 0)
 
-func init() {
-	roundrobin.SetDefaultWeight(0)
-}
-
 // Server is the reverse-proxy/load-balancer engine
 type Server struct {
 	serverEntryPoints             serverEntryPoints

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containous/traefik/healthcheck"
 	"github.com/containous/traefik/metrics"
 	"github.com/containous/traefik/middlewares"
+	"github.com/containous/traefik/provider/label"
 	"github.com/containous/traefik/rules"
 	"github.com/containous/traefik/testhelpers"
 	"github.com/containous/traefik/tls"
@@ -1220,7 +1221,7 @@ func buildBackend(backendBuilders ...func(*types.Backend)) *types.Backend {
 
 func withServer(name, url string) func(backend *types.Backend) {
 	return func(be *types.Backend) {
-		be.Servers[name] = types.Server{URL: url}
+		be.Servers[name] = types.Server{URL: url, Weight: label.DefaultWeight}
 	}
 }
 

--- a/vendor/github.com/containous/traefik-extra-service-fabric/servicefabric_config.go
+++ b/vendor/github.com/containous/traefik-extra-service-fabric/servicefabric_config.go
@@ -38,7 +38,7 @@ func (p *Provider) buildConfiguration(sfClient sfClient) (*types.Configuration, 
 		"filterServicesByLabelValue": filterServicesByLabelValue, // FIXME unused
 
 		// Backend functions
-		"getWeight":         getFuncServiceStringLabel(label.TraefikWeight, label.DefaultWeight),
+		"getWeight":         getFuncServiceIntLabel(label.TraefikWeight, label.DefaultWeightInt),
 		"getProtocol":       getFuncServiceStringLabel(label.TraefikProtocol, label.DefaultProtocol),
 		"getMaxConn":        getMaxConn,
 		"getHealthCheck":    getHealthCheck,
@@ -46,8 +46,8 @@ func (p *Provider) buildConfiguration(sfClient sfClient) (*types.Configuration, 
 		"getLoadBalancer":   getLoadBalancer,
 
 		// Frontend Functions
-		"getPriority":       getFuncServiceStringLabel(label.TraefikFrontendPriority, label.DefaultFrontendPriority),
-		"getPassHostHeader": getFuncServiceStringLabel(label.TraefikFrontendPassHostHeader, label.DefaultPassHostHeader),
+		"getPriority":       getFuncServiceIntLabel(label.TraefikFrontendPriority, label.DefaultFrontendPriorityInt),
+		"getPassHostHeader": getFuncServiceBoolLabel(label.TraefikFrontendPassHostHeader, label.DefaultPassHostHeaderBool),
 		"getPassTLSCert":    getFuncBoolLabel(label.TraefikFrontendPassTLSCert, false),
 		"getEntryPoints":    getFuncServiceSliceStringLabel(label.TraefikFrontendEntryPoints),
 		"getBasicAuth":      getFuncServiceSliceStringLabel(label.TraefikFrontendAuthBasic),

--- a/vendor/github.com/containous/traefik-extra-service-fabric/servicefabric_labelfuncs.go
+++ b/vendor/github.com/containous/traefik-extra-service-fabric/servicefabric_labelfuncs.go
@@ -30,6 +30,18 @@ func getFuncServiceStringLabel(labelName string, defaultValue string) func(servi
 	}
 }
 
+func getFuncServiceIntLabel(labelName string, defaultValue int) func(service ServiceItemExtended) int {
+	return func(service ServiceItemExtended) int {
+		return label.GetIntValue(service.Labels, labelName, defaultValue)
+	}
+}
+
+func getFuncServiceBoolLabel(labelName string, defaultValue bool) func(service ServiceItemExtended) bool {
+	return func(service ServiceItemExtended) bool {
+		return label.GetBoolValue(service.Labels, labelName, defaultValue)
+	}
+}
+
 func getFuncServiceSliceStringLabel(labelName string) func(service ServiceItemExtended) []string {
 	return func(service ServiceItemExtended) []string {
 		return label.GetSliceStringValue(service.Labels, labelName)


### PR DESCRIPTION
## What does this PR do?

Currently, a server with a  weight of `0` continue to receive calls: it's because if a server have a weight of `0` the real weight is `1`.

These PR change this behavior:
- a server with a weight of `0` will have a real weight of `0`.
- if a server have a weight of `0`, the server will be removed from the available servers.

### Motivation

Fixes #1294

### More

- [x] Added/updated tests

### Additional Notes

Related to https://github.com/vulcand/oxy/pull/121, https://github.com/containous/oxy/pull/18, #1780
