### PR TITLE
A tiny rewording on the documentation API's page

### DIFF
--- a/docs/configuration/api.md
+++ b/docs/configuration/api.md
@@ -4,7 +4,7 @@
 
 ```toml
 # API definition
-# Warning: Enabling API will expose Træfik's configuration and secret.
+# Warning: Enabling API will expose Træfik's configuration.
 # It is not recommended in production,
 # unless secured by authentication and authorizations
 [api]
@@ -44,7 +44,7 @@ For more customization, see [entry points](/configuration/entrypoints/) document
 ## Security
 
 Enabling the API will expose all configuration elements,
-including secret.
+including sensitive data.
 
 It is not recommended in production,
 unless secured by authentication and authorizations.


### PR DESCRIPTION
Signed-off-by: Damien DUPORTAL <damien.duportal@gmail.com>

### What does this PR do?

Rewording "secret" to "sensitive data" in the documentation's APi page
for a better semantic and meaning.

### Motivation

The previous word usage was scary and not conveying the right information.


### More

- [x] Added/updated documentation
