### PR TITLE
Adding segments to ECS

### DIFF
--- a/provider/ecs/config_segment_test.go
+++ b/provider/ecs/config_segment_test.go
@@ -1,12 +1,12 @@
 package ecs
 
 import (
-	"testing"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/containous/traefik/provider/label"
 	"github.com/containous/traefik/types"
 	"github.com/stretchr/testify/assert"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/containous/traefik/provider/label"
-	"github.com/aws/aws-sdk-go/service/ecs"
+	"testing"
 )
 
 func TestSegmentBuildConfiguration(t *testing.T) {
@@ -17,24 +17,24 @@ func TestSegmentBuildConfiguration(t *testing.T) {
 		expectedBackends  map[string]*types.Backend
 	}{
 		{
-			desc:              "when container 2 container-ports",
-			instanceInfo:      ecsInstance{
-					Name: "foo-http",
-					ID:   "123456789abc",
-					containerDefinition: &ecs.ContainerDefinition{},
-					machine: &machine{
-						state:     ec2.InstanceStateNameRunning,
-						privateIP: "10.0.0.1",
-						ports:     []portMapping{
-							{hostPort: 12354, containerPort: 8000},  // service1
-							{hostPort: 45678, containerPort: 8001},  // service2
-						},
-					},
-					TraefikLabels: map[string]string{
-						"traefik.service1.port": "8000",
-						"traefik.service2.port": "8001",
+			desc: "when container 2 container-ports",
+			instanceInfo: ecsInstance{
+				Name:                "foo-http",
+				ID:                  "123456789abc",
+				containerDefinition: &ecs.ContainerDefinition{},
+				machine: &machine{
+					state:     ec2.InstanceStateNameRunning,
+					privateIP: "10.0.0.1",
+					ports: []portMapping{
+						{hostPort: 12354, containerPort: 8000}, // service1
+						{hostPort: 45678, containerPort: 8001}, // service2
 					},
 				},
+				TraefikLabels: map[string]string{
+					"traefik.service1.port": "8000",
+					"traefik.service2.port": "8001",
+				},
+			},
 			expectedFrontends: map[string]*types.Frontend{
 				"frontend-foo-http-service1": {
 					Backend:        "backend-foo-http-service1",
@@ -78,7 +78,6 @@ func TestSegmentBuildConfiguration(t *testing.T) {
 				},
 			},
 		},
-
 	}
 
 	for _, test := range testCases {

--- a/provider/ecs/config_segment_test.go
+++ b/provider/ecs/config_segment_test.go
@@ -1,0 +1,100 @@
+package ecs
+
+import (
+	"testing"
+	"github.com/containous/traefik/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/containous/traefik/provider/label"
+	"github.com/aws/aws-sdk-go/service/ecs"
+)
+
+func TestSegmentBuildConfiguration(t *testing.T) {
+	testCases := []struct {
+		desc              string
+		instanceInfo      ecsInstance
+		expectedFrontends map[string]*types.Frontend
+		expectedBackends  map[string]*types.Backend
+	}{
+		{
+			desc:              "when container 2 container-ports",
+			instanceInfo:      ecsInstance{
+					Name: "foo-http",
+					ID:   "123456789abc",
+					containerDefinition: &ecs.ContainerDefinition{},
+					machine: &machine{
+						state:     ec2.InstanceStateNameRunning,
+						privateIP: "10.0.0.1",
+						ports:     []portMapping{
+							{hostPort: 12354, containerPort: 8000},  // service1
+							{hostPort: 45678, containerPort: 8001},  // service2
+						},
+					},
+					TraefikLabels: map[string]string{
+						"traefik.service1.port": "8000",
+						"traefik.service2.port": "8001",
+					},
+				},
+			expectedFrontends: map[string]*types.Frontend{
+				"frontend-foo-http-service1": {
+					Backend:        "backend-foo-http-service1",
+					PassHostHeader: true,
+					EntryPoints:    []string{},
+					Routes: map[string]types.Route{
+						"route-frontend-foo-http-service1": {
+							Rule: "Host:foo-http.",
+						},
+					},
+				},
+				"frontend-foo-http-service2": {
+					Backend:        "backend-foo-http-service2",
+					PassHostHeader: true,
+					EntryPoints:    []string{},
+					Routes: map[string]types.Route{
+						"route-frontend-foo-http-service2": {
+							Rule: "Host:foo-http.",
+						},
+					},
+				},
+			},
+			expectedBackends: map[string]*types.Backend{
+				"backend-foo-http-service1": {
+					Servers: map[string]types.Server{
+						"server-foo-http-123456789abc-service1": {
+							URL:    "http://10.0.0.1:12354",
+							Weight: label.DefaultWeight,
+						},
+					},
+					CircuitBreaker: nil,
+				},
+				"backend-foo-http-service2": {
+					Servers: map[string]types.Server{
+						"server-foo-http-123456789abc-service2": {
+							URL:    "http://10.0.0.1:45678",
+							Weight: label.DefaultWeight,
+						},
+					},
+					CircuitBreaker: nil,
+				},
+			},
+		},
+
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			p := &Provider{ExposedByDefault: true}
+
+			var instances []ecsInstance
+			instances = append(instances, test.instanceInfo)
+
+			actualConfig, _ := p.buildConfiguration(instances)
+
+			assert.EqualValues(t, test.expectedBackends, actualConfig.Backends)
+			assert.EqualValues(t, test.expectedFrontends, actualConfig.Frontends)
+		})
+	}
+}

--- a/provider/ecs/ecs.go
+++ b/provider/ecs/ecs.go
@@ -46,8 +46,8 @@ type ecsInstance struct {
 	containerDefinition *ecs.ContainerDefinition
 	machine             *machine
 	TraefikLabels       map[string]string
-	SegmentLabels   map[string]string
-	SegmentName     string
+	SegmentLabels       map[string]string
+	SegmentName         string
 }
 
 type portMapping struct {

--- a/provider/ecs/ecs.go
+++ b/provider/ecs/ecs.go
@@ -46,6 +46,8 @@ type ecsInstance struct {
 	containerDefinition *ecs.ContainerDefinition
 	machine             *machine
 	TraefikLabels       map[string]string
+	SegmentLabels   map[string]string
+	SegmentName     string
 }
 
 type portMapping struct {


### PR DESCRIPTION
## What does this PR do?
This PR is currently a work in progress. I'm mainly a Python developer so there is probably a fair bit that could be done better. The intention is to add in "segments" for ECS like there is with the docker backend. So therefore Traefik can make use of multiple ports exposed by an ECS container.

Here is a snippet of the docker labels I have in ECS on my test container
```
"traefik.enable": "true",
"traefik.service1.domain": "test.traefik",
"traefik.service1.port": "8888",
"traefik.service1.backend": "backend1",
"traefik.service1.frontend.rule": "Host:test.traefik",
"traefik.service2.domain": "test.traefik"
"traefik.service2.port": "4444",
"traefik.service2.backend": "backend2",
"traefik.service2.frontend.rule": "Host:test.traefik;Path:/test",
```
Attached is some sample cURL output of it working :D, a sample ecs task definition and the current output of /api/providers
[curl_output.txt](https://github.com/containous/traefik/files/2225546/curl_output.txt)
[ecs_taskdef.txt](https://github.com/containous/traefik/files/2225547/ecs_taskdef.txt)
[traefik_api_providers.txt](https://github.com/containous/traefik/files/2225548/traefik_api_providers.txt)


I could do with someone looking over this and ensuring I'm going about this in the right way and also any ideas on what else is needed would be helpful too :)

### More
- [ ] Add more tests
- [ ] Update documentation
