### PR TITLE
Add xforwarded method

### DIFF
--- a/middlewares/auth/forward.go
+++ b/middlewares/auth/forward.go
@@ -14,7 +14,8 @@ import (
 )
 
 const (
-	xForwardedURI = "X-Forwarded-Uri"
+	xForwardedURI    = "X-Forwarded-Uri"
+	xForwardedMethod = "X-Forwarded-Method"
 )
 
 // Forward the authentication to a external server
@@ -107,6 +108,14 @@ func writeHeader(req *http.Request, forwardReq *http.Request, trustForwardHeader
 			}
 		}
 		forwardReq.Header.Set(forward.XForwardedFor, clientIP)
+	}
+
+	if xMethod := req.Header.Get(xForwardedMethod); xMethod != "" && trustForwardHeader {
+		forwardReq.Header.Set(xForwardedMethod, xMethod)
+	} else if req.Method != "" {
+		forwardReq.Header.Set(xForwardedMethod, req.Method)
+	} else {
+		forwardReq.Header.Del(xForwardedMethod)
 	}
 
 	if xfp := req.Header.Get(forward.XForwardedProto); xfp != "" && trustForwardHeader {

--- a/middlewares/auth/forward_test.go
+++ b/middlewares/auth/forward_test.go
@@ -257,6 +257,25 @@ func Test_writeHeader(t *testing.T) {
 				"X-Forwarded-Host": "foo.bar",
 				"X-Forwarded-Uri":  "/path?q=1",
 			},
+		}, {
+			name: "trust Forward Header with forwarded request Method",
+			headers: map[string]string{
+				"X-Forwarded-Method": "OPTIONS",
+			},
+			trustForwardHeader: true,
+			expectedHeaders: map[string]string{
+				"X-Forwarded-Method": "OPTIONS",
+			},
+		},
+		{
+			name: "not trust Forward Header with forward request Method",
+			headers: map[string]string{
+				"X-Forwarded-Method": "OPTIONS",
+			},
+			trustForwardHeader: false,
+			expectedHeaders: map[string]string{
+				"X-Forwarded-Method": "GET",
+			},
 		},
 	}
 


### PR DESCRIPTION
### What does this PR do?
Added requested Method to auth server for Forward Authentication.

### Motivation
Missing feature for authentication decision based on the request method. For example CORS responses can not be forwarded to API-endpoints without the ability to white list OPTIONS in the auth server.  This could also be solved by https://github.com/containous/traefik/issues/2162 but this ticket still holds merit.

### More
Added implementation and test.

### Additional Notes
The PR is very close cousin of https://github.com/containous/traefik/pull/2398/
[There is no standard header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers) for forwarding the HTTP Verb so I went with `X-Forwarded-Method`

