### PR TITLE
Does not generate ACME certificate if domain is checked by dynamic certificate

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -202,7 +202,7 @@ func runCmd(globalConfiguration *configuration.GlobalConfiguration, configFile s
 				DynamicCerts: &safe.Safe{},
 				StaticCerts:  &safe.Safe{},
 			}
-			acmeprovider.SetCertificateStore(*entryPoint.CertificateStore)
+			acmeprovider.SetCertificateStore(entryPoint.CertificateStore)
 
 		}
 

--- a/provider/acme/provider.go
+++ b/provider/acme/provider.go
@@ -55,7 +55,7 @@ type Provider struct {
 	client                 *acme.Client
 	certsChan              chan *Certificate
 	configurationChan      chan<- types.ConfigMessage
-	certificateStore       traefiktls.CertificateStore
+	certificateStore       *traefiktls.CertificateStore
 	clientMutex            sync.Mutex
 	configFromListenerChan chan types.Configuration
 	pool                   *safe.Pool
@@ -185,7 +185,7 @@ func (p *Provider) watchNewDomains() {
 }
 
 // SetCertificateStore allow to initialize certificate store
-func (p *Provider) SetCertificateStore(certificateStore traefiktls.CertificateStore) {
+func (p *Provider) SetCertificateStore(certificateStore *traefiktls.CertificateStore) {
 	p.certificateStore = certificateStore
 }
 

--- a/provider/acme/provider_test.go
+++ b/provider/acme/provider_test.go
@@ -147,7 +147,7 @@ func TestGetUncheckedCertificates(t *testing.T) {
 			t.Parallel()
 
 			acmeProvider := Provider{
-				certificateStore: traefiktls.CertificateStore{
+				certificateStore: &traefiktls.CertificateStore{
 					DynamicCerts: test.dynamicCerts,
 					StaticCerts:  test.staticCerts,
 				},

--- a/server/server.go
+++ b/server/server.go
@@ -92,7 +92,7 @@ type serverEntryPoint struct {
 	httpServer       *http.Server
 	listener         net.Listener
 	httpRouter       *middlewares.HandlerSwitcher
-	certs            safe.Safe
+	certs            *safe.Safe
 	onDemandListener func(string) (*tls.Certificate, error)
 }
 
@@ -674,7 +674,7 @@ func (s *Server) createTLSConfig(entryPointName string, tlsOption *traefiktls.TL
 				return false
 			}
 
-			err := s.globalConfiguration.ACME.CreateClusterConfig(s.leadership, config, &s.serverEntryPoints[entryPointName].certs, checkOnDemandDomain)
+			err := s.globalConfiguration.ACME.CreateClusterConfig(s.leadership, config, s.serverEntryPoints[entryPointName].certs, checkOnDemandDomain)
 			if err != nil {
 				return nil, err
 			}
@@ -836,7 +836,9 @@ func (s *Server) buildEntryPoints() map[string]*serverEntryPoint {
 			onDemandListener: entryPoint.OnDemandListener,
 		}
 		if entryPoint.CertificateStore != nil {
-			serverEntryPoints[entryPointName].certs = *entryPoint.CertificateStore.DynamicCerts
+			serverEntryPoints[entryPointName].certs = entryPoint.CertificateStore.DynamicCerts
+		} else {
+			serverEntryPoints[entryPointName].certs = &safe.Safe{}
 		}
 	}
 	return serverEntryPoints


### PR DESCRIPTION
### What does this PR do?
Change `CertificateStore` to `*CertificateStore` in `server` and `provider.ACME`.

### Motivation
No ACME challenge when a certificate already exists in dynamic certs.