### PR TITLE
Substitude hardcoded "<namespace>/<name>" with k8s ListerGetter

### DIFF
--- a/provider/kubernetes/client.go
+++ b/provider/kubernetes/client.go
@@ -170,11 +170,9 @@ func (c *clientImpl) GetIngresses() []*extensionsv1beta1.Ingress {
 
 // UpdateIngressStatus updates an Ingress with a provided status.
 func (c *clientImpl) UpdateIngressStatus(namespace, name, ip, hostname string) error {
-	keyName := namespace + "/" + name
-
 	ing, err := c.factories[c.lookupNamespace(namespace)].Extensions().V1beta1().Ingresses().Lister().Ingresses(namespace).Get(name)
 	if err != nil {
-		return fmt.Errorf("failed to get ingress %s with error: %v", keyName, err)
+		return fmt.Errorf("failed to get ingress %s: %v", namespace+"/"+name, err)
 	}
 
 	if len(ing.Status.LoadBalancer.Ingress) > 0 {
@@ -189,9 +187,9 @@ func (c *clientImpl) UpdateIngressStatus(namespace, name, ip, hostname string) e
 
 	_, err = c.clientset.ExtensionsV1beta1().Ingresses(ingCopy.Namespace).UpdateStatus(ingCopy)
 	if err != nil {
-		return fmt.Errorf("failed to update ingress status %s with error: %v", keyName, err)
+		return fmt.Errorf("failed to update ingress status %s: %v", namespace+"/"+name, err)
 	}
-	log.Infof("Updated status on ingress %s", keyName)
+	log.Infof("Updated status on ingress %s", namespace+"/"+name)
 	return nil
 }
 
@@ -256,11 +254,8 @@ func eventHandlerFunc(events chan<- interface{}, obj interface{}) {
 // translateNotFoundError will translate a "not found" error to a boolean return
 // value which indicates if the resource exists and a nil error.
 func translateNotFoundError(err error) (bool, error) {
-	if err != nil {
-		if kubeerror.IsNotFound(err) {
-			return false, nil
-		}
-		return false, err
+	if kubeerror.IsNotFound(err) {
+		return false, nil
 	}
-	return true, nil
+	return err == nil, err
 }

--- a/provider/kubernetes/client.go
+++ b/provider/kubernetes/client.go
@@ -172,7 +172,7 @@ func (c *clientImpl) GetIngresses() []*extensionsv1beta1.Ingress {
 func (c *clientImpl) UpdateIngressStatus(namespace, name, ip, hostname string) error {
 	ing, err := c.factories[c.lookupNamespace(namespace)].Extensions().V1beta1().Ingresses().Lister().Ingresses(namespace).Get(name)
 	if err != nil {
-		return fmt.Errorf("failed to get ingress %s: %v", namespace+"/"+name, err)
+		return fmt.Errorf("failed to get ingress %s/%s: %v", namespace, name, err)
 	}
 
 	if len(ing.Status.LoadBalancer.Ingress) > 0 {
@@ -187,9 +187,9 @@ func (c *clientImpl) UpdateIngressStatus(namespace, name, ip, hostname string) e
 
 	_, err = c.clientset.ExtensionsV1beta1().Ingresses(ingCopy.Namespace).UpdateStatus(ingCopy)
 	if err != nil {
-		return fmt.Errorf("failed to update ingress status %s: %v", namespace+"/"+name, err)
+		return fmt.Errorf("failed to update ingress status %s/%s: %v", namespace, name, err)
 	}
-	log.Infof("Updated status on ingress %s", namespace+"/"+name)
+	log.Infof("Updated status on ingress %s/%s", namespace, name)
 	return nil
 }
 

--- a/provider/kubernetes/client_test.go
+++ b/provider/kubernetes/client_test.go
@@ -1,0 +1,38 @@
+package kubernetes
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	kubeerror "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"testing"
+)
+
+func TestTranslateNotFoundError(t *testing.T) {
+	testCases := []struct {
+		err            error
+		expectedExists bool
+		expectedError  error
+	}{
+		{
+			err:            kubeerror.NewNotFound(schema.GroupResource{}, "foo"),
+			expectedExists: false,
+			expectedError:  nil,
+		},
+		{
+			err:            nil,
+			expectedExists: true,
+			expectedError:  nil,
+		},
+		{
+			err:            fmt.Errorf("bar error"),
+			expectedExists: false,
+			expectedError:  fmt.Errorf("bar error"),
+		},
+	}
+	for _, testCase := range testCases {
+		exists, err := translateNotFoundError(testCase.err)
+		assert.Equal(t, testCase.expectedExists, exists)
+		assert.Equal(t, testCase.expectedError, err)
+	}
+}

--- a/provider/kubernetes/client_test.go
+++ b/provider/kubernetes/client_test.go
@@ -11,30 +11,31 @@ import (
 
 func TestTranslateNotFoundError(t *testing.T) {
 	testCases := []struct {
-		err            error
 		desc           string
+		err            error
 		expectedExists bool
 		expectedError  error
 	}{
 		{
-			err:            kubeerror.NewNotFound(schema.GroupResource{}, "foo"),
 			desc:           "kubernetes not found error",
+			err:            kubeerror.NewNotFound(schema.GroupResource{}, "foo"),
 			expectedExists: false,
 			expectedError:  nil,
 		},
 		{
-			err:            nil,
 			desc:           "nil error",
+			err:            nil,
 			expectedExists: true,
 			expectedError:  nil,
 		},
 		{
-			err:            fmt.Errorf("bar error"),
 			desc:           "not a kubernetes not found error",
+			err:            fmt.Errorf("bar error"),
 			expectedExists: false,
 			expectedError:  fmt.Errorf("bar error"),
 		},
 	}
+
 	for _, testCase := range testCases {
 		test := testCase
 		t.Run(test.desc, func(t *testing.T) {

--- a/provider/kubernetes/client_test.go
+++ b/provider/kubernetes/client_test.go
@@ -2,37 +2,47 @@ package kubernetes
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	kubeerror "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"testing"
 )
 
 func TestTranslateNotFoundError(t *testing.T) {
 	testCases := []struct {
 		err            error
+		desc           string
 		expectedExists bool
 		expectedError  error
 	}{
 		{
 			err:            kubeerror.NewNotFound(schema.GroupResource{}, "foo"),
+			desc:           "kubernetes not found error",
 			expectedExists: false,
 			expectedError:  nil,
 		},
 		{
 			err:            nil,
+			desc:           "nil error",
 			expectedExists: true,
 			expectedError:  nil,
 		},
 		{
 			err:            fmt.Errorf("bar error"),
+			desc:           "not a kubernetes not found error",
 			expectedExists: false,
 			expectedError:  fmt.Errorf("bar error"),
 		},
 	}
 	for _, testCase := range testCases {
-		exists, err := translateNotFoundError(testCase.err)
-		assert.Equal(t, testCase.expectedExists, exists)
-		assert.Equal(t, testCase.expectedError, err)
+		test := testCase
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			exists, err := translateNotFoundError(test.err)
+			assert.Equal(t, test.expectedExists, exists)
+			assert.Equal(t, test.expectedError, err)
+		})
 	}
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Small refactor for kubernetes provider.

Remove those hardcoded `<namespace>/<name>` index and use common functions of `ListerGetter` provided by kubernetes informers.  Or developers might get confused by previous code. 🤔

Note that according to current implementations of kubernetes informers on master branch which haven't been changed for a long time, the error returned by `ListerGetter` can only be "Not Found" error. So, with this PR, the return value by `GetEndpoints`,`GetService`,`GetSecret` will only be:

- Endpoints/Service/Secret, true, nil
- nil, false, "Not Found Error"

### Motivation

<!-- What inspired you to submit this pull request? -->

For better human readability

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
