### PR TITLE
Fix the Consulcatalog provider not refreshing a service with multiple health checks

### DIFF
--- a/provider/consulcatalog/consul_catalog.go
+++ b/provider/consulcatalog/consul_catalog.go
@@ -277,7 +277,7 @@ func (p *Provider) watchHealthState(stopCh <-chan struct{}, watchCh chan<- map[s
 			var current []string
 			if healthyState != nil {
 				for _, healthy := range healthyState {
-					current = append(current, healthy.ServiceID)
+					current = append(current, healthy.CheckID)
 				}
 
 			}


### PR DESCRIPTION
### What does this PR do?

Fixes an issue with the Consulcatalog provider when there are multiple health checks defined for a service, and only part of them starts failing or comes back. Because only Service IDs were previously collected, the set of them didn't change. Check IDs should be unique, so we'll notice when any of them goes away or comes back.

### Motivation

I was setting up some demos with Traefik and Consul, and it was bothering me why it doesn't always work. :)
See an example here: https://github.com/rycus86/podlike/tree/master/examples/service-mesh

### More

- [x] Added/updated tests
- [ ] ~~Added/updated documentation~~

### Additional Notes

Thank you!
