### PR TITLE
Uses both binded HostIP and HostPort when useBindPortIP=true

### DIFF
--- a/provider/docker/config.go
+++ b/provider/docker/config.go
@@ -312,7 +312,7 @@ func getPort(container dockerData) string {
 }
 
 func (p *Provider) getPortBinding (container dockerData) (nat.PortBinding, error) {
-	port := getPortV1(container)
+	port := getPort(container)
 	for netPort, portBindings := range container.NetworkSettings.Ports {
 		if strings.EqualFold(string(netPort), port+"/TCP") || strings.EqualFold(string(netPort), port+"/UDP") {
 			for _, p := range portBindings {

--- a/provider/docker/config.go
+++ b/provider/docker/config.go
@@ -197,7 +197,6 @@ func (p *Provider) getFrontendRule(container dockerData, segmentLabels map[strin
 	return ""
 }
 
-//TODO: Should we expose getIPPort instead in the template?
 func (p Provider) getIPAddress(container dockerData) string {
 	if value := label.GetStringValue(container.Labels, labelDockerNetwork, p.Network); value != "" {
 		networkSettings := container.NetworkSettings
@@ -334,6 +333,7 @@ func (p *Provider) getPortBinding(container dockerData) (*nat.PortBinding, error
 	return nil, fmt.Errorf("unable to find the external IP:Port for the container %q", container.Name)
 }
 
+//TODO: Should we expose it (instead of getIPAddress) in the template?
 func (p *Provider) getIPPort(container dockerData) (string, string, error) {
 	var ip, port string
 
@@ -371,13 +371,15 @@ func (p *Provider) getServers(containers []dockerData) map[string]types.Server {
 			continue
 		}
 
-		protocol := label.GetStringValue(container.SegmentLabels, label.TraefikProtocol, label.DefaultProtocol)
-		serverURL := fmt.Sprintf("%s://%s", protocol, net.JoinHostPort(ip, port))
-		serverName := getServerName(container.Name, serverURL)
-
 		if servers == nil {
 			servers = make(map[string]types.Server)
 		}
+
+		protocol := label.GetStringValue(container.SegmentLabels, label.TraefikProtocol, label.DefaultProtocol)
+
+		serverURL := fmt.Sprintf("%s://%s", protocol, net.JoinHostPort(ip, port))
+
+		serverName := getServerName(container.Name, serverURL)
 		if _, exist := servers[serverName]; exist {
 			log.Debugf("Skipping server %q with the same URL.", serverName)
 			continue

--- a/provider/docker/config.go
+++ b/provider/docker/config.go
@@ -243,6 +243,7 @@ func (p Provider) getIPAddress(container dockerData) string {
 	return ""
 }
 
+//Deprecated: Please use getIPPort instead
 func (p *Provider) getDeprecatedIPAddress(container dockerData) string {
 	ip, _, err := p.getIPPort(container)
 	if err != nil {

--- a/provider/docker/config.go
+++ b/provider/docker/config.go
@@ -334,7 +334,7 @@ func (p *Provider) getPortBinding(container dockerData) (*nat.PortBinding, error
 	return nil, fmt.Errorf("unable to find the external IP:Port for the container %q", container.Name)
 }
 
-//TODO: Should we expose it (instead of getIPAddress) in the template?
+// TODO: Should we expose it (instead of getIPAddress) in the template?
 func (p *Provider) getIPPort(container dockerData) (string, string, error) {
 	var ip, port string
 

--- a/provider/docker/config.go
+++ b/provider/docker/config.go
@@ -311,25 +311,25 @@ func getPort(container dockerData) string {
 	return ""
 }
 
-func (p *Provider) getPortBinding(container dockerData) *nat.PortBinding {
+func (p *Provider) getPortBinding(container dockerData) (*nat.PortBinding, error) {
 	port := getPort(container)
 	for netPort, portBindings := range container.NetworkSettings.Ports {
 		if strings.EqualFold(string(netPort), port+"/TCP") || strings.EqualFold(string(netPort), port+"/UDP") {
 			for _, p := range portBindings {
-				return &p
+				return &p, nil
 			}
 		}
 	}
 
-	return nil
+	return nil, fmt.Errorf("Unable to find the external IP:Port for the container %q", container.Name)
 }
 
 func (p *Provider) getIPPort(container dockerData) (string, string, error) {
 	var ip, port string
 
 	if p.UseBindPortIP {
-		portBinding := p.getPortBinding(container)
-		if portBinding == nil {
+		portBinding, err := p.getPortBinding(container)
+		if err != nil {
 			return "", "", fmt.Errorf("unable to find a binding for the container %q: ignoring server", container.Name)
 		}
 

--- a/provider/docker/config.go
+++ b/provider/docker/config.go
@@ -321,7 +321,7 @@ func (p *Provider) getPortBinding(container dockerData) (*nat.PortBinding, error
 		}
 	}
 
-	return nil, fmt.Errorf("Unable to find the external IP:Port for the container %q", container.Name)
+	return nil, fmt.Errorf("unable to find the external IP:Port for the container %q", container.Name)
 }
 
 func (p *Provider) getIPPort(container dockerData) (string, string, error) {

--- a/provider/docker/config.go
+++ b/provider/docker/config.go
@@ -33,7 +33,7 @@ func (p *Provider) buildConfigurationV2(containersInspected []dockerData) *types
 		"getDomain":        label.GetFuncString(label.TraefikDomain, p.Domain),
 
 		// Backend functions
-		"getIPAddress":      p.getDeprecatedIPAddress,
+		"getIPAddress":      p.getDeprecatedIPAddress, // TODO: Should we expose getIPPort instead?
 		"getServers":        p.getServers,
 		"getMaxConn":        label.GetMaxConn,
 		"getHealthCheck":    label.GetHealthCheck,
@@ -334,7 +334,6 @@ func (p *Provider) getPortBinding(container dockerData) (*nat.PortBinding, error
 	return nil, fmt.Errorf("unable to find the external IP:Port for the container %q", container.Name)
 }
 
-// TODO: Should we expose it (instead of getIPAddress) in the template?
 func (p *Provider) getIPPort(container dockerData) (string, string, error) {
 	var ip, port string
 

--- a/provider/docker/config.go
+++ b/provider/docker/config.go
@@ -33,13 +33,13 @@ func (p *Provider) buildConfigurationV2(containersInspected []dockerData) *types
 		"getDomain":        label.GetFuncString(label.TraefikDomain, p.Domain),
 
 		// Backend functions
-		"getIPAddress":      p.getDeprecatedIPAddress, // TODO: Should we expose getIPPort instead?
-		"getServers":        p.getServers,
-		"getMaxConn":        label.GetMaxConn,
-		"getHealthCheck":    label.GetHealthCheck,
-		"getBuffering":      label.GetBuffering,
-		"getCircuitBreaker": label.GetCircuitBreaker,
-		"getLoadBalancer":   label.GetLoadBalancer,
+		"getDeprecatedIPAddress": p.getDeprecatedIPAddress, // TODO: Should we expose getIPPort instead?
+		"getServers":             p.getServers,
+		"getMaxConn":             label.GetMaxConn,
+		"getHealthCheck":         label.GetHealthCheck,
+		"getBuffering":           label.GetBuffering,
+		"getCircuitBreaker":      label.GetCircuitBreaker,
+		"getLoadBalancer":        label.GetLoadBalancer,
 
 		// Frontend functions
 		"getBackendName":    getBackendName,

--- a/provider/docker/config.go
+++ b/provider/docker/config.go
@@ -33,7 +33,7 @@ func (p *Provider) buildConfigurationV2(containersInspected []dockerData) *types
 		"getDomain":        label.GetFuncString(label.TraefikDomain, p.Domain),
 
 		// Backend functions
-		"getIPAddress":      p.getIPAddress,
+		"getIPAddress":      p.getDeprecatedIPAddress,
 		"getServers":        p.getServers,
 		"getMaxConn":        label.GetMaxConn,
 		"getHealthCheck":    label.GetHealthCheck,
@@ -197,6 +197,7 @@ func (p *Provider) getFrontendRule(container dockerData, segmentLabels map[strin
 	return ""
 }
 
+//TODO: Should we expose getIPPort instead in the template?
 func (p Provider) getIPAddress(container dockerData) string {
 	if value := label.GetStringValue(container.Labels, labelDockerNetwork, p.Network); value != "" {
 		networkSettings := container.NetworkSettings
@@ -241,6 +242,15 @@ func (p Provider) getIPAddress(container dockerData) string {
 
 	log.Warnf("Unable to find the IP address for the container %q.", container.Name)
 	return ""
+}
+
+func (p *Provider) getDeprecatedIPAddress(container dockerData) string {
+	ip, _, err := p.getIPPort(container)
+	if err != nil {
+		log.Warn(err)
+		return ""
+	}
+	return ip
 }
 
 // Escape beginning slash "/", convert all others to dash "-", and convert underscores "_" to dash "-"

--- a/provider/docker/config.go
+++ b/provider/docker/config.go
@@ -243,7 +243,7 @@ func (p Provider) getIPAddress(container dockerData) string {
 	return ""
 }
 
-//Deprecated: Please use getIPPort instead
+// Deprecated: Please use getIPPort instead
 func (p *Provider) getDeprecatedIPAddress(container dockerData) string {
 	ip, _, err := p.getIPPort(container)
 	if err != nil {

--- a/provider/docker/config.go
+++ b/provider/docker/config.go
@@ -311,7 +311,7 @@ func getPort(container dockerData) string {
 	return ""
 }
 
-func (p *Provider) getPortBinding (container dockerData) (nat.PortBinding, error) {
+func (p *Provider) getPortBinding(container dockerData) (nat.PortBinding, error) {
 	port := getPort(container)
 	for netPort, portBindings := range container.NetworkSettings.Ports {
 		if strings.EqualFold(string(netPort), port+"/TCP") || strings.EqualFold(string(netPort), port+"/UDP") {
@@ -321,8 +321,7 @@ func (p *Provider) getPortBinding (container dockerData) (nat.PortBinding, error
 		}
 	}
 
-	return nat.PortBinding{HostIP: "", HostPort: ""}, fmt.Errorf(
-		"Unable to find the port binding for the %q container: the server is ignored.", container.Name)
+	return nat.PortBinding{HostIP: "", HostPort: ""}, fmt.Errorf("Unable to find the port binding for the %q container: the server is ignored.", container.Name)
 }
 
 func (p *Provider) getServers(containers []dockerData) map[string]types.Server {

--- a/provider/docker/config.go
+++ b/provider/docker/config.go
@@ -33,13 +33,13 @@ func (p *Provider) buildConfigurationV2(containersInspected []dockerData) *types
 		"getDomain":        label.GetFuncString(label.TraefikDomain, p.Domain),
 
 		// Backend functions
-		"getDeprecatedIPAddress": p.getDeprecatedIPAddress, // TODO: Should we expose getIPPort instead?
-		"getServers":             p.getServers,
-		"getMaxConn":             label.GetMaxConn,
-		"getHealthCheck":         label.GetHealthCheck,
-		"getBuffering":           label.GetBuffering,
-		"getCircuitBreaker":      label.GetCircuitBreaker,
-		"getLoadBalancer":        label.GetLoadBalancer,
+		"getIPAddress":      p.getDeprecatedIPAddress, // TODO: Should we expose getIPPort instead?
+		"getServers":        p.getServers,
+		"getMaxConn":        label.GetMaxConn,
+		"getHealthCheck":    label.GetHealthCheck,
+		"getBuffering":      label.GetBuffering,
+		"getCircuitBreaker": label.GetCircuitBreaker,
+		"getLoadBalancer":   label.GetLoadBalancer,
 
 		// Frontend functions
 		"getBackendName":    getBackendName,

--- a/provider/docker/config.go
+++ b/provider/docker/config.go
@@ -321,7 +321,7 @@ func (p *Provider) getPortBinding(container dockerData) (nat.PortBinding, error)
 		}
 	}
 
-	return nat.PortBinding{HostIP: "", HostPort: ""}, fmt.Errorf("Unable to find the port binding for the %q container: the server is ignored.", container.Name)
+	return nat.PortBinding{HostIP: "", HostPort: ""}, fmt.Errorf("Unable to find the port binding for the %q container: the server is ignored", container.Name)
 }
 
 func (p *Provider) getServers(containers []dockerData) map[string]types.Server {

--- a/provider/docker/config_container_docker_test.go
+++ b/provider/docker/config_container_docker_test.go
@@ -1293,7 +1293,7 @@ func TestDockerGetIPAddress(t *testing.T) {
 	}
 }
 
-func TestName(t *testing.T) {
+func TestDockerGetIPPort(t *testing.T) {
 	testCases := []struct {
 		desc         string
 		container    docker.ContainerJSON

--- a/provider/docker/config_container_docker_test.go
+++ b/provider/docker/config_container_docker_test.go
@@ -1293,6 +1293,167 @@ func TestDockerGetIPAddress(t *testing.T) {
 	}
 }
 
+func TestName(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		container    docker.ContainerJSON
+		ip, port     string
+		expectsError bool
+	}{
+		{
+			desc: "label traefik.port not set, binding with ip:port should create a route to the bound ip:port",
+			container: containerJSON(
+				ports(nat.PortMap{
+					"80/tcp": []nat.PortBinding{
+						{
+							HostIP:   "1.2.3.4",
+							HostPort: "8081",
+						},
+					},
+				}),
+				withNetwork("testnet", ipv4("10.11.12.13"))),
+			ip:   "1.2.3.4",
+			port: "8081",
+		},
+		{
+			desc: "label traefik.port set, multiple bindings on different ports, uses the label to select the correct (first) binding",
+			container: containerJSON(
+				labels(map[string]string{
+					label.TraefikPort: "80",
+				}),
+				ports(nat.PortMap{
+					"80/tcp": []nat.PortBinding{
+						{
+							HostIP:   "1.2.3.4",
+							HostPort: "8081",
+						},
+					},
+					"443/tcp": []nat.PortBinding{
+						{
+							HostIP:   "5.6.7.8",
+							HostPort: "8082",
+						},
+					},
+				}),
+				withNetwork("testnet", ipv4("10.11.12.13"))),
+			ip:   "1.2.3.4",
+			port: "8081",
+		},
+		{
+			desc: "label traefik.port set, multiple bindings on different ports, uses the label to select the correct (second) binding",
+			container: containerJSON(
+				labels(map[string]string{
+					label.TraefikPort: "443",
+				}),
+				ports(nat.PortMap{
+					"80/tcp": []nat.PortBinding{
+						{
+							HostIP:   "1.2.3.4",
+							HostPort: "8081",
+						},
+					},
+					"443/tcp": []nat.PortBinding{
+						{
+							HostIP:   "5.6.7.8",
+							HostPort: "8082",
+						},
+					},
+				}),
+				withNetwork("testnet", ipv4("10.11.12.13"))),
+			ip:   "5.6.7.8",
+			port: "8082",
+		},
+		{
+			desc: "label traefik.port set, single binding with ip:port for the label, creates the route",
+			container: containerJSON(
+				labels(map[string]string{
+					label.TraefikPort: "443",
+				}),
+				ports(nat.PortMap{
+					"443/tcp": []nat.PortBinding{
+						{
+							HostIP:   "5.6.7.8",
+							HostPort: "8082",
+						},
+					},
+				}),
+				withNetwork("testnet", ipv4("10.11.12.13"))),
+			ip:   "5.6.7.8",
+			port: "8082",
+		},
+		{
+			desc: "label traefik.port not set, single binding with port only, server ignored",
+			container: containerJSON(
+				ports(nat.PortMap{
+					"80/tcp": []nat.PortBinding{
+						{
+							HostPort: "8082",
+						},
+					},
+				}),
+				withNetwork("testnet", ipv4("10.11.12.13"))),
+			expectsError: true,
+		},
+		{
+			desc: "label traefik.port not set, no binding, server ignored",
+			container: containerJSON(
+				withNetwork("testnet", ipv4("10.11.12.13"))),
+			expectsError: true,
+		},
+		{
+			desc: "label traefik.port set, no binding on the corresponding port, server ignored",
+			container: containerJSON(
+				labels(map[string]string{
+					label.TraefikPort: "80",
+				}),
+				ports(nat.PortMap{
+					"443/tcp": []nat.PortBinding{
+						{
+							HostIP:   "5.6.7.8",
+							HostPort: "8082",
+						},
+					},
+				}),
+				withNetwork("testnet", ipv4("10.11.12.13"))),
+			expectsError: true,
+		},
+		{
+			desc: "label traefik.port set, no binding, server ignored",
+			container: containerJSON(
+				labels(map[string]string{
+					label.TraefikPort: "80",
+				}),
+				withNetwork("testnet", ipv4("10.11.12.13"))),
+			expectsError: true,
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			dData := parseContainer(test.container)
+			segmentProperties := label.ExtractTraefikLabels(dData.Labels)
+			dData.SegmentLabels = segmentProperties[""]
+
+			provider := &Provider{
+				Network:       "webnet",
+				UseBindPortIP: true,
+			}
+
+			actualIP, actualPort, actualError := provider.getIPPort(dData)
+			if test.expectsError {
+				require.Error(t, actualError)
+			} else {
+				require.NoError(t, actualError)
+			}
+			assert.Equal(t, test.ip, actualIP)
+			assert.Equal(t, test.port, actualPort)
+		})
+	}
+}
+
 func TestDockerGetPort(t *testing.T) {
 	testCases := []struct {
 		container docker.ContainerJSON

--- a/provider/docker/config_container_docker_test.go
+++ b/provider/docker/config_container_docker_test.go
@@ -1287,7 +1287,7 @@ func TestDockerGetIPAddress(t *testing.T) {
 				Network: "webnet",
 			}
 
-			actual := provider.getIPAddress(dData)
+			actual := provider.getDeprecatedIPAddress(dData)
 			assert.Equal(t, test.expected, actual)
 		})
 	}

--- a/provider/docker/config_container_swarm_test.go
+++ b/provider/docker/config_container_swarm_test.go
@@ -933,7 +933,7 @@ func TestSwarmGetIPAddress(t *testing.T) {
 			segmentProperties := label.ExtractTraefikLabels(dData.Labels)
 			dData.SegmentLabels = segmentProperties[""]
 
-			actual := provider.getIPAddress(dData)
+			actual := provider.getDeprecatedIPAddress(dData)
 			assert.Equal(t, test.expected, actual)
 		})
 	}

--- a/provider/docker/deprecated_config.go
+++ b/provider/docker/deprecated_config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math"
 	"strconv"
+	"strings"
 	"text/template"
 
 	"github.com/BurntSushi/ty/fun"
@@ -245,7 +246,7 @@ func (p Provider) getIPAddressV1(container dockerData) string {
 	if p.UseBindPortIP {
 		port := getPortV1(container)
 		for netPort, portBindings := range container.NetworkSettings.Ports {
-			if string(netPort) == port+"/TCP" || string(netPort) == port+"/UDP" {
+			if strings.EqualFold(string(netPort), port+"/TCP") || strings.EqualFold(string(netPort), port+"/UDP") {
 				for _, p := range portBindings {
 					return p.HostIP
 				}

--- a/provider/docker/deprecated_config.go
+++ b/provider/docker/deprecated_config.go
@@ -19,10 +19,10 @@ func (p *Provider) buildConfigurationV1(containersInspected []dockerData) *types
 		"isBackendLBSwarm": isBackendLBSwarm,
 
 		// Backend functions
-		"getIPAddress": p.getIPAddress,
-		"getPort":      getPortV1,
-		"getWeight":    getFuncIntLabelV1(label.TraefikWeight, label.DefaultWeight),
-		"getProtocol":  getFuncStringLabelV1(label.TraefikProtocol, label.DefaultProtocol),
+		"getDeprecatedIPAddress": p.getDeprecatedIPAddress,
+		"getPort":                getPortV1,
+		"getWeight":              getFuncIntLabelV1(label.TraefikWeight, label.DefaultWeight),
+		"getProtocol":            getFuncStringLabelV1(label.TraefikProtocol, label.DefaultProtocol),
 
 		"hasCircuitBreakerLabel":      hasFuncV1(label.TraefikBackendCircuitBreakerExpression),
 		"getCircuitBreakerExpression": getFuncStringLabelV1(label.TraefikBackendCircuitBreakerExpression, label.DefaultCircuitBreakerExpression),

--- a/provider/docker/deprecated_container_docker_test.go
+++ b/provider/docker/deprecated_container_docker_test.go
@@ -898,7 +898,7 @@ func TestDockerGetIPAddressV1(t *testing.T) {
 			t.Parallel()
 			dData := parseContainer(test.container)
 			provider := &Provider{}
-			actual := provider.getIPAddress(dData)
+			actual := provider.getDeprecatedIPAddress(dData)
 			if actual != test.expected {
 				t.Errorf("expected %q, got %q", test.expected, actual)
 			}

--- a/provider/docker/deprecated_container_swarm_test.go
+++ b/provider/docker/deprecated_container_swarm_test.go
@@ -667,7 +667,7 @@ func TestSwarmGetIPAddressV1(t *testing.T) {
 				SwarmMode: true,
 			}
 
-			actual := provider.getIPAddress(dData)
+			actual := provider.getDeprecatedIPAddress(dData)
 			if actual != test.expected {
 				t.Errorf("expected %q, got %q", test.expected, actual)
 			}


### PR DESCRIPTION
### What does this PR do?

Context: docker provider with usebindportip

Currently:
- Traefik doesn't find the port bindings when the API responds in lowercase.
- When the API responds in uppercase, Traefik uses the external IP only, and not the port
- When no IP is specified, Traefik creates a route using the IP 0.0.0.0
- When the label `traefik.port`is specified, it is used both for selecting the binding _and_ in the route

This PR: 
- ignores the case when looking for port bindings
- takes the external IP _and_ port into account to create the routes
- excludes servers with no binding
- excludes servers with no IP specified in the binding (0.0.0.0)
- the label `traefik.port` is used to select the binding (which enables the use of segments)

To sum it up:

| label                  | Binding      | Routes to |
|----------------|------------|-----------|
| `traefik.port` not set | `IP_E1:P_E1:P_I1` | `IP_E1:P_E1` |
| `traefik.port` not set | `P_E1:P_I1` | Warning & Ignored (cannot route to `0.0.0.0`) |
| `traefik.port` not set | None | Warning & Ignored (Binding is missing) |
| `traefik.port=P_I1` | `IP_E1:P_E1:P_I1` | `IP_E1:P_E1` |
| `traefik.port=P_I2` | `IP_E1:P_E1:P_I1` | Warning  & Ignored (cannot find binding for `XX:XX:P_I2`) |
| `traefik.port=P_I2`  | `IP_E1:P_E1:P_I1` & `IP_E2:P_E2:P_I2` | `IP_E2:P_E2` |
| `traefik.port=P_I1`  | None | Warning & Ignored (Binding is missing) |

### Motivation

Fixes #3622 

(kudos to @systemmonkey42 for the awesome description in the issue) 

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Examples 

<details>
<summary>docker-compose.yml</summary>

```yml
version: '3'

services:
  whoami-1:
    image: emilevauge/whoami
    ports:
      -  xx.xx.xx.xx:8082:80 # Routes to XX.XX.XX.XX:8082
    labels: 
      - traefik.enable=true
      - traefik.backend=whoami
      - "traefik.frontend.rule=PathPrefix:/whoami-1"

  whoami-2:
    image: emilevauge/whoami
    ports:
      -  8083:80 # Warning Cannot determine the IP address (got 0.0.0.0) for the container "/issue_3622_whoami-2_1": ignoring server 
    labels: 
      - traefik.enable=true
      - traefik.backend=whoami-2
      - "traefik.frontend.rule=PathPrefix:/whoami-2"

  whoami-3:
    image: emilevauge/whoami
    # Warning Unable to find a binding for the container "/issue_3622_whoami-3_1": ignoring server
    labels: 
      - traefik.enable=true
      - traefik.backend=whoami-3
      - "traefik.frontend.rule=PathPrefix:/whoami-3"
  
  whoami-4:
    image: emilevauge/whoami
    ports:
      -  xx.xx.xx.xx:8085:80 # routes to XX:XX:XX:XX:8085
    labels:
      - traefik.port=80
      - traefik.enable=true
      - traefik.backend=whoami-4
      - "traefik.frontend.rule=PathPrefix:/whoami-4"

  whoami-5:
    image: emilevauge/whoami
    ports:
      -  xx.xx.xx.xx:8086:80 # Warning Unable to find a binding for the container "/issue_3622_whoami-5_1": ignoring server
    labels:
      - traefik.port=81
      - traefik.enable=true
      - traefik.backend=whoami-5
      - "traefik.frontend.rule=PathPrefix:/whoami-5"

  whoami-6:
    image: emilevauge/whoami
    ports:
      -  xx.xx.xx.xx:8087:80
      -  xx.xx.xx.xx:8088:81 # routes to xx.xx.xx.xx:8088
    labels:
      - traefik.port=81
      - traefik.enable=true
      - traefik.backend=whoami-6
      - "traefik.frontend.rule=PathPrefix:/whoami-6"

  whoami-7:
    image: emilevauge/whoami
    # Warning Unable to find a binding for the container "/issue_3622_whoami-7_1": ignoring server
    labels:
      - traefik.port=81
      - traefik.enable=true
      - traefik.backend=whoami-7
      - "traefik.frontend.rule=PathPrefix:/whoami-7"
```

</details>

<details>
<summary>traefik/api</summary>

```json
{
  "docker": {
    "backends": {
      "backend-whoami": {
        "servers": {
          "server-issue-3622-whoami-1-1-7c60b6958b968de9998659c11d7406a0": {
            "url": "http://xx.xx.xx.xx:8082",
            "weight": 1
          }
        },
      },
      "backend-whoami-4": {
        "servers": {
          "server-issue-3622-whoami-4-1-5dcf432359cd6ad04e1779a85d45314a": {
            "url": "http://xx.xx.xx.xx:8085",
            "weight": 1
          }
        },
      },
      "backend-whoami-6": {
        "servers": {
          "server-issue-3622-whoami-6-1-554f0078ab3c259e14fc03848f9f8ce4": {
            "url": "http://xx.xx.xx.xx:8088",
            "weight": 1
          }
        },
      }
    },
  }
}
```
</details>
