### PR TITLE
examples/k8s: Add missing type on service

### DIFF
--- a/examples/k8s/traefik-ds.yaml
+++ b/examples/k8s/traefik-ds.yaml
@@ -57,3 +57,4 @@ spec:
     - protocol: TCP
       port: 8080
       name: admin
+  type: NodePort


### PR DESCRIPTION
When following the tutorial, k8s complains about the traefik-ingress-service:

```
$ kubectl apply -f traefik-ds.yaml
serviceaccount "traefik-ingress-controller" unchanged
daemonset.extensions "traefik-ingress-controller" created
The Service "traefik-ingress-service" is invalid: 
* spec.ports[0].nodePort: Forbidden: may not be used when `type` is 'ClusterIP'
* spec.ports[1].nodePort: Forbidden: may not be used when `type` is 'ClusterIP
```

The default type seems to be wrong for this use-case. Setting it to the same type as it was previously set by `traefik-deployment.yaml`.