### PR TITLE
Avoid a panic during Prometheus registering

### DIFF
--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -167,13 +167,12 @@ func initStandardRegistry(config *types.Prometheus) Registry {
 }
 
 func registerPromState() bool {
-	err := stdprometheus.Register(promState)
-	if err != nil {
+	if err := stdprometheus.Register(promState); err != nil {
 		if _, ok := err.(stdprometheus.AlreadyRegisteredError); !ok {
 			log.Errorf("Unable to register Traefik to Prometheus: %v", err)
 			return false
 		}
-		log.Debugln("Prometheus collector already registered.")
+		log.Debug("Prometheus collector already registered.")
 	}
 	return true
 }

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -16,25 +16,31 @@ import (
 )
 
 const (
-	metricNamePrefix = "traefik_"
+	// MetricNamePrefix prefix of all metric names
+	MetricNamePrefix = "traefik_"
 
 	// server meta information
-	configReloadsTotalName         = metricNamePrefix + "config_reloads_total"
-	configReloadsFailuresTotalName = metricNamePrefix + "config_reloads_failure_total"
-	configLastReloadSuccessName    = metricNamePrefix + "config_last_reload_success"
-	configLastReloadFailureName    = metricNamePrefix + "config_last_reload_failure"
+	metricConfigPrefix             = MetricNamePrefix + "config_"
+	configReloadsTotalName         = metricConfigPrefix + "reloads_total"
+	configReloadsFailuresTotalName = metricConfigPrefix + "reloads_failure_total"
+	configLastReloadSuccessName    = metricConfigPrefix + "last_reload_success"
+	configLastReloadFailureName    = metricConfigPrefix + "last_reload_failure"
 
 	// entrypoint
-	entrypointReqsTotalName   = metricNamePrefix + "entrypoint_requests_total"
-	entrypointReqDurationName = metricNamePrefix + "entrypoint_request_duration_seconds"
-	entrypointOpenConnsName   = metricNamePrefix + "entrypoint_open_connections"
+	metricEntryPointPrefix    = MetricNamePrefix + "entrypoint_"
+	entrypointReqsTotalName   = metricEntryPointPrefix + "requests_total"
+	entrypointReqDurationName = metricEntryPointPrefix + "request_duration_seconds"
+	entrypointOpenConnsName   = metricEntryPointPrefix + "open_connections"
 
-	// backend level
-	backendReqsTotalName    = metricNamePrefix + "backend_requests_total"
-	backendReqDurationName  = metricNamePrefix + "backend_request_duration_seconds"
-	backendOpenConnsName    = metricNamePrefix + "backend_open_connections"
-	backendRetriesTotalName = metricNamePrefix + "backend_retries_total"
-	backendServerUpName     = metricNamePrefix + "backend_server_up"
+	// backend level.
+
+	// MetricBackendPrefix prefix of all backend metric names
+	MetricBackendPrefix     = MetricNamePrefix + "backend_"
+	backendReqsTotalName    = MetricBackendPrefix + "requests_total"
+	backendReqDurationName  = MetricBackendPrefix + "request_duration_seconds"
+	backendOpenConnsName    = MetricBackendPrefix + "open_connections"
+	backendRetriesTotalName = MetricBackendPrefix + "retries_total"
+	backendServerUpName     = MetricBackendPrefix + "server_up"
 )
 
 // promState holds all metric state internally and acts as the only Collector we register for Prometheus.

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -169,12 +169,11 @@ func initStandardRegistry(config *types.Prometheus) Registry {
 func registerPromState() bool {
 	err := stdprometheus.Register(promState)
 	if err != nil {
-		if _, ok := err.(stdprometheus.AlreadyRegisteredError); ok {
-			log.Debugln("Prometheus collector already registered.")
-		} else {
+		if _, ok := err.(stdprometheus.AlreadyRegisteredError); !ok {
 			log.Errorf("Unable to register Traefik to Prometheus: %v", err)
 			return false
 		}
+		log.Debugln("Prometheus collector already registered.")
 	}
 	return true
 }

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -11,7 +11,81 @@ import (
 	"github.com/containous/traefik/types"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
 )
+
+func TestRegisterPromState(t *testing.T) {
+	// Reset state of global promState.
+	defer promState.reset()
+
+	testCases := []struct {
+		desc                 string
+		prometheusSlice      []*types.Prometheus
+		initPromState        bool
+		unregisterPromState  bool
+		expectedNbRegistries int
+	}{
+		{
+			desc:                 "Register once",
+			prometheusSlice:      []*types.Prometheus{{}},
+			expectedNbRegistries: 1,
+			initPromState:        true,
+		},
+		{
+			desc:                 "Register once with no promState init",
+			prometheusSlice:      []*types.Prometheus{{}},
+			expectedNbRegistries: 0,
+		},
+		{
+			desc:                 "Register twice",
+			prometheusSlice:      []*types.Prometheus{{}, {}},
+			expectedNbRegistries: 2,
+			initPromState:        true,
+		},
+		{
+			desc:                 "Register twice with no promstate init",
+			prometheusSlice:      []*types.Prometheus{{}, {}},
+			expectedNbRegistries: 0,
+		},
+		{
+			desc:                 "Register twice with unregister",
+			prometheusSlice:      []*types.Prometheus{{}, {}},
+			unregisterPromState:  true,
+			expectedNbRegistries: 2,
+			initPromState:        true,
+		},
+		{
+			desc:                 "Register twice with unregister but no promstate init",
+			prometheusSlice:      []*types.Prometheus{{}, {}},
+			unregisterPromState:  true,
+			expectedNbRegistries: 0,
+		},
+	}
+
+	for _, test := range testCases {
+		actualNbRegistries := 0
+		for _, prom := range test.prometheusSlice {
+			if test.initPromState {
+				initStandardRegistry(prom)
+			}
+
+			promReg := registerPromState()
+			if promReg != false {
+				actualNbRegistries++
+			}
+
+			if test.unregisterPromState {
+				prometheus.Unregister(promState)
+			}
+
+			promState.reset()
+		}
+
+		prometheus.Unregister(promState)
+
+		assert.Equal(t, test.expectedNbRegistries, actualNbRegistries)
+	}
+}
 
 func TestPrometheus(t *testing.T) {
 	// Reset state of global promState.

--- a/server/server.go
+++ b/server/server.go
@@ -652,8 +652,11 @@ func registerMetricClients(metricsConfig *types.Metrics) metrics.Registry {
 
 	var registries []metrics.Registry
 	if metricsConfig.Prometheus != nil {
-		registries = append(registries, metrics.RegisterPrometheus(metricsConfig.Prometheus))
-		log.Debug("Configured Prometheus metrics")
+		prometheusRegister := metrics.RegisterPrometheus(metricsConfig.Prometheus)
+		if prometheusRegister != nil {
+			registries = append(registries, prometheusRegister)
+			log.Debug("Configured Prometheus metrics")
+		}
 	}
 	if metricsConfig.Datadog != nil {
 		registries = append(registries, metrics.RegisterDatadog(metricsConfig.Datadog))


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This PR replaces the function which registers Træfik to Prometheus (which can generate `panic`) by another one which never generates `panic`.

### Motivation

<!-- What inspired you to submit this pull request? -->
Do not generate `panic` and stop Træfik if it can not be registred to Prometheus (overkill?).

### More

- [x] Added/updated 

<!-- Anything else we should know when reviewing? -->
