### PR TITLE
Add traefik prefix to k8s annotations

### DIFF
--- a/docs/user-guide/kubernetes.md
+++ b/docs/user-guide/kubernetes.md
@@ -453,8 +453,8 @@ kubectl create secret generic mysecret --from-file auth --namespace=monitoring
 
 C. Attach the following annotations to the Ingress object:
 
-- `ingress.kubernetes.io/auth-type: "basic"`
-- `ingress.kubernetes.io/auth-secret: "mysecret"`
+- `traefik.ingress.kubernetes.io/auth-type: "basic"`
+- `traefik.ingress.kubernetes.io/auth-secret: "mysecret"`
 
 They specify basic authentication and reference the Secret `mysecret` containing the credentials.
 
@@ -468,8 +468,8 @@ metadata:
  namespace: monitoring
  annotations:
    kubernetes.io/ingress.class: traefik
-   ingress.kubernetes.io/auth-type: "basic"
-   ingress.kubernetes.io/auth-secret: "mysecret"
+   traefik.ingress.kubernetes.io/auth-type: "basic"
+   traefik.ingress.kubernetes.io/auth-secret: "mysecret"
 spec:
  rules:
  - host: dashboard.prometheus.example.com


### PR DESCRIPTION
### What does this PR do?

Documentation: fix missing traefik prefix in k8s authentification annotations.

### Motivation

—

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Likely to have other occurences. I can update this PR to change all of them. 
However I need to be clear which annotations requires `traefik` in front of them beforehand.
