### PR TITLE
Migrate Compress from bool to struct

### DIFF
--- a/anonymize/anonymize_config_test.go
+++ b/anonymize/anonymize_config_test.go
@@ -81,7 +81,7 @@ func TestDo_globalConfiguration(t *testing.T) {
 				},
 			},
 			WhitelistSourceRange: []string{"foo WhitelistSourceRange 1", "foo WhitelistSourceRange 2", "foo WhitelistSourceRange 3"},
-			Compress:             true,
+			Compress:             &configuration.Compress{},
 			ProxyProtocol: &configuration.ProxyProtocol{
 				TrustedIPs: []string{"127.0.0.1/32", "192.168.0.1"},
 			},
@@ -126,7 +126,7 @@ func TestDo_globalConfiguration(t *testing.T) {
 				},
 			},
 			WhitelistSourceRange: []string{"fii WhitelistSourceRange 1", "fii WhitelistSourceRange 2", "fii WhitelistSourceRange 3"},
-			Compress:             true,
+			Compress:             &configuration.Compress{},
 			ProxyProtocol: &configuration.ProxyProtocol{
 				TrustedIPs: []string{"127.0.0.1/32", "192.168.0.1"},
 			},

--- a/configuration/entrypoints.go
+++ b/configuration/entrypoints.go
@@ -17,9 +17,13 @@ type EntryPoint struct {
 	Auth                 *types.Auth       `export:"true"`
 	WhitelistSourceRange []string          // Deprecated
 	WhiteList            *types.WhiteList  `export:"true"`
-	Compress             bool              `export:"true"`
+	Compress             *Compress         `export:"true"`
 	ProxyProtocol        *ProxyProtocol    `export:"true"`
 	ForwardedHeaders     *ForwardedHeaders `export:"true"`
+}
+
+// Compress contains compress configuration
+type Compress struct {
 }
 
 // ProxyProtocol contains Proxy-Protocol configuration
@@ -69,7 +73,10 @@ func (ep *EntryPoints) Set(value string) error {
 		whiteListSourceRange = strings.Split(result["whitelistsourcerange"], ",")
 	}
 
-	compress := toBool(result, "compress")
+	var compress *Compress
+	if len(result["compress"]) > 0 {
+		compress = &Compress{}
+	}
 
 	configTLS, err := makeEntryPointTLS(result)
 	if err != nil {

--- a/configuration/entrypoints_test.go
+++ b/configuration/entrypoints_test.go
@@ -278,7 +278,7 @@ func TestEntryPoints_Set(t *testing.T) {
 					},
 					UseXForwardedFor: true,
 				},
-				Compress: true,
+				Compress: &Compress{},
 				ProxyProtocol: &ProxyProtocol{
 					Insecure:   false,
 					TrustedIPs: []string{"192.168.0.1"},
@@ -380,7 +380,7 @@ func TestEntryPoints_Set(t *testing.T) {
 					"152.89.1.33/32",
 					"afed:be44::/16",
 				},
-				Compress: true,
+				Compress: &Compress{},
 				ProxyProtocol: &ProxyProtocol{
 					Insecure:   false,
 					TrustedIPs: []string{"192.168.0.1"},
@@ -462,7 +462,7 @@ func TestEntryPoints_Set(t *testing.T) {
 			expression:             "Name:foo Compress:on",
 			expectedEntryPointName: "foo",
 			expectedEntryPoint: &EntryPoint{
-				Compress:         true,
+				Compress:         &Compress{},
 				ForwardedHeaders: &ForwardedHeaders{Insecure: true},
 			},
 		},
@@ -471,7 +471,7 @@ func TestEntryPoints_Set(t *testing.T) {
 			expression:             "Name:foo Compress:true",
 			expectedEntryPointName: "foo",
 			expectedEntryPoint: &EntryPoint{
-				Compress:         true,
+				Compress:         &Compress{},
 				ForwardedHeaders: &ForwardedHeaders{Insecure: true},
 			},
 		},

--- a/docs/configuration/entrypoints.md
+++ b/docs/configuration/entrypoints.md
@@ -13,7 +13,7 @@ defaultEntryPoints = ["http", "https"]
 [entryPoints]
   [entryPoints.http]
     address = ":80"
-    compress = true
+    [entryPoints.http.compress]
 
     [entryPoints.http.whitelist]
       sourceRange = ["10.42.0.0/16", "152.89.1.33/32", "afed:be44::/16"]
@@ -453,7 +453,7 @@ To enable compression support using gzip format.
 [entryPoints]
   [entryPoints.http]
   address = ":80"
-  compress = true
+  [entryPoints.http.compress]
 ```
 
 Responses are compressed when:

--- a/middlewares/compress.go
+++ b/middlewares/compress.go
@@ -9,7 +9,7 @@ import (
 	"github.com/containous/traefik/log"
 )
 
-// Compress is a middleware that allows redirection
+// Compress is a middleware that allows to compress the response
 type Compress struct{}
 
 // ServeHTTP is a function used by Negroni

--- a/server/server_middlewares.go
+++ b/server/server_middlewares.go
@@ -158,7 +158,7 @@ func (s *Server) buildServerEntryPointMiddlewares(serverEntryPointName string, s
 		serverMiddlewares = append(serverMiddlewares, s.wrapNegroniHandlerWithAccessLog(authMiddleware, fmt.Sprintf("Auth for entrypoint %s", serverEntryPointName)))
 	}
 
-	if s.entryPoints[serverEntryPointName].Configuration.Compress {
+	if s.entryPoints[serverEntryPointName].Configuration.Compress != nil {
 		serverMiddlewares = append(serverMiddlewares, &middlewares.Compress{})
 	}
 


### PR DESCRIPTION
### What does this PR do?

Migrate Compress from bool to struct. 

### Motivation
To be able to manage evolutions. For example  #2124

### More

- [x] Added/updated tests
- [x] Added/updated documentation
