### PR TITLE
Add a matcher for partitioning services

### DIFF
--- a/rules/rules.go
+++ b/rules/rules.go
@@ -126,10 +126,7 @@ func (r *Rules) hashedRange(rule ...string) *mux.Route {
 		hash := hash(value)
 
 		factor := float64(rangeHigh-rangeLow) / float64(maxUint)
-		log.Error(factor)
 		adjustedResult := (float64(hash) * factor) + float64(rangeLow)
-
-		log.Error(adjustedResult)
 
 		if adjustedResult >= float64(matchLow) && adjustedResult < float64(matchHigh) {
 			return true

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -3,14 +3,17 @@ package rules
 import (
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"net"
 	"net/http"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/BurntSushi/ty/fun"
 	"github.com/containous/mux"
+	"github.com/containous/traefik/log"
 	"github.com/containous/traefik/types"
 )
 
@@ -31,6 +34,107 @@ func (r *Rules) host(hosts ...string) *mux.Route {
 				return true
 			}
 		}
+		return false
+	})
+}
+
+const (
+	maxUint             = ^uint64(0)
+	hashRangeHeaderType = "header"
+)
+
+func hash(s string) uint64 {
+	h := fnv.New64a()
+	h.Write([]byte(s))
+	return h.Sum64()
+}
+
+func getMinMax(s string) (min, max int, err error) {
+	matchParts := strings.Split(s, "-")
+	if len(matchParts) != 2 {
+		return 0, 0, fmt.Errorf("failed to parse int range: %v", s)
+	}
+	min, err = strconv.Atoi(matchParts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to parse int range: %v", s)
+	}
+	max, err = strconv.Atoi(matchParts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to parse int range: %v", s)
+	}
+	return
+}
+
+func (r *Rules) hashedRange(rule ...string) *mux.Route {
+	falseMatch := func(req *http.Request, route *mux.RouteMatch) bool { return false }
+	args := map[string]string{}
+	items := strings.Split(rule[0], " ")
+	//expect 4 parts: type, value, match and range
+	if len(items) != 4 {
+		log.Errorf("Failed parsing hashedRange matcher rule: %v", rule)
+		return r.Route.Route.MatcherFunc(falseMatch)
+	}
+	for _, item := range items {
+		parts := strings.Split(item, ":")
+		//expect format 'type:header'
+		if len(parts) != 2 {
+			log.Error("Failed parsing hashedRange matcher rule: %v", rule)
+			r.Route.Route.MatcherFunc(falseMatch)
+		}
+		args[parts[0]] = parts[1]
+	}
+
+	//check parts included
+	typeMatch, exists := args["type"]
+	if !exists {
+		log.Errorf("Failed parsing hashedRange matcher rule: %v", rule)
+		r.Route.Route.MatcherFunc(falseMatch)
+	}
+	typeValue, exists := args["value"]
+	if !exists {
+		log.Errorf("Failed parsing hashedRange matcher rule: %v", rule)
+		r.Route.Route.MatcherFunc(falseMatch)
+	}
+	matchString, exists := args["match"]
+	if !exists {
+		log.Errorf("Failed parsing hashedRange matcher rule: %v", rule)
+		r.Route.Route.MatcherFunc(falseMatch)
+	}
+	matchLow, matchHigh, err := getMinMax(matchString)
+	if err != nil {
+		log.Errorf("Failed parsing hashedRange matcher rule: %v", rule)
+		r.Route.Route.MatcherFunc(falseMatch)
+	}
+
+	rangeString, exists := args["range"]
+	if !exists {
+		log.Errorf("Failed parsing hashedRange matcher rule: %v", rule)
+		r.Route.Route.MatcherFunc(falseMatch)
+	}
+	rangeLow, rangeHigh, err := getMinMax(rangeString)
+	if err != nil {
+		log.Errorf("Failed parsing hashedRange matcher rule: %v", rule)
+		r.Route.Route.MatcherFunc(falseMatch)
+	}
+
+	return r.Route.Route.MatcherFunc(func(req *http.Request, route *mux.RouteMatch) bool {
+		var value string
+		if typeMatch == hashRangeHeaderType {
+			value = req.Header.Get(typeValue)
+		}
+
+		hash := hash(value)
+
+		factor := float64(rangeHigh-rangeLow) / float64(maxUint)
+		log.Error(factor)
+		adjustedResult := (float64(hash) * factor) + float64(rangeLow)
+
+		log.Error(adjustedResult)
+
+		if adjustedResult >= float64(matchLow) && adjustedResult < float64(matchHigh) {
+			return true
+		}
+
 		return false
 	})
 }
@@ -185,6 +289,7 @@ func (r *Rules) parseRules(expression string, onRule func(functionName string, f
 		"ReplacePath":          r.replacePath,
 		"ReplacePathRegex":     r.replacePathRegex,
 		"Query":                r.query,
+		"HashedRange":          r.hashedRange,
 	}
 
 	if len(expression) == 0 {

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
@@ -8,9 +9,105 @@ import (
 	"github.com/containous/mux"
 	"github.com/containous/traefik/testhelpers"
 	"github.com/containous/traefik/types"
+	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestParseHashRangeRule(t *testing.T) {
+
+	testCases := []struct {
+		desc        string
+		expectMatch bool
+		request     func() *http.Request
+		rule        string
+	}{
+		{
+			desc: "Match: header in range",
+			request: func() *http.Request {
+				request := testhelpers.MustNewRequest(http.MethodGet, "http://foo.bar", nil)
+				request.Header.Add("x-partitionheader", "hello")
+				return request
+			},
+			expectMatch: true,
+			rule:        "HashedRange: type:header value:x-partitionheader match:50-200 range:0-300",
+		},
+		{
+			desc: "Don't match: header not in range",
+			request: func() *http.Request {
+				request := testhelpers.MustNewRequest(http.MethodGet, "http://foo.bar", nil)
+				request.Header.Add("x-partitionheader", "hello outside range please")
+				return request
+			},
+			expectMatch: false,
+			rule:        "HashedRange: type:header value:x-partitionheader match:50-200 range:0-300",
+		},
+		{
+			desc: "Error case: missing part",
+			request: func() *http.Request {
+				request := testhelpers.MustNewRequest(http.MethodGet, "http://foo.bar", nil)
+				return request
+			},
+			expectMatch: false,
+			rule:        "HashedRange: type:header match:50-200 range:0-300",
+		},
+	}
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			router := mux.NewRouter()
+			route := router.NewRoute()
+			serverRoute := &types.ServerRoute{Route: route}
+			rules := &Rules{Route: serverRoute}
+			routeResult, err := rules.Parse(test.rule)
+			require.NoError(t, err, "Error while building route for %s", test.rule)
+
+			routeMatch := routeResult.Match(test.request(), &mux.RouteMatch{Route: routeResult})
+
+			if test.expectMatch {
+				assert.True(t, routeMatch, "Rule %s don't match.", test.rule)
+			} else {
+				assert.False(t, routeMatch, "Rule %s matched when not expected.", test.rule)
+
+			}
+		})
+	}
+}
+
+func TestHashRangeRuleDistribution(t *testing.T) {
+	router := mux.NewRouter()
+	route := router.NewRoute()
+	serverRoute := &types.ServerRoute{Route: route}
+	rules := &Rules{Route: serverRoute}
+
+	expression := "HashedRange: type:header value:x-partitionheader match:0-100 range:0-500"
+	routeResult, err := rules.Parse(expression)
+	require.NoError(t, err, "Error while building route for %s", expression)
+
+	i := 0
+	matches := 0
+	attempts := 1000
+	allowedVariance := (float64(attempts) / 100) * 5
+	for i < attempts {
+		request := testhelpers.MustNewRequest(http.MethodGet, "http://foo.bar", nil)
+		request.Header.Add("x-partitionheader", uuid.NewV4().String())
+		routeMatch := routeResult.Match(request, &mux.RouteMatch{Route: routeResult})
+		if routeMatch {
+			matches++
+		}
+		i++
+	}
+
+	// For a range 0-500 matching 0-100 we expect 1/5th of requests to match this rule
+	expectedEvenDistribution := float64(attempts) / 5
+	lowAcceptableMatch := expectedEvenDistribution - allowedVariance
+	highAcceptableMatch := expectedEvenDistribution + allowedVariance
+	if float64(matches) < lowAcceptableMatch || float64(matches) > highAcceptableMatch {
+		assert.Fail(t, fmt.Sprintf("Matched attempts: %v fell outside acceptable range: %v -> %v for even distrubtion", matches, lowAcceptableMatch, highAcceptableMatch))
+	}
+}
 
 func TestParseOneRule(t *testing.T) {
 	router := mux.NewRouter()


### PR DESCRIPTION
### What does this PR do?

This adds a new matcher for partitioned services. For detail see [proposal](https://github.com/containous/traefik/issues/3224)

### Motivation

Allow services to partition/shard load easily. For detail see [proposal](https://github.com/containous/traefik/issues/3224)

### More

- [x] Added/updated tests
- [ ] Added/updated documentation (Waiting on review of approach before adding)

### Additional Notes

I'm not happy with the code which pulls out the 'range', 'type' etc from the rule. Currently it sits in the `hashedRange` function but I think it may be better suited to the `parseRule` function. Currently if the rule is missing required details it returns matcher which is always `false`. I think in `parseRule` I could do something more sensible. Likewise we could change the format of the rule to be less verbose which could simplify the code. 