### PR TITLE
Make accesslogs.logTheRoundTrip async to get lost performance

### DIFF
--- a/docs/configuration/logs.md
+++ b/docs/configuration/logs.md
@@ -128,7 +128,14 @@ To write the logs in async, specify `bufferingSize` as the format (must be >0):
 ```toml
 [accessLog]
 filePath = "/path/to/access.log"
-bufferingSize = 262140
+# Buffering Size
+#
+# Optional
+# Default: 0
+#
+# Number of access log lines to process in a buffered way.
+#
+bufferingSize = 100
 ```
 
 To filter logs you can specify a set of filters which are logically "OR-connected". Thus, specifying multiple filters will keep more access logs than specifying only one:

--- a/docs/configuration/logs.md
+++ b/docs/configuration/logs.md
@@ -124,6 +124,13 @@ filePath = "/path/to/access.log"
 format = "json"
 ```
 
+To write the logs in async, specify `bufferingSize` as the format (must be >0):
+```toml
+[accessLog]
+filePath = "/path/to/access.log"
+bufferingSize = 262140
+```
+
 To filter logs you can specify a set of filters which are logically "OR-connected". Thus, specifying multiple filters will keep more access logs than specifying only one:
 ```toml
 [accessLog]

--- a/middlewares/accesslog/logger_test.go
+++ b/middlewares/accesslog/logger_test.go
@@ -130,6 +130,21 @@ func TestLoggerCLF(t *testing.T) {
 	assertValidLogData(t, expectedLog, logData)
 }
 
+func TestAsyncLoggerCLF(t *testing.T) {
+	tmpDir := createTempDir(t, CommonFormat)
+	defer os.RemoveAll(tmpDir)
+
+	logFilePath := filepath.Join(tmpDir, logFileNameSuffix)
+	config := &types.AccessLog{FilePath: logFilePath, Format: CommonFormat, BufferingSize: 1024}
+	doLogging(t, config)
+
+	logData, err := ioutil.ReadFile(logFilePath)
+	require.NoError(t, err)
+
+	expectedLog := ` TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath HTTP/0.0" 123 12 "testReferer" "testUserAgent" 1 "testFrontend" "http://127.0.0.1/testBackend" 1ms`
+	assertValidLogData(t, expectedLog, logData)
+}
+
 func assertString(exp string) func(t *testing.T, actual interface{}) {
 	return func(t *testing.T, actual interface{}) {
 		t.Helper()

--- a/types/logs.go
+++ b/types/logs.go
@@ -26,7 +26,7 @@ type AccessLog struct {
 	Format        string            `json:"format,omitempty" description:"Access log format: json | common" export:"true"`
 	Filters       *AccessLogFilters `json:"filters,omitempty" description:"Access log filters, used to keep only specific access logs" export:"true"`
 	Fields        *AccessLogFields  `json:"fields,omitempty" description:"AccessLogFields" export:"true"`
-	BufferingSize int64             `json:"bufferingSize,omitempty" description:"Size of buffering access logs. Default 0." export:"true"`
+	BufferingSize int64             `json:"bufferingSize,omitempty" description:"Number of access log lines to process in a buffered way. Default 0." export:"true"`
 }
 
 // AccessLogFilters holds filters configuration

--- a/types/logs.go
+++ b/types/logs.go
@@ -22,10 +22,11 @@ type TraefikLog struct {
 
 // AccessLog holds the configuration settings for the access logger (middlewares/accesslog).
 type AccessLog struct {
-	FilePath string            `json:"file,omitempty" description:"Access log file path. Stdout is used when omitted or empty" export:"true"`
-	Format   string            `json:"format,omitempty" description:"Access log format: json | common" export:"true"`
-	Filters  *AccessLogFilters `json:"filters,omitempty" description:"Access log filters, used to keep only specific access logs" export:"true"`
-	Fields   *AccessLogFields  `json:"fields,omitempty" description:"AccessLogFields" export:"true"`
+	FilePath      string            `json:"file,omitempty" description:"Access log file path. Stdout is used when omitted or empty" export:"true"`
+	Format        string            `json:"format,omitempty" description:"Access log format: json | common" export:"true"`
+	Filters       *AccessLogFilters `json:"filters,omitempty" description:"Access log filters, used to keep only specific access logs" export:"true"`
+	Fields        *AccessLogFields  `json:"fields,omitempty" description:"AccessLogFields" export:"true"`
+	BufferingSize int64             `json:"bufferingSize,omitempty" description:"Size of buffering access logs. Default 0." export:"true"`
 }
 
 // AccessLogFilters holds filters configuration


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?
Add a async accesslogs.logTheRoundTrip for access logs.
<!-- A brief description of the change being made with this pull request. -->


### Motivation
On my current project, we use traefik and recently we activate access logs. When i checked the overhead this functionality, i realize that we lost a lot! So i tried to figure why and i found that we use sync io.Writer. So i did that PR https://github.com/containous/traefik/pull/3059 and after some tests i realized that i can do simpler and more effective with this PR(with or without fileFormat per example).

Small benchs:

Base configuration:
```toml
[entryPoints]
    [entryPoints.http]
       address = ":8080"
[accessLog]
filePath = 'test'
```

Without accesslogs from hey (without json format):
```console
$ hey -n 200000 http://127.0.0.1:8080/test
Summary:
  Total:	6.4238 secs
  Slowest:	0.0333 secs
  Fastest:	0.0002 secs
  Average:	0.0016 secs
  Requests/sec:	31134.0972
  
  Total data:	3800000 bytes
  Size/request:	19 bytes

Response time histogram:
  0.000 [1]	|
  0.003 [192996]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.007 [6398]	|∎
  0.010 [446]	|
  0.013 [107]	|
  0.017 [39]	|
  0.020 [9]	|
  0.023 [2]	|
  0.027 [0]	|
  0.030 [0]	|
  0.033 [2]	|


Latency distribution:
  10% in 0.0008 secs
  25% in 0.0011 secs
  50% in 0.0014 secs
  75% in 0.0018 secs
  90% in 0.0024 secs
  95% in 0.0030 secs
  99% in 0.0052 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0000 secs, 0.0002 secs, 0.0333 secs
  DNS-lookup:	0.0000 secs, 0.0000 secs, 0.0000 secs
  req write:	0.0000 secs, 0.0000 secs, 0.0191 secs
  resp wait:	0.0013 secs, 0.0001 secs, 0.0232 secs
  resp read:	0.0001 secs, 0.0000 secs, 0.0299 secs
```

With accesslogs (without json format):
```console
$ hey -n 200000 http://127.0.0.1:8080/test
Summary:
  Total:	20.0173 secs
  Slowest:	0.0261 secs
  Fastest:	0.0002 secs
  Average:	0.0050 secs
  Requests/sec:	9991.3647
  
  Total data:	3800000 bytes
  Size/request:	19 bytes

Response time histogram:
  0.000 [1]	|
  0.003 [2732]	|∎
  0.005 [154054]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.008 [32652]	|∎∎∎∎∎∎∎∎
  0.011 [7629]	|∎∎
  0.013 [2026]	|∎
  0.016 [556]	|
  0.018 [177]	|
  0.021 [148]	|
  0.024 [19]	|
  0.026 [6]	|


Latency distribution:
  10% in 0.0041 secs
  25% in 0.0042 secs
  50% in 0.0045 secs
  75% in 0.0053 secs
  90% in 0.0063 secs
  95% in 0.0081 secs
  99% in 0.0115 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0000 secs, 0.0002 secs, 0.0261 secs
  DNS-lookup:	0.0000 secs, 0.0000 secs, 0.0000 secs
  req write:	0.0000 secs, 0.0000 secs, 0.0023 secs
  resp wait:	0.0049 secs, 0.0002 secs, 0.0260 secs
  resp read:	0.0000 secs, 0.0000 secs, 0.0038 secs
```

With async accesslogs.logTheRoundTrip (with or without json format and with bufferingSize = 262140):
```console
$ hey -n 200000 http://127.0.0.1:8080/test
Summary:
  Total:	9.5298 secs
  Slowest:	0.0992 secs
  Fastest:	0.0002 secs
  Average:	0.0024 secs
  Requests/sec:	20986.9069
  
  Total data:	3800000 bytes
  Size/request:	19 bytes

Response time histogram:
  0.000 [1]	|
  0.010 [198312]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.020 [1164]	|
  0.030 [362]	|
  0.040 [80]	|
  0.050 [51]	|
  0.060 [18]	|
  0.070 [5]	|
  0.079 [1]	|
  0.089 [1]	|
  0.099 [5]	|


Latency distribution:
  10% in 0.0008 secs
  25% in 0.0012 secs
  50% in 0.0019 secs
  75% in 0.0028 secs
  90% in 0.0043 secs
  95% in 0.0054 secs
  99% in 0.0093 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0000 secs, 0.0002 secs, 0.0992 secs
  DNS-lookup:	0.0000 secs, 0.0000 secs, 0.0000 secs
  req write:	0.0000 secs, 0.0000 secs, 0.0569 secs
  resp wait:	0.0022 secs, 0.0001 secs, 0.0991 secs
  resp read:	0.0001 secs, 0.0000 secs, 0.0662 secs
```
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [x] Added/updated documentation: Access Logs

### Additional Notes

<!-- Anything else we should know when reviewing? -->
I think that there is more to do to optimize access logs overhead but it's a first step.
Replace PR https://github.com/containous/traefik/pull/3059.