### PR TITLE
Split the error handling from Consul Catalog (deadlock)

### DIFF
--- a/provider/consulcatalog/consul_catalog.go
+++ b/provider/consulcatalog/consul_catalog.go
@@ -154,7 +154,7 @@ func (p *Provider) watch(configurationChan chan<- types.ConfigMessage, stop chan
 	defer close(stopCh)
 	defer close(watchCh)
 
-	go func() {
+	safe.Go(func() {
 		for index := range watchCh {
 			log.Debug("List of services changed")
 			nodes, err := p.getNodes(index)
@@ -167,7 +167,7 @@ func (p *Provider) watch(configurationChan chan<- types.ConfigMessage, stop chan
 				Configuration: configuration,
 			}
 		}
-	}()
+	})
 
 	for {
 		select {


### PR DESCRIPTION
### The issue
There's a deadlock in Consul Catalog's watch method: the notifyError function writes to the same channel where the select loop is trying to read from.

### Fix
Separating the watch channel from the stop/kill channels and implement it using a different goroutine 
so that read & write from the error channel won't block each other.

### Steps to reproduce
1. Launch traefik using a Consul Catalog against a Consul agent.
2. Restart Consul agent (causes Consul to return an error).
3. Change/deploy a new service to Consul and see that the backends/frontends don't get updated.


