### PR TITLE
Correct App-Root kubernetes behavior

### DIFF
--- a/docs/configuration/backends/kubernetes.md
+++ b/docs/configuration/backends/kubernetes.md
@@ -205,8 +205,9 @@ retryexpression: IsNetworkError() && Attempts() <= 2
 
 <4> `traefik.ingress.kubernetes.io/app-root`:
 Non-root paths will not be affected by this annotation and handled normally.
-This annotation may not be combined with the `ReplacePath` rule type or any other annotation leveraging that rule type.
-Trying to do so leads to an error and the corresponding Ingress object being ignored.
+This annotation may not be combined with other redirect annotations.
+Trying to do so will result in the other redirects being ignored.
+This annotation can be used in combination with `traefik.ingress.kubernetes.io/redirect-permanent` to configure whether the `app-root` redirect is a 301 or a 302.
 
 <5> `traefik.ingress.kubernetes.io/service-weights`:
 Service weights enable to split traffic across multiple backing services in a fine-grained manner.

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -851,7 +851,7 @@ func getFrontendRedirect(i *extensionsv1beta1.Ingress, baseName, path string) *t
 
 	if appRoot := getStringValue(i.Annotations, annotationKubernetesAppRoot, ""); appRoot != "" && path == "/" {
 		return &types.Redirect{
-			Regex:       baseName,
+			Regex:       fmt.Sprintf("%s$", baseName),
 			Replacement: fmt.Sprintf("%s/%s", strings.TrimRight(baseName, "/"), strings.TrimLeft(appRoot, "/")),
 			Permanent:   permanent,
 		}

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -258,7 +258,7 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 						Routes:         make(map[string]types.Route),
 						Priority:       priority,
 						WhiteList:      getWhiteList(i),
-						Redirect:       getFrontendRedirect(i),
+						Redirect:       getFrontendRedirect(i, baseName, pa.Path),
 						EntryPoints:    entryPoints,
 						Headers:        getHeader(i),
 						Errors:         getErrorPages(i),
@@ -500,7 +500,7 @@ func (p *Provider) addGlobalBackend(cl Client, i *extensionsv1beta1.Ingress, tem
 		Routes:         make(map[string]types.Route),
 		Priority:       priority,
 		WhiteList:      getWhiteList(i),
-		Redirect:       getFrontendRedirect(i),
+		Redirect:       getFrontendRedirect(i, defaultFrontendName, "/"),
 		EntryPoints:    entryPoints,
 		Headers:        getHeader(i),
 		Errors:         getErrorPages(i),
@@ -531,25 +531,12 @@ func getRuleForPath(pa extensionsv1beta1.HTTPIngressPath, i *extensionsv1beta1.I
 
 	rules := []string{ruleType + ":" + pa.Path}
 
-	var pathReplaceAnnotation string
-	if ruleType == ruleTypeReplacePath {
-		pathReplaceAnnotation = annotationKubernetesRuleType
-	}
-
 	if rewriteTarget := getStringValue(i.Annotations, annotationKubernetesRewriteTarget, ""); rewriteTarget != "" {
-		if pathReplaceAnnotation != "" {
-			return "", fmt.Errorf("rewrite-target must not be used together with annotation %q", pathReplaceAnnotation)
+		if ruleType == ruleTypeReplacePath {
+			return "", fmt.Errorf("rewrite-target must not be used together with annotation %q", annotationKubernetesRuleType)
 		}
 		rewriteTargetRule := fmt.Sprintf("ReplacePathRegex: ^%s/(.*) %s/$1", pa.Path, strings.TrimRight(rewriteTarget, "/"))
 		rules = append(rules, rewriteTargetRule)
-		pathReplaceAnnotation = annotationKubernetesRewriteTarget
-	}
-
-	if rootPath := getStringValue(i.Annotations, annotationKubernetesAppRoot, ""); rootPath != "" && pa.Path == "/" {
-		if pathReplaceAnnotation != "" {
-			return "", fmt.Errorf("app-root must not be used together with annotation %q", pathReplaceAnnotation)
-		}
-		rules = append(rules, ruleTypeReplacePath+":"+rootPath)
 	}
 
 	if requestModifier := getStringValue(i.Annotations, annotationKubernetesRequestModifier, ""); requestModifier != "" {
@@ -859,8 +846,16 @@ func loadAuthTLSSecret(namespace, secretName string, k8sClient Client) (string, 
 	return getCertificateBlocks(secret, namespace, secretName)
 }
 
-func getFrontendRedirect(i *extensionsv1beta1.Ingress) *types.Redirect {
+func getFrontendRedirect(i *extensionsv1beta1.Ingress, baseName, path string) *types.Redirect {
 	permanent := getBoolValue(i.Annotations, annotationKubernetesRedirectPermanent, false)
+
+	if appRoot := getStringValue(i.Annotations, annotationKubernetesAppRoot, ""); appRoot != "" && path == "/" {
+		return &types.Redirect{
+			Regex:       baseName,
+			Replacement: fmt.Sprintf("%s/%s", strings.TrimRight(baseName, "/"), strings.TrimLeft(appRoot, "/")),
+			Permanent:   permanent,
+		}
+	}
 
 	redirectEntryPoint := getStringValue(i.Annotations, annotationKubernetesRedirectEntryPoint, "")
 	if len(redirectEntryPoint) > 0 {

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -1470,8 +1470,9 @@ rateset:
 			),
 			frontend("root/",
 				passHostHeader(),
+				redirectRegex("root/", "root/root"),
 				routes(
-					route("/", "PathPrefix:/;ReplacePath:/root"),
+					route("/", "PathPrefix:/"),
 					route("root", "Host:root"),
 				),
 			),

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -1470,7 +1470,7 @@ rateset:
 			),
 			frontend("root/",
 				passHostHeader(),
-				redirectRegex("root/", "root/root"),
+				redirectRegex("root/$", "root/root"),
 				routes(
 					route("/", "PathPrefix:/"),
 					route("root", "Host:root"),


### PR DESCRIPTION
### What does this PR do?

Corrects App-Root kubernetes Behavior

### Motivation

Fixes #3589 


### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

We will need to update documentation to reflect being unable to mix regex with app-root.

The ingress:

```yml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: whoami
  annotations:
     traefik.ingress.kubernetes.io/app-root: /app1/index.html
spec:
  rules:
  - host: localhost
    http:
      paths:
      - path: /
        backend:
          serviceName: whoami
          servicePort: http
```
Now results in:

```console
$ curl -v localhost
* Rebuilt URL to: localhost/
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 80 (#0)
> GET / HTTP/1.1
> Host: localhost
> User-Agent: curl/7.54.0
> Accept: */*
> 
< HTTP/1.1 302 Found
< Location: http://localhost/app1/index.html
< Date: Tue, 10 Jul 2018 19:31:55 GMT
< Content-Length: 5
< Content-Type: text/plain; charset=utf-8
< 
* Connection #0 to host localhost left intact
```