### PR TITLE
Add HTTP authentification to influxdb metric backend

### DIFF
--- a/docs/configuration/metrics.md
+++ b/docs/configuration/metrics.md
@@ -104,6 +104,20 @@
     #
     protocol = "udp"
 
+    # InfluxDB's username
+    #
+    # Optional
+    # Default: "" (no username)
+    #
+    username = ""
+
+    # InfluxDB's password
+    #
+    # Optional
+    # Default: "" (no password)
+    #
+    password = ""
+
     # InfluxDB push interval
     #
     # Optional

--- a/metrics/influxdb.go
+++ b/metrics/influxdb.go
@@ -157,7 +157,9 @@ func (w *influxDBWriter) Write(bp influxdb.BatchPoints) error {
 func (w *influxDBWriter) initWriteClient() (influxdb.Client, error) {
 	if w.config.Protocol == "http" {
 		return influxdb.NewHTTPClient(influxdb.HTTPConfig{
-			Addr: w.config.Address,
+			Addr:     w.config.Address,
+			Username: w.config.Username,
+			Password: w.config.Password,
 		})
 	}
 

--- a/types/types.go
+++ b/types/types.go
@@ -455,13 +455,15 @@ type Statsd struct {
 	PushInterval string `description:"StatsD push interval" export:"true"`
 }
 
-// InfluxDB contains address and metrics pushing interval configuration
+// InfluxDB contains address, login and metrics pushing interval configuration
 type InfluxDB struct {
 	Address         string `description:"InfluxDB address"`
 	Protocol        string `description:"InfluxDB address protocol (udp or http)"`
 	PushInterval    string `description:"InfluxDB push interval" export:"true"`
 	Database        string `description:"InfluxDB database used when protocol is http" export:"true"`
 	RetentionPolicy string `description:"InfluxDB retention policy used when protocol is http" export:"true"`
+	Username        string `description:"InfluxDB username (only with http)" export:"true"`
+	Password        string `description:"InfluxDB password (only with http)" export:"true"`
 }
 
 // Buckets holds Prometheus Buckets


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Add some configuration options and corresponding structures to pass `username` and `password` to the `influxdb` metric backend. These options are **only** usable with HTTP and NOT with the UDP configuration.

### Motivation

Passwords are good for security I guess? Also I needed it for my work and it was easily implemented as the HTTP backend was ready since #3391.

### More

- [x] Added/updated documentation

### Additional Notes

Built and tested, apparently traefik doesn't report metrics when there is no request. Is that by design? Other influxdb colletors (such as `telegraf`) usually report one record per second for each metrics.
<!-- Anything else we should know when reviewing? -->
