### PR TITLE
Improve ACME account registration URI management

### DIFF
--- a/acme/account.go
+++ b/acme/account.go
@@ -46,7 +46,7 @@ func (a *Account) Init() error {
 
 	err = a.RemoveAccountV1Values()
 	if err != nil {
-		log.Errorf("Unable to remove ACME Account V1 values during account initialization: %s", err.Error())
+		log.Errorf("Unable to remove ACME Account V1 values during account initialization: %v", err)
 	}
 
 	for _, cert := range a.ChallengeCerts {

--- a/acme/acme.go
+++ b/acme/acme.go
@@ -178,6 +178,10 @@ func (a *ACME) leadershipListener(elected bool) error {
 
 		account := object.(*Account)
 		account.Init()
+		// Reset Account values if caServer changed, thus registration URI can be updated
+		if account != nil && account.Registration != nil && !strings.HasPrefix(account.Registration.URI, a.CAServer) {
+			account.reset()
+		}
 
 		var needRegister bool
 		if account == nil || len(account.Email) == 0 {

--- a/acme/localStore.go
+++ b/acme/localStore.go
@@ -80,13 +80,13 @@ func ConvertToNewFormat(fileName string) {
 		if account != nil && len(account.Email) > 0 {
 			err = backupACMEFile(fileName, account)
 			if err != nil {
-				log.Errorf("Unable to create a backup for the V1 formatted ACME file: %s", err.Error())
+				log.Errorf("Unable to create a backup for the V1 formatted ACME file: %v", err)
 				return
 			}
 
 			err = account.RemoveAccountV1Values()
 			if err != nil {
-				log.Errorf("Unable to remove ACME Account V1 values during format conversion: %s", err.Error())
+				log.Errorf("Unable to remove ACME Account V1 values during format conversion: %v", err)
 				return
 			}
 

--- a/acme/localStore.go
+++ b/acme/localStore.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
-	"regexp"
 
 	"github.com/containous/traefik/log"
 	"github.com/containous/traefik/provider/acme"
@@ -51,24 +50,6 @@ func (s *LocalStore) Get() (*Account, error) {
 	return account, nil
 }
 
-// RemoveAccountV1Values removes ACME account V1 values
-func RemoveAccountV1Values(account *Account) error {
-	// Check if ACME Account is in ACME V1 format
-	if account != nil && account.Registration != nil {
-		isOldRegistration, err := regexp.MatchString(acme.RegistrationURLPathV1Regexp, account.Registration.URI)
-		if err != nil {
-			return err
-		}
-
-		if isOldRegistration {
-			account.Email = ""
-			account.Registration = nil
-			account.PrivateKey = nil
-		}
-	}
-	return nil
-}
-
 // ConvertToNewFormat converts old acme.json format to the new one and store the result into the file (used for the backward compatibility)
 func ConvertToNewFormat(fileName string) {
 	localStore := acme.NewLocalStore(fileName)
@@ -103,9 +84,9 @@ func ConvertToNewFormat(fileName string) {
 				return
 			}
 
-			err = RemoveAccountV1Values(account)
+			err = account.RemoveAccountV1Values()
 			if err != nil {
-				log.Errorf("Unable to remove ACME Account V1 values: %s", err.Error())
+				log.Errorf("Unable to remove ACME Account V1 values during format conversion: %s", err.Error())
 				return
 			}
 

--- a/cmd/storeconfig/storeconfig.go
+++ b/cmd/storeconfig/storeconfig.go
@@ -140,7 +140,7 @@ func migrateACMEData(fileName string) (*acme.Account, error) {
 				return nil, err
 			}
 
-			err = acme.RemoveAccountV1Values(account)
+			err = account.RemoveAccountV1Values()
 			if err != nil {
 				return nil, err
 			}

--- a/provider/acme/local_store.go
+++ b/provider/acme/local_store.go
@@ -60,6 +60,7 @@ func (s *LocalStore) get() (*StoredData, error) {
 					return nil, err
 				}
 				if isOldRegistration {
+					log.Debug("Reset ACME account.")
 					s.storedData.Account = nil
 					s.SaveDataChan <- s.storedData
 				}

--- a/provider/acme/provider.go
+++ b/provider/acme/provider.go
@@ -114,6 +114,11 @@ func (p *Provider) init() error {
 		return fmt.Errorf("unable to get ACME account : %v", err)
 	}
 
+	// Reset Account if caServer changed, thus registration URI can be updated
+	if p.account != nil && p.account.Registration != nil && !strings.HasPrefix(p.account.Registration.URI, p.CAServer) {
+		p.account = nil
+	}
+
 	p.certificates, err = p.Store.GetCertificates()
 	if err != nil {
 		return fmt.Errorf("unable to get ACME certificates : %v", err)
@@ -315,7 +320,6 @@ func (p *Provider) getClient() (*acme.Client, error) {
 		}
 		p.client = client
 	}
-
 	return p.client, nil
 }
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This PR allows improving the ACME registration URI management by adding an automatic update when caServer is modified.

### Motivation

<!-- What inspired you to submit this pull request? -->
- Be homogeneouse between KV store and file : the ACME URI registration is now automatically updated during migration from ACME V1 to ACME V2.
- Update automatically the value if the `acme.caServer` option is updated.

Related to https://github.com/containous/traefik/issues/3372#issuecomment-391641704

### Additional Notes

<!-- Anything else we should know when reviewing? -->
