### PR TITLE
 Mapping ExternalNames to custom ports

### DIFF
--- a/provider/kubernetes/builder_service_test.go
+++ b/provider/kubernetes/builder_service_test.go
@@ -120,6 +120,23 @@ func TestBuildService(t *testing.T) {
 	)
 
 	assert.EqualValues(t, sampleService2(), actual2)
+
+	actual3 := buildService(
+		sName("service3"),
+		sNamespace("testing"),
+		sUID("3"),
+		sSpec(
+			clusterIP("10.0.0.3"),
+			sType("ExternalName"),
+			sExternalName("example.com"),
+			sPorts(
+				sPort(8080, "http"),
+				sPort(8443, "https"),
+			),
+		),
+	)
+
+	assert.EqualValues(t, sampleService3(), actual3)
 }
 
 func sampleService1() *corev1.Service {
@@ -159,6 +176,31 @@ func sampleService2() *corev1.Service {
 				{
 					Name: "https",
 					Port: 443,
+				},
+			},
+		},
+	}
+}
+
+func sampleService3() *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "service3",
+			UID:       "3",
+			Namespace: "testing",
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP:    "10.0.0.3",
+			Type:         "ExternalName",
+			ExternalName: "example.com",
+			Ports: []corev1.ServicePort{
+				{
+					Name: "http",
+					Port: 8080,
+				},
+				{
+					Name: "https",
+					Port: 8443,
 				},
 			},
 		},

--- a/provider/kubernetes/builder_service_test.go
+++ b/provider/kubernetes/builder_service_test.go
@@ -105,11 +105,11 @@ func TestBuildService(t *testing.T) {
 	assert.EqualValues(t, sampleService1(), actual1)
 
 	actual2 := buildService(
-		sName("service3"),
+		sName("service2"),
 		sNamespace("testing"),
-		sUID("3"),
+		sUID("2"),
 		sSpec(
-			clusterIP("10.0.0.3"),
+			clusterIP("10.0.0.2"),
 			sType("ExternalName"),
 			sExternalName("example.com"),
 			sPorts(
@@ -143,12 +143,12 @@ func sampleService1() *corev1.Service {
 func sampleService2() *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "service3",
-			UID:       "3",
+			Name:      "service2",
+			UID:       "2",
 			Namespace: "testing",
 		},
 		Spec: corev1.ServiceSpec{
-			ClusterIP:    "10.0.0.3",
+			ClusterIP:    "10.0.0.2",
 			Type:         "ExternalName",
 			ExternalName: "example.com",
 			Ports: []corev1.ServicePort{

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -270,7 +270,7 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 				protocol := label.DefaultProtocol
 				for _, port := range service.Spec.Ports {
 					if equalPorts(port, pa.Backend.ServicePort) {
-						if port.Port == 443 || port.Name == "https" {
+						if port.Port == 443 || strings.HasPrefix(port.Name, "https") {
 							protocol = "https"
 						}
 

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -278,8 +278,8 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 							url := protocol + "://" + service.Spec.ExternalName
 							name := url
 							if port.Port != 443 && port.Port != 80 {
-                                                                url = fmt.Sprintf("%s:%d", url, port.Port)
-                                                        }
+								url = fmt.Sprintf("%s:%d", url, port.Port)
+							}
 
 							templateObjects.Backends[baseName].Servers[name] = types.Server{
 								URL:    url,

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -270,13 +270,16 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 				protocol := label.DefaultProtocol
 				for _, port := range service.Spec.Ports {
 					if equalPorts(port, pa.Backend.ServicePort) {
-						if port.Port == 443 {
+						if port.Port == 443 || port.Name == "https" {
 							protocol = "https"
 						}
 
 						if service.Spec.Type == "ExternalName" {
 							url := protocol + "://" + service.Spec.ExternalName
 							name := url
+							if port.Port != 443 && port.Port != 80 {
+                                                                url = fmt.Sprintf("%s:%d", url, port.Port)
+                                                        }
 
 							templateObjects.Backends[baseName].Servers[name] = types.Server{
 								URL:    url,


### PR DESCRIPTION
### What does this PR do?

This fixes issue #1816 

Basically, if the `servicePort.Port` is not 443 or 80, we add it to the url (not the name).
And if the `servicePort.name` is "https" we also use "https" as the protocol. That allows to proxy https traffic to any port.

### Motivation

In my deployment, I need træfik to proxy to external servers on custom ports. I do not control these servers.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation
