### PR TITLE
Normalize parameter names in configs

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -645,18 +645,18 @@ Once a day (the first call begins 10 minutes after the start of Træfik), we col
   swarmMode = true
 
   [Docker.TLS]
-    CA = "dockerCA"
-    Cert = "dockerCert"
-    Key = "dockerKey"
-    InsecureSkipVerify = true
+    ca = "dockerCA"
+    cert = "dockerCert"
+    key = "dockerKey"
+    insecureSkipVerify = true
 
 [ECS]
-  Domain = "foo.bar"
-  ExposedByDefault = true
-  Clusters = ["foo-bar"]
-  Region = "us-west-2"
-  AccessKeyID = "AccessKeyID"
-  SecretAccessKey = "SecretAccessKey"
+  domain = "foo.bar"
+  exposedByDefault = true
+  clusters = ["foo-bar"]
+  region = "us-west-2"
+  accessKeyID = "AccessKeyID"
+  secretAccessKey = "SecretAccessKey"
 ```
 
 - Obfuscated and anonymous configuration:
@@ -669,24 +669,24 @@ Once a day (the first call begins 10 minutes after the start of Træfik), we col
 [api]
 
 [Docker]
-  Endpoint = "xxxx"
-  Domain = "xxxx"
-  ExposedByDefault = true
-  SwarmMode = true
+  endpoint = "xxxx"
+  domain = "xxxx"
+  exposedByDefault = true
+  swarmMode = true
 
   [Docker.TLS]
-    CA = "xxxx"
-    Cert = "xxxx"
-    Key = "xxxx"
-    InsecureSkipVerify = false
+    ca = "xxxx"
+    cert = "xxxx"
+    key = "xxxx"
+    insecureSkipVerify = false
 
 [ECS]
-  Domain = "xxxx"
-  ExposedByDefault = true
-  Clusters = []
-  Region = "us-west-2"
-  AccessKeyID = "xxxx"
-  SecretAccessKey = "xxxx"
+  domain = "xxxx"
+  exposedByDefault = true
+  clusters = []
+  region = "us-west-2"
+  accessKeyID = "xxxx"
+  secretAccessKey = "xxxx"
 ```
 
 ### Show me the code !

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -118,7 +118,7 @@ server {
 Here is the `traefik.toml` file used:
 
 ```toml
-MaxIdleConnsPerHost = 100000
+maxIdleConnsPerHost = 100000
 defaultEntryPoints = ["http"]
 
 [entryPoints]

--- a/docs/configuration/backends/boltdb.md
+++ b/docs/configuration/backends/boltdb.md
@@ -53,7 +53,7 @@ filename = "boltdb.tmpl"
 #    ca = "/etc/ssl/ca.crt"
 #    cert = "/etc/ssl/boltdb.crt"
 #    key = "/etc/ssl/boltdb.key"
-#    insecureskipverify = true
+#    insecureSkipVerify = true
 ```
 
 To enable constraints see [backend-specific constraints section](/configuration/commons/#backend-specific).

--- a/docs/configuration/backends/consul.md
+++ b/docs/configuration/backends/consul.md
@@ -53,7 +53,7 @@ prefix = "traefik"
 #    ca = "/etc/ssl/ca.crt"
 #    cert = "/etc/ssl/consul.crt"
 #    key = "/etc/ssl/consul.key"
-#    insecureskipverify = true
+#    insecureSkipVerify = true
 ```
 
 To enable constraints see [backend-specific constraints section](/configuration/commons/#backend-specific).

--- a/docs/configuration/backends/consulcatalog.md
+++ b/docs/configuration/backends/consulcatalog.md
@@ -57,7 +57,7 @@ prefix = "traefik"
 #    ca = "/etc/ssl/ca.crt"
 #    cert = "/etc/ssl/consul.crt"
 #    key = "/etc/ssl/consul.key"
-#    insecureskipverify = true
+#    insecureSkipVerify = true
 
 # Override default configuration template.
 # For advanced users :)

--- a/docs/configuration/backends/docker.md
+++ b/docs/configuration/backends/docker.md
@@ -54,7 +54,7 @@ watch = true
 # Optional
 # Default: true
 #
-exposedbydefault = true
+exposedByDefault = true
 
 # Use the IP address from the binded port instead of the inner network one.
 # For specific use-case :)
@@ -69,7 +69,7 @@ usebindportip = true
 # Optional
 # Default: false
 #
-swarmmode = false
+swarmMode = false
 
 # Enable docker TLS connection.
 #
@@ -79,7 +79,7 @@ swarmmode = false
 #  ca = "/etc/ssl/ca.crt"
 #  cert = "/etc/ssl/docker.crt"
 #  key = "/etc/ssl/docker.key"
-#  insecureskipverify = true
+#  insecureSkipVerify = true
 ```
 
 To enable constraints see [backend-specific constraints section](/configuration/commons/#backend-specific).
@@ -89,7 +89,7 @@ To enable constraints see [backend-specific constraints section](/configuration/
 
 ```toml
 ################################################################
-# Docker Swarmmode configuration backend
+# Docker Swarm Mode configuration backend
 ################################################################
 
 # Enable Docker configuration backend.
@@ -123,7 +123,7 @@ watch = true
 # Optional
 # Default: false
 #
-swarmmode = true
+swarmMode = true
 
 # Override default configuration template.
 # For advanced users :)
@@ -146,7 +146,7 @@ swarmmode = true
 # Optional
 # Default: true
 #
-exposedbydefault = false
+exposedByDefault = false
 
 # Enable docker TLS connection.
 #
@@ -156,7 +156,7 @@ exposedbydefault = false
 #  ca = "/etc/ssl/ca.crt"
 #  cert = "/etc/ssl/docker.crt"
 #  key = "/etc/ssl/docker.key"
-#  insecureskipverify = true
+#  insecureSkipVerify = true
 ```
 
 To enable constraints see [backend-specific constraints section](/configuration/commons/#backend-specific).

--- a/docs/configuration/backends/dynamodb.md
+++ b/docs/configuration/backends/dynamodb.md
@@ -39,13 +39,13 @@ watch = true
 #
 refreshSeconds = 15
 
-# AccessKeyID to use when connecting to AWS.
+# Access Key ID to use when connecting to AWS.
 #
 # Optional
 #
 accessKeyID = "abc"
 
-# SecretAccessKey to use when connecting to AWS.
+# Secret Access Key to use when connecting to AWS.
 #
 # Optional
 #

--- a/docs/configuration/backends/ecs.md
+++ b/docs/configuration/backends/ecs.md
@@ -66,13 +66,13 @@ exposedByDefault = false
 #
 region = "us-east-1"
 
-# AccessKeyID to use when connecting to AWS.
+# Access Key ID to use when connecting to AWS.
 #
 # Optional
 #
 accessKeyID = "abc"
 
-# SecretAccessKey to use when connecting to AWS.
+# Secret Access Key to use when connecting to AWS.
 #
 # Optional
 #
@@ -95,7 +95,7 @@ secretAccessKey = "123"
 # templateVersion = "2"
 ```
 
-If `AccessKeyID`/`SecretAccessKey` is not given credentials will be resolved in the following order:
+If `accessKeyID`/`secretAccessKey` is not given credentials will be resolved in the following order:
 
 - From environment variables; `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN`.
 - Shared credentials, determined by `AWS_PROFILE` and `AWS_SHARED_CREDENTIALS_FILE`, defaults to `default` and `~/.aws/credentials`.

--- a/docs/configuration/backends/etcd.md
+++ b/docs/configuration/backends/etcd.md
@@ -63,7 +63,7 @@ useAPIV3 = true
 #    ca = "/etc/ssl/ca.crt"
 #    cert = "/etc/ssl/etcd.crt"
 #    key = "/etc/ssl/etcd.key"
-#    insecureskipverify = true
+#    insecureSkipVerify = true
 ```
 
 To enable constraints see [backend-specific constraints section](/configuration/commons/#backend-specific).

--- a/docs/configuration/backends/kubernetes.md
+++ b/docs/configuration/backends/kubernetes.md
@@ -114,7 +114,7 @@ If the service port defined in the ingress spec is 443, then the backend communi
 !!! note
     Please note that by enabling TLS communication between traefik and your pods, you will have to have trusted certificates that have the proper trust chain and IP subject name. 
     If this is not an option, you may need to skip TLS certificate verification.
-    See the [InsecureSkipVerify](/configuration/commons/#main-section) setting for more details.
+    See the [insecureSkipVerify](/configuration/commons/#main-section) setting for more details.
 
 ## Annotations
 

--- a/docs/configuration/backends/marathon.md
+++ b/docs/configuration/backends/marathon.md
@@ -103,7 +103,7 @@ domain = "marathon.localhost"
 #    CA = "/etc/ssl/ca.crt"
 #    Cert = "/etc/ssl/marathon.cert"
 #    Key = "/etc/ssl/marathon.key"
-#    InsecureSkipVerify = true
+#    insecureSkipVerify = true
 
 # DCOSToken for DCOS environment.
 # This will override the Authorization header.

--- a/docs/configuration/backends/mesos.md
+++ b/docs/configuration/backends/mesos.md
@@ -62,34 +62,34 @@ domain = "mesos.localhost"
 # Optional
 #
 # [mesos.TLS]
-# InsecureSkipVerify = true
+# insecureSkipVerify = true
 
 # Zookeeper timeout (in seconds).
 #
 # Optional
 # Default: 30
 #
-# ZkDetectionTimeout = 30
+# zkDetectionTimeout = 30
 
 # Polling interval (in seconds).
 #
 # Optional
 # Default: 30
 #
-# RefreshSeconds = 30
+# refreshSeconds = 30
 
 # IP sources (e.g. host, docker, mesos, netinfo).
 #
 # Optional
 #
-# IPSources = "host"
+# ipSources = "host"
 
 # HTTP Timeout (in seconds).
 #
 # Optional
 # Default: 30
 #
-# StateTimeoutSecond = "30"
+# stateTimeoutSecond = "30"
 
 # Convert groups to subdomains.
 # Default behavior: /foo/bar/myapp => foo-bar-myapp.{defaultDomain}

--- a/docs/configuration/backends/rancher.md
+++ b/docs/configuration/backends/rancher.md
@@ -77,7 +77,7 @@ To enable constraints see [backend-specific constraints section](/configuration/
 #
 [rancher.metadata]
 
-# Poll the Rancher metadata service for changes every `rancher.RefreshSeconds`.
+# Poll the Rancher metadata service for changes every `rancher.refreshSeconds`.
 # NOTE: this is less accurate than the default long polling technique which
 # will provide near instantaneous updates to Traefik
 #

--- a/docs/configuration/backends/servicefabric.md
+++ b/docs/configuration/backends/servicefabric.md
@@ -42,7 +42,7 @@ refreshSeconds = 10
 #   ca = "/etc/ssl/ca.crt"
 #   cert = "/etc/ssl/servicefabric.crt"
 #   key = "/etc/ssl/servicefabric.key"
-#   insecureskipverify = true
+#   insecureSkipVerify = true
 ```
 
 ## Labels

--- a/docs/configuration/backends/zookeeper.md
+++ b/docs/configuration/backends/zookeeper.md
@@ -53,7 +53,7 @@ prefix = "traefik"
 #    ca = "/etc/ssl/ca.crt"
 #    cert = "/etc/ssl/zookeeper.crt"
 #    key = "/etc/ssl/zookeeper.key"
-#    insecureskipverify = true
+#    insecureSkipVerify = true
 ```
 
 To enable constraints see [backend-specific constraints section](/configuration/commons/#backend-specific).

--- a/docs/configuration/commons.md
+++ b/docs/configuration/commons.md
@@ -38,14 +38,14 @@
 # Optional
 # Default: "2s"
 #
-# ProvidersThrottleDuration = "2s"
+# providersThrottleDuration = "2s"
 
 # Controls the maximum idle (keep-alive) connections to keep per-host.
 #
 # Optional
 # Default: 200
 #
-# MaxIdleConnsPerHost = 200
+# maxIdleConnsPerHost = 200
 
 # If set to true invalid SSL certificates are accepted for backends.
 # This disables detection of man-in-the-middle attacks so should only be used on secure backend networks.
@@ -53,14 +53,14 @@
 # Optional
 # Default: false
 #
-# InsecureSkipVerify = true
+# insecureSkipVerify = true
 
-# Register Certificates in the RootCA.
+# Register Certificates in the rootCA.
 #
 # Optional
 # Default: []
 #
-# RootCAs = [ "/mycert.cert" ]
+# rootCAs = [ "/mycert.cert" ]
 
 # Entrypoints to be used by frontends that do not specify any entrypoint.
 # Each frontend can specify its own entrypoints.
@@ -76,19 +76,19 @@ Can be provided in a format supported by [time.ParseDuration](https://golang.org
 If no units are provided, the value is parsed assuming seconds.  
 **Note:** in this time frame no new requests are accepted.
 
-- `ProvidersThrottleDuration`: Backends throttle duration: minimum duration in seconds between 2 events from providers before applying a new configuration.
+- `providersThrottleDuration`: Backends throttle duration: minimum duration in seconds between 2 events from providers before applying a new configuration.
 It avoids unnecessary reloads if multiples events are sent in a short amount of time.  
 Can be provided in a format supported by [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration) or as raw values (digits).
 If no units are provided, the value is parsed assuming seconds.
 
-- `MaxIdleConnsPerHost`: Controls the maximum idle (keep-alive) connections to keep per-host.  
+- `maxIdleConnsPerHost`: Controls the maximum idle (keep-alive) connections to keep per-host.  
 If zero, `DefaultMaxIdleConnsPerHost` from the Go standard library net/http module is used.
 If you encounter 'too many open files' errors, you can either increase this value or change the `ulimit`.
 
-- `InsecureSkipVerify` : If set to true invalid SSL certificates are accepted for backends.  
+- `insecureSkipVerify` : If set to true invalid SSL certificates are accepted for backends.  
 **Note:** This disables detection of man-in-the-middle attacks so should only be used on secure backend networks.
 
-- `RootCAs`: Register Certificates in the RootCA. This certificates will be use for backends calls.  
+- `rootCAs`: Register Certificates in the RootCA. This certificates will be use for backends calls.  
 **Note** You can use file path or cert content directly
 
 - `defaultEntryPoints`: Entrypoints to be used by frontends that do not specify any entrypoint.  
@@ -386,24 +386,24 @@ If no units are provided, the value is parsed assuming seconds.
 
 ### Idle Timeout (deprecated)
 
-Use [respondingTimeouts](/configuration/commons/#responding-timeouts) instead of `IdleTimeout`.
+Use [respondingTimeouts](/configuration/commons/#responding-timeouts) instead of `idleTimeout`.
 In the case both settings are configured, the deprecated option will be overwritten.
 
-`IdleTimeout` is the maximum amount of time an idle (keep-alive) connection will remain idle before closing itself.
+`idleTimeout` is the maximum amount of time an idle (keep-alive) connection will remain idle before closing itself.
 This is set to enforce closing of stale client connections.
 
 Can be provided in a format supported by [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration) or as raw values (digits).
 If no units are provided, the value is parsed assuming seconds.
 
 ```toml
-# IdleTimeout
+# idleTimeout
 #
 # DEPRECATED - see [respondingTimeouts] section.
 #
 # Optional
 # Default: "180s"
 #
-IdleTimeout = "360s"
+idleTimeout = "360s"
 ```
 
 

--- a/docs/configuration/tracing.md
+++ b/docs/configuration/tracing.md
@@ -15,28 +15,28 @@ Træfik supports two backends: Jaeger and Zipkin.
   #
   # Default: "jaeger"
   #
-  Backend = "jaeger"
+  backend = "jaeger"
 
   # Service name used in Jaeger backend
   #
   # Default: "traefik"
   #
-  ServiceName = "traefik"
+  serviceName = "traefik"
 
   [tracing.jaeger]
-    # SamplingServerURL is the address of jaeger-agent's HTTP sampling server
+    # Sampling Server URL is the address of jaeger-agent's HTTP sampling server
     #
     # Default: "http://localhost:5778/sampling"
     #
-    SamplingServerURL = "http://localhost:5778/sampling"
+    samplingServerURL = "http://localhost:5778/sampling"
 
     # Sampling Type specifies the type of the sampler: const, probabilistic, rateLimiting
     #
     # Default: "const"
     #
-    SamplingType = "const"
+    samplingType = "const"
 
-    # SamplingParam Param is a value passed to the sampler.
+    # Sampling Param is a value passed to the sampler.
     # Valid values for Param field are:
     #   - for "const" sampler, 0 or 1 for always false/true respectively
     #   - for "probabilistic" sampler, a probability between 0 and 1
@@ -44,13 +44,13 @@ Træfik supports two backends: Jaeger and Zipkin.
     #
     # Default: 1.0
     #
-    SamplingParam = 1.0
+    samplingParam = 1.0
 
-    # LocalAgentHostPort instructs reporter to send spans to jaeger-agent at this address
+    # Local Agent Host Port instructs reporter to send spans to jaeger-agent at this address
     #
     # Default: "127.0.0.1:6832"
     #
-    LocalAgentHostPort = "127.0.0.1:6832"
+    localAgentHostPort = "127.0.0.1:6832"
 ```
 
 ## Zipkin
@@ -62,36 +62,36 @@ Træfik supports two backends: Jaeger and Zipkin.
   #
   # Default: "jaeger"
   #
-  Backend = "zipkin"
+  backend = "zipkin"
 
   # Service name used in Zipkin backend
   #
   # Default: "traefik"
   #
-  ServiceName = "traefik"
+  serviceName = "traefik"
 
   [tracing.zipkin]
     # Zipking HTTP endpoint used to send data
     #
     # Default: "http://localhost:9411/api/v1/spans"
     #
-    HTTPEndpoint = "http://localhost:9411/api/v1/spans"
+    httpEndpoint = "http://localhost:9411/api/v1/spans"
 
     # Enable Zipkin debug
     #
     # Default: false
     #
-    Debug = false
+    debug = false
 
     # Use ZipKin SameSpan RPC style traces
     #
     # Default: false
     #
-    SameSpan = false
+    sameSpan = false
 
     # Use ZipKin 128 bit root span IDs
     #
     # Default: true
     #
-    ID128Bit = true
+    id128Bit = true
 ```

--- a/docs/user-guide/cluster-docker-consul.md
+++ b/docs/user-guide/cluster-docker-consul.md
@@ -77,12 +77,12 @@ TL;DR:
 ```shell
 $ traefik \
     --docker \
-    --docker.swarmmode \
+    --docker.swarmMode \
     --docker.domain=mydomain.ca \
     --docker.watch
 ```
 
-To enable docker and swarm-mode support, you need to add `--docker` and `--docker.swarmmode` flags.
+To enable docker and swarm-mode support, you need to add `--docker` and `--docker.swarmMode` flags.
 To watch docker events, add `--docker.watch`.
 
 ### Full docker-compose file
@@ -101,11 +101,11 @@ services:
       - "--acme.storage=/etc/traefik/acme/acme.json"
       - "--acme.entryPoint=https"
       - "--acme.httpChallenge.entryPoint=http"
-      - "--acme.OnHostRule=true"
+      - "--acme.onHostRule=true"
       - "--acme.onDemand=false"
       - "--acme.email=contact@mydomain.ca"
       - "--docker"
-      - "--docker.swarmmode"
+      - "--docker.swarmMode"
       - "--docker.domain=mydomain.ca"
       - "--docker.watch"
     volumes:
@@ -211,11 +211,11 @@ services:
       - "--acme.storage=traefik/acme/account"
       - "--acme.entryPoint=https"
       - "--acme.httpChallenge.entryPoint=http"
-      - "--acme.OnHostRule=true"
+      - "--acme.onHostRule=true"
       - "--acme.onDemand=false"
       - "--acme.email=foobar@example.com"
       - "--docker"
-      - "--docker.swarmmode"
+      - "--docker.swarmMode"
       - "--docker.domain=example.com"
       - "--docker.watch"
       - "--consul"

--- a/docs/user-guide/docker-and-lets-encrypt.md
+++ b/docs/user-guide/docker-and-lets-encrypt.md
@@ -97,13 +97,13 @@ defaultEntryPoints = ["https","http"]
 endpoint = "unix:///var/run/docker.sock"
 domain = "my-awesome-app.org"
 watch = true
-exposedbydefault = false
+exposedByDefault = false
 
 [acme]
 email = "your-email-here@my-awesome-app.org"
 storage = "acme.json"
 entryPoint = "https"
-OnHostRule = true
+onHostRule = true
 [acme.httpChallenge]
 entryPoint = "http"
 ```
@@ -250,7 +250,7 @@ Træfik will create a frontend to listen to incoming HTTP requests which contain
 - Always specify the correct port where the container expects HTTP traffic using `traefik.port` label.  
     If a container exposes multiple ports, Træfik may forward traffic to the wrong port.
     Even if a container only exposes one port, you should always write configuration defensively and explicitly.
-- Should you choose to enable the `exposedbydefault` flag in the `traefik.toml` configuration, be aware that all containers that are placed in the same network as Træfik will automatically be reachable from the outside world, for everyone and everyone to see.
+- Should you choose to enable the `exposedByDefault` flag in the `traefik.toml` configuration, be aware that all containers that are placed in the same network as Træfik will automatically be reachable from the outside world, for everyone and everyone to see.
     Usually, this is a bad idea.
 - With the `traefik.frontend.auth.basic` label, it's possible for Træfik to provide a HTTP basic-auth challenge for the endpoints you provide the label for.
 - Træfik has built-in support to automatically export [Prometheus](https://prometheus.io) metrics

--- a/docs/user-guide/examples.md
+++ b/docs/user-guide/examples.md
@@ -89,7 +89,7 @@ This configuration allows generating Let's Encrypt certificates (thanks to `HTTP
 
 Træfik generates these certificates when it starts and it needs to be restart if new domains are added.
 
-### OnHostRule option (with HTTP challenge)
+### onHostRule option (with HTTP challenge)
 
 ```toml
 [entryPoints]
@@ -225,7 +225,7 @@ These variables are described [in this section](/configuration/acme/#provider).
 
 More information about wildcard certificates are available [in this section](/configuration/acme/#wildcard-domain).
 
-### OnHostRule option and provided certificates (with HTTP challenge)
+### onHostRule option and provided certificates (with HTTP challenge)
 
 ```toml
 [entryPoints]
@@ -358,7 +358,7 @@ defaultEntryPoints = ["http"]
     users = ["test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/", "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"]
 ```
 
-## Override the Traefik HTTP server IdleTimeout and/or throttle configurations from re-loading too quickly
+## Override the Traefik HTTP server idleTimeout and/or throttle configurations from re-loading too quickly
 
 ```toml
 providersThrottleDuration = "5s"

--- a/docs/user-guide/grpc.md
+++ b/docs/user-guide/grpc.md
@@ -45,7 +45,7 @@ At last, we configure our Træfik instance to use both self-signed certificates.
 defaultEntryPoints = ["https"]
 
 # For secure connection on backend.local
-RootCAs = [ "./backend.cert" ]
+rootCAs = [ "./backend.cert" ]
 
 [entryPoints]
   [entryPoints.https]
@@ -76,7 +76,7 @@ RootCAs = [ "./backend.cert" ]
 ```
 
 !!! warning
-    With some backends, the server URLs use the IP, so you may need to configure `InsecureSkipVerify` instead of the `RootCAS` to activate HTTPS without hostname verification.
+    With some backends, the server URLs use the IP, so you may need to configure `insecureSkipVerify` instead of the `rootCAS` to activate HTTPS without hostname verification.
 
 ## Conclusion
 

--- a/docs/user-guide/swarm-mode.md
+++ b/docs/user-guide/swarm-mode.md
@@ -87,7 +87,7 @@ docker-machine ssh manager "docker service create \
 	--network traefik-net \
 	traefik \
 	--docker \
-	--docker.swarmmode \
+	--docker.swarmMode \
 	--docker.domain=traefik \
 	--docker.watch \
 	--api"
@@ -101,7 +101,7 @@ Let's explain this command:
 | `--constraint=node.role==manager`                                           | we ask docker to schedule Træfik on a manager node.                                            |
 | `--mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock` | we bind mount the docker socket where Træfik is scheduled to be able to speak to the daemon.   |
 | `--network traefik-net`                                                     | we attach the Træfik service (and thus the underlying container) to the `traefik-net` network. |
-| `--docker`                                                                  | enable docker backend, and `--docker.swarmmode` to enable the swarm mode on Træfik.            |
+| `--docker`                                                                  | enable docker backend, and `--docker.swarmMode` to enable the swarm mode on Træfik.            |
 | `--api                                                                      | activate the webUI on port 8080                                                                |
 
 

--- a/examples/acme/acme.toml
+++ b/examples/acme/acme.toml
@@ -16,7 +16,7 @@ email = "test@traefik.io"
 storage = "/etc/traefik/conf/acme.json"
 entryPoint = "https"
 onDemand = false
-OnHostRule = true
+onHostRule = true
 caServer = "http://traefik.boulder.com:4001/directory"
   [acme.httpChallenge]
   entryPoint="http"
@@ -27,6 +27,6 @@ caServer = "http://traefik.boulder.com:4001/directory"
 endpoint = "unix:///var/run/docker.sock"
 domain = "traefik.localhost.com"
 watch = true
-exposedbydefault = false
+exposedByDefault = false
 
 

--- a/examples/cluster/traefik.toml.tmpl
+++ b/examples/cluster/traefik.toml.tmpl
@@ -13,7 +13,7 @@ defaultEntryPoints = ["http", "https"]
 email = "test@traefik.io"
 storage = "traefik/acme/account"
 entryPoint = "https"
-OnHostRule = true
+onHostRule = true
 caServer = "http://traefik.boulder.com:4001/directory"
 [acme.httpChallenge]
 entryPoint="http"
@@ -25,4 +25,4 @@ entryPoint="http"
 endpoint = "unix:///var/run/docker.sock"
 domain = "localhost.com"
 watch = true
-exposedbydefault = false
+exposedByDefault = false

--- a/integration/fixtures/acme/acme_http01.toml
+++ b/integration/fixtures/acme/acme_http01.toml
@@ -15,7 +15,7 @@ email = "test@traefik.io"
 storage = "/dev/null"
 entryPoint = "https"
 onDemand = {{.OnDemand}}
-OnHostRule = {{.OnHostRule}}
+onHostRule = {{.OnHostRule}}
 caServer = "http://{{.BoulderHost}}:4001/directory"
   [acme.httpchallenge]
   entrypoint="http"

--- a/integration/fixtures/acme/acme_http01_web.toml
+++ b/integration/fixtures/acme/acme_http01_web.toml
@@ -14,7 +14,7 @@ email = "test@traefik.io"
 storage = "/dev/null"
 entryPoint = "https"
 onDemand = {{.OnDemand}}
-OnHostRule = {{.OnHostRule}}
+onHostRule = {{.OnHostRule}}
 caServer = "http://{{.BoulderHost}}:4001/directory"
   [acme.httpchallenge]
   entrypoint="http"

--- a/integration/fixtures/acme/acme_provided.toml
+++ b/integration/fixtures/acme/acme_provided.toml
@@ -17,7 +17,7 @@ email = "test@traefik.io"
 storage = "/dev/null"
 entryPoint = "https"
 onDemand = {{.OnDemand}}
-OnHostRule = {{.OnHostRule}}
+onHostRule = {{.OnHostRule}}
 caServer = "http://{{.BoulderHost}}:4001/directory"
 [acme.httpChallenge]
 entryPoint="http"

--- a/integration/fixtures/acme/acme_provided_dynamic.toml
+++ b/integration/fixtures/acme/acme_provided_dynamic.toml
@@ -15,7 +15,7 @@ email = "test@traefik.io"
 storage = "/dev/null"
 entryPoint = "https"
 onDemand = {{.OnDemand}}
-OnHostRule = {{.OnHostRule}}
+onHostRule = {{.OnHostRule}}
 caServer = "http://{{.BoulderHost}}:4001/directory"
 [acme.httpChallenge]
 entryPoint="http"

--- a/integration/fixtures/acme/no_challenge_acme.toml
+++ b/integration/fixtures/acme/no_challenge_acme.toml
@@ -16,7 +16,7 @@ defaultEntryPoints = ["http", "https"]
 email = "test@traefik.io"
 storage = "/dev/null"
 entryPoint = "https"
-OnHostRule = true
+onHostRule = true
 caServer = "http://{{.BoulderHost}}:4001/directory"
 # No challenge defined
 

--- a/integration/fixtures/acme/wrong_acme.toml
+++ b/integration/fixtures/acme/wrong_acme.toml
@@ -16,7 +16,7 @@ defaultEntryPoints = ["http", "https"]
 email = "test@traefik.io"
 storage = "/dev/null"
 entryPoint = "https"
-OnHostRule = true
+onHostRule = true
 caServer = "http://wrongurl:4001/directory"
 
 [file]

--- a/integration/fixtures/docker/simple.toml
+++ b/integration/fixtures/docker/simple.toml
@@ -14,4 +14,4 @@ logLevel = "DEBUG"
 endpoint = "{{.DockerHost}}"
 
 domain = "docker.localhost"
-exposedbydefault = true
+exposedByDefault = true

--- a/integration/fixtures/dynamodb/simple.toml
+++ b/integration/fixtures/dynamodb/simple.toml
@@ -9,10 +9,10 @@ logLevel = "DEBUG"
   address = ":8081"
 
 [dynamodb]
-  AccessKeyID = "key"
-  SecretAccessKey = "secret"
-  Endpoint = "{{.DynamoURL}}"
-  Region = "us-east-1"
+  accessKeyID = "key"
+  secretAccessKey = "secret"
+  endpoint = "{{.DynamoURL}}"
+  region = "us-east-1"
 
 [api]
   entryPoint = "api"

--- a/integration/fixtures/grpc/config.toml
+++ b/integration/fixtures/grpc/config.toml
@@ -1,6 +1,6 @@
 defaultEntryPoints = ["https"]
 
-RootCAs = [ """{{ .CertContent }}""" ]
+rootCAs = [ """{{ .CertContent }}""" ]
 
 [entryPoints]
   [entryPoints.https]

--- a/integration/fixtures/grpc/config_insecure.toml
+++ b/integration/fixtures/grpc/config_insecure.toml
@@ -1,6 +1,6 @@
 defaultEntryPoints = ["https"]
 
-InsecureSkipVerify = true
+insecureSkipVerify = true
 
 [entryPoints]
   [entryPoints.https]

--- a/integration/fixtures/https/rootcas/https.toml
+++ b/integration/fixtures/https/rootcas/https.toml
@@ -3,7 +3,7 @@ logLevel = "DEBUG"
 defaultEntryPoints = ["http"]
 
 # Use certificate in net/internal/testcert.go
-RootCAs =  [ """
+rootCAs =  [ """
 -----BEGIN CERTIFICATE-----
 MIICEzCCAXygAwIBAgIQMIMChMLGrR+QvmQvpwAU6zANBgkqhkiG9w0BAQsFADAS
 MRAwDgYDVQQKEwdBY21lIENvMCAXDTcwMDEwMTAwMDAwMFoYDzIwODQwMTI5MTYw

--- a/integration/fixtures/https/rootcas/https_with_file.toml
+++ b/integration/fixtures/https/rootcas/https_with_file.toml
@@ -3,7 +3,7 @@ logLevel = "DEBUG"
 defaultEntryPoints = ["http"]
 
 # Use certificate in net/internal/testcert.go
-RootCAs =  [ "fixtures/https/rootcas/local.crt"]
+rootCAs =  [ "fixtures/https/rootcas/local.crt"]
 
 [entryPoints]
   [entryPoints.http]

--- a/integration/fixtures/multiple_provider.toml
+++ b/integration/fixtures/multiple_provider.toml
@@ -11,7 +11,7 @@ debug=true
 [docker]
 endpoint = "unix:///var/run/docker.sock"
 watch = true
-exposedbydefault = false
+exposedByDefault = false
 
 [file]
   [frontends]

--- a/integration/fixtures/provideracme/acme.toml
+++ b/integration/fixtures/provideracme/acme.toml
@@ -15,7 +15,7 @@ email = "test@traefik.io"
 storage = "/dev/null"
 entryPoint = "https"
 onDemand = {{.OnDemand}}
-OnHostRule = {{.OnHostRule}}
+onHostRule = {{.OnHostRule}}
 caServer = "http://{{.BoulderHost}}:4001/directory"
 [acme.httpChallenge]
 entryPoint="http"

--- a/integration/fixtures/provideracme/acme_insan.toml
+++ b/integration/fixtures/provideracme/acme_insan.toml
@@ -15,7 +15,7 @@ email = "test@traefik.io"
 storage = "/dev/null"
 entryPoint = "https"
 onDemand = false
-OnHostRule = false
+onHostRule = false
 caServer = "http://{{.BoulderHost}}:4001/directory"
 [acme.httpChallenge]
 entryPoint="http"

--- a/integration/fixtures/provideracme/acme_onhost.toml
+++ b/integration/fixtures/provideracme/acme_onhost.toml
@@ -15,7 +15,7 @@ email = "test@traefik.io"
 storage = "/dev/null"
 entryPoint = "https"
 onDemand = {{.OnDemand}}
-OnHostRule = {{.OnHostRule}}
+onHostRule = {{.OnHostRule}}
 caServer = "http://{{.BoulderHost}}:4001/directory"
 [acme.httpChallenge]
 entryPoint="http"

--- a/integration/fixtures/tracing/simple.toml
+++ b/integration/fixtures/tracing/simple.toml
@@ -13,11 +13,11 @@ debug = true
     backend = "{{.TracingBackend}}"
     servicename = "tracing"
     [tracing.zipkin]
-        HTTPEndpoint = "http://{{.ZipkinIP}}:9411/api/v1/spans"
+        httpEndpoint = "http://{{.ZipkinIP}}:9411/api/v1/spans"
         debug = true
     [tracing.jaeger]
-        SamplingType = "const"
-        SamplingParam = 1.0
+        samplingType = "const"
+        samplingParam = 1.0
 [retry]
     attempts = 3
 [file]

--- a/integration/fixtures/websocket/config_https.toml
+++ b/integration/fixtures/websocket/config_https.toml
@@ -1,7 +1,7 @@
 defaultEntryPoints = ["wss"]
 
 logLevel = "DEBUG"
-InsecureSkipVerify=true
+insecureSkipVerify=true
 
 [entryPoints]
   [entryPoints.wss]

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -151,4 +151,4 @@
 # Optional
 # Default: true
 #
-# exposedbydefault = true
+# exposedByDefault = true


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

This PR is a response to https://github.com/containous/traefik/issues/3005, where it was agreed to improve consistency in config parameter names. It:
* renames parameter names to lowerCamelCase in tomls throughout the docs (e.g. `InsecureSkipVerify` becomes `insecureSkipVerify`)
* ~~~standardizes the use of term `entrypoint` (renames occurrences of `entry point` and `entryPoint`)~~~

<!-- A brief description of the change being made with this pull request. -->


### Motivation

Close #3005
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated documentation

### Additional Notes

<s>Renaming `entryPoint` to `entrypoint` may not sound like an obvious improvement in the first place, but let me explain the motivation behind this decision. Initially, I simply noticed that all three possible variants (`entryPoint`, `entrypoint` and `entry point`) are used in the docs, which required some cleanup. I started renaming the occurrences of `entrypoint` to `entryPoint` in tomls and `entry point` in text, however, in the middle of the process I noticed that a few things were getting worse. This made me I change my mind about the naming of this term and go into the opposite direction. Here are the problems that getting rid of `entrypoint` was creating:

* I had to rename a header in `basics.html`, which would break at [least one anchor link](https://docs.traefik.io/basics/#entrypoints) as well as the search:
     <img width="278" alt="screen shot 2018-04-04 at 22 27 59" src="https://user-images.githubusercontent.com/608862/38336031-591a1246-3858-11e8-88b3-ebadcc347210.png">

* `entryPoint` was becoming different to other common terms like `frontend` or `filename` and this looked pretty bad when such terms stood next to each other.
* Because docker compose uses [`entrypoint`](https://docs.docker.com/compose/compose-file/#entrypoint), an inconsistency was occurring.

I have not renamed `EntryPoint` to `Entrypoint` in any of the Go code, but I'm wondering if this should be done in future as well.

FYI: Renaming `entrypoint` to `entryPoint`/`entry point` would not make the PR smaller, both flavours of this term were very common in the docs.</s>
