### PR TITLE
Added support for Trace name truncation for traces

### DIFF
--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containous/traefik/configuration"
 	"github.com/containous/traefik/middlewares/accesslog"
 	"github.com/containous/traefik/middlewares/tracing"
+	"github.com/containous/traefik/middlewares/tracing/datadog"
 	"github.com/containous/traefik/middlewares/tracing/jaeger"
 	"github.com/containous/traefik/middlewares/tracing/zipkin"
 	"github.com/containous/traefik/ping"
@@ -218,8 +219,9 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 
 	// default Tracing
 	defaultTracing := tracing.Tracing{
-		Backend:     "jaeger",
-		ServiceName: "traefik",
+		Backend:       "jaeger",
+		ServiceName:   "traefik",
+		SpanNameLimit: 100,
 		Jaeger: &jaeger.Config{
 			SamplingServerURL:  "http://localhost:5778/sampling",
 			SamplingType:       "const",
@@ -231,6 +233,11 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 			SameSpan:     false,
 			ID128Bit:     true,
 			Debug:        false,
+		},
+		DataDog: &datadog.Config{
+			LocalAgentHostPort: "localhost:8126",
+			GlobalTag:          "",
+			Debug:              false,
 		},
 	}
 

--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -221,7 +221,7 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 	defaultTracing := tracing.Tracing{
 		Backend:       "jaeger",
 		ServiceName:   "traefik",
-		SpanNameLimit: 100,
+		SpanNameLimit: 0,
 		Jaeger: &jaeger.Config{
 			SamplingServerURL:  "http://localhost:5778/sampling",
 			SamplingType:       "const",

--- a/docs/configuration/tracing.md
+++ b/docs/configuration/tracing.md
@@ -24,6 +24,7 @@ Træfik supports two backends: Jaeger and Zipkin.
   serviceName = "traefik"
     
   # Span name limit allows for name truncation in case of very long Frontend/Backend names
+  # This can prevent certain tracing providers to drop traces that exceed their length limits
   #
   # Default: 0 - no truncation will occur
   # 
@@ -80,6 +81,7 @@ Træfik supports two backends: Jaeger and Zipkin.
   serviceName = "traefik"
     
   # Span name limit allows for name truncation in case of very long Frontend/Backend names
+  # This can prevent certain tracing providers to drop traces that exceed their length limits
   #
   # Default: 0 - no truncation will occur
   # 
@@ -129,6 +131,7 @@ Træfik supports two backends: Jaeger and Zipkin.
   serviceName = "traefik"
   
   # Span name limit allows for name truncation in case of very long Frontend/Backend names
+  # This can prevent certain tracing providers to drop traces that exceed their length limits
   #
   # Default: 0 - no truncation will occur
   # 

--- a/docs/configuration/tracing.md
+++ b/docs/configuration/tracing.md
@@ -22,6 +22,12 @@ Træfik supports two backends: Jaeger and Zipkin.
   # Default: "traefik"
   #
   serviceName = "traefik"
+    
+  # Span name limit allows for name truncation in case of very long Frontend/Backend names
+  #
+  # Default: 0 - no truncation will occur
+  # 
+  spanNameLimit = 0
 
   [tracing.jaeger]
     # Sampling Server URL is the address of jaeger-agent's HTTP sampling server
@@ -72,6 +78,12 @@ Træfik supports two backends: Jaeger and Zipkin.
   # Default: "traefik"
   #
   serviceName = "traefik"
+    
+  # Span name limit allows for name truncation in case of very long Frontend/Backend names
+  #
+  # Default: 0 - no truncation will occur
+  # 
+  spanNameLimit = 150
 
   [tracing.zipkin]
     # Zipking HTTP endpoint used to send data
@@ -115,6 +127,12 @@ Træfik supports two backends: Jaeger and Zipkin.
   # Default: "traefik"
   #
   serviceName = "traefik"
+  
+  # Span name limit allows for name truncation in case of very long Frontend/Backend names
+  #
+  # Default: 0 - no truncation will occur
+  # 
+  spanNameLimit = 100
 
   [tracing.datadog]
     # Local Agent Host Port instructs reporter to send spans to datadog-tracing-agent at this address

--- a/middlewares/tracing/entrypoint.go
+++ b/middlewares/tracing/entrypoint.go
@@ -45,7 +45,7 @@ func (e *entryPointMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request,
 func generateEntryPointSpanName(r *http.Request, entryPoint string, spanLimit int) string {
 	name := fmt.Sprintf("Entrypoint %s %s", entryPoint, r.Host)
 
-	if len(name) > spanLimit {
+	if spanLimit > 0 && len(name) > spanLimit {
 		if spanLimit < EntryPointMagicNumber {
 			log.Warnf("SpanNameLimit is set to be less then required static number of characters, defaulting to %d + 3", EntryPointMagicNumber)
 			spanLimit = EntryPointMagicNumber + 3

--- a/middlewares/tracing/entrypoint.go
+++ b/middlewares/tracing/entrypoint.go
@@ -39,7 +39,7 @@ func (e *entryPointMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request,
 	span.Finish()
 }
 
-// generateEntryPointSpanName will return a Span name of an appropriate lenth based on the 'spanLimit' argument.  If needed, it will be truncated, but will not be less than 24 characters
+// generateEntryPointSpanName will return a Span name of an appropriate lenth based on the 'spanLimit' argument.  If needed, it will be truncated, but will not be less than 24 characters.
 func generateEntryPointSpanName(r *http.Request, entryPoint string, spanLimit int) string {
 	name := fmt.Sprintf("Entrypoint %s %s", entryPoint, r.Host)
 

--- a/middlewares/tracing/entrypoint.go
+++ b/middlewares/tracing/entrypoint.go
@@ -48,9 +48,9 @@ func generateEntryPointSpanName(r *http.Request, entryPoint string, spanLimit in
 			log.Warnf("SpanNameLimit is set to be less than required static number of characters, defaulting to %d + 3", EntryPointMaxLengthNumber)
 			spanLimit = EntryPointMaxLengthNumber + 3
 		}
-		hash := ComputeHash(name)
+		hash := computeHash(name)
 		limit := (spanLimit - EntryPointMaxLengthNumber) / 2
-		name = fmt.Sprintf("Entrypoint %s %s %s", TruncateString(entryPoint, limit), TruncateString(r.Host, limit), hash)
+		name = fmt.Sprintf("Entrypoint %s %s %s", truncateString(entryPoint, limit), truncateString(r.Host, limit), hash)
 	}
 
 	return name

--- a/middlewares/tracing/entrypoint.go
+++ b/middlewares/tracing/entrypoint.go
@@ -39,12 +39,13 @@ func (e *entryPointMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request,
 	span.Finish()
 }
 
+// generateEntryPointSpanName will return a Span name of an appropriate lenth based on the 'spanLimit' argument.  If needed, it will be truncated, but will not be less than 24 characters
 func generateEntryPointSpanName(r *http.Request, entryPoint string, spanLimit int) string {
 	name := fmt.Sprintf("Entrypoint %s %s", entryPoint, r.Host)
 
 	if spanLimit > 0 && len(name) > spanLimit {
 		if spanLimit < EntryPointMaxLengthNumber {
-			log.Warnf("SpanNameLimit is set to be less then required static number of characters, defaulting to %d + 3", EntryPointMaxLengthNumber)
+			log.Warnf("SpanNameLimit is set to be less than required static number of characters, defaulting to %d + 3", EntryPointMaxLengthNumber)
 			spanLimit = EntryPointMaxLengthNumber + 3
 		}
 		hash := ComputeHash(name)

--- a/middlewares/tracing/entrypoint.go
+++ b/middlewares/tracing/entrypoint.go
@@ -22,9 +22,6 @@ func (t *Tracing) NewEntryPoint(name string) negroni.Handler {
 }
 
 func (e *entryPointMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-	//opNameFunc := func(r *http.Request) string {
-	//	return fmt.Sprintf("Entrypoint %s %s", e.entryPoint, r.Host)
-	//}
 	opNameFunc := generateEntryPointSpanName
 
 	ctx, _ := e.Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(r.Header))

--- a/middlewares/tracing/entrypoint.go
+++ b/middlewares/tracing/entrypoint.go
@@ -22,12 +22,13 @@ func (t *Tracing) NewEntryPoint(name string) negroni.Handler {
 }
 
 func (e *entryPointMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-	opNameFunc := func(r *http.Request) string {
-		return fmt.Sprintf("Entrypoint %s %s", e.entryPoint, r.Host)
-	}
+	//opNameFunc := func(r *http.Request) string {
+	//	return fmt.Sprintf("Entrypoint %s %s", e.entryPoint, r.Host)
+	//}
+	opNameFunc := generateEntryPointSpanName
 
 	ctx, _ := e.Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(r.Header))
-	span := e.StartSpan(opNameFunc(r), ext.RPCServerOption(ctx))
+	span := e.StartSpan(opNameFunc(r, e.entryPoint, e.SpanNameLimit), ext.RPCServerOption(ctx))
 	ext.Component.Set(span, e.ServiceName)
 	LogRequest(span, r)
 	ext.SpanKindRPCServer.Set(span)
@@ -39,4 +40,20 @@ func (e *entryPointMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request,
 
 	LogResponseCode(span, recorder.Status())
 	span.Finish()
+}
+
+func generateEntryPointSpanName(r *http.Request, entryPoint string, spanLimit int) string {
+	name := fmt.Sprintf("Entrypoint %s %s", entryPoint, r.Host)
+
+	if len(name) > spanLimit {
+		if spanLimit < EntryPointMagicNumber {
+			log.Warnf("SpanNameLimit is set to be less then required static number of characters, defaulting to %d + 3", EntryPointMagicNumber)
+			spanLimit = EntryPointMagicNumber + 3
+		}
+		hash := ComputeHash(name)
+		limit := (spanLimit - EntryPointMagicNumber) / 2
+		name = fmt.Sprintf("Entrypoint %s %s %s", TruncateString(entryPoint, limit), TruncateString(r.Host, limit), hash)
+	}
+
+	return name
 }

--- a/middlewares/tracing/entrypoint.go
+++ b/middlewares/tracing/entrypoint.go
@@ -43,12 +43,12 @@ func generateEntryPointSpanName(r *http.Request, entryPoint string, spanLimit in
 	name := fmt.Sprintf("Entrypoint %s %s", entryPoint, r.Host)
 
 	if spanLimit > 0 && len(name) > spanLimit {
-		if spanLimit < EntryPointMagicNumber {
-			log.Warnf("SpanNameLimit is set to be less then required static number of characters, defaulting to %d + 3", EntryPointMagicNumber)
-			spanLimit = EntryPointMagicNumber + 3
+		if spanLimit < EntryPointMaxLengthNumber {
+			log.Warnf("SpanNameLimit is set to be less then required static number of characters, defaulting to %d + 3", EntryPointMaxLengthNumber)
+			spanLimit = EntryPointMaxLengthNumber + 3
 		}
 		hash := ComputeHash(name)
-		limit := (spanLimit - EntryPointMagicNumber) / 2
+		limit := (spanLimit - EntryPointMaxLengthNumber) / 2
 		name = fmt.Sprintf("Entrypoint %s %s %s", TruncateString(entryPoint, limit), TruncateString(r.Host, limit), hash)
 	}
 

--- a/middlewares/tracing/entrypoint_test.go
+++ b/middlewares/tracing/entrypoint_test.go
@@ -10,6 +10,13 @@ import (
 )
 
 func TestEntryPointMiddlewareServeHTTP(t *testing.T) {
+	expectedTags := map[string]interface{}{
+		"span.kind":   ext.SpanKindRPCServerEnum,
+		"http.method": "GET",
+		"component":   "",
+		"http.url":    "http://www.test.com",
+		"http.host":   "www.test.com",
+	}
 	testCases := []struct {
 		desc         string
 		entryPoint   string
@@ -18,36 +25,23 @@ func TestEntryPointMiddlewareServeHTTP(t *testing.T) {
 		expectedName string
 	}{
 		{
-			desc:       "basic test",
-			entryPoint: "test",
-			tracing: &Tracing{
-				SpanNameLimit: 25,
-				tracer:        &MockTracer{Span: &MockSpan{Tags: make(map[string]interface{})}},
-			},
-			expectedTags: map[string]interface{}{
-				"span.kind":   ext.SpanKindRPCServerEnum,
-				"http.method": "GET",
-				"component":   "",
-				"http.url":    "http://www.test.com",
-				"http.host":   "www.test.com",
-			},
-			expectedName: "Entrypoint te... ww... 39b97e58",
-		},
-		{
 			desc:       "no truncation test",
 			entryPoint: "test",
 			tracing: &Tracing{
 				SpanNameLimit: 0,
 				tracer:        &MockTracer{Span: &MockSpan{Tags: make(map[string]interface{})}},
 			},
-			expectedTags: map[string]interface{}{
-				"span.kind":   ext.SpanKindRPCServerEnum,
-				"http.method": "GET",
-				"component":   "",
-				"http.url":    "http://www.test.com",
-				"http.host":   "www.test.com",
-			},
+			expectedTags: expectedTags,
 			expectedName: "Entrypoint test www.test.com",
+		}, {
+			desc:       "basic test",
+			entryPoint: "test",
+			tracing: &Tracing{
+				SpanNameLimit: 25,
+				tracer:        &MockTracer{Span: &MockSpan{Tags: make(map[string]interface{})}},
+			},
+			expectedTags: expectedTags,
+			expectedName: "Entrypoint te... ww... 39b97e58",
 		},
 	}
 
@@ -69,7 +63,7 @@ func TestEntryPointMiddlewareServeHTTP(t *testing.T) {
 				assert.Equal(t, test.expectedName, span.OpName)
 			}
 
-			e.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "http://www.test.com", nil), next)
+			e.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "http://www.test.com", nil), next)
 		})
 	}
 }

--- a/middlewares/tracing/entrypoint_test.go
+++ b/middlewares/tracing/entrypoint_test.go
@@ -1,14 +1,15 @@
 package tracing
 
 import (
-	"github.com/opentracing/opentracing-go/ext"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/opentracing/opentracing-go/ext"
+	"github.com/stretchr/testify/assert"
 )
 
-func Test_entryPointMiddleware_ServeHTTP(t *testing.T) {
+func TestEntryPointMiddlewareServeHTTP(t *testing.T) {
 	type fields struct {
 		entryPoint string
 		Tracing    *Tracing
@@ -18,7 +19,8 @@ func Test_entryPointMiddleware_ServeHTTP(t *testing.T) {
 		r    *http.Request
 		next http.HandlerFunc
 	}
-	tests := []struct {
+
+	testCases := []struct {
 		desc   string
 		fields fields
 		args   args
@@ -78,14 +80,16 @@ func Test_entryPointMiddleware_ServeHTTP(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.desc, func(t *testing.T) {
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
 			defaultMockSpan.Reset()
 			e := &entryPointMiddleware{
-				entryPoint: tt.fields.entryPoint,
-				Tracing:    tt.fields.Tracing,
+				entryPoint: test.fields.entryPoint,
+				Tracing:    test.fields.Tracing,
 			}
-			e.ServeHTTP(tt.args.w, tt.args.r, tt.args.next)
+
+			e.ServeHTTP(test.args.w, test.args.r, test.args.next)
 		})
 	}
 }

--- a/middlewares/tracing/entrypoint_test.go
+++ b/middlewares/tracing/entrypoint_test.go
@@ -1,0 +1,63 @@
+package tracing
+
+import (
+	"github.com/opentracing/opentracing-go/ext"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func Test_entryPointMiddleware_ServeHTTP(t *testing.T) {
+	type fields struct {
+		entryPoint string
+		Tracing    *Tracing
+	}
+	type args struct {
+		w    http.ResponseWriter
+		r    *http.Request
+		next http.HandlerFunc
+	}
+	tests := []struct {
+		desc   string
+		fields fields
+		args   args
+	}{
+		{
+			desc: "basic test",
+			fields: fields{
+				entryPoint: "test",
+				Tracing: &Tracing{
+					SpanNameLimit: 25,
+					tracer:        defaultMockTracer,
+				},
+			},
+			args: args{
+				w: httptest.NewRecorder(),
+				r: httptest.NewRequest("GET", "http://www.test.com", nil),
+				next: func(http.ResponseWriter, *http.Request) {
+					// Asserts go here...
+					want := make(map[string]interface{})
+					want["span.kind"] = ext.SpanKindRPCServerEnum
+					want["http.method"] = "GET"
+					want["component"] = ""
+					want["http.url"] = "http://www.test.com"
+					want["http.host"] = "www.test.com"
+
+					got := defaultMockSpan.Tags
+					assert.Equal(t, got, want, "ServeHTTP() = %+v want %+v", got, want)
+					assert.Equal(t, defaultMockSpan.OpName, "Entrypoint te... ww... 39b97e58")
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			e := &entryPointMiddleware{
+				entryPoint: tt.fields.entryPoint,
+				Tracing:    tt.fields.Tracing,
+			}
+			e.ServeHTTP(tt.args.w, tt.args.r, tt.args.next)
+		})
+	}
+}

--- a/middlewares/tracing/forwarder.go
+++ b/middlewares/tracing/forwarder.go
@@ -45,12 +45,13 @@ func (f *forwarderMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, 
 	LogResponseCode(span, recorder.Status())
 }
 
+// generateForwardSpanName will return a Span name of an appropriate lenth based on the 'spanLimit' argument.  If needed, it will be truncated, but will not be less than 21 characters
 func generateForwardSpanName(frontend, backend string, spanLimit int) string {
 	name := fmt.Sprintf("forward %s/%s", frontend, backend)
 
 	if spanLimit > 0 && len(name) > spanLimit {
 		if spanLimit < ForwardMaxLengthNumber {
-			log.Warnf("SpanNameLimit is set to be less then required static number of characters, defaulting to %d + 3", ForwardMaxLengthNumber)
+			log.Warnf("SpanNameLimit is set to be less than required static number of characters, defaulting to %d + 3", ForwardMaxLengthNumber)
 			spanLimit = ForwardMaxLengthNumber + 3
 		}
 		hash := ComputeHash(name)

--- a/middlewares/tracing/forwarder.go
+++ b/middlewares/tracing/forwarder.go
@@ -54,9 +54,9 @@ func generateForwardSpanName(frontend, backend string, spanLimit int) string {
 			log.Warnf("SpanNameLimit is set to be less than required static number of characters, defaulting to %d + 3", ForwardMaxLengthNumber)
 			spanLimit = ForwardMaxLengthNumber + 3
 		}
-		hash := ComputeHash(name)
+		hash := computeHash(name)
 		limit := (spanLimit - ForwardMaxLengthNumber) / 2
-		name = fmt.Sprintf("forward %s/%s/%s", TruncateString(frontend, limit), TruncateString(backend, limit), hash)
+		name = fmt.Sprintf("forward %s/%s/%s", truncateString(frontend, limit), truncateString(backend, limit), hash)
 	}
 
 	return name

--- a/middlewares/tracing/forwarder.go
+++ b/middlewares/tracing/forwarder.go
@@ -49,12 +49,12 @@ func generateForwardSpanName(frontend, backend string, spanLimit int) string {
 	name := fmt.Sprintf("forward %s/%s", frontend, backend)
 
 	if spanLimit > 0 && len(name) > spanLimit {
-		if spanLimit < ForwardMagicNumber {
-			log.Warnf("SpanNameLimit is set to be less then required static number of characters, defaulting to %d + 3", ForwardMagicNumber)
-			spanLimit = ForwardMagicNumber + 3
+		if spanLimit < ForwardMaxLengthNumber {
+			log.Warnf("SpanNameLimit is set to be less then required static number of characters, defaulting to %d + 3", ForwardMaxLengthNumber)
+			spanLimit = ForwardMaxLengthNumber + 3
 		}
 		hash := ComputeHash(name)
-		limit := (spanLimit - ForwardMagicNumber) / 2
+		limit := (spanLimit - ForwardMaxLengthNumber) / 2
 		name = fmt.Sprintf("forward %s/%s/%s", TruncateString(frontend, limit), TruncateString(backend, limit), hash)
 	}
 

--- a/middlewares/tracing/forwarder.go
+++ b/middlewares/tracing/forwarder.go
@@ -48,7 +48,7 @@ func (f *forwarderMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, 
 func generateForwardSpanName(frontend, backend string, spanLimit int) string {
 	name := fmt.Sprintf("forward %s/%s", frontend, backend)
 
-	if len(name) > spanLimit {
+	if spanLimit > 0 && len(name) > spanLimit {
 		if spanLimit < ForwardMagicNumber {
 			log.Warnf("SpanNameLimit is set to be less then required static number of characters, defaulting to %d + 3", ForwardMagicNumber)
 			spanLimit = ForwardMagicNumber + 3

--- a/middlewares/tracing/forwarder_test.go
+++ b/middlewares/tracing/forwarder_test.go
@@ -1,0 +1,54 @@
+package tracing
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTracing_NewForwarderMiddleware(t *testing.T) {
+	trace := &Tracing{
+		SpanNameLimit: 101,
+	}
+	tests := []struct {
+		desc     string
+		frontend string
+		backend  string
+		name     string
+		tracer   *Tracing
+	}{
+		{
+			desc:     "Simple Forward Tracer with truncation and hashing",
+			frontend: "some-service-100.slug.namespace.environment.domain.tld",
+			backend:  "some-service-100.slug.namespace.environment.domain.tld",
+			name:     "forward some-service-100.slug.namespace.enviro.../some-service-100.slug.namespace.enviro.../bc4a0d48",
+			tracer:   trace,
+		},
+		{
+			desc:     "Simple Forward Tracer without truncation and hashing",
+			frontend: "some-service.domain.tld",
+			backend:  "some-service.domain.tld",
+			name:     "forward some-service.domain.tld/some-service.domain.tld",
+			tracer:   trace,
+		},
+		{
+			desc:     "Exactly 101 chars",
+			frontend: "some-service1.namespace.environment.domain.tld",
+			backend:  "some-service1.namespace.environment.domain.tld",
+			name:     "forward some-service1.namespace.environment.domain.tld/some-service1.namespace.environment.domain.tld",
+			tracer:   trace,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			want := &forwarderMiddleware{
+				Tracing:  trace,
+				frontend: tt.frontend,
+				backend:  tt.backend,
+				opName:   tt.name,
+			}
+			if got := tt.tracer.NewForwarderMiddleware(tt.frontend, tt.backend); !reflect.DeepEqual(got, want) || len(want.opName) > trace.SpanNameLimit {
+				t.Errorf("Tracing.NewForwarderMiddleware() = %+v, want %+v", got, want)
+			}
+		})
+	}
+}

--- a/middlewares/tracing/forwarder_test.go
+++ b/middlewares/tracing/forwarder_test.go
@@ -15,22 +15,6 @@ func TestTracingNewForwarderMiddleware(t *testing.T) {
 		expected *forwarderMiddleware
 	}{
 		{
-			desc: "Simple Forward Tracer with truncation and hashing",
-			tracer: &Tracing{
-				SpanNameLimit: 101,
-			},
-			frontend: "some-service-100.slug.namespace.environment.domain.tld",
-			backend:  "some-service-100.slug.namespace.environment.domain.tld",
-			expected: &forwarderMiddleware{
-				Tracing: &Tracing{
-					SpanNameLimit: 101,
-				},
-				frontend: "some-service-100.slug.namespace.environment.domain.tld",
-				backend:  "some-service-100.slug.namespace.environment.domain.tld",
-				opName:   "forward some-service-100.slug.namespace.enviro.../some-service-100.slug.namespace.enviro.../bc4a0d48",
-			},
-		},
-		{
 			desc: "Simple Forward Tracer without truncation and hashing",
 			tracer: &Tracing{
 				SpanNameLimit: 101,
@@ -44,6 +28,21 @@ func TestTracingNewForwarderMiddleware(t *testing.T) {
 				frontend: "some-service.domain.tld",
 				backend:  "some-service.domain.tld",
 				opName:   "forward some-service.domain.tld/some-service.domain.tld",
+			},
+		}, {
+			desc: "Simple Forward Tracer with truncation and hashing",
+			tracer: &Tracing{
+				SpanNameLimit: 101,
+			},
+			frontend: "some-service-100.slug.namespace.environment.domain.tld",
+			backend:  "some-service-100.slug.namespace.environment.domain.tld",
+			expected: &forwarderMiddleware{
+				Tracing: &Tracing{
+					SpanNameLimit: 101,
+				},
+				frontend: "some-service-100.slug.namespace.environment.domain.tld",
+				backend:  "some-service-100.slug.namespace.environment.domain.tld",
+				opName:   "forward some-service-100.slug.namespace.enviro.../some-service-100.slug.namespace.enviro.../bc4a0d48",
 			},
 		},
 		{

--- a/middlewares/tracing/forwarder_test.go
+++ b/middlewares/tracing/forwarder_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 )
 
-func TestTracing_NewForwarderMiddleware(t *testing.T) {
+func TestTracingNewForwarderMiddleware(t *testing.T) {
 	trace := &Tracing{
 		SpanNameLimit: 101,
 	}
-	tests := []struct {
+
+	testCases := []struct {
 		desc     string
 		frontend string
 		backend  string
@@ -38,15 +39,18 @@ func TestTracing_NewForwarderMiddleware(t *testing.T) {
 			tracer:   trace,
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.desc, func(t *testing.T) {
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
 			want := &forwarderMiddleware{
 				Tracing:  trace,
-				frontend: tt.frontend,
-				backend:  tt.backend,
-				opName:   tt.name,
+				frontend: test.frontend,
+				backend:  test.backend,
+				opName:   test.name,
 			}
-			if got := tt.tracer.NewForwarderMiddleware(tt.frontend, tt.backend); !reflect.DeepEqual(got, want) || len(want.opName) > trace.SpanNameLimit {
+			if got := test.tracer.NewForwarderMiddleware(test.frontend, test.backend); !reflect.DeepEqual(got, want) || len(want.opName) > trace.SpanNameLimit {
 				t.Errorf("Tracing.NewForwarderMiddleware() = %+v, want %+v", got, want)
 			}
 		})

--- a/middlewares/tracing/tracing.go
+++ b/middlewares/tracing/tracing.go
@@ -1,11 +1,11 @@
 package tracing
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"net/http"
 
-	"crypto/sha256"
 	"github.com/containous/traefik/log"
 	"github.com/containous/traefik/middlewares/tracing/datadog"
 	"github.com/containous/traefik/middlewares/tracing/jaeger"
@@ -14,11 +14,11 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 )
 
-// ForwardMagicNumber defines the number of static characters in the Forwarding Span Trace name - 8 chars for 'forward ' + 8 chars for hash + 2 chars for '_'
-const ForwardMagicNumber = 18
+// ForwardMaxLengthNumber defines the number of static characters in the Forwarding Span Trace name - 8 chars for 'forward ' + 8 chars for hash + 2 chars for '_'
+const ForwardMaxLengthNumber = 18
 
-// EntryPointMagicNumber defines the number of static characters in the Entrypoint Span Trace name - 11 chars for 'Entrypoint ' + 8 chars for hash + 2 chars for '_'
-const EntryPointMagicNumber = 21
+// EntryPointMaxLengthNumber defines the number of static characters in the Entrypoint Span Trace name - 11 chars for 'Entrypoint ' + 8 chars for hash + 2 chars for '_'
+const EntryPointMaxLengthNumber = 21
 
 // TraceNameHashLength defines the number of characters to use from the head of the generated hash
 const TraceNameHashLength = 8

--- a/middlewares/tracing/tracing.go
+++ b/middlewares/tracing/tracing.go
@@ -172,8 +172,8 @@ func SetErrorAndWarnLog(r *http.Request, format string, args ...interface{}) {
 	LogEventf(r, format, args...)
 }
 
-// TruncateString reduces the length of the 'str' argument to 'num' - 3 and adds a '...' suffix to the tail.
-func TruncateString(str string, num int) string {
+// truncateString reduces the length of the 'str' argument to 'num' - 3 and adds a '...' suffix to the tail.
+func truncateString(str string, num int) string {
 	text := str
 	if len(str) > num {
 		if num > 3 {
@@ -184,8 +184,8 @@ func TruncateString(str string, num int) string {
 	return text
 }
 
-// ComputeHash returns the first TraceNameHashLength character of the sha256 hash for 'name' argument.
-func ComputeHash(name string) string {
+// computeHash returns the first TraceNameHashLength character of the sha256 hash for 'name' argument.
+func computeHash(name string) string {
 	data := []byte(name)
 	hash := sha256.New()
 	if _, err := hash.Write(data); err != nil {

--- a/middlewares/tracing/tracing.go
+++ b/middlewares/tracing/tracing.go
@@ -27,7 +27,7 @@ const TraceNameHashLength = 8
 type Tracing struct {
 	Backend       string          `description:"Selects the tracking backend ('jaeger','zipkin', 'datadog')." export:"true"`
 	ServiceName   string          `description:"Set the name for this service" export:"true"`
-	SpanNameLimit int             `description:"Set the maximum character limit for Span names (default 100)" export:"true"`
+	SpanNameLimit int             `description:"Set the maximum character limit for Span names (default 0 = no limit)" export:"true"`
 	Jaeger        *jaeger.Config  `description:"Settings for jaeger"`
 	Zipkin        *zipkin.Config  `description:"Settings for zipkin"`
 	DataDog       *datadog.Config `description:"Settings for DataDog"`

--- a/middlewares/tracing/tracing.go
+++ b/middlewares/tracing/tracing.go
@@ -14,13 +14,13 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 )
 
-// ForwardMaxLengthNumber defines the number of static characters in the Forwarding Span Trace name - 8 chars for 'forward ' + 8 chars for hash + 2 chars for '_'
+// ForwardMaxLengthNumber defines the number of static characters in the Forwarding Span Trace name : 8 chars for 'forward ' + 8 chars for hash + 2 chars for '_'.
 const ForwardMaxLengthNumber = 18
 
-// EntryPointMaxLengthNumber defines the number of static characters in the Entrypoint Span Trace name - 11 chars for 'Entrypoint ' + 8 chars for hash + 2 chars for '_'
+// EntryPointMaxLengthNumber defines the number of static characters in the Entrypoint Span Trace name : 11 chars for 'Entrypoint ' + 8 chars for hash + 2 chars for '_'.
 const EntryPointMaxLengthNumber = 21
 
-// TraceNameHashLength defines the number of characters to use from the head of the generated hash
+// TraceNameHashLength defines the number of characters to use from the head of the generated hash.
 const TraceNameHashLength = 8
 
 // Tracing middleware
@@ -158,21 +158,21 @@ func SetError(r *http.Request) {
 	}
 }
 
-// SetErrorAndDebugLog flags the span associated with this request as in error and create a debug log
+// SetErrorAndDebugLog flags the span associated with this request as in error and create a debug log.
 func SetErrorAndDebugLog(r *http.Request, format string, args ...interface{}) {
 	SetError(r)
 	log.Debugf(format, args...)
 	LogEventf(r, format, args...)
 }
 
-// SetErrorAndWarnLog flags the span associated with this request as in error and create a debug log
+// SetErrorAndWarnLog flags the span associated with this request as in error and create a debug log.
 func SetErrorAndWarnLog(r *http.Request, format string, args ...interface{}) {
 	SetError(r)
 	log.Warnf(format, args...)
 	LogEventf(r, format, args...)
 }
 
-// TruncateString reduces the length of the 'str' argument to 'num' - 3 and adds a '...' suffix to the tail
+// TruncateString reduces the length of the 'str' argument to 'num' - 3 and adds a '...' suffix to the tail.
 func TruncateString(str string, num int) string {
 	text := str
 	if len(str) > num {
@@ -184,12 +184,11 @@ func TruncateString(str string, num int) string {
 	return text
 }
 
-// ComputeHash returns the first TraceNameHashLength character of the sha256 hash for 'name' argument
+// ComputeHash returns the first TraceNameHashLength character of the sha256 hash for 'name' argument.
 func ComputeHash(name string) string {
 	data := []byte(name)
 	hash := sha256.New()
-	_, err := hash.Write(data)
-	if err != nil {
+	if _, err := hash.Write(data); err != nil {
 		// Impossible case
 		log.Errorf("Fail to create Span name hash for %s: %v", name, err)
 	}

--- a/middlewares/tracing/tracing_test.go
+++ b/middlewares/tracing/tracing_test.go
@@ -70,16 +70,16 @@ func TestTruncateString(t *testing.T) {
 		expected string
 	}{
 		{
-			desc:     "basic truncate with limit 10",
-			text:     "some very long pice of text",
-			limit:    10,
-			expected: "some ve...",
-		},
-		{
 			desc:     "short text less than limit 10",
 			text:     "short",
 			limit:    10,
 			expected: "short",
+		},
+		{
+			desc:     "basic truncate with limit 10",
+			text:     "some very long pice of text",
+			limit:    10,
+			expected: "some ve...",
 		},
 		{
 			desc:     "truncate long FQDN to 39 chars",

--- a/middlewares/tracing/tracing_test.go
+++ b/middlewares/tracing/tracing_test.go
@@ -45,6 +45,9 @@ func (n MockSpan) Tracer() opentracing.Tracer                             { retu
 func (n MockSpan) LogEvent(event string)                                  {}
 func (n MockSpan) LogEventWithPayload(event string, payload interface{})  {}
 func (n MockSpan) Log(data opentracing.LogData)                           {}
+func (n MockSpan) Reset() {
+	defaultMockSpan.Tags = make(map[string]interface{})
+}
 
 // StartSpan belongs to the Tracer interface.
 func (n MockTracer) StartSpan(operationName string, opts ...opentracing.StartSpanOption) opentracing.Span {

--- a/middlewares/tracing/tracing_test.go
+++ b/middlewares/tracing/tracing_test.go
@@ -5,9 +5,11 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
+	"github.com/stretchr/testify/assert"
 )
 
 type MockTracer struct {
+	Span *MockSpan
 }
 
 type MockSpan struct {
@@ -18,21 +20,15 @@ type MockSpan struct {
 type MockSpanContext struct {
 }
 
-var (
-	defaultMockSpanContext = MockSpanContext{}
-	defaultMockSpan        = MockSpan{
-		Tags: make(map[string]interface{}),
-	}
-	defaultMockTracer = MockTracer{}
-)
-
 // MockSpanContext:
 func (n MockSpanContext) ForeachBaggageItem(handler func(k, v string) bool) {}
 
 // MockSpan:
-func (n MockSpan) Context() opentracing.SpanContext                { return defaultMockSpanContext }
-func (n MockSpan) SetBaggageItem(key, val string) opentracing.Span { return defaultMockSpan }
-func (n MockSpan) BaggageItem(key string) string                   { return "" }
+func (n MockSpan) Context() opentracing.SpanContext { return MockSpanContext{} }
+func (n MockSpan) SetBaggageItem(key, val string) opentracing.Span {
+	return MockSpan{Tags: make(map[string]interface{})}
+}
+func (n MockSpan) BaggageItem(key string) string { return "" }
 func (n MockSpan) SetTag(key string, value interface{}) opentracing.Span {
 	n.Tags[key] = value
 	return n
@@ -42,18 +38,18 @@ func (n MockSpan) LogKV(keyVals ...interface{})                           {}
 func (n MockSpan) Finish()                                                {}
 func (n MockSpan) FinishWithOptions(opts opentracing.FinishOptions)       {}
 func (n MockSpan) SetOperationName(operationName string) opentracing.Span { return n }
-func (n MockSpan) Tracer() opentracing.Tracer                             { return defaultMockTracer }
+func (n MockSpan) Tracer() opentracing.Tracer                             { return MockTracer{} }
 func (n MockSpan) LogEvent(event string)                                  {}
 func (n MockSpan) LogEventWithPayload(event string, payload interface{})  {}
 func (n MockSpan) Log(data opentracing.LogData)                           {}
 func (n MockSpan) Reset() {
-	defaultMockSpan.Tags = make(map[string]interface{})
+	n.Tags = make(map[string]interface{})
 }
 
 // StartSpan belongs to the Tracer interface.
 func (n MockTracer) StartSpan(operationName string, opts ...opentracing.StartSpanOption) opentracing.Span {
-	defaultMockSpan.OpName = operationName
-	return defaultMockSpan
+	n.Span.OpName = operationName
+	return n.Span
 }
 
 // Inject belongs to the Tracer interface.
@@ -68,65 +64,70 @@ func (n MockTracer) Extract(format interface{}, carrier interface{}) (opentracin
 
 func TestTruncateString(t *testing.T) {
 	testCases := []struct {
-		desc  string
-		text  string
-		limit int
-		want  string
+		desc     string
+		text     string
+		limit    int
+		expected string
 	}{
 		{
-			desc:  "basic truncate with limit 10",
-			text:  "some very long pice of text",
-			limit: 10,
-			want:  "some ve...",
+			desc:     "basic truncate with limit 10",
+			text:     "some very long pice of text",
+			limit:    10,
+			expected: "some ve...",
 		},
 		{
-			desc:  "short text less than limit 10",
-			text:  "short",
-			limit: 10,
-			want:  "short",
+			desc:     "short text less than limit 10",
+			text:     "short",
+			limit:    10,
+			expected: "short",
 		},
 		{
-			desc:  "truncate long FQDN to 39 chars",
-			text:  "some-service-100.slug.namespace.environment.domain.tld",
-			limit: 39,
-			want:  "some-service-100.slug.namespace.envi...",
+			desc:     "truncate long FQDN to 39 chars",
+			text:     "some-service-100.slug.namespace.environment.domain.tld",
+			limit:    39,
+			expected: "some-service-100.slug.namespace.envi...",
 		},
 	}
 
 	for _, test := range testCases {
+		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
-			if got := TruncateString(test.text, test.limit); got != test.want || len(got) > test.limit {
-				t.Errorf("TruncateString() = %v, want %v - limit %v, length %v", got, test.want, test.limit, len(got))
-			}
+
+			actual := TruncateString(test.text, test.limit)
+
+			assert.Equal(t, test.expected, actual)
+			assert.True(t, len(actual) <= test.limit)
 		})
 	}
 }
 
 func TestComputeHash(t *testing.T) {
 	testCases := []struct {
-		desc string
-		text string
-		want string
+		desc     string
+		text     string
+		expected string
 	}{
 		{
-			desc: "hashing",
-			text: "some very long pice of text",
-			want: "0258ea1c",
+			desc:     "hashing",
+			text:     "some very long pice of text",
+			expected: "0258ea1c",
 		},
 		{
-			desc: "short text less than limit 10",
-			text: "short",
-			want: "f9b0078b",
+			desc:     "short text less than limit 10",
+			text:     "short",
+			expected: "f9b0078b",
 		},
 	}
 
 	for _, test := range testCases {
+		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
-			if got := ComputeHash(test.text); got != test.want {
-				t.Errorf("ComputeHash() = %v, want %v", got, test.want)
-			}
+
+			actual := ComputeHash(test.text)
+
+			assert.Equal(t, test.expected, actual)
 		})
 	}
 }

--- a/middlewares/tracing/tracing_test.go
+++ b/middlewares/tracing/tracing_test.go
@@ -94,7 +94,7 @@ func TestTruncateString(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			actual := TruncateString(test.text, test.limit)
+			actual := truncateString(test.text, test.limit)
 
 			assert.Equal(t, test.expected, actual)
 			assert.True(t, len(actual) <= test.limit)
@@ -125,7 +125,7 @@ func TestComputeHash(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			actual := ComputeHash(test.text)
+			actual := computeHash(test.text)
 
 			assert.Equal(t, test.expected, actual)
 		})

--- a/middlewares/tracing/tracing_test.go
+++ b/middlewares/tracing/tracing_test.go
@@ -1,9 +1,10 @@
 package tracing
 
 import (
+	"testing"
+
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
-	"testing"
 )
 
 type MockTracer struct {
@@ -66,7 +67,7 @@ func (n MockTracer) Extract(format interface{}, carrier interface{}) (opentracin
 }
 
 func TestTruncateString(t *testing.T) {
-	tests := []struct {
+	testCases := []struct {
 		desc  string
 		text  string
 		limit int
@@ -91,17 +92,19 @@ func TestTruncateString(t *testing.T) {
 			want:  "some-service-100.slug.namespace.envi...",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.desc, func(t *testing.T) {
-			if got := TruncateString(tt.text, tt.limit); got != tt.want || len(got) > tt.limit {
-				t.Errorf("TruncateString() = %v, want %v - limit %v, length %v", got, tt.want, tt.limit, len(got))
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+			if got := TruncateString(test.text, test.limit); got != test.want || len(got) > test.limit {
+				t.Errorf("TruncateString() = %v, want %v - limit %v, length %v", got, test.want, test.limit, len(got))
 			}
 		})
 	}
 }
 
 func TestComputeHash(t *testing.T) {
-	tests := []struct {
+	testCases := []struct {
 		desc string
 		text string
 		want string
@@ -117,10 +120,12 @@ func TestComputeHash(t *testing.T) {
 			want: "f9b0078b",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.desc, func(t *testing.T) {
-			if got := ComputeHash(tt.text); got != tt.want {
-				t.Errorf("ComputeHash() = %v, want %v", got, tt.want)
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+			if got := ComputeHash(test.text); got != test.want {
+				t.Errorf("ComputeHash() = %v, want %v", got, test.want)
 			}
 		})
 	}

--- a/middlewares/tracing/tracing_test.go
+++ b/middlewares/tracing/tracing_test.go
@@ -1,0 +1,124 @@
+package tracing
+
+import (
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
+	"testing"
+)
+
+type MockTracer struct {
+}
+
+type MockSpan struct {
+	OpName string
+	Tags   map[string]interface{}
+}
+
+type MockSpanContext struct {
+}
+
+var (
+	defaultMockSpanContext = MockSpanContext{}
+	defaultMockSpan        = MockSpan{
+		Tags: make(map[string]interface{}),
+	}
+	defaultMockTracer = MockTracer{}
+)
+
+// MockSpanContext:
+func (n MockSpanContext) ForeachBaggageItem(handler func(k, v string) bool) {}
+
+// MockSpan:
+func (n MockSpan) Context() opentracing.SpanContext                { return defaultMockSpanContext }
+func (n MockSpan) SetBaggageItem(key, val string) opentracing.Span { return defaultMockSpan }
+func (n MockSpan) BaggageItem(key string) string                   { return "" }
+func (n MockSpan) SetTag(key string, value interface{}) opentracing.Span {
+	n.Tags[key] = value
+	return n
+}
+func (n MockSpan) LogFields(fields ...log.Field)                          {}
+func (n MockSpan) LogKV(keyVals ...interface{})                           {}
+func (n MockSpan) Finish()                                                {}
+func (n MockSpan) FinishWithOptions(opts opentracing.FinishOptions)       {}
+func (n MockSpan) SetOperationName(operationName string) opentracing.Span { return n }
+func (n MockSpan) Tracer() opentracing.Tracer                             { return defaultMockTracer }
+func (n MockSpan) LogEvent(event string)                                  {}
+func (n MockSpan) LogEventWithPayload(event string, payload interface{})  {}
+func (n MockSpan) Log(data opentracing.LogData)                           {}
+
+// StartSpan belongs to the Tracer interface.
+func (n MockTracer) StartSpan(operationName string, opts ...opentracing.StartSpanOption) opentracing.Span {
+	defaultMockSpan.OpName = operationName
+	return defaultMockSpan
+}
+
+// Inject belongs to the Tracer interface.
+func (n MockTracer) Inject(sp opentracing.SpanContext, format interface{}, carrier interface{}) error {
+	return nil
+}
+
+// Extract belongs to the Tracer interface.
+func (n MockTracer) Extract(format interface{}, carrier interface{}) (opentracing.SpanContext, error) {
+	return nil, opentracing.ErrSpanContextNotFound
+}
+
+func TestTruncateString(t *testing.T) {
+	tests := []struct {
+		desc  string
+		text  string
+		limit int
+		want  string
+	}{
+		{
+			desc:  "basic truncate with limit 10",
+			text:  "some very long pice of text",
+			limit: 10,
+			want:  "some ve...",
+		},
+		{
+			desc:  "short text less than limit 10",
+			text:  "short",
+			limit: 10,
+			want:  "short",
+		},
+		{
+			desc:  "truncate long FQDN to 39 chars",
+			text:  "some-service-100.slug.namespace.environment.domain.tld",
+			limit: 39,
+			want:  "some-service-100.slug.namespace.envi...",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			if got := TruncateString(tt.text, tt.limit); got != tt.want || len(got) > tt.limit {
+				t.Errorf("TruncateString() = %v, want %v - limit %v, length %v", got, tt.want, tt.limit, len(got))
+			}
+		})
+	}
+}
+
+func TestComputeHash(t *testing.T) {
+	tests := []struct {
+		desc string
+		text string
+		want string
+	}{
+		{
+			desc: "hashing",
+			text: "some very long pice of text",
+			want: "0258ea1c",
+		},
+		{
+			desc: "short text less than limit 10",
+			text: "short",
+			want: "f9b0078b",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			if got := ComputeHash(tt.text); got != tt.want {
+				t.Errorf("ComputeHash() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?
In many situations the trace name gets pretty large (over 100 chars, especially when using k8s provider).  This provides an option to truncate the name to a configurable length to avoid dropped traces.

### More

- [x] Added/updated tests
- [x] Added/updated documentation
