### PR TITLE
Store serialized JSON ACME Account as String

### DIFF
--- a/cluster/datastore.go
+++ b/cluster/datastore.go
@@ -19,7 +19,7 @@ import (
 // Metadata stores Object plus metadata
 type Metadata struct {
 	object Object
-	Object []byte
+	Object string
 	Lock   string
 }
 
@@ -30,8 +30,10 @@ func NewMetadata(object Object) *Metadata {
 
 // Marshall marshalls object
 func (m *Metadata) Marshall() error {
+	var byteArray []byte
 	var err error
-	m.Object, err = json.Marshal(m.object)
+	byteArray, err = json.Marshal(m.object)
+	m.Object = string(byteArray)
 	return err
 }
 
@@ -39,7 +41,7 @@ func (m *Metadata) unmarshall() error {
 	if len(m.Object) == 0 {
 		return nil
 	}
-	return json.Unmarshal(m.Object, m.object)
+	return json.Unmarshal([]byte(m.Object), m.object)
 }
 
 // Listener is called when Object has been changed in KV store


### PR DESCRIPTION

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Before it was stored as []byte which make it hard to backup ACME
Certificates and debug the behaviour of getting new Certificates. So this PR changes this behaviour and stores the serialized JSON ACME Account as String


### Motivation

Basically the motivation were these two issues, as for a productive usage of traefik it's a must have to backup certs. #1512

Also I have several problems during an upgrade process with kubernetes I can't really debug without knowing what happens there: #3754
<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
Actually I don't know why this Meta object is used for the Account. Guess using [staert](https://github.com/containous/staert) with the Account struct itself could remove the limitation: 
> !!! note It's possible to store up to approximately 100 ACME certificates in Consul.

Otherwise it would make more sense to have a dedicated storeMethod/Transferobject for the Account or certificate.

Described here: https://github.com/nmengin/traefik/blob/357d8762a16405a881d72907c39f61d78372a26f/docs/configuration/acme.md
Issued here: https://github.com/containous/traefik/issues/1325

Also this may bring up again the topic about: https://github.com/containous/traefik/issues/1325 but where #1325 makes it hard having multiple certs, the current behaviour makes it impossible to backup certs which prevents the usage of traefik in production