### PR TITLE
Call functions to enable block/mutex pprof profiles.

### DIFF
--- a/api/debug.go
+++ b/api/debug.go
@@ -38,6 +38,8 @@ func (g DebugHandler) AddRoutes(router *mux.Router) {
 			fmt.Fprint(w, "\n}\n")
 		})
 
+	runtime.SetBlockProfileRate(1)
+	runtime.SetMutexProfileFraction(5)
 	router.Methods(http.MethodGet).PathPrefix("/debug/pprof/cmdline").HandlerFunc(pprof.Cmdline)
 	router.Methods(http.MethodGet).PathPrefix("/debug/pprof/profile").HandlerFunc(pprof.Profile)
 	router.Methods(http.MethodGet).PathPrefix("/debug/pprof/symbol").HandlerFunc(pprof.Symbol)


### PR DESCRIPTION
### What does this PR do?

Call `runtime.SetBlockProfileRate` and `runtime.SetMutexProfileFraction` when debug mode is enabled.

### Motivation

According to the [documentation](https://golang.org/pkg/net/http/pprof/), these functions must be called for block and mutex pprof profiles to be generated actually.