### PR TITLE
Update Kubernetes provider to support IPv6 Backends

### DIFF
--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"net"
 	"os"
 	"reflect"
 	"strconv"
@@ -302,7 +303,7 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 
 							for _, subset := range endpoints.Subsets {
 								for _, address := range subset.Addresses {
-									url := protocol + "://" + address.IP + ":" + strconv.Itoa(endpointPortNumber(port, subset.Ports))
+									url := protocol + "://" + net.JoinHostPort(address.IP, strconv.Itoa(endpointPortNumber(port, subset.Ports)))
 									name := url
 									if address.TargetRef != nil && address.TargetRef.Name != "" {
 										name = address.TargetRef.Name


### PR DESCRIPTION
### What does this PR do?

Adds brackets around IPv6 Backend Addresses in the Kubernetes Provider


### Motivation

Fixes #3428 


### Additional Notes

The brackets are recommended as per https://tools.ietf.org/html/rfc5952 for portability, and required in certain cases.
