### PR TITLE
webui: display health durations with a 3 digits precision

### DIFF
--- a/webui/src/app/components/health/health.component.ts
+++ b/webui/src/app/components/health/health.component.ts
@@ -41,8 +41,9 @@ export class HealthComponent implements OnInit, OnDestroy {
           this.pid = data.pid;
           this.uptime = distanceInWordsStrict(subSeconds(new Date(), data.uptime_sec), new Date());
           this.uptimeSince = format(subSeconds(new Date(), data.uptime_sec), 'MM/DD/YYYY HH:mm:ss');
-          this.totalResponseTime = data.total_response_time;
-          this.averageResponseTime = data.average_response_time;
+          const re = /(.*\.\d{3})\d+(.*)/    // To display up to 3 digits of precision in durations
+          this.totalResponseTime = data.total_response_time.replace(re, '$1$2');
+          this.averageResponseTime = data.average_response_time.replace(re, '$1$2');
           this.codeCount = data.count;
           this.totalCodeCount = data.total_count;
         }


### PR DESCRIPTION

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/.github/CONTRIBUTING.md.

-->

### What does this PR do?

webui: display health durations with a 3 digits precision

### Motivation
So instead of `10h50m42.15673436371s`, display `10h50m42.156s`
It is applied to "total response time" and "average response time".

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
