### PR TITLE
Move prometheusState.reset() to test file.

### DIFF
--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -197,16 +197,6 @@ type prometheusState struct {
 	state         map[string]*collector
 }
 
-// reset is a utility method for unit testing. It should be called after each
-// test run that changes promState internally in order to avoid dependencies
-// between unit tests.
-func (ps *prometheusState) reset() {
-	ps.collectors = make(chan *collector)
-	ps.describers = []func(ch chan<- *stdprometheus.Desc){}
-	ps.dynamicConfig = newDynamicConfig()
-	ps.state = make(map[string]*collector)
-}
-
 func (ps *prometheusState) SetDynamicConfig(dynamicConfig *dynamicConfig) {
 	ps.mtx.Lock()
 	defer ps.mtx.Unlock()

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -13,6 +13,16 @@ import (
 	dto "github.com/prometheus/client_model/go"
 )
 
+// reset is a utility method for unit testing. It should be called after each
+// test run that changes promState internally in order to avoid dependencies
+// between unit tests.
+func (ps *prometheusState) reset() {
+	ps.collectors = make(chan *collector)
+	ps.describers = []func(ch chan<- *prometheus.Desc){}
+	ps.dynamicConfig = newDynamicConfig()
+	ps.state = make(map[string]*collector)
+}
+
 func TestPrometheus(t *testing.T) {
 	// Reset state of global promState.
 	defer promState.reset()


### PR DESCRIPTION
### What does this PR do?

Move the `prometheusState.reset()` function to testfile. It's a method just for unit testing, so really, it should be in the test file(s).

### Motivation

Clean code

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
