### PR TITLE
 StoreConfig always initializes the account if it is missing

### DIFF
--- a/cmd/storeconfig/storeconfig.go
+++ b/cmd/storeconfig/storeconfig.go
@@ -124,6 +124,7 @@ func keyExists(source *staert.KvSource, key string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	
 	return len(list) > 0, nil
 }
 

--- a/cmd/storeconfig/storeconfig.go
+++ b/cmd/storeconfig/storeconfig.go
@@ -85,8 +85,13 @@ func Run(kv *staert.KvSource, traefikConfiguration *cmd.TraefikConfiguration) fu
 				}
 			}
 
+			storageExists, err := storageExists(kv, traefikConfiguration.GlobalConfiguration.ACME.Storage)
+			if err != nil {
+				return err
+			}
+
 			// Check to see if ACME account object is already in kv store
-			if traefikConfiguration.GlobalConfiguration.ACME.OverrideCertificates {
+			if traefikConfiguration.GlobalConfiguration.ACME.OverrideCertificates || !storageExists {
 
 				// Store the ACME Account into the KV Store
 				// Certificates in KV Store will be overridden
@@ -112,6 +117,14 @@ func Run(kv *staert.KvSource, traefikConfiguration *cmd.TraefikConfiguration) fu
 		}
 		return nil
 	}
+}
+
+func storageExists(source *staert.KvSource, key string) (bool, error) {
+	list, err := source.List(key, nil)
+	if err != nil {
+		return false, err
+	}
+	return len(list) > 0, nil
 }
 
 // migrateACMEData allows migrating data from acme.json file to KV store in function of the file format

--- a/cmd/storeconfig/storeconfig.go
+++ b/cmd/storeconfig/storeconfig.go
@@ -85,13 +85,13 @@ func Run(kv *staert.KvSource, traefikConfiguration *cmd.TraefikConfiguration) fu
 				}
 			}
 
-			storageExists, err := storageExists(kv, traefikConfiguration.GlobalConfiguration.ACME.Storage)
+			accountInitialized, err := keyExists(kv, traefikConfiguration.GlobalConfiguration.ACME.Storage)
 			if err != nil {
 				return err
 			}
 
 			// Check to see if ACME account object is already in kv store
-			if traefikConfiguration.GlobalConfiguration.ACME.OverrideCertificates || !storageExists {
+			if traefikConfiguration.GlobalConfiguration.ACME.OverrideCertificates || !accountInitialized {
 
 				// Store the ACME Account into the KV Store
 				// Certificates in KV Store will be overridden
@@ -119,7 +119,7 @@ func Run(kv *staert.KvSource, traefikConfiguration *cmd.TraefikConfiguration) fu
 	}
 }
 
-func storageExists(source *staert.KvSource, key string) (bool, error) {
+func keyExists(source *staert.KvSource, key string) (bool, error) {
 	list, err := source.List(key, nil)
 	if err != nil {
 		return false, err

--- a/cmd/storeconfig/storeconfig.go
+++ b/cmd/storeconfig/storeconfig.go
@@ -124,7 +124,7 @@ func keyExists(source *staert.KvSource, key string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	
+
 	return len(list) > 0, nil
 }
 


### PR DESCRIPTION
### What does this PR do?

The StoreConfig command will now always initialize the account (which key path is defined by acme.storage) if it is not yet initialized.

### Motivation

Related #3787 #3776 
Fixes #3754 
