### PR TITLE
Freeze mkdocs version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs>=0.17.3
-pymdown-extensions>=1.4
-mkdocs-bootswatch>=0.4.0
-mkdocs-material>=2.2.6
+mkdocs==0.17.5
+pymdown-extensions==4.12
+mkdocs-bootswatch==0.5.0
+mkdocs-material==2.9.4


### PR DESCRIPTION
### What does this PR do?
Fix mkdocs version


### Motivation

Due to the [v1.0 of mkdocs](https://github.com/mkdocs/mkdocs/releases/tag/1.0).

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

It's a temporary fix.