### PR TITLE
Allow log rotation in Windows

### DIFF
--- a/server/server_signals_windows.go
+++ b/server/server_signals_windows.go
@@ -2,6 +2,82 @@
 
 package server
 
-func (s *Server) configureSignals() {}
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
 
-func (s *Server) listenSignals() {}
+	"github.com/containous/traefik/log"
+)
+
+var (
+	kernel32        = syscall.NewLazyDLL("kernel32.dll")
+	procCreateEvent = kernel32.NewProc("CreateEventW")
+	procSetEvent    = kernel32.NewProc("SetEvent")
+)
+
+const windowsEventName = "SomeMutexNameGUID"
+
+var windowsEventHandle uintptr
+
+func (s *Server) configureSignals() {
+	handle, err := createEvent(windowsEventName)
+
+	if err != nil {
+		panic("server already running?")
+	}
+
+	windowsEventHandle = handle
+}
+
+func (s *Server) listenSignals() {
+
+	for {
+		syscall.WaitForSingleObject(syscall.Handle(windowsEventHandle), syscall.INFINITE)
+
+		signalFileRotation(s)
+	}
+}
+
+func createEvent(name string) (uintptr, error) {
+	paramEventName := uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(name)))
+
+	ret, _, err := procCreateEvent.Call(
+		0, // default security attributes
+		0, // manual-reset event
+		0, // initial state
+		paramEventName)
+
+	switch int(err.(syscall.Errno)) {
+	case 0:
+		return ret, nil
+	default:
+		return ret, err
+	}
+}
+
+func setEvent(handle uintptr) error {
+	_, _, err := procSetEvent.Call(handle)
+
+	switch int(err.(syscall.Errno)) {
+	case 0:
+		return nil
+	default:
+		return err
+	}
+}
+
+func signalFileRotation(s *Server) {
+	log.Infof("Closing and re-opening log files for rotation")
+	fmt.Println("Closing and re-opening log files for rotation")
+
+	if s.accessLoggerMiddleware != nil {
+		if err := s.accessLoggerMiddleware.Rotate(); err != nil {
+			log.Errorf("Error rotating access log: %s", err)
+		}
+	}
+
+	if err := log.RotateFile(); err != nil {
+		log.Errorf("Error rotating traefik log: %s", err)
+	}
+}

--- a/server/server_signals_windows.go
+++ b/server/server_signals_windows.go
@@ -4,6 +4,7 @@ package server
 
 import (
 	"fmt"
+	"os"
 	"syscall"
 	"unsafe"
 
@@ -16,11 +17,15 @@ var (
 	procSetEvent    = kernel32.NewProc("SetEvent")
 )
 
-const windowsEventName = "SomeMutexNameGUID"
+const windowsEventName = "traefik-GUID"
 
 var windowsEventHandle uintptr
 
 func (s *Server) configureSignals() {
+
+	windowsEventNameWithPid := fmt.Sprintf("%s-pid-%d", windowsEventName, os.Getpid())
+	fmt.Println("Watching Windows Object {", windowsEventNameWithPid, "}")
+
 	handle, err := createEvent(windowsEventName)
 
 	if err != nil {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This implementation contains a proposal for Log Rotation in Windows. 

### Motivation

<!-- What inspired you to submit this pull request? -->
The current work done in #1761 allows the user to signal the process to rotate the log. However, it is well known that Windows has no support for unix signals.

Here we implemented the tradicional approach of watching WinObjects. We create a global Event object, and keep watching the signaling.

### More

- [ ] Pending: rotate access log
- [ ] Pending: tests
- [ ] Pending: documentation
- [ ] Pending: client example

### Additional Notes

<!-- Anything else we should know when reviewing? -->
Unfortunately, the current RotateFile function fails with "file already in use" in Windows. Because of that, we had to adopt another approach for log rotation. In our case, we chose generating new filenames. 
I explored other options available in Windows such as MoveFileEx, ReplaceFile and also using Hard Links. However, all options have problems for not being atomic operations. There is a long discussion around this theme in Internet, so I opted for the simplest one.
- https://github.com/golang/go/issues/8914
- https://blogs.msdn.microsoft.com/adioltean/2005/12/28/how-to-do-atomic-writes-in-a-file/
- https://msdn.microsoft.com/en-us/library/hh802690(v=vs.85).aspx

//cc: @eladiw @jjcollinge @lawrencegripper 