### PR TITLE
Enable to override certificates in key-value store when using storeconfig

### DIFF
--- a/acme/acme.go
+++ b/acme/acme.go
@@ -52,7 +52,7 @@ type ACME struct {
 	DNSProvider           string                      `description:"(Deprecated) Activate DNS-01 Challenge"`                                                                    // Deprecated
 	DelayDontCheckDNS     flaeg.Duration              `description:"(Deprecated) Assume DNS propagates after a delay in seconds rather than finding and querying nameservers."` // Deprecated
 	ACMELogging           bool                        `description:"Enable debug logging of ACME actions."`
-	KeepCerts             bool                        `description:"Enable to keep certificates already in key-value store when using storeconfig"`
+	OverrideCertificates  bool                        `description:"Enable to override certificates in key-value store when using storeconfig"`
 	client                *acme.Client
 	defaultCertificate    *tls.Certificate
 	store                 cluster.Store

--- a/acme/acme.go
+++ b/acme/acme.go
@@ -52,6 +52,7 @@ type ACME struct {
 	DNSProvider           string                      `description:"(Deprecated) Activate DNS-01 Challenge"`                                                                    // Deprecated
 	DelayDontCheckDNS     flaeg.Duration              `description:"(Deprecated) Assume DNS propagates after a delay in seconds rather than finding and querying nameservers."` // Deprecated
 	ACMELogging           bool                        `description:"Enable debug logging of ACME actions."`
+	KeepCerts             bool                        `description:"Enable to keep certificates already in key-value store when using storeconfig"`
 	client                *acme.Client
 	defaultCertificate    *tls.Certificate
 	store                 cluster.Store

--- a/cmd/storeconfig/storeconfig.go
+++ b/cmd/storeconfig/storeconfig.go
@@ -85,6 +85,16 @@ func Run(kv *staert.KvSource, traefikConfiguration *cmd.TraefikConfiguration) fu
 				}
 			}
 
+			// Check to see if ACME account object is already in kv store
+			if traefikConfiguration.GlobalConfiguration.ACME.KeepCerts {
+				if exists, err := kv.Exists(
+					traefikConfiguration.GlobalConfiguration.ACME.Storage+"/object",
+					&store.ReadOptions{Consistent: true}); err == nil && exists {
+					// Force to delete storagefile (early exit)
+					return kv.Delete(kv.Prefix + "/acme/storagefile")
+				}
+			}
+
 			// Store the ACME Account into the KV Store
 			meta := cluster.NewMetadata(account)
 			err = meta.Marshall()

--- a/cmd/storeconfig/storeconfig.go
+++ b/cmd/storeconfig/storeconfig.go
@@ -86,7 +86,7 @@ func Run(kv *staert.KvSource, traefikConfiguration *cmd.TraefikConfiguration) fu
 			}
 
 			// Check to see if ACME account object is already in kv store
-			if traefikConfiguration.GlobalConfiguration.ACME.KeepCerts {
+			if !traefikConfiguration.GlobalConfiguration.ACME.OverrideCertificates {
 				if exists, err := kv.Exists(
 					traefikConfiguration.GlobalConfiguration.ACME.Storage+"/object",
 					&store.ReadOptions{Consistent: true}); err == nil && exists {
@@ -96,6 +96,7 @@ func Run(kv *staert.KvSource, traefikConfiguration *cmd.TraefikConfiguration) fu
 			}
 
 			// Store the ACME Account into the KV Store
+			// Certificates in KV Store will be overridden
 			meta := cluster.NewMetadata(account)
 			err = meta.Marshall()
 			if err != nil {

--- a/docs/configuration/acme.md
+++ b/docs/configuration/acme.md
@@ -63,12 +63,12 @@ entryPoint = "https"
 #
 # acmeLogging = true
 
-# If true, keep certificates already in key-value store when using storeconfig.
+# If true, override certificates in key-value store when using storeconfig.
 #
 # Optional
 # Default: false
 #
-# keepCerts = true
+# overrideCertificates = true
 
 # Enable on demand certificate generation.
 #

--- a/docs/configuration/acme.md
+++ b/docs/configuration/acme.md
@@ -63,6 +63,13 @@ entryPoint = "https"
 #
 # acmeLogging = true
 
+# If true, keep certificates already in key-value store when using storeconfig.
+#
+# Optional
+# Default: false
+#
+# keepCerts = true
+
 # Enable on demand certificate generation.
 #
 # Optional (Deprecated)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

Adds `--acme.keepcerts` option to traefik. When this option is set to true, certificates already in key-value store will not be overwritten when using `storeconfig`.

### Motivation

Closes https://github.com/containous/traefik/issues/3003. 

### More

- [ ] Added/updated tests.
- [x] Added/updated documentation