### PR TITLE
Create a custom logger for jaeger

### DIFF
--- a/middlewares/tracing/jaeger/jaeger.go
+++ b/middlewares/tracing/jaeger/jaeger.go
@@ -6,7 +6,6 @@ import (
 	"github.com/containous/traefik/log"
 	"github.com/opentracing/opentracing-go"
 	jaegercfg "github.com/uber/jaeger-client-go/config"
-	jaegerlog "github.com/uber/jaeger-client-go/log"
 	jaegermet "github.com/uber/jaeger-lib/metrics"
 )
 
@@ -35,13 +34,12 @@ func (c *Config) Setup(componentName string) (opentracing.Tracer, io.Closer, err
 		},
 	}
 
-	jLogger := jaegerlog.StdLogger
 	jMetricsFactory := jaegermet.NullFactory
 
 	// Initialize tracer with a logger and a metrics factory
 	closer, err := jcfg.InitGlobalTracer(
 		componentName,
-		jaegercfg.Logger(jLogger),
+		jaegercfg.Logger(&jaegerLogger{}),
 		jaegercfg.Metrics(jMetricsFactory),
 	)
 	if err != nil {

--- a/middlewares/tracing/jaeger/logger.go
+++ b/middlewares/tracing/jaeger/logger.go
@@ -1,0 +1,15 @@
+package jaeger
+
+import "github.com/containous/traefik/log"
+
+// jaegerLogger is an implementation of the Logger interface that delegates to traefik log
+type jaegerLogger struct{}
+
+func (l *jaegerLogger) Error(msg string) {
+	log.Errorf("Tracing jaeger error: %s", msg)
+}
+
+// Infof logs a message at debug priority
+func (l *jaegerLogger) Infof(msg string, args ...interface{}) {
+	log.Debugf(msg, args...)
+}


### PR DESCRIPTION
### What does this PR do?

This PR creates a custom logger for jaeger to avoid to use `Printf`

https://github.com/containous/traefik/blob/30ffba78e6f55a00e55e8f90c819469731db9e8b/vendor/github.com/uber/jaeger-client-go/logger.go#L40-L51

### Motivation

Consistent log
Fixes #3539

### Additional Notes

Jaeger log will be display only when `logLevel=DEBUG`