### PR TITLE
Added default configuration for DataDog APM Tracer

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containous/traefik/api"
 	"github.com/containous/traefik/log"
 	"github.com/containous/traefik/middlewares/tracing"
+	"github.com/containous/traefik/middlewares/tracing/datadog"
 	"github.com/containous/traefik/middlewares/tracing/jaeger"
 	"github.com/containous/traefik/middlewares/tracing/zipkin"
 	"github.com/containous/traefik/ping"
@@ -344,6 +345,18 @@ func (gc *GlobalConfiguration) initTracing() {
 			if gc.Tracing.Jaeger != nil {
 				log.Warn("Jaeger configuration will be ignored")
 				gc.Tracing.Jaeger = nil
+			}
+		case datadog.Name:
+			if gc.Tracing.DataDog == nil {
+				gc.Tracing.DataDog = &datadog.Config{
+					LocalAgentHostPort: "localhost:8126",
+					GlobalTag:          "",
+					Debug:              false,
+				}
+			}
+			if gc.Tracing.DataDog != nil {
+				log.Warn("DataDog configuration will be ignored")
+				gc.Tracing.DataDog = nil
 			}
 		default:
 			log.Warnf("Unknown tracer %q", gc.Tracing.Backend)

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -333,6 +333,10 @@ func (gc *GlobalConfiguration) initTracing() {
 				log.Warn("Zipkin configuration will be ignored")
 				gc.Tracing.Zipkin = nil
 			}
+			if gc.Tracing.DataDog != nil {
+				log.Warn("DataDog configuration will be ignored")
+				gc.Tracing.DataDog = nil
+			}
 		case zipkin.Name:
 			if gc.Tracing.Zipkin == nil {
 				gc.Tracing.Zipkin = &zipkin.Config{
@@ -346,6 +350,10 @@ func (gc *GlobalConfiguration) initTracing() {
 				log.Warn("Jaeger configuration will be ignored")
 				gc.Tracing.Jaeger = nil
 			}
+			if gc.Tracing.DataDog != nil {
+				log.Warn("DataDog configuration will be ignored")
+				gc.Tracing.DataDog = nil
+			}
 		case datadog.Name:
 			if gc.Tracing.DataDog == nil {
 				gc.Tracing.DataDog = &datadog.Config{
@@ -354,9 +362,13 @@ func (gc *GlobalConfiguration) initTracing() {
 					Debug:              false,
 				}
 			}
-			if gc.Tracing.DataDog != nil {
-				log.Warn("DataDog configuration will be ignored")
-				gc.Tracing.DataDog = nil
+			if gc.Tracing.Zipkin != nil {
+				log.Warn("Zipkin configuration will be ignored")
+				gc.Tracing.Zipkin = nil
+			}
+			if gc.Tracing.Jaeger != nil {
+				log.Warn("Jaeger configuration will be ignored")
+				gc.Tracing.Jaeger = nil
 			}
 		default:
 			log.Warnf("Unknown tracer %q", gc.Tracing.Backend)


### PR DESCRIPTION
Fixed DataDog APM initialization error due to missing default configs.