### PR TITLE
Allow any kubernetes ingressClass value

### DIFF
--- a/docs/configuration/backends/kubernetes.md
+++ b/docs/configuration/backends/kubernetes.md
@@ -54,8 +54,6 @@ See also [Kubernetes user guide](/user-guide/kubernetes).
 # If the parameter is non-empty, only Ingresses containing an annotation with the same value are processed.
 # Otherwise, Ingresses missing the annotation, having an empty value, or the value `traefik` are processed.
 #
-# Note : `ingressClass` option must begin with the "traefik" prefix.
-#
 # Optional
 # Default: empty
 #

--- a/docs/user-guide/kubernetes.md
+++ b/docs/user-guide/kubernetes.md
@@ -864,8 +864,8 @@ It is also possible to set the `ingressClass` option in Træfik to a particular 
 For instance, setting the option to `traefik-internal` causes Træfik to process Ingress objects with the same `kubernetes.io/ingress.class` annotation value, ignoring all other objects (including those with a `traefik` value, empty value, and missing annotation).
 
 !!! note
-    Letting multiple ingress controllers handle the same ingress objects can lead to uninteded behavior.
-    It is recommended to prefix all ingressClass values with traefik to avoid unintended collisions with other ingress implementations.
+    Letting multiple ingress controllers handle the same ingress objects can lead to unintended behavior.
+    It is recommended to prefix all ingressClass values with `traefik` to avoid unintended collisions with other ingress implementations.
 
 ### Between multiple Træfik Deployments
 

--- a/docs/user-guide/kubernetes.md
+++ b/docs/user-guide/kubernetes.md
@@ -859,10 +859,8 @@ Sometimes Træfik runs along other Ingress controller implementations. One such 
 The `kubernetes.io/ingress.class` annotation can be attached to any Ingress object in order to control whether Træfik should handle it.
 
 If the annotation is missing, contains an empty value, or the value `traefik`, then the Træfik controller will take responsibility and process the associated Ingress object.
-If the annotation contains any other value (usually the name of a different Ingress controller), Træfik will ignore the object.
 
-It is also possible to set the `ingressClass` option in Træfik to a particular value.
-If that's the case and the value contains a `traefik` prefix, then only those Ingress objects matching the same value will be processed.
+It is also possible to set the `ingressClass` option in Træfik to a particular value. Træfik will only process matching Ingress objects.
 For instance, setting the option to `traefik-internal` causes Træfik to process Ingress objects with the same `kubernetes.io/ingress.class` annotation value, ignoring all other objects (including those with a `traefik` value, empty value, and missing annotation).
 
 ### Between multiple Træfik Deployments

--- a/docs/user-guide/kubernetes.md
+++ b/docs/user-guide/kubernetes.md
@@ -863,6 +863,10 @@ If the annotation is missing, contains an empty value, or the value `traefik`, t
 It is also possible to set the `ingressClass` option in Træfik to a particular value. Træfik will only process matching Ingress objects.
 For instance, setting the option to `traefik-internal` causes Træfik to process Ingress objects with the same `kubernetes.io/ingress.class` annotation value, ignoring all other objects (including those with a `traefik` value, empty value, and missing annotation).
 
+!!! note
+    Letting multiple ingress controllers handle the same ingress objects can lead to uninteded behavior.
+    It is recommended to prefix all ingressClass values with traefik to avoid unintended collisions with other ingress implementations.
+
 ### Between multiple Træfik Deployments
 
 Sometimes multiple Træfik Deployments are supposed to run concurrently.

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -100,12 +100,6 @@ func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *s
 		return err
 	}
 
-	// We require that IngressClasses start with `traefik` to reduce chances of
-	// conflict with other Ingress Providers
-	if len(p.IngressClass) > 0 && !strings.HasPrefix(p.IngressClass, traefikDefaultIngressClass) {
-		return fmt.Errorf("value for IngressClass has to be empty or start with the prefix %q, instead found %q", traefikDefaultIngressClass, p.IngressClass)
-	}
-
 	log.Debugf("Using Ingress label selector: %q", p.LabelSelector)
 	k8sClient, err := p.newK8sClient(p.LabelSelector)
 	if err != nil {

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -1169,6 +1169,15 @@ func TestIngressClassAnnotation(t *testing.T) {
 					iPaths(onePath(iPath("/derp"), iBackend("service1", intstr.FromInt(80))))),
 			),
 		),
+		buildIngress(
+			iNamespace("testing"),
+			iAnnotation(annotationKubernetesIngressClass, "custom"),
+			iRules(
+				iRule(
+					iHost("herp"),
+					iPaths(onePath(iPath("/derp"), iBackend("service1", intstr.FromInt(80))))),
+			),
+		),
 	}
 
 	services := []*corev1.Service{
@@ -1245,6 +1254,28 @@ func TestIngressClassAnnotation(t *testing.T) {
 		{
 			desc:     "Provided IngressClass annotation",
 			provider: Provider{IngressClass: traefikDefaultRealm + "-other"},
+			expected: buildConfiguration(
+				backends(
+					backend("herp/derp",
+						servers(
+							server("http://example.com", weight(1)),
+							server("http://example.com", weight(1))),
+						lbMethod("wrr"),
+					),
+				),
+				frontends(
+					frontend("herp/derp",
+						passHostHeader(),
+						routes(
+							route("/derp", "PathPrefix:/derp"),
+							route("herp", "Host:herp")),
+					),
+				),
+			),
+		},
+		{
+			desc:     "Provided IngressClass annotation",
+			provider: Provider{IngressClass: "custom"},
 			expected: buildConfiguration(
 				backends(
 					backend("herp/derp",

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -1165,8 +1165,8 @@ func TestIngressClassAnnotation(t *testing.T) {
 			iAnnotation(annotationKubernetesIngressClass, traefikDefaultIngressClass+"-other"),
 			iRules(
 				iRule(
-					iHost("herp"),
-					iPaths(onePath(iPath("/derp"), iBackend("service1", intstr.FromInt(80))))),
+					iHost("foo"),
+					iPaths(onePath(iPath("/bar"), iBackend("service1", intstr.FromInt(80))))),
 			),
 		),
 		buildIngress(
@@ -1174,8 +1174,8 @@ func TestIngressClassAnnotation(t *testing.T) {
 			iAnnotation(annotationKubernetesIngressClass, "custom"),
 			iRules(
 				iRule(
-					iHost("herp"),
-					iPaths(onePath(iPath("/derp"), iBackend("service1", intstr.FromInt(80))))),
+					iHost("foo"),
+					iPaths(onePath(iPath("/bar"), iBackend("service2", intstr.FromInt(80))))),
 			),
 		),
 	}
@@ -1191,12 +1191,32 @@ func TestIngressClassAnnotation(t *testing.T) {
 				sExternalName("example.com"),
 				sPorts(sPort(80, "http"))),
 		),
+		buildService(
+			sName("service2"),
+			sNamespace("testing"),
+			sUID("2"),
+			sSpec(
+				clusterIP("10.0.0.2"),
+				sPorts(sPort(80, "http"))),
+		),
+	}
+
+	endpoints := []*corev1.Endpoints{
+		buildEndpoint(
+			eName("service2"),
+			eUID("1"),
+			eNamespace("testing"),
+			subset(
+				eAddresses(eAddress("10.10.0.1")),
+				ePorts(ePort(80, "http"))),
+		),
 	}
 
 	watchChan := make(chan interface{})
 	client := clientMock{
 		ingresses: ingresses,
 		services:  services,
+		endpoints: endpoints,
 		watchChan: watchChan,
 	}
 
@@ -1256,19 +1276,18 @@ func TestIngressClassAnnotation(t *testing.T) {
 			provider: Provider{IngressClass: traefikDefaultRealm + "-other"},
 			expected: buildConfiguration(
 				backends(
-					backend("herp/derp",
+					backend("foo/bar",
 						servers(
-							server("http://example.com", weight(1)),
 							server("http://example.com", weight(1))),
 						lbMethod("wrr"),
 					),
 				),
 				frontends(
-					frontend("herp/derp",
+					frontend("foo/bar",
 						passHostHeader(),
 						routes(
-							route("/derp", "PathPrefix:/derp"),
-							route("herp", "Host:herp")),
+							route("/bar", "PathPrefix:/bar"),
+							route("foo", "Host:foo")),
 					),
 				),
 			),
@@ -1278,19 +1297,18 @@ func TestIngressClassAnnotation(t *testing.T) {
 			provider: Provider{IngressClass: "custom"},
 			expected: buildConfiguration(
 				backends(
-					backend("herp/derp",
+					backend("foo/bar",
 						servers(
-							server("http://example.com", weight(1)),
-							server("http://example.com", weight(1))),
+							server("http://10.10.0.1:80", weight(1))),
 						lbMethod("wrr"),
 					),
 				),
 				frontends(
-					frontend("herp/derp",
+					frontend("foo/bar",
 						passHostHeader(),
 						routes(
-							route("/derp", "PathPrefix:/derp"),
-							route("herp", "Host:herp")),
+							route("/bar", "PathPrefix:/bar"),
+							route("foo", "Host:foo")),
 					),
 				),
 			),


### PR DESCRIPTION
Migrating from one ingress controller to another can require an intentional collision of ingressClass values.

### What does this PR do?

The ingressClass in kubernetes can be used to run multiple ingress controllers or to otherwise split the defined ingresses into multiple sets.
The values that Traefik would allow for an ingress class must start with `traefik`.

This patch removes that limitation as
1. The name is user defined anyway
2. It makes migrations from other ingress controllers harder

### Motivation

I am trying to move a larger cluster over to traefik and our ingress classes were split into internal and external. Traefik can't handle these names which makes a migration harder than necessary.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

The key change is the removal of a few lines in `provider/kubernetes/kubernetes.go`
