### PR TITLE
Include missing key in error message for KV store

### DIFF
--- a/cluster/datastore.go
+++ b/cluster/datastore.go
@@ -78,7 +78,7 @@ func (d *Datastore) watchChanges() error {
 	stopCh := make(chan struct{})
 	kvCh, err := d.kv.Watch(d.lockKey, stopCh, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("%v: %s", err, d.lockKey)
 	}
 	safe.Go(func() {
 		ctx, cancel := context.WithCancel(d.ctx)

--- a/cluster/datastore.go
+++ b/cluster/datastore.go
@@ -78,7 +78,7 @@ func (d *Datastore) watchChanges() error {
 	stopCh := make(chan struct{})
 	kvCh, err := d.kv.Watch(d.lockKey, stopCh, nil)
 	if err != nil {
-		return fmt.Errorf("%v: %s", err, d.lockKey)
+		return fmt.Errorf("error while watching key %s: %v", d.lockKey, err)
 	}
 	safe.Go(func() {
 		ctx, cancel := context.WithCancel(d.ctx)


### PR DESCRIPTION
### What does this PR do?

The generic missing-key error message that comes from valkeyrie doesn't point the operator at the key that's missing. Several folk, including myself, have spent time figuring out what that missing key is. When setting up TLS there's a further potential confusion between KV store keys and TLS keys!

See https://github.com/containous/traefik/issues/2712 for an example issue that might have gone smoother with this more detailed logging.

### Motivation

I spent several hours debugging this, and that time could've been saved by knowing what the missing key was.

### More

No tests / docs updated. I don't believe this warrants a test.

I began running the tests but had to go do something else before they finished!

### Additional Notes

Worth checking that the format string is safe with all possible return values.