### PR TITLE
Handle buffer pool for oxy

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1217,7 +1217,7 @@
     "roundrobin",
     "utils"
   ]
-  revision = "7a2284ad8d6f4d362a6b38f3cdcc812291dce293"
+  revision = "d5b73186eed4aa34b52748699ad19e90f61d4059"
 
 [[projects]]
   name = "github.com/vulcand/predicate"

--- a/server/bufferpool.go
+++ b/server/bufferpool.go
@@ -1,0 +1,27 @@
+package server
+
+import "sync"
+
+const bufferPoolSize int = 32 * 1024
+
+func newBufferPool() *bufferPool {
+	return &bufferPool{
+		pool: sync.Pool{
+			New: func() interface{} {
+				return make([]byte, bufferPoolSize)
+			},
+		},
+	}
+}
+
+type bufferPool struct {
+	pool sync.Pool
+}
+
+func (b *bufferPool) Get() []byte {
+	return b.pool.Get().([]byte)
+}
+
+func (b *bufferPool) Put(bytes []byte) {
+	b.pool.Put(bytes)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -11,6 +11,7 @@ import (
 	stdlog "log"
 	"net"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"os"
 	"os/signal"
@@ -75,6 +76,7 @@ type Server struct {
 	metricsRegistry               metrics.Registry
 	provider                      provider.Provider
 	configurationListeners        []func(types.Configuration)
+	bufferPool                    httputil.BufferPool
 }
 
 type serverEntryPoints map[string]*serverEntryPoint
@@ -105,6 +107,8 @@ func NewServer(globalConfiguration configuration.GlobalConfiguration, provider p
 	if server.globalConfiguration.API != nil {
 		server.globalConfiguration.API.CurrentConfigurations = &server.currentConfigurations
 	}
+
+	server.bufferPool = newBufferPool()
 
 	server.routinesPool = safe.NewPool(context.Background())
 	server.defaultForwardingRoundTripper = createHTTPTransport(globalConfiguration)
@@ -1001,6 +1005,7 @@ func (s *Server) loadConfig(configurations types.Configurations, globalConfigura
 						forward.ErrorHandler(errorHandler),
 						forward.Rewriter(rewriter),
 						forward.ResponseModifier(responseModifier),
+						forward.BufferPool(s.bufferPool),
 					)
 
 					if err != nil {

--- a/vendor/github.com/vulcand/oxy/forward/fwd.go
+++ b/vendor/github.com/vulcand/oxy/forward/fwd.go
@@ -85,6 +85,14 @@ func ErrorHandler(h utils.ErrorHandler) optSetter {
 	}
 }
 
+// BufferPool specifies a buffer pool for httputil.ReverseProxy.
+func BufferPool(pool httputil.BufferPool) optSetter {
+	return func(f *Forwarder) error {
+		f.bufferPool = pool
+		return nil
+	}
+}
+
 // Stream specifies if HTTP responses should be streamed.
 func Stream(stream bool) optSetter {
 	return func(f *Forwarder) error {
@@ -176,6 +184,8 @@ type httpForwarder struct {
 	tlsClientConfig *tls.Config
 
 	log OxyLogger
+
+	bufferPool httputil.BufferPool
 }
 
 const (
@@ -478,6 +488,7 @@ func (f *httpForwarder) serveHTTP(w http.ResponseWriter, inReq *http.Request, ct
 		Transport:      f.roundTripper,
 		FlushInterval:  f.flushInterval,
 		ModifyResponse: f.modifyResponse,
+		BufferPool:     f.bufferPool,
 	}
 	revproxy.ServeHTTP(pw, outReq)
 


### PR DESCRIPTION
### What does this PR do?
Add a buffer pool to handle the copy of body in oxy.
https://github.com/vulcand/oxy/pull/138

### Motivation
Better performance
Fixes #3422 

### More

Some benchmark:
I use `emilevauge/whoami` binary, and traefik binary (without docker)
```
$ ./whoamI -port 8090
```

traefik.toml
```toml
maxIdleConnsPerHost = 100000
defaultEntryPoints = ["http"]

loglevel="ERROR"

[entryPoints]
  [entryPoints.http]
  address = ":8081"

[file]
  [frontends.frontend-f]
    backend = "b" 
  [frontends.frontend-f.routes.test_1]
  rule = "Host:localhost"
  [backends]
    [backends.b]
        [backends.b.servers.website]
            url = "http://127.0.0.1:8090"
```

#### Træfik v1.4
```console
$ wrk -t20 -c1000 -d60s -H "Host: localhost" --latency  http://127.0.0.1:8081/bench
Running 1m test @ http://127.0.0.1:8081/bench
  20 threads and 1000 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    30.45ms   21.50ms 467.58ms   61.19%
    Req/Sec     1.69k   241.43     7.55k    88.77%
  Latency Distribution
     50%   29.68ms
     75%   44.56ms
     90%   56.40ms
     99%   84.52ms
  2013008 requests in 1.00m, 195.81MB read
Requests/sec:  33499.60
Transfer/sec:      3.26MB
```

#### PR version
```console
$ wrk -t20 -c1000 -d60s -H "Host: localhost" --latency  http://127.0.0.1:8081/bench
Running 1m test @ http://127.0.0.1:8081/bench
  20 threads and 1000 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    27.10ms   15.42ms 208.96ms   70.76%
    Req/Sec     1.87k   209.22    11.31k    82.94%
  Latency Distribution
     50%   28.99ms
     75%   36.52ms
     90%   44.77ms
     99%   63.80ms
  2237140 requests in 1.00m, 217.62MB read
Requests/sec:  37222.81
Transfer/sec:      3.62MB
```
