### PR TITLE
Changed "is could" to should

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 Træfik is a modern HTTP reverse proxy and load balancer that makes deploying microservices easy.
 Træfik integrates with your existing infrastructure components ([Docker](https://www.docker.com/), [Swarm mode](https://docs.docker.com/engine/swarm/), [Kubernetes](https://kubernetes.io), [Marathon](https://mesosphere.github.io/marathon/), [Consul](https://www.consul.io/), [Etcd](https://coreos.com/etcd/), [Rancher](https://rancher.com), [Amazon ECS](https://aws.amazon.com/ecs), ...) and configures itself automatically and dynamically.
-Telling Træfik where your orchestrator is could be the _only_ configuration step you need to do.
+Pointing Træfik at your orchestrator should be the _only_ configuration step you need.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@
 
 Træfik is a modern HTTP reverse proxy and load balancer that makes deploying microservices easy.
 Træfik integrates with your existing infrastructure components ([Docker](https://www.docker.com/), [Swarm mode](https://docs.docker.com/engine/swarm/), [Kubernetes](https://kubernetes.io), [Marathon](https://mesosphere.github.io/marathon/), [Consul](https://www.consul.io/), [Etcd](https://coreos.com/etcd/), [Rancher](https://rancher.com), [Amazon ECS](https://aws.amazon.com/ecs), ...) and configures itself automatically and dynamically.
-Telling Træfik where your orchestrator should be the _only_ configuration step you need to do.
+Pointing Træfik at your orchestrator should be the _only_ configuration step you need.
 
 ## Overview
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@
 
 Træfik is a modern HTTP reverse proxy and load balancer that makes deploying microservices easy.
 Træfik integrates with your existing infrastructure components ([Docker](https://www.docker.com/), [Swarm mode](https://docs.docker.com/engine/swarm/), [Kubernetes](https://kubernetes.io), [Marathon](https://mesosphere.github.io/marathon/), [Consul](https://www.consul.io/), [Etcd](https://coreos.com/etcd/), [Rancher](https://rancher.com), [Amazon ECS](https://aws.amazon.com/ecs), ...) and configures itself automatically and dynamically.
-Telling Træfik where your orchestrator is could be the _only_ configuration step you need to do.
+Telling Træfik where your orchestrator should be the _only_ configuration step you need to do.
 
 ## Overview
 


### PR DESCRIPTION
### What does this PR do?
Changes `is could` to `should` in the documentation

### Motivation
It bothered me, I had to read the sentence twice because it was phrased weird.
