### PR TITLE
Prevent unparsable strings from being rendered in the Kubernetes template

### DIFF
--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -883,7 +883,19 @@ func getFrontendRedirect(i *extensionsv1beta1.Ingress, baseName, path string) *t
 	}
 
 	redirectRegex := getStringValue(i.Annotations, annotationKubernetesRedirectRegex, "")
+	_, err := strconv.Unquote(`"` + redirectRegex + `"`)
+	if err != nil {
+		log.Debugf("Skipping Redirect on Ingress %s/%s due to invalid regex: %s", i.Namespace, i.Name, redirectRegex)
+		return nil
+	}
+
 	redirectReplacement := getStringValue(i.Annotations, annotationKubernetesRedirectReplacement, "")
+	_, err = strconv.Unquote(`"` + redirectReplacement + `"`)
+	if err != nil {
+		log.Debugf("Skipping Redirect on Ingress %s/%s due to invalid replacement: %q", i.Namespace, i.Name, redirectRegex)
+		return nil
+	}
+
 	if len(redirectRegex) > 0 && len(redirectReplacement) > 0 {
 		return &types.Redirect{
 			Regex:       redirectRegex,

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -741,6 +741,34 @@ func TestGetPassTLSCert(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestInvalidRedirectAnnotation(t *testing.T) {
+	ingresses := []*extensionsv1beta1.Ingress{
+		buildIngress(iNamespace("awesome"),
+			iAnnotation(annotationKubernetesRedirectRegex, `bad\.regex`),
+			iAnnotation(annotationKubernetesRedirectReplacement, "test"),
+			iRules(iRule(
+				iHost("foo"),
+				iPaths(onePath(iPath("/bar"), iBackend("service1", intstr.FromInt(80))))),
+			),
+		),
+		buildIngress(iNamespace("awesome"),
+			iAnnotation(annotationKubernetesRedirectRegex, `test`),
+			iAnnotation(annotationKubernetesRedirectReplacement, `bad\.replacement`),
+			iRules(iRule(
+				iHost("foo"),
+				iPaths(onePath(iPath("/bar"), iBackend("service1", intstr.FromInt(80))))),
+			),
+		),
+	}
+
+	for _, ingress := range ingresses {
+		actual := getFrontendRedirect(ingress, "test", "/")
+		var expected *types.Redirect
+
+		assert.Equal(t, expected, actual)
+	}
+}
+
 func TestOnlyReferencesServicesFromOwnNamespace(t *testing.T) {
 	ingresses := []*extensionsv1beta1.Ingress{
 		buildIngress(iNamespace("awesome"),


### PR DESCRIPTION
### What does this PR do?

Adds a parsing test to the ingress annotation to prevent unparsable strings being added into the provider template.


### Motivation

Fixes #3731 

### More

- [x] Added/updated tests
- [x] Added/updated documentation - Not needed, bugfix
