### PR TITLE
Enable Ingress Status updates

### DIFF
--- a/docs/configuration/backends/kubernetes.md
+++ b/docs/configuration/backends/kubernetes.md
@@ -90,11 +90,11 @@ See also [Kubernetes user guide](/user-guide/kubernetes).
 # [kubernetes.ingressEndpoint]
 #
 # One must be configured.
-# Publishedservice will override the hostname and ip settings if configured.
+# `publishedservice` will override the `hostname` and `ip` settings if configured.
 #
 # hostname = "localhost"
 # ip = "127.0.0.1"
-# publishedService = "default/cheddar"
+# publishedService = "namespace/servicename"
 ```
 
 ### `endpoint`
@@ -121,7 +121,7 @@ See [label-selectors](https://kubernetes.io/docs/concepts/overview/working-with-
 
 ### `ingressEndpoint`
 
-You can configure a static hostname or IP address that traefik will add to the status section of ingress objects that it manages.
+You can configure a static hostname or IP address that Traefik will add to the status section of Ingress objects that it manages.
 If you prefer, you can provide a service, which traefik will copy the status spec from.
 This will give more flexibility in cloud/dynamic environments.
 

--- a/docs/configuration/backends/kubernetes.md
+++ b/docs/configuration/backends/kubernetes.md
@@ -81,6 +81,20 @@ See also [Kubernetes user guide](/user-guide/kubernetes).
 # Default: <built-in template>
 #
 # filename = "kubernetes.tmpl"
+
+# Enable IngressEndpoint configuration.
+# This will allow Traefik to update the status section of ingress objects, if desired.
+#
+# Optional
+#
+# [kubernetes.ingressEndpoint]
+#
+# One must be configured.
+# Publishedservice will override the hostname and ip settings if configured.
+#
+# hostname = "localhost"
+# ip = "127.0.0.1"
+# publishedService = "default/cheddar"
 ```
 
 ### `endpoint`
@@ -105,23 +119,7 @@ A label selector can be defined to filter on specific Ingress objects only.
 
 See [label-selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) for details.
 
-```toml
-# Enable IngressEndpoint configuration.
-# This will allow Traefik to update the status section of ingress objects, if desired.
-#
-# Optional
-#
-[kubernetes.ingressEndpoint]
-
-# One must be configured.
-# Publishedservice will override the hostname and ip settings if configured.
-
-# hostname = localhost
-
-# ip = 127.0.0.1
-
-# publishedservice = default/cheddar
-```
+### `ingressEndpoint`
 
 You can configure a static hostname or IP address that traefik will add to the status section of ingress objects that it manages.
 If you prefer, you can provide a service, which traefik will copy the status spec from.

--- a/docs/configuration/backends/kubernetes.md
+++ b/docs/configuration/backends/kubernetes.md
@@ -105,6 +105,28 @@ A label selector can be defined to filter on specific Ingress objects only.
 
 See [label-selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) for details.
 
+```toml
+# Enable IngressEndpoint configuration.
+# This will allow Traefik to update the status section of ingress objects, if desired.
+#
+# Optional
+#
+[kubernetes.ingressEndpoint]
+
+# One must be configured.
+# Publishedservice will override the hostname and ip settings if configured.
+
+# hostname = localhost
+
+# ip = 127.0.0.1
+
+# publishedservice = default/cheddar
+```
+
+You can configure a static hostname or IP address that traefik will add to the status section of ingress objects that it manages.
+If you prefer, you can provide a service, which traefik will copy the status spec from.
+This will give more flexibility in cloud/dynamic environments.
+
 ### TLS communication between Traefik and backend pods
 
 Traefik automatically requests endpoint information based on the service provided in the ingress spec.

--- a/docs/configuration/backends/kubernetes.md
+++ b/docs/configuration/backends/kubernetes.md
@@ -89,7 +89,7 @@ See also [Kubernetes user guide](/user-guide/kubernetes).
 #
 # [kubernetes.ingressEndpoint]
 #
-# One must be configured.
+# At least one must be configured.
 # `publishedservice` will override the `hostname` and `ip` settings if configured.
 #
 # hostname = "localhost"

--- a/provider/kubernetes/builder_service_test.go
+++ b/provider/kubernetes/builder_service_test.go
@@ -45,12 +45,36 @@ func sAnnotation(name string, value string) func(*corev1.Service) {
 }
 
 func sSpec(opts ...func(*corev1.ServiceSpec)) func(*corev1.Service) {
-	return func(i *corev1.Service) {
+	return func(s *corev1.Service) {
 		spec := &corev1.ServiceSpec{}
 		for _, opt := range opts {
 			opt(spec)
 		}
-		i.Spec = *spec
+		s.Spec = *spec
+	}
+}
+
+func sLoadBalancerStatus(opts ...func(*corev1.LoadBalancerStatus)) func(service *corev1.Service) {
+	return func(s *corev1.Service) {
+		loadBalancer := &corev1.LoadBalancerStatus{}
+		for _, opt := range opts {
+			if opt != nil {
+				opt(loadBalancer)
+			}
+		}
+		s.Status = corev1.ServiceStatus{
+			LoadBalancer: *loadBalancer,
+		}
+	}
+}
+
+func sLoadBalancerIngress(ip string, hostname string) func(*corev1.LoadBalancerStatus) {
+	return func(status *corev1.LoadBalancerStatus) {
+		ingress := corev1.LoadBalancerIngress{
+			IP:       ip,
+			Hostname: hostname,
+		}
+		status.Ingress = append(status.Ingress, ingress)
 	}
 }
 

--- a/provider/kubernetes/client.go
+++ b/provider/kubernetes/client.go
@@ -169,12 +169,14 @@ func (c *clientImpl) GetIngresses() []*extensionsv1beta1.Ingress {
 
 // UpdateIngressStatus updates an Ingress with a provided status.
 func (c *clientImpl) UpdateIngressStatus(namespace, name, ip, hostname string) error {
-	item, exists, err := c.factories[c.lookupNamespace(namespace)].Extensions().V1beta1().Ingresses().Informer().GetStore().GetByKey(namespace + "/" + name)
+	keyName := namespace + "/" + name
+
+	item, exists, err := c.factories[c.lookupNamespace(namespace)].Extensions().V1beta1().Ingresses().Informer().GetStore().GetByKey(keyName)
 	if err != nil {
-		return fmt.Errorf("failed to get ingress %s/%s with error: %v", namespace, name, err)
+		return fmt.Errorf("failed to get ingress %s with error: %v", keyName, err)
 	}
 	if !exists {
-		return fmt.Errorf("failed to update ingress %s/%s because it does not exist", namespace, name)
+		return fmt.Errorf("failed to update ingress %s because it does not exist", keyName)
 	}
 
 	ing := item.(*extensionsv1beta1.Ingress)
@@ -187,9 +189,9 @@ func (c *clientImpl) UpdateIngressStatus(namespace, name, ip, hostname string) e
 
 		_, err := c.clientset.ExtensionsV1beta1().Ingresses(ingCopy.Namespace).UpdateStatus(ingCopy)
 		if err != nil {
-			return fmt.Errorf("failed to update ingress status %s/%s with error: %v", namespace, name, err)
+			return fmt.Errorf("failed to update ingress status %s with error: %v", keyName, err)
 		}
-		log.Infof("Updated status on ingress %s/%s", namespace, name)
+		log.Infof("Updated status on ingress %s", keyName)
 	}
 	return nil
 }

--- a/provider/kubernetes/client_mock_test.go
+++ b/provider/kubernetes/client_mock_test.go
@@ -64,3 +64,7 @@ func (c clientMock) GetSecret(namespace, name string) (*corev1.Secret, bool, err
 func (c clientMock) WatchAll(namespaces Namespaces, stopCh <-chan struct{}) (<-chan interface{}, error) {
 	return c.watchChan, nil
 }
+
+func (c clientMock) UpdateIngressStatus(namespace, name, ip, hostname string) error {
+	return nil
+}

--- a/provider/kubernetes/client_mock_test.go
+++ b/provider/kubernetes/client_mock_test.go
@@ -12,9 +12,10 @@ type clientMock struct {
 	endpoints []*corev1.Endpoints
 	watchChan chan interface{}
 
-	apiServiceError   error
-	apiSecretError    error
-	apiEndpointsError error
+	apiServiceError       error
+	apiSecretError        error
+	apiEndpointsError     error
+	apiIngressStatusError error
 }
 
 func (c clientMock) GetIngresses() []*extensionsv1beta1.Ingress {
@@ -31,7 +32,7 @@ func (c clientMock) GetService(namespace, name string) (*corev1.Service, bool, e
 			return service, true, nil
 		}
 	}
-	return nil, false, nil
+	return nil, false, c.apiServiceError
 }
 
 func (c clientMock) GetEndpoints(namespace, name string) (*corev1.Endpoints, bool, error) {
@@ -66,5 +67,5 @@ func (c clientMock) WatchAll(namespaces Namespaces, stopCh <-chan struct{}) (<-c
 }
 
 func (c clientMock) UpdateIngressStatus(namespace, name, ip, hostname string) error {
-	return nil
+	return c.apiIngressStatusError
 }

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -339,7 +339,7 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 
 		err = p.updateIngressStatus(i, k8sClient)
 		if err != nil {
-			log.Printf("cannot update Ingress %s/%s due to error: %s", i.Namespace, i.Name, err)
+			log.Errorf("Cannot update Ingress %s/%s due to error: %v", i.Namespace, i.Name, err)
 		}
 	}
 	return &templateObjects, nil

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -359,8 +359,11 @@ func (p *Provider) updateIngressStatus(i *extensionsv1beta1.Ingress, k8sClient C
 		return k8sClient.UpdateIngressStatus(i.Namespace, i.Name, p.IngressEndpoint.IP, p.IngressEndpoint.Hostname)
 	}
 
-	serviceInfos := strings.Split(p.IngressEndpoint.PublishedService, "/")
-	serviceNamespace, serviceName := serviceInfos[0], serviceInfos[1]
+	serviceInfo := strings.Split(p.IngressEndpoint.PublishedService, "/")
+	if len(serviceInfo) != 2 {
+		return fmt.Errorf("invalid publishedService format (expected 'namespace/service' format): %s", p.IngressEndpoint.PublishedService)
+	}
+	serviceNamespace, serviceName := serviceInfo[0], serviceInfo[1]
 
 	service, exists, err := k8sClient.GetService(serviceNamespace, serviceName)
 	if err != nil {

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -351,7 +351,11 @@ func (p *Provider) updateIngressStatus(i *extensionsv1beta1.Ingress, k8sClient C
 		return nil
 	}
 
-	if p.IngressEndpoint.PublishedService == "" {
+	if len(p.IngressEndpoint.PublishedService) == 0 {
+		if len(p.IngressEndpoint.IP) == 0 && len(p.IngressEndpoint.Hostname) == 0 {
+			return errors.New("publishedService or ip or hostname must be defined")
+		}
+
 		return k8sClient.UpdateIngressStatus(i.Namespace, i.Name, p.IngressEndpoint.IP, p.IngressEndpoint.Hostname)
 	}
 

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -36,17 +36,25 @@ const (
 	traefikDefaultIngressClass = "traefik"
 )
 
+// IngressEndpoint holds the endpoint information for the Kubernetes provider
+type IngressEndpoint struct {
+	IP               string `description:"IP used for Kubernetes Ingress endpoints"`
+	Hostname         string `description:"Hostname used for Kubernetes Ingress endpoints"`
+	PublishedService string `description:"Published Kubernetes Service to copy status from"`
+}
+
 // Provider holds configurations of the provider.
 type Provider struct {
 	provider.BaseProvider  `mapstructure:",squash" export:"true"`
-	Endpoint               string     `description:"Kubernetes server endpoint (required for external cluster client)"`
-	Token                  string     `description:"Kubernetes bearer token (not needed for in-cluster client)"`
-	CertAuthFilePath       string     `description:"Kubernetes certificate authority file path (not needed for in-cluster client)"`
-	DisablePassHostHeaders bool       `description:"Kubernetes disable PassHost Headers" export:"true"`
-	EnablePassTLSCert      bool       `description:"Kubernetes enable Pass TLS Client Certs" export:"true"`
-	Namespaces             Namespaces `description:"Kubernetes namespaces" export:"true"`
-	LabelSelector          string     `description:"Kubernetes Ingress label selector to use" export:"true"`
-	IngressClass           string     `description:"Value of kubernetes.io/ingress.class annotation to watch for" export:"true"`
+	Endpoint               string           `description:"Kubernetes server endpoint (required for external cluster client)"`
+	Token                  string           `description:"Kubernetes bearer token (not needed for in-cluster client)"`
+	CertAuthFilePath       string           `description:"Kubernetes certificate authority file path (not needed for in-cluster client)"`
+	DisablePassHostHeaders bool             `description:"Kubernetes disable PassHost Headers" export:"true"`
+	EnablePassTLSCert      bool             `description:"Kubernetes enable Pass TLS Client Certs" export:"true"`
+	Namespaces             Namespaces       `description:"Kubernetes namespaces" export:"true"`
+	LabelSelector          string           `description:"Kubernetes Ingress label selector to use" export:"true"`
+	IngressClass           string           `description:"Value of kubernetes.io/ingress.class annotation to watch for" export:"true"`
+	IngressEndpoint        *IngressEndpoint `description:"Kubernetes Ingress Endpoint"`
 	lastConfiguration      safe.Safe
 }
 
@@ -125,10 +133,12 @@ func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *s
 						return nil
 					case event := <-eventsChan:
 						log.Debugf("Received Kubernetes event kind %T", event)
+
 						templateObjects, err := p.loadIngresses(k8sClient)
 						if err != nil {
 							return err
 						}
+
 						if reflect.DeepEqual(p.lastConfiguration.Get(), templateObjects) {
 							log.Debugf("Skipping Kubernetes event kind %T", event)
 						} else {
@@ -326,8 +336,43 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 				}
 			}
 		}
+
+		err = p.updateIngressStatus(i, k8sClient)
+		if err != nil {
+			log.Printf("cannot update Ingress %s/%s due to error: %s", i.Namespace, i.Name, err)
+		}
 	}
 	return &templateObjects, nil
+}
+
+func (p *Provider) updateIngressStatus(i *extensionsv1beta1.Ingress, k8sClient Client) error {
+	// Only process if an IngressEndpoint has been configured
+	if p.IngressEndpoint != nil {
+		if p.IngressEndpoint.PublishedService == "" {
+			return k8sClient.UpdateIngressStatus(i.Namespace, i.Name, p.IngressEndpoint.IP, p.IngressEndpoint.Hostname)
+		}
+
+		serviceInfos := strings.Split(p.IngressEndpoint.PublishedService, "/")
+		serviceNamespace, serviceName := serviceInfos[0], serviceInfos[1]
+
+		service, exists, err := k8sClient.GetService(serviceNamespace, serviceName)
+		if err != nil {
+			return fmt.Errorf("cannot get service %s, received error: %s", p.IngressEndpoint.PublishedService, err)
+		}
+
+		if exists && service.Status.LoadBalancer.Ingress == nil {
+			// service exists, but has no Load Balancer status
+			log.Debugf("Skipping updating Ingress %s/%s due to service %s having no status set", i.Namespace, i.Name, p.IngressEndpoint.PublishedService)
+			return nil
+		}
+
+		if !exists {
+			return fmt.Errorf("missing service: %s", p.IngressEndpoint.PublishedService)
+		}
+
+		return k8sClient.UpdateIngressStatus(i.Namespace, i.Name, service.Status.LoadBalancer.Ingress[0].IP, service.Status.LoadBalancer.Ingress[0].Hostname)
+	}
+	return nil
 }
 
 func (p *Provider) loadConfig(templateObjects types.Configuration) *types.Configuration {


### PR DESCRIPTION
### What does this PR do?

Allows Traefik to update the Status section of Ingress objects either via static IP/Hostname configuration, or via extracting the status section of a fronting service.

### Motivation

Fixes #2173

Users requested that the status field be set so that DNS and other discovery tools would work properly.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

This configuration is entirely optional, and will only apply if one of the 3 configuration settings are enabled.
