### PR TITLE
Fix backend reuse

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -950,7 +950,7 @@ func (s *Server) loadConfig(configurations types.Configurations, globalConfigura
 						redirectHandlers[entryPointName] = handlerToUse
 					}
 				}
-				if backends[entryPointName+providerName+frontend.Backend] == nil {
+				if backends[entryPointName+providerName+frontend.Hash()] == nil {
 					log.Debugf("Creating backend %s", frontend.Backend)
 
 					roundTripper, err := s.getRoundTripper(entryPointName, globalConfiguration, frontend.PassTLSCert, entryPoint.TLS)
@@ -1208,14 +1208,14 @@ func (s *Server) loadConfig(configurations types.Configurations, globalConfigura
 					} else {
 						n.UseHandler(lb)
 					}
-					backends[entryPointName+providerName+frontend.Backend] = n
+					backends[entryPointName+providerName+frontend.Hash()] = n
 				} else {
 					log.Debugf("Reusing backend %s", frontend.Backend)
 				}
 				if frontend.Priority > 0 {
 					newServerRoute.Route.Priority(frontend.Priority)
 				}
-				s.wireFrontendBackend(newServerRoute, backends[entryPointName+providerName+frontend.Backend])
+				s.wireFrontendBackend(newServerRoute, backends[entryPointName+providerName+frontend.Hash()])
 
 				err := newServerRoute.Route.GetError()
 				if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -950,7 +950,14 @@ func (s *Server) loadConfig(configurations types.Configurations, globalConfigura
 						redirectHandlers[entryPointName] = handlerToUse
 					}
 				}
-				backendCacheKey := entryPointName + providerName + frontend.Hash()
+
+				frontendHash, err := frontend.Hash()
+				if err != nil {
+					log.Errorf("Error calculating hash value for frontend %s: %v", frontendName, err)
+					log.Errorf("Skipping frontend %s...", frontendName)
+					continue frontend
+				}
+				backendCacheKey := entryPointName + providerName + frontendHash
 				if backends[backendCacheKey] == nil {
 					log.Debugf("Creating backend %s", frontend.Backend)
 
@@ -1218,7 +1225,7 @@ func (s *Server) loadConfig(configurations types.Configurations, globalConfigura
 				}
 				s.wireFrontendBackend(newServerRoute, backends[backendCacheKey])
 
-				err := newServerRoute.Route.GetError()
+				err = newServerRoute.Route.GetError()
 				if err != nil {
 					log.Errorf("Error building route: %s", err)
 				}

--- a/server/server.go
+++ b/server/server.go
@@ -950,7 +950,8 @@ func (s *Server) loadConfig(configurations types.Configurations, globalConfigura
 						redirectHandlers[entryPointName] = handlerToUse
 					}
 				}
-				if backends[entryPointName+providerName+frontend.Hash()] == nil {
+				backendCacheKey := entryPointName + providerName + frontend.Hash()
+				if backends[backendCacheKey] == nil {
 					log.Debugf("Creating backend %s", frontend.Backend)
 
 					roundTripper, err := s.getRoundTripper(entryPointName, globalConfiguration, frontend.PassTLSCert, entryPoint.TLS)
@@ -1208,14 +1209,14 @@ func (s *Server) loadConfig(configurations types.Configurations, globalConfigura
 					} else {
 						n.UseHandler(lb)
 					}
-					backends[entryPointName+providerName+frontend.Hash()] = n
+					backends[backendCacheKey] = n
 				} else {
 					log.Debugf("Reusing backend %s", frontend.Backend)
 				}
 				if frontend.Priority > 0 {
 					newServerRoute.Route.Priority(frontend.Priority)
 				}
-				s.wireFrontendBackend(newServerRoute, backends[entryPointName+providerName+frontend.Hash()])
+				s.wireFrontendBackend(newServerRoute, backends[backendCacheKey])
 
 				err := newServerRoute.Route.GetError()
 				if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -1053,7 +1053,7 @@ func (s *Server) loadConfig(configurations types.Configurations, globalConfigura
 						if hcOpts != nil {
 							log.Debugf("Setting up backend health check %s", *hcOpts)
 							hcOpts.Transport = s.defaultForwardingRoundTripper
-							backendsHealthCheck[entryPointName+frontend.Backend] = healthcheck.NewBackendHealthCheck(*hcOpts, frontend.Backend)
+							backendsHealthCheck[backendCacheKey] = healthcheck.NewBackendHealthCheck(*hcOpts, frontend.Backend)
 						}
 						lb = middlewares.NewEmptyBackendHandler(rebalancer, lb)
 					case types.Wrr:
@@ -1075,7 +1075,7 @@ func (s *Server) loadConfig(configurations types.Configurations, globalConfigura
 						if hcOpts != nil {
 							log.Debugf("Setting up backend health check %s", *hcOpts)
 							hcOpts.Transport = s.defaultForwardingRoundTripper
-							backendsHealthCheck[entryPointName+frontend.Backend] = healthcheck.NewBackendHealthCheck(*hcOpts, frontend.Backend)
+							backendsHealthCheck[backendCacheKey] = healthcheck.NewBackendHealthCheck(*hcOpts, frontend.Backend)
 						}
 						lb = middlewares.NewEmptyBackendHandler(rr, lb)
 					}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -962,7 +962,7 @@ func TestServerResponseEmptyBackend(t *testing.T) {
 	}
 }
 
-func TestBackendCaching(t *testing.T) {
+func TestReuseBackend(t *testing.T) {
 	testServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusOK)
 	}))
@@ -981,10 +981,12 @@ func TestBackendCaching(t *testing.T) {
 	dynamicConfigs := types.Configurations{
 		"config": th.BuildConfiguration(
 			th.WithFrontends(
-				th.WithFrontend("frontend0", "backend",
+				th.WithFrontend("backend",
+					th.WithFrontendName("frontend0"),
 					th.WithEntryPoints("http"),
 					th.WithRoutes(th.WithRoute("/ok", "Path: /ok"))),
-				th.WithFrontend("frontend1", "backend",
+				th.WithFrontend("backend",
+					th.WithFrontendName("frontend1"),
 					th.WithEntryPoints("http"),
 					th.WithRoutes(th.WithRoute("/unauthorized", "Path: /unauthorized")),
 					th.WithBasicAuth("foo", "bar")),

--- a/testhelpers/config.go
+++ b/testhelpers/config.go
@@ -137,6 +137,13 @@ func WithRoute(name string, rule string) func(*types.Route) string {
 	}
 }
 
+// WithBasicAuth is a helper to create a configuration
+func WithBasicAuth(username string, password string) func(*types.Frontend) {
+	return func(fe *types.Frontend) {
+		fe.BasicAuth = []string{username + ":" + password}
+	}
+}
+
 // WithLBSticky is a helper to create a configuration
 func WithLBSticky(cookieName string) func(*types.Backend) {
 	return func(b *types.Backend) {

--- a/types/types.go
+++ b/types/types.go
@@ -194,10 +194,14 @@ type Frontend struct {
 }
 
 // Hash returns the hash value of a Frontend struct.
-func (f *Frontend) Hash() string {
-	hash, _ := hashstructure.Hash(f, nil)
+func (f *Frontend) Hash() (string, error) {
+	hash, err := hashstructure.Hash(f, nil)
 
-	return strconv.FormatUint(hash, 10)
+	if err != nil {
+		return "", err
+	}
+
+	return strconv.FormatUint(hash, 10), nil
 }
 
 // Redirect configures a redirection of an entry point to another, or to an URL

--- a/types/types.go
+++ b/types/types.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containous/mux"
 	"github.com/containous/traefik/log"
 	traefiktls "github.com/containous/traefik/tls"
+	"github.com/mitchellh/hashstructure"
 	"github.com/ryanuber/go-glob"
 )
 
@@ -177,9 +178,9 @@ func (h *Headers) HasSecureHeadersDefined() bool {
 
 // Frontend holds frontend configuration.
 type Frontend struct {
-	EntryPoints          []string              `json:"entryPoints,omitempty"`
+	EntryPoints          []string              `json:"entryPoints,omitempty" hash:"ignore"`
 	Backend              string                `json:"backend,omitempty"`
-	Routes               map[string]Route      `json:"routes,omitempty"`
+	Routes               map[string]Route      `json:"routes,omitempty" hash:"ignore"`
 	PassHostHeader       bool                  `json:"passHostHeader,omitempty"`
 	PassTLSCert          bool                  `json:"passTLSCert,omitempty"`
 	Priority             int                   `json:"priority"`
@@ -192,9 +193,11 @@ type Frontend struct {
 	Redirect             *Redirect             `json:"redirect,omitempty"`
 }
 
-// Hash returns a string to cache Fronted by.
+// Hash returns the hash value of a Frontend struct.
 func (f *Frontend) Hash() string {
-	return f.Backend
+	hash, _ := hashstructure.Hash(f, nil)
+
+	return strconv.FormatUint(hash, 10)
 }
 
 // Redirect configures a redirection of an entry point to another, or to an URL

--- a/types/types.go
+++ b/types/types.go
@@ -192,6 +192,11 @@ type Frontend struct {
 	Redirect             *Redirect             `json:"redirect,omitempty"`
 }
 
+// Hash returns a string to cache Fronted by.
+func (f *Frontend) Hash() string {
+	return f.Backend
+}
+
 // Redirect configures a redirection of an entry point to another, or to an URL
 type Redirect struct {
 	EntryPoint  string `json:"entryPoint,omitempty"`


### PR DESCRIPTION
### What does this PR do?

This fixes the way backends are currently cached leading t some frontend configuration being ignored when re-using same backend (reported in #2323).

### Motivation

Not being able to reuse backends in different frontends is unexpected and the workaround results in defining additional, identical backends.

In a current project of mine I could potentially end up with 400 identical backends to work around this.

Fixes  #2323

### More

- [x] Added/updated tests
- [x] Added/updated documentation: No, this fixes a bug in internal behaviour

### Additional Notes

Currently backends are cached under a key generated by `entryPointName+providerName+frontend.Backend`. The `frontend.Backend` doesn't respect the differences present in frontends.

I add `Hash()` method to the `Frontend` struct and use that instead of just the backend name.

The Hash method uses [github.com/mitchellh/hashstructure](https://github.com/mitchellh/hashstructure) which is also used in [collector/collector.go](/containous/traefik/blob/master/collector/collector.go) (a nice feature of it is being able to ignore some fields when computing the hash).

