### PR TITLE
Don't merge kubernetes ingresses when priority is set

### DIFF
--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -224,7 +224,12 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 			}
 
 			for _, pa := range r.HTTP.Paths {
+				priority := getIntValue(i.Annotations, annotationKubernetesPriority, 0)
 				baseName := r.Host + pa.Path
+				if priority > 0 {
+					baseName = strconv.Itoa(priority) + "-" + baseName
+				}
+
 				if _, exists := templateObjects.Backends[baseName]; !exists {
 					templateObjects.Backends[baseName] = &types.Backend{
 						Servers: make(map[string]types.Server),
@@ -250,7 +255,6 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 
 					passHostHeader := getBoolValue(i.Annotations, annotationKubernetesPreserveHost, !p.DisablePassHostHeaders)
 					passTLSCert := getBoolValue(i.Annotations, annotationKubernetesPassTLSCert, p.EnablePassTLSCert)
-					priority := getIntValue(i.Annotations, annotationKubernetesPriority, 0)
 					entryPoints := getSliceStringValue(i.Annotations, annotationKubernetesFrontendEntryPoints)
 
 					templateObjects.Frontends[baseName] = &types.Frontend{

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -1849,13 +1849,13 @@ func TestPriorityHeaderValue(t *testing.T) {
 
 	expected := buildConfiguration(
 		backends(
-			backend("foo/bar",
+			backend("1337-foo/bar",
 				servers(server("http://example.com", weight(1))),
 				lbMethod("wrr"),
 			),
 		),
 		frontends(
-			frontend("foo/bar",
+			frontend("1337-foo/bar",
 				passHostHeader(),
 				priority(1337),
 				routes(


### PR DESCRIPTION
### What does this PR do?

Ensures separate frontends are created when ingress priorities are set

### Motivation

Fixes #3710 

### More

- [x] Added/updated tests
- [x] Added/updated documentation - None needed, intended behavior

### Additional Notes
1. The issue reported in the ticket #3710 may not be _solved_ by this ticket, but it does resolve some of the unintended behavior
2. This change still allows duplicate host/paths to be skipped across namespaces.
3. Changing the basename to `{{namespace}}/{{ingress.name}}-{{host}}{{path}}` although unique, would be too breaking for a minor release.