### PR TITLE
Improve the wording in the documentation for Docker and fix title for Docker User Guide

### DIFF
--- a/docs/configuration/backends/docker.md
+++ b/docs/configuration/backends/docker.md
@@ -19,7 +19,7 @@ Træfik can be configured to use Docker as a provider.
 #
 endpoint = "unix:///var/run/docker.sock"
 
-# Default domain used.
+# Default base domain used for the frontend rules.
 # Can be overridden by setting the "traefik.domain" label on a container.
 #
 # Required
@@ -110,7 +110,7 @@ To enable constraints see [provider-specific constraints section](/configuration
 #
 endpoint = "tcp://127.0.0.1:2375"
 
-# Default domain used.
+# Default base domain used for the frontend rules.
 # Can be overridden by setting the "traefik.domain" label on a services.
 #
 # Optional
@@ -210,7 +210,7 @@ Labels can be used on containers to override default behavior.
 | Label                                                      | Description                                                                                                                                                                                                                      |
 |------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `traefik.docker.network`                                   | Overrides the default docker network to use for connections to the container. [1]                                                                                                                                                |
-| `traefik.domain`                                           | Sets the default domain for the frontend rules.                                                                                                                                                                                  |
+| `traefik.domain`                                           | Sets the default base domain for the frontend rules. For more information, check the [Container Labels section's of the user guide "Let's Encrypt & Docker"](/user-guide/docker-and-lets-encrypt/#container-labels)                                                                                                                                                                                   |
 | `traefik.enable=false`                                     | Disables this container in Træfik.                                                                                                                                                                                               |
 | `traefik.port=80`                                          | Registers this port. Useful when the container exposes multiples ports.                                                                                                                                                          |
 | `traefik.protocol=https`                                   | Overrides the default `http` protocol                                                                                                                                                                                            |

--- a/docs/user-guide/docker-and-lets-encrypt.md
+++ b/docs/user-guide/docker-and-lets-encrypt.md
@@ -1,4 +1,4 @@
-# Docker & Traefik
+# Let's Encrypt & Docker
 
 In this use case, we want to use Træfik as a _layer-7_ load balancer with SSL termination for a set of micro-services used to run a web application.
 


### PR DESCRIPTION
### What does this PR do?

This Pull Request introduce 2 changes:

- Improving the wording in the documentation for the Docker configuration page, 
about the `domain` directive

- Fixing the title of the documentation's user guide about Let's Encrypt & Docker

### Motivation

- While trying to reproduce some basic user configuration issue in the Slack support, 
I was stuck on a basic use case: "1 container behind 1 traefik". Being too quick, I directly read the Docker's Configuration page, where it was saying "docker.domain: set the domain to use". This simple rewording put an attention point for the newcomer, so they will search for the rule, and won't be stuck on this. Having checked this with @nmengin confirmed me it could be a good idea to reword (Hence the rewording I propose is not an absolute one :) )
- While proposing ths rewording, I realized that the title of the User guide about Let's Encrypt & Docker was not matching its table of content's item.


### More

- [-] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
