### PR TITLE
Fix rewrite-target Annotation behavior

### DIFF
--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -538,7 +538,8 @@ func getRuleForPath(pa extensionsv1beta1.HTTPIngressPath, i *extensionsv1beta1.I
 		if pathReplaceAnnotation != "" {
 			return "", fmt.Errorf("rewrite-target must not be used together with annotation %q", pathReplaceAnnotation)
 		}
-		rules = append(rules, ruleTypeReplacePath+":"+rewriteTarget)
+		rewriteTargetRule := fmt.Sprintf("ReplacePathRegex: ^%s/(.*) %s/$1", pa.Path, strings.TrimRight(rewriteTarget, "/"))
+		rules = append(rules, rewriteTargetRule)
 		pathReplaceAnnotation = annotationKubernetesRewriteTarget
 	}
 

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -1371,7 +1371,7 @@ rateset:
 			frontend("rewrite/api",
 				passHostHeader(),
 				routes(
-					route("/api", "PathPrefix:/api;ReplacePath:/"),
+					route("/api", "PathPrefix:/api;ReplacePathRegex: ^/api/(.*) /$1"),
 					route("rewrite", "Host:rewrite")),
 			),
 			frontend("error-pages/errorpages",


### PR DESCRIPTION
### What does this PR do?

Corrects incorrect `rewrite-target` behavior


### Motivation

Fixes #3566

### More

- [x] Added/updated tests
- [ ] Added/updated documentation - Not needed, as this corrects unintended behavior

### Additional Notes

This ingress:
```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: whoami
  annotations:
     traefik.ingress.kubernetes.io/rewrite-target: /demo
spec:
  rules:
  - host: localhost
    http:
      paths:
      - path: /testing
        backend:
          serviceName: whoami
          servicePort: http
```

Now correctly rewrites the target request:

```
curl -v localhost:30183/testing/bacon/index.php?something
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 30183 (#0)
> GET /testing/bacon/index.php?something HTTP/1.1
> Host: localhost:30183
> User-Agent: curl/7.54.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Content-Length: 442
< Content-Type: text/plain; charset=utf-8
< Date: Mon, 09 Jul 2018 17:02:12 GMT
< 
Hostname: whoami-7fbb4599b4-m5k4h
IP: 127.0.0.1
IP: 10.1.1.18
GET /demo/bacon/index.php?something HTTP/1.1
Host: localhost:30183
User-Agent: curl/7.54.0
Accept: */*
Accept-Encoding: gzip
X-Forwarded-For: 192.168.65.3
X-Forwarded-Host: localhost:30183
X-Forwarded-Port: 30183
X-Forwarded-Proto: http
X-Forwarded-Server: traefik-ingress-controller-84869bf64-nlhxb
X-Real-Ip: 192.168.65.3
X-Replaced-Path: /testing/bacon/index.php

* Connection #0 to host localhost left intact
```
