### PR TITLE
sane default and configurable Marathon request timeouts

### DIFF
--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -88,7 +88,7 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 	defaultMarathon.Endpoint = "http://127.0.0.1:8080"
 	defaultMarathon.ExposedByDefault = true
 	defaultMarathon.Constraints = types.Constraints{}
-	defaultMarathon.DialerTimeout = flaeg.Duration(60 * time.Second)
+	defaultMarathon.DialerTimeout = flaeg.Duration(5 * time.Second)
 	defaultMarathon.KeepAlive = flaeg.Duration(10 * time.Second)
 
 	// default Consul

--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -89,6 +89,8 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 	defaultMarathon.ExposedByDefault = true
 	defaultMarathon.Constraints = types.Constraints{}
 	defaultMarathon.DialerTimeout = flaeg.Duration(5 * time.Second)
+	defaultMarathon.ResponseHeaderTimeout = flaeg.Duration(60 * time.Second)
+	defaultMarathon.TLSHandshakeTimeout = flaeg.Duration(5 * time.Second)
 	defaultMarathon.KeepAlive = flaeg.Duration(10 * time.Second)
 
 	// default Consul

--- a/docs/configuration/backends/marathon.md
+++ b/docs/configuration/backends/marathon.md
@@ -120,9 +120,33 @@ domain = "marathon.localhost"
 # If no units are provided, the value is parsed assuming seconds.
 #
 # Optional
+# Default: "5s"
+#
+# dialerTimeout = "5s"
+
+# Override ResponseHeaderTimeout.
+# Amount of time to allow the Marathon provider to wait until the first response
+# header from the Marathon master is received.
+# Can be provided in a format supported by [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration) or as raw
+# values (digits).
+# If no units are provided, the value is parsed assuming seconds.
+#
+# Optional
 # Default: "60s"
 #
-# dialerTimeout = "60s"
+# responseHeaderTimeout = "60s"
+
+# Override TLSHandshakeTimeout.
+# Amount of time to allow the Marathon provider to wait until the TLS
+# handshake completes.
+# Can be provided in a format supported by [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration) or as raw
+# values (digits).
+# If no units are provided, the value is parsed assuming seconds.
+#
+# Optional
+# Default: "5s"
+#
+# TLSHandshakeTimeout = "5s"
 
 # Set the TCP Keep Alive interval for the Marathon HTTP Client.
 # Can be provided in a format supported by [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration) or as raw

--- a/provider/marathon/marathon.go
+++ b/provider/marathon/marathon.go
@@ -55,7 +55,9 @@ type Provider struct {
 	MarathonLBCompatibility   bool             `description:"Add compatibility with marathon-lb labels" export:"true"`
 	FilterMarathonConstraints bool             `description:"Enable use of Marathon constraints in constraint filtering" export:"true"`
 	TLS                       *types.ClientTLS `description:"Enable TLS support" export:"true"`
-	DialerTimeout             flaeg.Duration   `description:"Set a non-default connection timeout for Marathon" export:"true"`
+	DialerTimeout             flaeg.Duration   `description:"Set a non-default dialer timeout for Marathon" export:"true"`
+	ResponseHeaderTimeout     flaeg.Duration   `description:"Set a non-default response header timeout for Marathon" export:"true"`
+	TLSHandshakeTimeout       flaeg.Duration   `description:"Set a non-default TLS handhsake timeout for Marathon" export:"true"`
 	KeepAlive                 flaeg.Duration   `description:"Set a non-default TCP Keep Alive time in seconds" export:"true"`
 	ForceTaskHostname         bool             `description:"Force to use the task's hostname." export:"true"`
 	Basic                     *Basic           `description:"Enable basic authentication" export:"true"`
@@ -105,8 +107,8 @@ func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *s
 					KeepAlive: time.Duration(p.KeepAlive),
 					Timeout:   time.Duration(p.DialerTimeout),
 				}).DialContext,
-				ResponseHeaderTimeout: 10 * time.Second,
-				TLSHandshakeTimeout:   5 * time.Second,
+				ResponseHeaderTimeout: time.Duration(p.ResponseHeaderTimeout),
+				TLSHandshakeTimeout:   time.Duration(p.TLSHandshakeTimeout),
 				TLSClientConfig:       TLSConfig,
 			},
 		}

--- a/provider/marathon/marathon.go
+++ b/provider/marathon/marathon.go
@@ -55,10 +55,10 @@ type Provider struct {
 	MarathonLBCompatibility   bool             `description:"Add compatibility with marathon-lb labels" export:"true"`
 	FilterMarathonConstraints bool             `description:"Enable use of Marathon constraints in constraint filtering" export:"true"`
 	TLS                       *types.ClientTLS `description:"Enable TLS support" export:"true"`
-	DialerTimeout             flaeg.Duration   `description:"Set a non-default dialer timeout for Marathon" export:"true"`
-	ResponseHeaderTimeout     flaeg.Duration   `description:"Set a non-default response header timeout for Marathon" export:"true"`
-	TLSHandshakeTimeout       flaeg.Duration   `description:"Set a non-default TLS handhsake timeout for Marathon" export:"true"`
-	KeepAlive                 flaeg.Duration   `description:"Set a non-default TCP Keep Alive time in seconds" export:"true"`
+	DialerTimeout             flaeg.Duration   `description:"Set a dialer timeout for Marathon" export:"true"`
+	ResponseHeaderTimeout     flaeg.Duration   `description:"Set a response header timeout for Marathon" export:"true"`
+	TLSHandshakeTimeout       flaeg.Duration   `description:"Set a TLS handhsake timeout for Marathon" export:"true"`
+	KeepAlive                 flaeg.Duration   `description:"Set a TCP Keep Alive time in seconds" export:"true"`
 	ForceTaskHostname         bool             `description:"Force to use the task's hostname." export:"true"`
 	Basic                     *Basic           `description:"Enable basic authentication" export:"true"`
 	RespectReadinessChecks    bool             `description:"Filter out tasks with non-successful readiness checks during deployments" export:"true"`

--- a/provider/marathon/marathon.go
+++ b/provider/marathon/marathon.go
@@ -105,7 +105,9 @@ func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *s
 					KeepAlive: time.Duration(p.KeepAlive),
 					Timeout:   time.Duration(p.DialerTimeout),
 				}).DialContext,
-				TLSClientConfig: TLSConfig,
+				ResponseHeaderTimeout: 10 * time.Second,
+				TLSHandshakeTimeout:   5 * time.Second,
+				TLSClientConfig:       TLSConfig,
 			},
 		}
 		client, err := marathon.NewClient(config)


### PR DESCRIPTION
### What does this PR do?

Set sane timeouts for requests to Marathon and make them configurable.

### Motivation

Before the timeouts were either overly excessive or not existent at all. For requests done by go-marathon there was no timeout, which means when there was temporarily a network problem which doesn't immediately show a failure (e.g. when the packets are dropped by a firewall) Traefik will never be able to create a connection to Marathon, as this one request will be running basically forever. I used the same timeouts as go-marathon does by default. We have to do this in Traefik as we pass in our own http.Client.

### More

- [x]  Added/updated tests: -> no adaption of tests required for this PR
- [x] Added/updated documentation
