### PR TITLE
Fix wrong tag in forward span in tracing middleware

### DIFF
--- a/middlewares/tracing/forwarder.go
+++ b/middlewares/tracing/forwarder.go
@@ -33,7 +33,7 @@ func (f *forwarderMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, 
 	span.SetTag("frontend.name", f.frontend)
 	span.SetTag("backend.name", f.backend)
 	ext.HTTPMethod.Set(span, r.Method)
-	ext.HTTPUrl.Set(span, r.URL.String())
+	ext.HTTPUrl.Set(span, fmt.Sprintf("%s%s", r.URL.String(), r.RequestURI))
 	span.SetTag("http.host", r.Host)
 
 	InjectRequestHeaders(r)


### PR DESCRIPTION
### What does this PR do?

This PR fix a bad `http.url` tag in `forward` span in tracing middleware

### Motivation

Fixes #3273 
