### PR TITLE
Fix ACME certificate for wildcard and root domains

### DIFF
--- a/provider/acme/provider.go
+++ b/provider/acme/provider.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/BurntSushi/ty/fun"
+	"github.com/cenk/backoff"
 	"github.com/containous/flaeg"
 	"github.com/containous/traefik/log"
 	"github.com/containous/traefik/rules"
@@ -74,6 +75,8 @@ type Certificate struct {
 type DNSChallenge struct {
 	Provider         string         `description:"Use a DNS-01 based challenge provider rather than HTTPS."`
 	DelayBeforeCheck flaeg.Duration `description:"Assume DNS propagates after a delay in seconds rather than finding and querying nameservers."`
+	preCheckTimeout  time.Duration
+	preCheckInterval time.Duration
 }
 
 // HTTPChallenge contains HTTP challenge Configuration
@@ -262,6 +265,17 @@ func (p *Provider) getClient() (*acme.Client, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		// Set the precheck timeout into the DNSChallenge provider
+		switch provider := provider.(type) {
+		case acme.ChallengeProviderTimeout:
+			p.DNSChallenge.preCheckTimeout, p.DNSChallenge.preCheckInterval = provider.Timeout()
+		default:
+			// Same default values than LEGO
+			p.DNSChallenge.preCheckTimeout = 60 * time.Second
+			p.DNSChallenge.preCheckInterval = 2 * time.Second
+		}
+
 	} else if p.HTTPChallenge != nil && len(p.HTTPChallenge.EntryPoint) > 0 {
 		log.Debug("Using HTTP Challenge provider.")
 
@@ -361,13 +375,20 @@ func (p *Provider) resolveCertificate(domain types.Domain, domainFromConfigurati
 		return nil, fmt.Errorf("cannot get ACME client %v", err)
 	}
 
+	var certificate *acme.CertificateResource
 	bundle := true
-
-	certificate, err := client.ObtainCertificate(uncheckedDomains, bundle, nil, OSCPMustStaple)
-	if err != nil {
-		return nil, fmt.Errorf("cannot obtain certificates: %+v", err)
+	if p.useBackOffToObtainCertificate(uncheckedDomains) {
+		certificate, err = obtainCertificateWithBackOff(domains, client, p.DNSChallenge.preCheckTimeout, p.DNSChallenge.preCheckInterval, bundle)
+	} else {
+		certificate, err = client.ObtainCertificate(domains, bundle, nil, OSCPMustStaple)
 	}
 
+	if err != nil {
+		return nil, fmt.Errorf("unable to generate a certificate for the domains %v: %v", uncheckedDomains, err)
+	}
+	if certificate == nil {
+		return nil, fmt.Errorf("domains %v do not generate a certificate", uncheckedDomains)
+	}
 	if len(certificate.Certificate) == 0 || len(certificate.PrivateKey) == 0 {
 		return nil, fmt.Errorf("domains %v generate certificate with no value: %v", uncheckedDomains, certificate)
 	}
@@ -380,6 +401,53 @@ func (p *Provider) resolveCertificate(domain types.Domain, domainFromConfigurati
 		domain = types.Domain{Main: uncheckedDomains[0]}
 	}
 	p.addCertificateForDomain(domain, certificate.Certificate, certificate.PrivateKey)
+
+	return certificate, nil
+}
+
+func (p *Provider) useBackOffToObtainCertificate(domains []string) bool {
+	// Check if we can use a backoff only if we use the DNS Challenge and if is there are at least 2 domains to check
+	if p.DNSChallenge != nil && len(domains) > 1 {
+		rootDomain := ""
+		for i := 0; i < len(domains); i++ {
+			// Search a wildcard domain if not already found
+			if len(rootDomain) == 0 && strings.HasPrefix(domains[i], "*.") {
+				rootDomain = strings.TrimPrefix(domains[i], "*.")
+				// Restart to the first indfex to check id the root domain of the wildcard domain exists
+				i = 0
+			} else if len(rootDomain) > 0 && rootDomain == domains[i] {
+				// If the domains list contains a wildcard domain and its root domain, we can use a backOff to obtain the certificate
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func obtainCertificateWithBackOff(domains []string, client *acme.Client, timeout, interval time.Duration, bundle bool) (*acme.CertificateResource, error) {
+	var certificate *acme.CertificateResource
+	var err error
+
+	operation := func() error {
+		certificate, err = client.ObtainCertificate(domains, bundle, nil, OSCPMustStaple)
+		return err
+	}
+
+	notify := func(err error, time time.Duration) {
+		log.Errorf("Error obtaining certificate retrying in %s", time)
+	}
+
+	ebo := backoff.NewExponentialBackOff()
+	// Give the time to LEGO to try to solve the challenge twice
+	ebo.MaxElapsedTime = 2 * timeout
+	ebo.MaxInterval = interval
+
+	err = backoff.RetryNotify(safe.OperationWithRecover(operation), ebo, notify)
+	if err != nil {
+		log.Errorf("Error obtaining certificate: %v", err)
+		return nil, err
+	}
 
 	return certificate, nil
 }

--- a/provider/acme/provider_test.go
+++ b/provider/acme/provider_test.go
@@ -557,7 +557,7 @@ func TestUseBackOffToObtainCertificate(t *testing.T) {
 
 			acmeProvider := Provider{Configuration: &Configuration{DNSChallenge: test.dnsChallenge}}
 
-			actualResponse := acmeProvider.useBackOffToObtainCertificate(test.domains)
+			actualResponse := acmeProvider.useCertificateWithRetry(test.domains)
 			assert.Equal(t, test.expectedResponse, actualResponse, "unexpected response to use backOff")
 		})
 	}

--- a/provider/acme/provider_test.go
+++ b/provider/acme/provider_test.go
@@ -504,3 +504,61 @@ func TestIsAccountMatchingCaServer(t *testing.T) {
 		})
 	}
 }
+
+func TestUseBackOffToObtainCertificate(t *testing.T) {
+	testCases := []struct {
+		desc             string
+		domains          []string
+		dnsChallenge     *DNSChallenge
+		expectedResponse bool
+	}{
+		{
+			desc:             "only one single domain",
+			domains:          []string{"acme.wtf"},
+			dnsChallenge:     &DNSChallenge{},
+			expectedResponse: false,
+		},
+		{
+			desc:             "only one wildcard domain",
+			domains:          []string{"*.acme.wtf"},
+			dnsChallenge:     &DNSChallenge{},
+			expectedResponse: false,
+		},
+		{
+			desc:             "wildcard domain with no root domain",
+			domains:          []string{"*.acme.wtf", "foo.acme.wtf", "bar.acme.wtf", "foo.bar"},
+			dnsChallenge:     &DNSChallenge{},
+			expectedResponse: false,
+		},
+		{
+			desc:             "wildcard and root domain",
+			domains:          []string{"*.acme.wtf", "foo.acme.wtf", "bar.acme.wtf", "acme.wtf"},
+			dnsChallenge:     &DNSChallenge{},
+			expectedResponse: true,
+		},
+		{
+			desc:             "wildcard and root domain but no DNS challenge",
+			domains:          []string{"*.acme.wtf", "acme.wtf"},
+			dnsChallenge:     nil,
+			expectedResponse: false,
+		},
+		{
+			desc:             "two wildcard domains (must never happen)",
+			domains:          []string{"*.acme.wtf", "*.bar.foo"},
+			dnsChallenge:     nil,
+			expectedResponse: false,
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			acmeProvider := Provider{Configuration: &Configuration{DNSChallenge: test.dnsChallenge}}
+
+			actualResponse := acmeProvider.useBackOffToObtainCertificate(test.domains)
+			assert.Equal(t, test.expectedResponse, actualResponse, "unexpected response to use backOff")
+		})
+	}
+}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

This Pull Request introduces a mechanims which allow retrying to generate a ACME certificate when a `DNSChallenge` failed to obtain a certificate for both wildcard and root domain.

### Motivation

<!-- What inspired you to submit this pull request? -->

Since the feature which allows Træfik users to generate ACME certificates for both wildcard domain (as CN) and root domain (as SAN), a flaky behavior is noted.

Sometimes everything works well, sometines challenges cannot be solved with different errors (TXT record missing or incorrect).
These errors exist for almost all the DNS providers.

Fixes #3468, #3445.

### More

- [x] Added/updated tests

### Additional Notes

A first analysis showed that **the problem is due to the name of the TXT records** needed by Let's Encrypt: a wildcard domain and its root domain are challenged thanks to a TXT record with the same name. In function of the TTL given to the TXT records, it was unable to Let's Encrypt the get all the values asked in the allowed time.

After analyzed deeply the problem (and made some tests), it appears that **the problem is due to the time to propagate a TXT record creation/deletion/update** in the DNS provider infrastructure.

Indeed, LEGO makes a pre-check on all the TXT records before to ask Let's Ecrypt to do the challenge. But, sometimes, the result caught by LEGO and the other one caught by Let's Encrypt are differents (it's maybe due to the time to propagate the modifications into all the DNS provider infrastructure).

The modification introduced by this PR allows Træfik to retry to obtain a ACME certificate for a wildcard and its root domain when errors happens.

**The retry works because Let's Encrypt does not ask to challenge twice the same domain**.
Thus, if during the first iteration the wildcard is successfully checked, during the second iteration only the root domain will be checked.