### PR TITLE
No need for npm progress=false

### DIFF
--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -14,7 +14,6 @@ COPY package.json $WEBUI_DIR/
 COPY yarn.lock $WEBUI_DIR/
 
 WORKDIR $WEBUI_DIR
-RUN npm set progress=false
 RUN yarn install
 
 COPY . $WEBUI_DIR/


### PR DESCRIPTION
### What does this PR do?

Removes a useless `RUN` in the `webui` `Dockerfile`.
yarn is used instead of npm, this line is outdated :stuck_out_tongue_closed_eyes: 

### Motivation

Clean `Dockerfile`s

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Signed-off-by: Vincent Demeester <vincent@sbr.pm>

