### PR TITLE
Remove ACME empty certificates from KV store

### DIFF
--- a/acme/account.go
+++ b/acme/account.go
@@ -152,10 +152,22 @@ func (dc *DomainsCertificates) removeDuplicates() {
 	}
 }
 
+func (dc *DomainsCertificates) removeEmpty() {
+	certs := []*DomainsCertificate{}
+	for _, cert := range dc.Certs {
+		if cert.Certificate != nil && len(cert.Certificate.Certificate) > 0 && len(cert.Certificate.PrivateKey) > 0 {
+			certs = append(certs, cert)
+		}
+	}
+	dc.Certs = certs
+}
+
 // Init DomainsCertificates
 func (dc *DomainsCertificates) Init() error {
 	dc.lock.Lock()
 	defer dc.lock.Unlock()
+
+	dc.removeEmpty()
 
 	for _, domainsCertificate := range dc.Certs {
 		tlsCert, err := tls.X509KeyPair(domainsCertificate.Certificate.Certificate, domainsCertificate.Certificate.PrivateKey)

--- a/acme/acme_test.go
+++ b/acme/acme_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -547,6 +548,271 @@ func TestAcme_getCertificateForDomain(t *testing.T) {
 			got, found := test.dc.getCertificateForDomain(test.domain)
 			assert.Equal(t, test.expectedFound, found)
 			assert.Equal(t, test.expected, got)
+		})
+	}
+}
+
+func TestRemoveEmptyCertificates(t *testing.T) {
+	now := time.Now()
+	fooCert, fooKey, _ := generate.KeyPair("foo.com", now)
+	acmeCert, acmeKey, _ := generate.KeyPair("acme.wtf", now.Add(24*time.Hour))
+	barCert, barKey, _ := generate.KeyPair("bar.com", now)
+	testCases := []struct {
+		desc       string
+		dc         *DomainsCertificates
+		expectedDc *DomainsCertificates
+	}{
+		{
+			desc: "No empty certificate",
+			dc: &DomainsCertificates{
+				Certs: []*DomainsCertificate{
+					{
+						Certificate: &Certificate{
+							Certificate: fooCert,
+							PrivateKey:  fooKey,
+						},
+						Domains: types.Domain{
+							Main: "foo.com",
+						},
+					},
+					{
+						Certificate: &Certificate{
+							Certificate: acmeCert,
+							PrivateKey:  acmeKey,
+						},
+						Domains: types.Domain{
+							Main: "acme.wtf",
+						},
+					},
+					{
+						Certificate: &Certificate{
+							Certificate: barCert,
+							PrivateKey:  barKey,
+						},
+						Domains: types.Domain{
+							Main: "bar.com",
+						},
+					},
+				},
+			},
+			expectedDc: &DomainsCertificates{
+				Certs: []*DomainsCertificate{
+					{
+						Certificate: &Certificate{
+							Certificate: fooCert,
+							PrivateKey:  fooKey,
+						},
+						Domains: types.Domain{
+							Main: "foo.com",
+						},
+					},
+					{
+						Certificate: &Certificate{
+							Certificate: acmeCert,
+							PrivateKey:  acmeKey,
+						},
+						Domains: types.Domain{
+							Main: "acme.wtf",
+						},
+					},
+					{
+						Certificate: &Certificate{
+							Certificate: barCert,
+							PrivateKey:  barKey,
+						},
+						Domains: types.Domain{
+							Main: "bar.com",
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "First certificate is nil",
+			dc: &DomainsCertificates{
+				Certs: []*DomainsCertificate{
+					{
+						Domains: types.Domain{
+							Main: "foo.com",
+						},
+					},
+					{
+						Certificate: &Certificate{
+							Certificate: acmeCert,
+							PrivateKey:  acmeKey,
+						},
+						Domains: types.Domain{
+							Main: "acme.wtf",
+						},
+					},
+					{
+						Certificate: &Certificate{
+							Certificate: barCert,
+							PrivateKey:  barKey,
+						},
+						Domains: types.Domain{
+							Main: "bar.com",
+						},
+					},
+				},
+			},
+			expectedDc: &DomainsCertificates{
+				Certs: []*DomainsCertificate{
+					{
+						Certificate: &Certificate{
+							Certificate: acmeCert,
+							PrivateKey:  acmeKey,
+						},
+						Domains: types.Domain{
+							Main: "acme.wtf",
+						},
+					},
+					{
+						Certificate: &Certificate{
+							Certificate: nil,
+							PrivateKey:  barKey,
+						},
+						Domains: types.Domain{
+							Main: "bar.com",
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "Last certificate is empty",
+			dc: &DomainsCertificates{
+				Certs: []*DomainsCertificate{
+					{
+						Certificate: &Certificate{
+							Certificate: fooCert,
+							PrivateKey:  fooKey,
+						},
+						Domains: types.Domain{
+							Main: "foo.com",
+						},
+					},
+					{
+						Certificate: &Certificate{
+							Certificate: acmeCert,
+							PrivateKey:  acmeKey,
+						},
+						Domains: types.Domain{
+							Main: "acme.wtf",
+						},
+					},
+					{
+						Certificate: &Certificate{},
+						Domains: types.Domain{
+							Main: "bar.com",
+						},
+					},
+				},
+			},
+			expectedDc: &DomainsCertificates{
+				Certs: []*DomainsCertificate{
+					{
+						Certificate: &Certificate{
+							Certificate: fooCert,
+							PrivateKey:  fooKey,
+						},
+						Domains: types.Domain{
+							Main: "foo.com",
+						},
+					},
+					{
+						Certificate: &Certificate{
+							Certificate: acmeCert,
+							PrivateKey:  acmeKey,
+						},
+						Domains: types.Domain{
+							Main: "acme.wtf",
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "First and last certificates are nil or empty",
+			dc: &DomainsCertificates{
+				Certs: []*DomainsCertificate{
+					{
+						Domains: types.Domain{
+							Main: "foo.com",
+						},
+					},
+					{
+						Certificate: &Certificate{
+							Certificate: acmeCert,
+							PrivateKey:  acmeKey,
+						},
+						Domains: types.Domain{
+							Main: "acme.wtf",
+						},
+					},
+					{
+						Certificate: &Certificate{},
+						Domains: types.Domain{
+							Main: "bar.com",
+						},
+					},
+				},
+			},
+			expectedDc: &DomainsCertificates{
+				Certs: []*DomainsCertificate{
+					{
+						Certificate: &Certificate{
+							Certificate: acmeCert,
+							PrivateKey:  acmeKey,
+						},
+						Domains: types.Domain{
+							Main: "acme.wtf",
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "All certificates are nil or empty",
+			dc: &DomainsCertificates{
+				Certs: []*DomainsCertificate{
+					{
+						Domains: types.Domain{
+							Main: "foo.com",
+						},
+					},
+					{
+						Domains: types.Domain{
+							Main: "foo24.com",
+						},
+					},
+					{
+						Certificate: &Certificate{},
+						Domains: types.Domain{
+							Main: "bar.com",
+						},
+					},
+				},
+			},
+			expectedDc: &DomainsCertificates{
+				Certs: []*DomainsCertificate{},
+			},
+		},
+	}
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			a := &Account{DomainsCertificate: *test.dc}
+			a.Init()
+
+			assert.Equal(t, len(test.expectedDc.Certs), len(a.DomainsCertificate.Certs))
+			sort.Sort(&a.DomainsCertificate)
+			sort.Sort(test.expectedDc)
+			for key, value := range test.expectedDc.Certs {
+				assert.Equal(t, value.Domains.Main, a.DomainsCertificate.Certs[key].Domains.Main)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Delete the empty ACME certificates from KV store as we do when certificates are stored in a file.

### Motivation

<!-- What inspired you to submit this pull request? -->

Allow regenerating in ACME malformed certificates.
Be homogeneouse between KV store and file storages.

Fixes #3372 
Related #3162, #3191 

### More

- [x] Added/updated tests

