### PR TITLE
Add a note about overrideCertificates to acme docs

### DIFF
--- a/docs/configuration/acme.md
+++ b/docs/configuration/acme.md
@@ -421,6 +421,8 @@ storage = "traefik/acme/account"
 
 Because KV stores (like Consul) have limited entry size the certificates list is compressed before it is saved as KV store entry.
 
+If using [storeconfig](/user-guide/kv-config/#store-configuration-in-key-value-store), consider using `acme.overrideCertificates = true` to create the `acme/account` and `acme/lock` keys required for certificate storage.
+
 !!! note
     It is possible to store up to approximately 100 ACME certificates in Consul.
 


### PR DESCRIPTION
### What does this PR do?

Add an extra note to the docs indicating that `overrideCertificates` will create some required keys when using a KV store to store TLS certs.

There's an [existing comment in the config file example](https://github.com/containous/traefik/commit/4a3b1f384750606c3fe77de3b1e4905aaa81b3ea#diff-9891ec9a4af35901191c75a98627b9e7R66), but it doesn't mention the specific keys that might be missing when a user runs into the log message in [my other PR](https://github.com/containous/traefik/pull/3779).

Although it introduces a coupling between docs and code, I think that the key names should be present in the docs so that the solution appears in search / browser find results.

### Motivation

Some sunk time figuring out how to do HA ACME with etcd and idempotent config. Ended up learning about this setting via a [Slack conversation](https://traefik.slack.com/archives/C34HHN6JZ/p1534513726000100?thread_ts=1534460459.000100&cid=C34HHN6JZ).

### More

- [X] Added/updated documentation