### PR TITLE
Fix nil value when tracing is enabled

### DIFF
--- a/middlewares/tracing/jaeger/jaeger.go
+++ b/middlewares/tracing/jaeger/jaeger.go
@@ -48,7 +48,7 @@ func (c *Config) Setup(componentName string) (opentracing.Tracer, io.Closer, err
 		log.Warnf("Could not initialize jaeger tracer: %s", err.Error())
 		return nil, nil, err
 	}
-	log.Debugf("jaeger tracer configured", err)
+	log.Debug("Jaeger tracer configured")
 
 	return opentracing.GlobalTracer(), closer, nil
 }

--- a/middlewares/tracing/zipkin/zipkin.go
+++ b/middlewares/tracing/zipkin/zipkin.go
@@ -3,6 +3,7 @@ package zipkin
 import (
 	"io"
 
+	"github.com/containous/traefik/log"
 	opentracing "github.com/opentracing/opentracing-go"
 	zipkin "github.com/openzipkin/zipkin-go-opentracing"
 )
@@ -38,6 +39,8 @@ func (c *Config) Setup(serviceName string) (opentracing.Tracer, io.Closer, error
 
 	// Without this, child spans are getting the NOOP tracer
 	opentracing.SetGlobalTracer(tracer)
+
+	log.Debug("Zipkin tracer configured")
 
 	return tracer, collector, nil
 }


### PR DESCRIPTION
### What does this PR do?

Fix nil value when tracing is enabled

### Motivation

```console
$ docker run traefik:1.6.0-rc5 --tracing --tracing.backend=zipkin --tracing.jaeger=false
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x87f6d7]goroutine 1 [running]:
github.com/containous/traefik/middlewares/tracing/zipkin.(*Config).Setup(0x0, 0x21b1c7b, 0x7, 0xb7413b, 0xc4208d2000, 0xc4208d4000, 0x0, 0x0, 0xc4205ef578)
    /go/src/github.com/containous/traefik/middlewares/tracing/zipkin/zipkin.go:23 +0x37
github.com/containous/traefik/middlewares/tracing.(*Tracing).Setup(0xc4203d8910)
    /go/src/github.com/containous/traefik/middlewares/tracing/tracing.go:54 +0x111
github.com/containous/traefik/server.NewServer(0xc4201d44f0, 0x0, 0x100, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc4203d8910, ...)
    /go/src/github.com/containous/traefik/server/server.go:114 +0x58e
main.runCmd(0xc4201f8000, 0x0, 0x0)
    /go/src/github.com/containous/traefik/cmd/traefik/traefik.go:180 +0x330
main.main.func1(0x1f0c4e0, 0xc420526660)
    /go/src/github.com/containous/traefik/cmd/traefik/traefik.go:54 +0x42
github.com/containous/traefik/vendor/github.com/containous/staert.(*Staert).Run(0xc420128360, 0xc4201f8000, 0xc420526660)
    /go/src/github.com/containous/traefik/vendor/github.com/containous/staert/staert.go:84 +0x2e
main.main()
    /go/src/github.com/containous/traefik/cmd/traefik/traefik.go:142 +0x1b19
```


### More

- [x] Added/updated tests