### PR TITLE
Fix Rewrite-target regex

### DIFF
--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -535,7 +535,7 @@ func getRuleForPath(pa extensionsv1beta1.HTTPIngressPath, i *extensionsv1beta1.I
 		if ruleType == ruleTypeReplacePath {
 			return "", fmt.Errorf("rewrite-target must not be used together with annotation %q", annotationKubernetesRuleType)
 		}
-		rewriteTargetRule := fmt.Sprintf("ReplacePathRegex: ^%s/(.*) %s/$1", pa.Path, strings.TrimRight(rewriteTarget, "/"))
+		rewriteTargetRule := fmt.Sprintf("ReplacePathRegex: ^%s(.*) %s$1", pa.Path, strings.TrimRight(rewriteTarget, "/"))
 		rules = append(rules, rewriteTargetRule)
 	}
 

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -1410,7 +1410,7 @@ rateset:
 			frontend("rewrite/api",
 				passHostHeader(),
 				routes(
-					route("/api", "PathPrefix:/api;ReplacePathRegex: ^/api/(.*) /$1"),
+					route("/api", "PathPrefix:/api;ReplacePathRegex: ^/api(.*) $1"),
 					route("rewrite", "Host:rewrite")),
 			),
 			frontend("error-pages/errorpages",


### PR DESCRIPTION
### What does this PR do?

Removes an added slash in the Redirect-target annotation regex

### Motivation

Fixes #3698, slash was accidentally added in #3582


### More

- [x] Added/updated tests
- [x] Added/updated documentation - None needed, bugfix

### Additional Notes

The ingress:
```yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: whoami
  annotations:
     traefik.ingress.kubernetes.io/rewrite-target: /demo
spec:
  rules:
  - host: localhost
    http:
      paths:
      - path: /testing
        backend:
          serviceName: whoami
          servicePort: http
```

Now properly creates the following path rewrites:

```bash
$ curl -v localhost:31117/testing -silent 2>&1 | grep GET

> GET /testing HTTP/1.1
GET /demo HTTP/1.1

$ curl -v localhost:31117/testing/ -silent 2>&1 | grep GET

> GET /testing/ HTTP/1.1
GET /demo/ HTTP/1.1

$ curl -v localhost:31117/testing/bacon -silent 2>&1 | grep GET

> GET /testing/bacon HTTP/1.1
GET /demo/bacon HTTP/1.1
```