### PR TITLE
Benchmark with newer version of traefik and nginx

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -6,15 +6,15 @@ I would like to thanks [vincentbernat](https://github.com/vincentbernat) from [e
 
 I used 4 VMs for the tests with the following configuration:
 
-- 32 GB RAM
+- 30 GB RAM
 - 8 CPU Cores
-- 10 GB SSD
-- Ubuntu 14.04 LTS 64-bit
+- 200 GB local SSD
+- CentOS Linux release 7.5.1804 (Kernel 3.10.0-693.21.1.el7.x86_64)
 
 ## Setup
 
 1. One VM used to launch the benchmarking tool [wrk](https://github.com/wg/wrk)
-2. One VM for Traefik (v1.0.0-beta.416) / nginx (v1.4.6)
+2. One VM for Traefik (v1.6.3 amd64) / nginx (v1.14.0)
 3. Two VMs for 2 backend servers in go [whoami](https://github.com/emilevauge/whoamI/)
 
 Each VM has been tuned using the following limits:
@@ -41,12 +41,16 @@ sysctl -w vm.overcommit_memory="1"
 ulimit -n 9999999
 ```
 
+### Latency
+
+Latency between each VM has been around 0.5 - 0.9ms
+
 ### Nginx
 
 Here is the config Nginx file use `/etc/nginx/nginx.conf`:
 
 ```
-user www-data;
+user nginx;
 worker_processes auto;
 worker_rlimit_nofile 200000;
 pid /var/run/nginx.pid;
@@ -97,18 +101,15 @@ upstream whoami {
 }
 
 server {
-    listen 8001;
-    server_name test.traefik;
+    listen 80;
+    server_name test.local;
     access_log off;
     error_log /dev/null crit;
-    if ($host != "test.traefik") {
-        return 404;
-    }
     location / {
         proxy_pass http://whoami;
         proxy_http_version 1.1;
         proxy_set_header Connection "";
-	proxy_set_header  X-Forwarded-Host $host;
+      	proxy_set_header  X-Forwarded-Host $host;
     }
 }
 ```
@@ -119,11 +120,10 @@ Here is the `traefik.toml` file used:
 
 ```toml
 maxIdleConnsPerHost = 100000
-defaultEntryPoints = ["http"]
 
 [entryPoints]
   [entryPoints.http]
-  address = ":8000"
+  address = ":80"
 
 [file]
 [backends]
@@ -139,73 +139,72 @@ defaultEntryPoints = ["http"]
   [frontends.frontend1]
   backend = "backend1"
     [frontends.frontend1.routes.test_1]
-    rule = "Host: test.traefik"
+    rule = "Host: test.local"
 ```
 
 ## Results
 
 ### whoami:
 ```shell
-wrk -t20 -c1000 -d60s -H "Host: test.traefik" --latency  http://IP-whoami:80/bench
-Running 1m test @ http://IP-whoami:80/bench
+wrk -t20 -c1000 -d60s -H "Host: test.local" --latency  http://IP-whoami:80/bench
+Running 1m test @ http://IP-whoami/bench
   20 threads and 1000 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    70.28ms  134.72ms   1.91s    89.94%
-    Req/Sec     2.92k   742.42     8.78k    68.80%
+    Latency    15.48ms    5.86ms 267.96ms   93.09%
+    Req/Sec     3.27k   398.14     4.88k    70.88%
   Latency Distribution
-     50%   10.63ms
-     75%   75.64ms
-     90%  205.65ms
-     99%  668.28ms
-  3476705 requests in 1.00m, 384.61MB read
-  Socket errors: connect 0, read 0, write 0, timeout 103
-Requests/sec:  57894.35
-Transfer/sec:      6.40MB
+     50%   14.87ms
+     75%   17.08ms
+     90%   19.68ms
+     99%   26.19ms
+  3906591 requests in 1.00m, 469.43MB read
+Requests/sec:  65083.24
+Transfer/sec:      7.82MB
 ```
 
 ### nginx:
 ```shell
-wrk -t20 -c1000 -d60s -H "Host: test.traefik" --latency  http://IP-nginx:8001/bench
-Running 1m test @ http://IP-nginx:8001/bench
+wrk -t20 -c1000 -d60s -H "Host: test.local" --latency  http://IP-nginx:80/bench
+Running 1m test @ http://IP-nginx:80/bench
   20 threads and 1000 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency   101.25ms  180.09ms   1.99s    89.34%
-    Req/Sec     1.69k   567.69     9.39k    72.62%
+    Latency    22.40ms   17.59ms   1.05s    99.60%
+    Req/Sec     2.30k   381.60     3.47k    68.27%
   Latency Distribution
-     50%   15.46ms
-     75%  129.11ms
-     90%  302.44ms
-     99%  846.59ms
-  2018427 requests in 1.00m, 298.36MB read
-  Socket errors: connect 0, read 0, write 0, timeout 90
-Requests/sec:  33591.67
-Transfer/sec:      4.97MB
+     50%   21.03ms
+     75%   24.74ms
+     90%   28.02ms
+     99%   35.19ms
+  2743560 requests in 1.00m, 368.92MB read
+Requests/sec:  45708.20
+Transfer/sec:      6.15MB
 ```
 
 ### Traefik:
 
 ```shell
-wrk -t20 -c1000 -d60s -H "Host: test.traefik" --latency  http://IP-traefik:8000/bench
-Running 1m test @ http://IP-traefik:8000/bench
+/wrk -t20 -c1000 -d60s -H "Host: test.local" --latency  http://IP-traefik:80/bench
+Running 1m test @ http://IP-traefik:80/bench
   20 threads and 1000 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    91.72ms  150.43ms   2.00s    90.50%
-    Req/Sec     1.43k   266.37     2.97k    69.77%
+    Latency    51.45ms   19.13ms 296.68ms   72.46%
+    Req/Sec     0.98k   125.96     1.41k    68.61%
   Latency Distribution
-     50%   19.74ms
-     75%  121.98ms
-     90%  237.39ms
-     99%  687.49ms
-  1705073 requests in 1.00m, 188.63MB read
-  Socket errors: connect 0, read 0, write 0, timeout 7
-Requests/sec:  28392.44
-Transfer/sec:      3.14MB
+     50%   53.88ms
+     75%   63.35ms
+     90%   72.72ms
+     99%   97.32ms
+  1167155 requests in 1.00m, 113.53MB read
+Requests/sec:  19440.05
+Transfer/sec:      1.89MB
 ```
 
 ## Conclusion
 
-Traefik is obviously slower than Nginx, but not so much: Traefik can serve 28392 requests/sec and Nginx 33591 requests/sec which gives a ratio of 85%.
-Not bad for young project :) !
+Traefik is slower than nginx:
+- Traefik can serve 19.440 req/sec 
+- nginx can serve 45.708 req/sec
+- whoami can serve 65.083 req/sec (without proxy)
 
 Some areas of possible improvements:
 


### PR DESCRIPTION
### What does this PR do?

Updated benchmarks with newer version of traefik (1.6.3) and nginx (1.14.0)
Infrastructure gladly provided by [evennode.com](https://www.evennode.com)

### Motivation

We did our own research and thought it might be helpful to share the results.
