### PR TITLE
Create OWNERS file for Helm chart management

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,14 @@
+approvers:
+- emilevauge
+- dtomcej
+- timoreimann
+reviewers:
+- vdemeester
+- nmengin
+- mmatur
+- ldez
+- Juliens
+- jbdoumenjou
+- geraldcroes
+- SantoDE
+- errm


### PR DESCRIPTION
### What does this PR do?

Create the OWNERS file required to manage the kubernetes helm chart

### Motivation

Allowing us to manage the chart gives us flexibility.

