### PR TITLE
Reflect changes in catalog healthy nodes in healthCheck watch

### DIFF
--- a/integration/consul_catalog_test.go
+++ b/integration/consul_catalog_test.go
@@ -42,7 +42,7 @@ func (s *ConsulCatalogSuite) waitToElectConsulLeader() error {
 		leader, err := s.consulClient.Status().Leader()
 
 		if err != nil || len(leader) == 0 {
-			return fmt.Errorf("Leader not found. %v", err)
+			return fmt.Errorf("leader not found. %v", err)
 		}
 
 		return nil

--- a/integration/consul_catalog_test.go
+++ b/integration/consul_catalog_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"time"
@@ -55,9 +56,6 @@ func (s *ConsulCatalogSuite) createConsulClient(config *api.Config, c *check.C) 
 	s.consulClient = consulClient
 	return consulClient
 }
-func (s *ConsulCatalogSuite) startConsulService(c *check.C) {
-
-}
 
 func (s *ConsulCatalogSuite) registerService(name string, address string, port int, tags []string) error {
 	catalog := s.consulClient.Catalog()
@@ -80,7 +78,7 @@ func (s *ConsulCatalogSuite) registerService(name string, address string, port i
 
 func (s *ConsulCatalogSuite) registerAgentService(name string, address string, port int, tags []string) error {
 	agent := s.consulClient.Agent()
-	err := agent.ServiceRegister(
+	return agent.ServiceRegister(
 		&api.AgentServiceRegistration{
 			ID:      address,
 			Tags:    tags,
@@ -93,13 +91,24 @@ func (s *ConsulCatalogSuite) registerAgentService(name string, address string, p
 			},
 		},
 	)
-	return err
+}
+
+func (s *ConsulCatalogSuite) registerCheck(name string, address string, port int) error {
+	agent := s.consulClient.Agent()
+	checkRegistration := &api.AgentCheckRegistration{
+		ID:        fmt.Sprintf("%s-%s", name, address),
+		Name:      name,
+		ServiceID: address,
+	}
+	checkRegistration.HTTP = fmt.Sprintf("http://%s:%d/health", address, port)
+	checkRegistration.Interval = "2s"
+	checkRegistration.CheckID = address
+	return agent.CheckRegister(checkRegistration)
 }
 
 func (s *ConsulCatalogSuite) deregisterAgentService(address string) error {
 	agent := s.consulClient.Agent()
-	err := agent.ServiceDeregister(address)
-	return err
+	return agent.ServiceDeregister(address)
 }
 
 func (s *ConsulCatalogSuite) deregisterService(name string, address string) error {
@@ -511,6 +520,79 @@ func (s *ConsulCatalogSuite) TestRetryWithConsulServer(c *check.C) {
 	c.Assert(err, checker.IsNil)
 
 	// Should be ok
+	err = try.Request(req, 10*time.Second, try.StatusCodeIs(http.StatusOK), try.HasBody())
+	c.Assert(err, checker.IsNil)
+}
+
+func (s *ConsulCatalogSuite) TestServiceWithMultipleHealthCheck(c *check.C) {
+	//Scale consul to 0 to be able to start traefik before and test retry
+	s.composeProject.Scale(c, "consul", 0)
+
+	cmd, display := s.traefikCmd(
+		withConfigFile("fixtures/consul_catalog/simple.toml"),
+		"--consulCatalog",
+		"--consulCatalog.watch=false",
+		"--consulCatalog.exposedByDefault=true",
+		"--consulCatalog.endpoint="+s.consulIP+":8500",
+		"--consulCatalog.domain=consul.localhost")
+	defer display(c)
+	err := cmd.Start()
+	c.Assert(err, checker.IsNil)
+	defer cmd.Process.Kill()
+
+	// Wait for Traefik to turn ready.
+	err = try.GetRequest("http://127.0.0.1:8000/", 2*time.Second, try.StatusCodeIs(http.StatusNotFound))
+	c.Assert(err, checker.IsNil)
+
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8000/", nil)
+	c.Assert(err, checker.IsNil)
+	req.Host = "test.consul.localhost"
+
+	// Request should fail
+	err = try.Request(req, 2*time.Second, try.StatusCodeIs(http.StatusNotFound), try.HasBody())
+	c.Assert(err, checker.IsNil)
+
+	// Scale consul to 1
+	s.composeProject.Scale(c, "consul", 1)
+	s.waitToElectConsulLeader()
+
+	whoami := s.composeProject.Container(c, "whoami1")
+	// Register service
+	err = s.registerAgentService("test", whoami.NetworkSettings.IPAddress, 80, []string{"name=whoami1"})
+	c.Assert(err, checker.IsNil, check.Commentf("Error registering agent service"))
+	defer s.deregisterAgentService(whoami.NetworkSettings.IPAddress)
+
+	// Register one healthcheck
+	err = s.registerCheck("test", whoami.NetworkSettings.IPAddress, 80)
+	c.Assert(err, checker.IsNil, check.Commentf("Error registering check"))
+
+	// Provider consul catalog should be present
+	err = try.GetRequest("http://127.0.0.1:8080/api/providers", 10*time.Second, try.BodyContains("consul_catalog"))
+	c.Assert(err, checker.IsNil)
+
+	// Should be ok
+	err = try.Request(req, 10*time.Second, try.StatusCodeIs(http.StatusOK), try.HasBody())
+	c.Assert(err, checker.IsNil)
+
+	// Change health value of service to critical
+	reqHealth, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s:80/health", whoami.NetworkSettings.IPAddress), bytes.NewBuffer([]byte("500")))
+	c.Assert(err, checker.IsNil)
+	reqHealth.Host = "test.consul.localhost"
+
+	err = try.Request(reqHealth, 10*time.Second, try.StatusCodeIs(http.StatusOK))
+	c.Assert(err, checker.IsNil)
+
+	// Should be a 404
+	err = try.Request(req, 10*time.Second, try.StatusCodeIs(http.StatusNotFound), try.HasBody())
+	c.Assert(err, checker.IsNil)
+
+	// Change health value of service to passing
+	reqHealth, err = http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s:80/health", whoami.NetworkSettings.IPAddress), bytes.NewBuffer([]byte("200")))
+	c.Assert(err, checker.IsNil)
+	err = try.Request(reqHealth, 10*time.Second, try.StatusCodeIs(http.StatusOK))
+	c.Assert(err, checker.IsNil)
+
+	// Should be a 200
 	err = try.Request(req, 10*time.Second, try.StatusCodeIs(http.StatusOK), try.HasBody())
 	c.Assert(err, checker.IsNil)
 }

--- a/provider/consulcatalog/consul_catalog.go
+++ b/provider/consulcatalog/consul_catalog.go
@@ -274,7 +274,6 @@ func (p *Provider) watchHealthState(stopCh <-chan struct{}, watchCh chan<- map[s
 				return
 			}
 
-
 			var current = make(map[string][]string)
 			if healthyState != nil {
 				for _, healthy := range healthyState {


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Resolve issue that "Traefik does not refresh backend list on state change of consul catalog health checks" 

### Motivation

<!-- What inspired you to submit this pull request? -->
The list of backends were not being reflected in Traefik with changes in health checks of nodes.

Fixes #3380
Related to #3157

### More

- [x] Added/updated tests

