### PR TITLE
Add logs when error is generated in error handler

### DIFF
--- a/server/errorhandler.go
+++ b/server/errorhandler.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 
+	"github.com/containous/traefik/log"
 	"github.com/containous/traefik/middlewares"
 )
 
@@ -37,4 +38,5 @@ func (eh *RecordingErrorHandler) ServeHTTP(w http.ResponseWriter, req *http.Requ
 
 	w.WriteHeader(statusCode)
 	w.Write([]byte(http.StatusText(statusCode)))
+	log.Debugf("'%d %s' caused by: %v", statusCode, http.StatusText(statusCode), err)
 }


### PR DESCRIPTION
### What does this PR do?
Add logs in the error handler when there is an error

### Motivation
More information when trying to debug some errors (like 502 in #3237 for example)