### PR TITLE
Set a keyType to ACME if the account is stored with no KeyType

### DIFF
--- a/acme/acme.go
+++ b/acme/acme.go
@@ -202,6 +202,9 @@ func (a *ACME) leadershipListener(elected bool) error {
 			}
 
 			needRegister = true
+		} else if len(account.KeyType) == 0 {
+			// Set the KeyType if not already defined in the account
+			account.KeyType = acmeprovider.GetKeyType(a.KeyType)
 		}
 
 		a.client, err = a.buildACMEClient(account)

--- a/provider/acme/provider.go
+++ b/provider/acme/provider.go
@@ -309,6 +309,12 @@ func (p *Provider) initAccount() (*Account, error) {
 			return nil, err
 		}
 	}
+
+	// Set the KeyType if not already defined in the account
+	if len(p.account.KeyType) == 0 {
+		p.account.KeyType = GetKeyType(p.KeyType)
+	}
+
 	return p.account, nil
 }
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

This PR set a `KeyType` to an already existent `ACME.account` if necessary.

### Motivation

<!-- What inspired you to submit this pull request? -->

Relates #3468 ([comment](https://github.com/containous/traefik/issues/3468#issuecomment-410192111)).

### More

- [x] Added/updated tests


<!-- Anything else we should know when reviewing? -->
