### PR TITLE
Add segments to the consulcatalog provider

### DIFF
--- a/docs/configuration/backends/consulcatalog.md
+++ b/docs/configuration/backends/consulcatalog.md
@@ -151,6 +151,16 @@ Additional settings can be defined using Consul Catalog tags.
 | `<prefix>.frontend.whiteList.sourceRange=RANGE`             | Sets a list of IP-Ranges which are allowed to access.<br>An unset or empty list allows all Source-IPs to access. If one of the Net-Specifications are invalid, the whole list is invalid and allows all Source-IPs to access. |
 | `<prefix>.frontend.whiteList.useXForwardedFor=true`         | Uses `X-Forwarded-For` header as valid source of IP for the white list.                                                                                                                                                       |
 
+### Multiple frontends for a single service (segment labels)
+If you need to support multiple frontends for a service, for example when having multiple `rules` that can't be combined, 
+specify them using segments:
+
+    <prefix>.A.frontend.rule=Host:A:PathPrefix:/A
+    <prefix>.B.frontend.rule=Host:B:PathPrefix:/
+
+`A` and `B` here are the segment names, they can be anything. You can use any setting that applies to `<prefix>.frontend` from the table above.
+Segment labels override the default behavior.
+
 ### Custom Headers
 
 !!! note

--- a/provider/consulcatalog/config_test.go
+++ b/provider/consulcatalog/config_test.go
@@ -121,6 +121,69 @@ func TestProviderBuildConfiguration(t *testing.T) {
 			},
 		},
 		{
+			desc: "Should build config which contains two frontends and one backend",
+			nodes: []catalogUpdate{
+				{
+					Service: &serviceUpdate{
+						ServiceName: "test",
+						Attributes: []string{
+							"random.foo=bar",
+							label.Prefix + "test1.frontend.rule=Host:B",
+							label.Prefix + "test2.frontend.rule=Host:C",
+						},
+					},
+					Nodes: []*api.ServiceEntry{
+						{
+							Service: &api.AgentService{
+								Service: "test",
+								Address: "127.0.0.1",
+								Port:    80,
+								Tags: []string{
+									"random.foo=bar",
+								},
+							},
+							Node: &api.Node{
+								Node:    "localhost",
+								Address: "127.0.0.1",
+							},
+						},
+					},
+				},
+			},
+			expectedFrontends: map[string]*types.Frontend{
+				"frontend-test-test1": {
+					Backend:        "backend-test",
+					PassHostHeader: true,
+					Routes: map[string]types.Route{
+						"route-host-test-test1": {
+							Rule: "Host:B",
+						},
+					},
+					EntryPoints: []string{},
+				},
+				"frontend-test-test2": {
+					Backend:        "backend-test",
+					PassHostHeader: true,
+					Routes: map[string]types.Route{
+						"route-host-test-test2": {
+							Rule: "Host:C",
+						},
+					},
+					EntryPoints: []string{},
+				},
+			},
+			expectedBackends: map[string]*types.Backend{
+				"backend-test": {
+					Servers: map[string]types.Server{
+						"test-0-O0Tnh-SwzY69M6SurTKP3wNKkzI": {
+							URL:    "http://127.0.0.1:80",
+							Weight: 1,
+						},
+					},
+				},
+			},
+		},
+		{
 			desc: "Should build config with a basic auth with a backward compatibility",
 			nodes: []catalogUpdate{
 				{

--- a/provider/consulcatalog/consul_catalog.go
+++ b/provider/consulcatalog/consul_catalog.go
@@ -50,9 +50,10 @@ type Service struct {
 }
 
 type serviceUpdate struct {
-	ServiceName   string
-	Attributes    []string
-	TraefikLabels map[string]string
+	ServiceName       string
+	ParentServiceName string
+	Attributes        []string
+	TraefikLabels     map[string]string
 }
 
 type catalogUpdate struct {


### PR DESCRIPTION
### What does this PR do?

This adds segments to the consulcatalog provider. It does this in the same way as the docker provider does.


### Motivation

https://github.com/containous/traefik/issues/3597
We are facing the issue that our consul services have routes for multiple domains and share the fqdn between services. This means we would need more than one `rule` to express the routes for each service. This PR enables us to do so.


### More

- [X] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

I implemented the segments using the existing `label.ExtractTraefikLabels`. I envision that the frontends which are the result of one single service have both the original service name and the segment name in their name: traefik.rule1.frontend.rule:*** on service `myservice` leads to a frontend named frontend-myservice-rule1. All the frontends which are generated out of a service, share the same backend, to minimise resources. For this I needed to adjust `getServiceBackendName` to use the original service name as a name, which I store in `serviceUpdate.ParentServiceName`.
I added a test that expands a single service into 2 frontends, by having 2 segments.
