### PR TITLE
Fix: error pages

### DIFF
--- a/autogen/gentemplates/gen.go
+++ b/autogen/gentemplates/gen.go
@@ -231,7 +231,7 @@ var _templatesConsul_catalogTmpl = []byte(`[backends]
         status = [{{range $page.Status }}
           "{{.}}",
           {{end}}]
-        backend = "{{ $page.Backend }}"
+        backend = "backend-{{ $page.Backend }}"
         query = "{{ $page.Query }}"
       {{end}}
     {{end}}
@@ -632,7 +632,7 @@ var _templatesDockerTmpl = []byte(`{{$backendServers := .Servers}}
         status = [{{range $page.Status }}
           "{{.}}",
           {{end}}]
-        backend = "{{ $page.Backend }}"
+        backend = "backend-{{ $page.Backend }}"
         query = "{{ $page.Query }}"
       {{end}}
     {{end}}
@@ -884,7 +884,7 @@ var _templatesEcsTmpl = []byte(`[backends]
         status = [{{range $page.Status }}
           "{{.}}",
           {{end}}]
-        backend = "{{ $page.Backend }}"
+        backend = "backend-{{ $page.Backend }}"
         query = "{{ $page.Query }}"
       {{end}}
     {{end}}
@@ -1588,7 +1588,7 @@ var _templatesMarathonTmpl = []byte(`{{ $apps := .Applications }}
         status = [{{range $page.Status }}
           "{{.}}",
           {{end}}]
-        backend = "{{ $page.Backend }}"
+        backend = "backend{{ $page.Backend }}"
         query = "{{ $page.Query }}"
       {{end}}
     {{end}}
@@ -1826,7 +1826,7 @@ var _templatesMesosTmpl = []byte(`[backends]
         status = [{{range $page.Status }}
         "{{.}}",
         {{end}}]
-        backend = "{{ $page.Backend }}"
+        backend = "backend-{{ $page.Backend }}"
         query = "{{ $page.Query }}"
       {{end}}
     {{end}}
@@ -2117,7 +2117,7 @@ var _templatesRancherTmpl = []byte(`{{ $backendServers := .Backends }}
         status = [{{range $page.Status }}
         "{{.}}",
         {{end}}]
-        backend = "{{ $page.Backend }}"
+        backend = "backend-{{ $page.Backend }}"
         query = "{{ $page.Query }}"
       {{end}}
     {{end}}

--- a/middlewares/errorpages/error_pages_test.go
+++ b/middlewares/errorpages/error_pages_test.go
@@ -212,6 +212,7 @@ func TestHandlerOldWay(t *testing.T) {
 	for _, test := range testCases {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 
 			errorPageHandler, err := NewHandler(test.errorPage, "test")
 			require.NoError(t, err)
@@ -250,8 +251,7 @@ func TestHandlerOldWayIntegration(t *testing.T) {
 		desc        string
 		errorPage   *types.ErrorPage
 		backendCode int
-		//errorPageForwarder http.HandlerFunc
-		validate func(t *testing.T, recorder *httptest.ResponseRecorder)
+		validate    func(t *testing.T, recorder *httptest.ResponseRecorder)
 	}{
 		{
 			desc:        "no error",

--- a/provider/docker/config_container_docker_test.go
+++ b/provider/docker/config_container_docker_test.go
@@ -236,12 +236,12 @@ func TestDockerBuildConfiguration(t *testing.T) {
 						"foo": {
 							Status:  []string{"404"},
 							Query:   "foo_query",
-							Backend: "foobar",
+							Backend: "backend-foobar",
 						},
 						"bar": {
 							Status:  []string{"500", "600"},
 							Query:   "bar_query",
-							Backend: "foobar",
+							Backend: "backend-foobar",
 						},
 					},
 					RateLimit: &types.RateLimit{

--- a/provider/docker/config_container_swarm_test.go
+++ b/provider/docker/config_container_swarm_test.go
@@ -243,12 +243,12 @@ func TestSwarmBuildConfiguration(t *testing.T) {
 						"foo": {
 							Status:  []string{"404"},
 							Query:   "foo_query",
-							Backend: "foobar",
+							Backend: "backend-foobar",
 						},
 						"bar": {
 							Status:  []string{"500", "600"},
 							Query:   "bar_query",
-							Backend: "foobar",
+							Backend: "backend-foobar",
 						},
 					},
 					RateLimit: &types.RateLimit{

--- a/provider/docker/config_segment_test.go
+++ b/provider/docker/config_segment_test.go
@@ -193,12 +193,12 @@ func TestSegmentBuildConfiguration(t *testing.T) {
 						"foo": {
 							Status:  []string{"404"},
 							Query:   "foo_query",
-							Backend: "foobar",
+							Backend: "backend-foobar",
 						},
 						"bar": {
 							Status:  []string{"500", "600"},
 							Query:   "bar_query",
-							Backend: "foobar",
+							Backend: "backend-foobar",
 						},
 					},
 					RateLimit: &types.RateLimit{

--- a/provider/ecs/config_test.go
+++ b/provider/ecs/config_test.go
@@ -317,14 +317,14 @@ func TestBuildConfiguration(t *testing.T) {
 									"500",
 									"600",
 								},
-								Backend: "foobar",
+								Backend: "backend-foobar",
 								Query:   "bar_query",
 							},
 							"foo": {
 								Status: []string{
 									"404",
 								},
-								Backend: "foobar",
+								Backend: "backend-foobar",
 								Query:   "foo_query",
 							},
 						},

--- a/provider/marathon/config_test.go
+++ b/provider/marathon/config_test.go
@@ -307,14 +307,14 @@ func TestBuildConfiguration(t *testing.T) {
 								"500",
 								"600",
 							},
-							Backend: "foobar",
+							Backend: "backendfoobar",
 							Query:   "bar_query",
 						},
 						"foo": {
 							Status: []string{
 								"404",
 							},
-							Backend: "foobar",
+							Backend: "backendfoobar",
 							Query:   "foo_query",
 						},
 					},
@@ -674,14 +674,14 @@ func TestBuildConfigurationSegments(t *testing.T) {
 								"500",
 								"600",
 							},
-							Backend: "foobar",
+							Backend: "backendfoobar",
 							Query:   "bar_query",
 						},
 						"foo": {
 							Status: []string{
 								"404",
 							},
-							Backend: "foobar",
+							Backend: "backendfoobar",
 							Query:   "foo_query",
 						},
 					},

--- a/provider/mesos/config_test.go
+++ b/provider/mesos/config_test.go
@@ -260,12 +260,12 @@ func TestBuildConfiguration(t *testing.T) {
 						"foo": {
 							Status:  []string{"404"},
 							Query:   "foo_query",
-							Backend: "foobar",
+							Backend: "backend-foobar",
 						},
 						"bar": {
 							Status:  []string{"500", "600"},
 							Query:   "bar_query",
-							Backend: "foobar",
+							Backend: "backend-foobar",
 						},
 					},
 					RateLimit: &types.RateLimit{

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -23,27 +23,25 @@ func (p *myProvider) Foo() string {
 
 func TestConfigurationErrors(t *testing.T) {
 	templateErrorFile, err := ioutil.TempFile("", "provider-configuration-error")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	defer os.RemoveAll(templateErrorFile.Name())
+
 	data := []byte("Not a valid template {{ Bar }}")
+
 	err = ioutil.WriteFile(templateErrorFile.Name(), data, 0700)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	templateInvalidTOMLFile, err := ioutil.TempFile("", "provider-configuration-error")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	defer os.RemoveAll(templateInvalidTOMLFile.Name())
+
 	data = []byte(`Hello {{ .Name }}
 {{ Foo }}`)
+
 	err = ioutil.WriteFile(templateInvalidTOMLFile.Name(), data, 0700)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	invalids := []struct {
 		provider        *myProvider
@@ -54,10 +52,9 @@ func TestConfigurationErrors(t *testing.T) {
 	}{
 		{
 			provider: &myProvider{
-				BaseProvider{
+				BaseProvider: BaseProvider{
 					Filename: "/non/existent/template.tmpl",
 				},
-				nil,
 			},
 			expectedError: "open /non/existent/template.tmpl: no such file or directory",
 		},
@@ -68,19 +65,17 @@ func TestConfigurationErrors(t *testing.T) {
 		},
 		{
 			provider: &myProvider{
-				BaseProvider{
+				BaseProvider: BaseProvider{
 					Filename: templateErrorFile.Name(),
 				},
-				nil,
 			},
 			expectedError: `function "Bar" not defined`,
 		},
 		{
 			provider: &myProvider{
-				BaseProvider{
+				BaseProvider: BaseProvider{
 					Filename: templateInvalidTOMLFile.Name(),
 				},
-				nil,
 			},
 			expectedError: "Near line 1 (last key parsed 'Hello'): expected key separator '=', but got '<' instead",
 			funcMap: template.FuncMap{
@@ -97,18 +92,17 @@ func TestConfigurationErrors(t *testing.T) {
 		if err == nil || !strings.Contains(err.Error(), invalid.expectedError) {
 			t.Fatalf("should have generate an error with %q, got %v", invalid.expectedError, err)
 		}
-		if configuration != nil {
-			t.Fatalf("shouldn't have return a configuration object : %v", configuration)
-		}
+
+		assert.Nil(t, configuration)
 	}
 }
 
 func TestGetConfiguration(t *testing.T) {
 	templateFile, err := ioutil.TempFile("", "provider-configuration")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	defer os.RemoveAll(templateFile.Name())
+
 	data := []byte(`[backends]
   [backends.backend1]
     [backends.backend1.circuitbreaker]
@@ -127,120 +121,103 @@ func TestGetConfiguration(t *testing.T) {
     [frontends.frontend11.routes.test_2]
     rule = "Path"
     value = "/test"`)
+
 	err = ioutil.WriteFile(templateFile.Name(), data, 0700)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	provider := &myProvider{
-		BaseProvider{
+		BaseProvider: BaseProvider{
 			Filename: templateFile.Name(),
 		},
-		nil,
 	}
+
 	configuration, err := provider.GetConfiguration(templateFile.Name(), nil, nil)
-	if err != nil {
-		t.Fatalf("Shouldn't have error out, got %v", err)
-	}
-	if configuration == nil {
-		t.Fatal("Configuration should not be nil, but was")
-	}
+	require.NoError(t, err)
+
+	assert.NotNil(t, configuration)
 }
 
 func TestGetConfigurationReturnsCorrectMaxConnConfiguration(t *testing.T) {
 	templateFile, err := ioutil.TempFile("", "provider-configuration")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	defer os.RemoveAll(templateFile.Name())
+
 	data := []byte(`[backends]
   [backends.backend1]
     [backends.backend1.maxconn]
       amount = 10
       extractorFunc = "request.host"`)
+
 	err = ioutil.WriteFile(templateFile.Name(), data, 0700)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	provider := &myProvider{
-		BaseProvider{
+		BaseProvider: BaseProvider{
 			Filename: templateFile.Name(),
 		},
-		nil,
 	}
+
 	configuration, err := provider.GetConfiguration(templateFile.Name(), nil, nil)
-	if err != nil {
-		t.Fatalf("Shouldn't have error out, got %v", err)
-	}
-	if configuration == nil {
-		t.Fatal("Configuration should not be nil, but was")
-	}
+	require.NoError(t, err)
 
-	if configuration.Backends["backend1"].MaxConn.Amount != 10 {
-		t.Fatal("Configuration did not parse MaxConn.Amount properly")
-	}
-
-	if configuration.Backends["backend1"].MaxConn.ExtractorFunc != "request.host" {
-		t.Fatal("Configuration did not parse MaxConn.ExtractorFunc properly")
-	}
+	require.NotNil(t, configuration)
+	require.Contains(t, configuration.Backends, "backend1")
+	assert.EqualValues(t, 10, configuration.Backends["backend1"].MaxConn.Amount)
+	assert.Equal(t, "request.host", configuration.Backends["backend1"].MaxConn.ExtractorFunc)
 }
 
 func TestNilClientTLS(t *testing.T) {
-	provider := &myProvider{
-		BaseProvider{
+	p := &myProvider{
+		BaseProvider: BaseProvider{
 			Filename: "",
 		},
-		nil,
 	}
-	_, err := provider.TLS.CreateTLSConfig()
-	if err != nil {
-		t.Fatal("CreateTLSConfig should assume that consumer does not want a TLS configuration if input is nil")
-	}
+
+	_, err := p.TLS.CreateTLSConfig()
+	require.NoError(t, err, "CreateTLSConfig should assume that consumer does not want a TLS configuration if input is nil")
 }
 
 func TestInsecureSkipVerifyClientTLS(t *testing.T) {
-	provider := &myProvider{
-		BaseProvider{
+	p := &myProvider{
+		BaseProvider: BaseProvider{
 			Filename: "",
 		},
-		&types.ClientTLS{
+		TLS: &types.ClientTLS{
 			InsecureSkipVerify: true,
 		},
 	}
-	config, err := provider.TLS.CreateTLSConfig()
-	if err != nil {
-		t.Fatal("CreateTLSConfig should assume that consumer does not want a TLS configuration if input is nil")
-	}
-	if !config.InsecureSkipVerify {
-		t.Fatal("CreateTLSConfig should support setting only InsecureSkipVerify property")
-	}
+
+	config, err := p.TLS.CreateTLSConfig()
+	require.NoError(t, err, "CreateTLSConfig should assume that consumer does not want a TLS configuration if input is nil")
+
+	assert.True(t, config.InsecureSkipVerify, "CreateTLSConfig should support setting only InsecureSkipVerify property")
 }
 
 func TestInsecureSkipVerifyFalseClientTLS(t *testing.T) {
-	provider := &myProvider{
-		BaseProvider{
+	p := &myProvider{
+		BaseProvider: BaseProvider{
 			Filename: "",
 		},
-		&types.ClientTLS{
+		TLS: &types.ClientTLS{
 			InsecureSkipVerify: false,
 		},
 	}
-	_, err := provider.TLS.CreateTLSConfig()
-	if err == nil {
-		t.Fatal("CreateTLSConfig should error if consumer does not set a TLS cert or key configuration and not chooses InsecureSkipVerify to be true")
-	}
-	t.Log(err)
+
+	_, err := p.TLS.CreateTLSConfig()
+	assert.Errorf(t, err, "CreateTLSConfig should error if consumer does not set a TLS cert or key configuration and not chooses InsecureSkipVerify to be true")
 }
 
 func TestMatchingConstraints(t *testing.T) {
-	cases := []struct {
+	testCases := []struct {
+		desc        string
 		constraints types.Constraints
 		tags        []string
 		expected    bool
 	}{
 		// simple test: must match
 		{
+			desc: "tag==us-east-1 with us-east-1",
 			constraints: types.Constraints{
 				{
 					Key:       "tag",
@@ -255,6 +232,7 @@ func TestMatchingConstraints(t *testing.T) {
 		},
 		// simple test: must match but does not match
 		{
+			desc: "tag==us-east-1 with us-east-2",
 			constraints: types.Constraints{
 				{
 					Key:       "tag",
@@ -269,6 +247,7 @@ func TestMatchingConstraints(t *testing.T) {
 		},
 		// simple test: must not match
 		{
+			desc: "tag!=us-east-1 with us-east-1",
 			constraints: types.Constraints{
 				{
 					Key:       "tag",
@@ -283,6 +262,7 @@ func TestMatchingConstraints(t *testing.T) {
 		},
 		// complex test: globbing
 		{
+			desc: "tag!=us-east-* with us-east-1",
 			constraints: types.Constraints{
 				{
 					Key:       "tag",
@@ -297,6 +277,7 @@ func TestMatchingConstraints(t *testing.T) {
 		},
 		// complex test: multiple constraints
 		{
+			desc: "tag==us-east-* & tag!=api with us-east-1 & api",
 			constraints: types.Constraints{
 				{
 					Key:       "tag",
@@ -317,26 +298,23 @@ func TestMatchingConstraints(t *testing.T) {
 		},
 	}
 
-	for i, c := range cases {
-		provider := myProvider{
-			BaseProvider{
-				Constraints: c.constraints,
+	for _, test := range testCases {
+		p := myProvider{
+			BaseProvider: BaseProvider{
+				Constraints: test.constraints,
 			},
-			nil,
 		}
-		actual, _ := provider.MatchConstraints(c.tags)
-		if actual != c.expected {
-			t.Fatalf("test #%v: expected %t, got %t, for %#v", i, c.expected, actual, c.constraints)
-		}
+
+		actual, _ := p.MatchConstraints(test.tags)
+		assert.Equal(t, test.expected, actual)
 	}
 }
 
 func TestDefaultFuncMap(t *testing.T) {
 	templateFile, err := ioutil.TempFile("", "provider-configuration")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer os.RemoveAll(templateFile.Name())
+
 	data := []byte(`
   [backends]
   [backends.{{ "backend-1" | replace  "-" "" }}]
@@ -360,38 +338,30 @@ func TestDefaultFuncMap(t *testing.T) {
     [frontends.frontend-1.routes.test_2]
     rule = "Path"
     value = "/test"`)
+
 	err = ioutil.WriteFile(templateFile.Name(), data, 0700)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	provider := &myProvider{
-		BaseProvider{
+		BaseProvider: BaseProvider{
 			Filename: templateFile.Name(),
 		},
-		nil,
 	}
+
 	configuration, err := provider.GetConfiguration(templateFile.Name(), nil, nil)
-	if err != nil {
-		t.Fatalf("Shouldn't have error out, got %v", err)
-	}
-	if configuration == nil {
-		t.Fatal("Configuration should not be nil, but was")
-	}
-	if _, ok := configuration.Backends["backend1"]; !ok {
-		t.Fatal("backend1 should exists, but it not")
-	}
-	if _, ok := configuration.Frontends["frontend-1"]; !ok {
-		t.Fatal("Frontend frontend-1 should exists, but it not")
-	}
+	require.NoError(t, err)
+
+	require.NotNil(t, configuration)
+	assert.Contains(t, configuration.Backends, "backend1")
+	assert.Contains(t, configuration.Frontends, "frontend-1")
 }
 
 func TestSprigFunctions(t *testing.T) {
 	templateFile, err := ioutil.TempFile("", "provider-configuration")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	defer os.RemoveAll(templateFile.Name())
+
 	data := []byte(`
   {{$backend_name := trimAll "-" uuidv4}}
   [backends]
@@ -408,30 +378,22 @@ func TestSprigFunctions(t *testing.T) {
     [frontends.frontend-1.routes.test_2]
     rule = "Path"
     value = "/test"`)
+
 	err = ioutil.WriteFile(templateFile.Name(), data, 0700)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	provider := &myProvider{
-		BaseProvider{
+		BaseProvider: BaseProvider{
 			Filename: templateFile.Name(),
 		},
-		nil,
 	}
+
 	configuration, err := provider.GetConfiguration(templateFile.Name(), nil, nil)
-	if err != nil {
-		t.Fatalf("Shouldn't have error out, got %v", err)
-	}
-	if configuration == nil {
-		t.Fatal("Configuration should not be nil, but was")
-	}
-	if len(configuration.Backends) != 1 {
-		t.Fatal("one backend should be defined, but it's not")
-	}
-	if _, ok := configuration.Frontends["frontend-1"]; !ok {
-		t.Fatal("Frontend frontend-1 should exists, but it not")
-	}
+	require.NoError(t, err)
+
+	require.NotNil(t, configuration)
+	assert.Len(t, configuration.Backends, 1)
+	assert.Contains(t, configuration.Frontends, "frontend-1")
 }
 
 func TestBaseProvider_GetConfiguration(t *testing.T) {

--- a/provider/rancher/config_test.go
+++ b/provider/rancher/config_test.go
@@ -179,12 +179,12 @@ func TestProviderBuildConfiguration(t *testing.T) {
 						"foo": {
 							Status:  []string{"404"},
 							Query:   "foo_query",
-							Backend: "foobar",
+							Backend: "backend-foobar",
 						},
 						"bar": {
 							Status:  []string{"500", "600"},
 							Query:   "bar_query",
-							Backend: "foobar",
+							Backend: "backend-foobar",
 						},
 					},
 					RateLimit: &types.RateLimit{
@@ -371,12 +371,12 @@ func TestProviderBuildConfiguration(t *testing.T) {
 					Errors: map[string]*types.ErrorPage{
 						"bar": {
 							Status:  []string{"500", "600"},
-							Backend: "foobar",
+							Backend: "backend-foobar",
 							Query:   "bar_query",
 						},
 						"foo": {
 							Status:  []string{"404"},
-							Backend: "foobar",
+							Backend: "backend-foobar",
 							Query:   "foo_query",
 						},
 					},

--- a/server/server.go
+++ b/server/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/containous/traefik/middlewares"
 	"github.com/containous/traefik/middlewares/accesslog"
 	mauth "github.com/containous/traefik/middlewares/auth"
+	"github.com/containous/traefik/middlewares/errorpages"
 	"github.com/containous/traefik/middlewares/redirect"
 	"github.com/containous/traefik/middlewares/tracing"
 	"github.com/containous/traefik/provider"
@@ -912,6 +913,8 @@ func (s *Server) loadConfig(configurations types.Configurations, globalConfigura
 	redirectHandlers := make(map[string]negroni.Handler)
 	backends := map[string]http.Handler{}
 	backendsHealthCheck := map[string]*healthcheck.BackendHealthCheck{}
+	errorPageHandlers := make(map[string]*errorpages.Handler)
+
 	errorHandler := NewRecordingErrorHandler(middlewares.DefaultNetErrorRecorder{})
 
 	for providerName, config := range configurations {
@@ -1089,42 +1092,57 @@ func (s *Server) loadConfig(configurations types.Configurations, globalConfigura
 					}
 
 					if len(frontend.Errors) > 0 {
-						for _, errorPage := range frontend.Errors {
-							errorPageHandler, err := createErrorPageHandler(config, errorPage, frontendName)
-							if err != nil {
-								log.Error(err)
+						for errorPageName, errorPage := range frontend.Errors {
+							if frontend.Backend == errorPage.Backend {
+								log.Errorf("Error when creating error page %q for frontend %q: error pages backend %q is the same as backend for the frontend (infinite call risk).",
+									errorPageName, frontendName, errorPage.Backend)
+							} else if config.Backends[errorPage.Backend] == nil {
+								log.Errorf("Error when creating error page %q for frontend %q: the backend %q doesn't exist.",
+									errorPageName, errorPage.Backend)
 							} else {
-								n.Use(errorPageHandler)
+								errorPagesHandler, err := errorpages.NewHandler(errorPage, entryPointName+providerName+errorPage.Backend)
+								if err != nil {
+									log.Error(err)
+								} else {
+									if errorPageServer, ok := config.Backends[errorPage.Backend].Servers["error"]; ok {
+										errorPagesHandler.FallbackURL = errorPageServer.URL
+									}
+
+									errorPageHandlers[entryPointName+providerName+frontendName+errorPageName] = errorPagesHandler
+									n.Use(errorPagesHandler)
+								}
 							}
 						}
 					}
 
 					if frontend.RateLimit != nil && len(frontend.RateLimit.RateSet) > 0 {
 						lb, err = s.buildRateLimiter(lb, frontend.RateLimit)
-						lb = s.wrapHTTPHandlerWithAccessLog(lb, fmt.Sprintf("rate limit for %s", frontendName))
 						if err != nil {
 							log.Errorf("Error creating rate limiter: %v", err)
 							log.Errorf("Skipping frontend %s...", frontendName)
 							continue frontend
 						}
+						lb = s.wrapHTTPHandlerWithAccessLog(lb, fmt.Sprintf("rate limit for %s", frontendName))
 					}
 
 					maxConns := config.Backends[frontend.Backend].MaxConn
 					if maxConns != nil && maxConns.Amount != 0 {
 						extractFunc, err := utils.NewExtractor(maxConns.ExtractorFunc)
 						if err != nil {
-							log.Errorf("Error creating connlimit: %v", err)
+							log.Errorf("Error creating connection limit: %v", err)
 							log.Errorf("Skipping frontend %s...", frontendName)
 							continue frontend
 						}
-						log.Debugf("Creating load-balancer connlimit")
+
+						log.Debugf("Creating load-balancer connection limit")
+
 						lb, err = connlimit.New(lb, extractFunc, maxConns.Amount)
-						lb = s.wrapHTTPHandlerWithAccessLog(lb, fmt.Sprintf("connection limit for %s", frontendName))
 						if err != nil {
-							log.Errorf("Error creating connlimit: %v", err)
+							log.Errorf("Error creating connection limit: %v", err)
 							log.Errorf("Skipping frontend %s...", frontendName)
 							continue frontend
 						}
+						lb = s.wrapHTTPHandlerWithAccessLog(lb, fmt.Sprintf("connection limit for %s", frontendName))
 					}
 
 					if globalConfiguration.Retry != nil {
@@ -1225,15 +1243,25 @@ func (s *Server) loadConfig(configurations types.Configurations, globalConfigura
 			}
 		}
 	}
+
+	for _, errorPageHandler := range errorPageHandlers {
+		if handler, ok := backends[errorPageHandler.BackendName]; ok {
+			errorPageHandler.PostLoad(handler)
+		} else {
+			errorPageHandler.PostLoad(nil)
+		}
+	}
+
 	healthcheck.GetHealthCheck(s.metricsRegistry).SetBackendsConfiguration(s.routinesPool.Ctx(), backendsHealthCheck)
+
 	// Get new certificates list sorted per entrypoints
 	// Update certificates
 	entryPointsCertificates, err := s.loadHTTPSConfiguration(configurations, globalConfiguration.DefaultEntryPoints)
+
 	// Sort routes and update certificates
 	for serverEntryPointName, serverEntryPoint := range serverEntryPoints {
 		serverEntryPoint.httpRouter.GetHandler().SortRoutes()
-		_, exists := entryPointsCertificates[serverEntryPointName]
-		if exists {
+		if _, exists := entryPointsCertificates[serverEntryPointName]; exists {
 			serverEntryPoint.certs.Set(entryPointsCertificates[serverEntryPointName])
 		}
 	}
@@ -1256,35 +1284,6 @@ func (s *Server) configureLBServers(lb healthcheck.LoadBalancer, config *types.C
 		s.metricsRegistry.BackendServerUpGauge().With("backend", frontend.Backend, "url", srv.URL).Set(1)
 	}
 	return nil
-}
-
-func createErrorPageHandler(config *types.Configuration, errorPage *types.ErrorPage, frontendName string) (negroni.Handler, error) {
-	if config.Backends[errorPage.Backend] != nil {
-		errorPageServers := config.Backends[errorPage.Backend].Servers
-
-		switch len(errorPageServers) {
-		case 0:
-			return nil, fmt.Errorf("error pages backend %q doesn't have server", errorPage.Backend)
-		case 1:
-			for _, errorPageServer := range errorPageServers {
-				errorPageHandler, err := middlewares.NewErrorPagesHandler(errorPage, errorPageServer.URL)
-				if err != nil {
-					return nil, fmt.Errorf("error creating custom error page middleware, %v", err)
-				}
-				return errorPageHandler, nil
-			}
-		default:
-			if errorPageServer, ok := errorPageServers["error"]; ok {
-				errorPageHandler, err := middlewares.NewErrorPagesHandler(errorPage, errorPageServer.URL)
-				if err != nil {
-					return nil, fmt.Errorf("error creating custom error page middleware, %v", err)
-				}
-				return errorPageHandler, nil
-			}
-			return nil, fmt.Errorf("error pages backend %q have too many server (%d) or 'error' server doesn't exist", errorPage.Backend, len(errorPageServers))
-		}
-	}
-	return nil, fmt.Errorf("error Page is configured for Frontend %s, but Backend %s is not set", frontendName, errorPage.Backend)
 }
 
 func buildIPWhiteLister(whiteList *types.WhiteList, wlRange []string) (*middlewares.IPWhiteLister, error) {

--- a/server/server.go
+++ b/server/server.go
@@ -913,7 +913,7 @@ func (s *Server) loadConfig(configurations types.Configurations, globalConfigura
 	redirectHandlers := make(map[string]negroni.Handler)
 	backends := map[string]http.Handler{}
 	backendsHealthCheck := map[string]*healthcheck.BackendHealthCheck{}
-	errorPageHandlers := make(map[string]*errorpages.Handler)
+	var errorPageHandlers []*errorpages.Handler
 
 	errorHandler := NewRecordingErrorHandler(middlewares.DefaultNetErrorRecorder{})
 
@@ -1102,13 +1102,13 @@ func (s *Server) loadConfig(configurations types.Configurations, globalConfigura
 							} else {
 								errorPagesHandler, err := errorpages.NewHandler(errorPage, entryPointName+providerName+errorPage.Backend)
 								if err != nil {
-									log.Error(err)
+									log.Errorf("Error creating error pages: %v", err)
 								} else {
 									if errorPageServer, ok := config.Backends[errorPage.Backend].Servers["error"]; ok {
 										errorPagesHandler.FallbackURL = errorPageServer.URL
 									}
 
-									errorPageHandlers[entryPointName+providerName+frontendName+errorPageName] = errorPagesHandler
+									errorPageHandlers = append(errorPageHandlers, errorPagesHandler)
 									n.Use(errorPagesHandler)
 								}
 							}

--- a/templates/consul_catalog.tmpl
+++ b/templates/consul_catalog.tmpl
@@ -96,7 +96,7 @@
         status = [{{range $page.Status }}
           "{{.}}",
           {{end}}]
-        backend = "{{ $page.Backend }}"
+        backend = "backend-{{ $page.Backend }}"
         query = "{{ $page.Query }}"
       {{end}}
     {{end}}

--- a/templates/docker.tmpl
+++ b/templates/docker.tmpl
@@ -97,7 +97,7 @@
         status = [{{range $page.Status }}
           "{{.}}",
           {{end}}]
-        backend = "{{ $page.Backend }}"
+        backend = "backend-{{ $page.Backend }}"
         query = "{{ $page.Query }}"
       {{end}}
     {{end}}

--- a/templates/ecs.tmpl
+++ b/templates/ecs.tmpl
@@ -96,7 +96,7 @@
         status = [{{range $page.Status }}
           "{{.}}",
           {{end}}]
-        backend = "{{ $page.Backend }}"
+        backend = "backend-{{ $page.Backend }}"
         query = "{{ $page.Query }}"
       {{end}}
     {{end}}

--- a/templates/marathon.tmpl
+++ b/templates/marathon.tmpl
@@ -99,7 +99,7 @@
         status = [{{range $page.Status }}
           "{{.}}",
           {{end}}]
-        backend = "{{ $page.Backend }}"
+        backend = "backend{{ $page.Backend }}"
         query = "{{ $page.Query }}"
       {{end}}
     {{end}}

--- a/templates/mesos.tmpl
+++ b/templates/mesos.tmpl
@@ -99,7 +99,7 @@
         status = [{{range $page.Status }}
         "{{.}}",
         {{end}}]
-        backend = "{{ $page.Backend }}"
+        backend = "backend-{{ $page.Backend }}"
         query = "{{ $page.Query }}"
       {{end}}
     {{end}}

--- a/templates/rancher.tmpl
+++ b/templates/rancher.tmpl
@@ -97,7 +97,7 @@
         status = [{{range $page.Status }}
         "{{.}}",
         {{end}}]
-        backend = "{{ $page.Backend }}"
+        backend = "backend-{{ $page.Backend }}"
         query = "{{ $page.Query }}"
       {{end}}
     {{end}}


### PR DESCRIPTION
### What does this PR do?

- add prefix for backend name in error pages in to template
- Be able to use error pages with providers without use a custom template

### Motivation

Fix bug.

Fixes #3144

### More

- [x] Added/updated tests
