### PR TITLE
H2C: Remove buggy line in init to make verbose switch working

### DIFF
--- a/h2c/h2c.go
+++ b/h2c/h2c.go
@@ -38,7 +38,6 @@ func init() {
 	if strings.Contains(e, "http2debug=1") || strings.Contains(e, "http2debug=2") {
 		http2VerboseLogs = true
 	}
-	http2VerboseLogs = true
 }
 
 // Server implements net.Handler and enables h2c. Users who want h2c just need


### PR DESCRIPTION
Signed-off-by: Damien DUPORTAL <damien.duportal@gmail.com>

### What does this PR do?

The "copy-and-pasted" line had been deleted: this deleted line was overwriting the user-provided verbose mode's switch, forcing the verbose mode to true.


### Motivation

Fixes #3662 

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Should be a quick one.
