### PR TITLE
Allow Træfik to know if a Host rule is malformed

### DIFF
--- a/provider/acme/provider.go
+++ b/provider/acme/provider.go
@@ -174,9 +174,14 @@ func (p *Provider) watchNewDomains() {
 				for _, frontend := range config.Frontends {
 					for _, route := range frontend.Routes {
 						domainRules := rules.Rules{}
-						domains, err := domainRules.ParseDomains(route.Rule)
+						isHostRule, domains, err := domainRules.ParseDomains(route.Rule)
 						if err != nil {
 							log.Errorf("Error parsing domains in provider ACME: %v", err)
+							continue
+						}
+
+						if isHostRule && len(domains) == 0 {
+							log.Errorf("Host rule detected into %s but no domain parsed in provider ACME.", route.Rule)
 							continue
 						}
 

--- a/provider/acme/provider.go
+++ b/provider/acme/provider.go
@@ -174,19 +174,14 @@ func (p *Provider) watchNewDomains() {
 				for _, frontend := range config.Frontends {
 					for _, route := range frontend.Routes {
 						domainRules := rules.Rules{}
-						isHostRule, domains, err := domainRules.ParseDomains(route.Rule)
+						domains, err := domainRules.ParseDomains(route.Rule)
 						if err != nil {
 							log.Errorf("Error parsing domains in provider ACME: %v", err)
 							continue
 						}
 
-						if isHostRule && len(domains) == 0 {
-							log.Errorf("Host rule detected into %s but no domain parsed in provider ACME.", route.Rule)
-							continue
-						}
-
 						if len(domains) == 0 {
-							log.Debugf("No domain parsed in rule %q", route.Rule)
+							log.Debugf("No domain parsed in rule %q in provider ACME", route.Rule)
 							continue
 						}
 

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -54,24 +54,40 @@ func TestParseDomains(t *testing.T) {
 	rules := &Rules{}
 
 	tests := []struct {
-		expression string
-		domain     []string
+		description      string
+		expression       string
+		domain           []string
+		hostRuleExpected bool
 	}{
 		{
-			expression: "Host:foo.bar,test.bar",
-			domain:     []string{"foo.bar", "test.bar"},
+			description:      "Many host rules",
+			expression:       "Host:foo.bar,test.bar",
+			domain:           []string{"foo.bar", "test.bar"},
+			hostRuleExpected: true,
 		},
 		{
-			expression: "Path:/test",
-			domain:     []string{},
+			description:      "No host rule",
+			expression:       "Path:/test",
+			domain:           []string{},
+			hostRuleExpected: false,
 		},
 		{
-			expression: "Host:foo.bar;Path:/test",
-			domain:     []string{"foo.bar"},
+			description:      "Host rule and another rule",
+			expression:       "Host:foo.bar;Path:/test",
+			domain:           []string{"foo.bar"},
+			hostRuleExpected: true,
 		},
 		{
-			expression: "Host: Foo.Bar ;Path:/test",
-			domain:     []string{"foo.bar"},
+			description:      "Host rule to trim and another rule",
+			expression:       "Host: Foo.Bar ;Path:/test",
+			domain:           []string{"foo.bar"},
+			hostRuleExpected: true,
+		},
+		{
+			description:      "Host rule with no domain",
+			expression:       "Host: ;Path:/test",
+			domain:           []string{},
+			hostRuleExpected: true,
 		},
 	}
 
@@ -80,9 +96,9 @@ func TestParseDomains(t *testing.T) {
 		t.Run(test.expression, func(t *testing.T) {
 			t.Parallel()
 
-			domains, err := rules.ParseDomains(test.expression)
+			isHostRule, domains, err := rules.ParseDomains(test.expression)
 			require.NoError(t, err, "%s: Error while parsing domain.", test.expression)
-
+			assert.EqualValues(t, test.hostRuleExpected, isHostRule, "%s: Error parsing rules from expression.", test.expression)
 			assert.EqualValues(t, test.domain, domains, "%s: Error parsing domains from expression.", test.expression)
 		})
 	}

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -54,40 +54,38 @@ func TestParseDomains(t *testing.T) {
 	rules := &Rules{}
 
 	tests := []struct {
-		description      string
-		expression       string
-		domain           []string
-		hostRuleExpected bool
+		description   string
+		expression    string
+		domain        []string
+		errorExpected bool
 	}{
 		{
-			description:      "Many host rules",
-			expression:       "Host:foo.bar,test.bar",
-			domain:           []string{"foo.bar", "test.bar"},
-			hostRuleExpected: true,
+			description:   "Many host rules",
+			expression:    "Host:foo.bar,test.bar",
+			domain:        []string{"foo.bar", "test.bar"},
+			errorExpected: false,
 		},
 		{
-			description:      "No host rule",
-			expression:       "Path:/test",
-			domain:           []string{},
-			hostRuleExpected: false,
+			description:   "No host rule",
+			expression:    "Path:/test",
+			errorExpected: false,
 		},
 		{
-			description:      "Host rule and another rule",
-			expression:       "Host:foo.bar;Path:/test",
-			domain:           []string{"foo.bar"},
-			hostRuleExpected: true,
+			description:   "Host rule and another rule",
+			expression:    "Host:foo.bar;Path:/test",
+			domain:        []string{"foo.bar"},
+			errorExpected: false,
 		},
 		{
-			description:      "Host rule to trim and another rule",
-			expression:       "Host: Foo.Bar ;Path:/test",
-			domain:           []string{"foo.bar"},
-			hostRuleExpected: true,
+			description:   "Host rule to trim and another rule",
+			expression:    "Host: Foo.Bar ;Path:/test",
+			domain:        []string{"foo.bar"},
+			errorExpected: false,
 		},
 		{
-			description:      "Host rule with no domain",
-			expression:       "Host: ;Path:/test",
-			domain:           []string{},
-			hostRuleExpected: true,
+			description:   "Host rule with no domain",
+			expression:    "Host: ;Path:/test",
+			errorExpected: true,
 		},
 	}
 
@@ -96,9 +94,14 @@ func TestParseDomains(t *testing.T) {
 		t.Run(test.expression, func(t *testing.T) {
 			t.Parallel()
 
-			isHostRule, domains, err := rules.ParseDomains(test.expression)
-			require.NoError(t, err, "%s: Error while parsing domain.", test.expression)
-			assert.EqualValues(t, test.hostRuleExpected, isHostRule, "%s: Error parsing rules from expression.", test.expression)
+			domains, err := rules.ParseDomains(test.expression)
+
+			if test.errorExpected {
+				require.Errorf(t, err, "unable to parse correctly the domains in the Host rule from %q", test.expression)
+			} else {
+				require.NoError(t, err, "%s: Error while parsing domain.", test.expression)
+			}
+
 			assert.EqualValues(t, test.domain, domains, "%s: Error parsing domains from expression.", test.expression)
 		})
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -673,10 +673,17 @@ func (s *Server) postLoadConfiguration() {
 				if acmeEnabled {
 					for _, route := range frontend.Routes {
 						rules := rules.Rules{}
-						domains, err := rules.ParseDomains(route.Rule)
+						isHostRule, domains, err := rules.ParseDomains(route.Rule)
 						if err != nil {
 							log.Errorf("Error parsing domains: %v", err)
-						} else {
+							continue
+						}
+
+						if isHostRule {
+							if len(domains) == 0 {
+								log.Errorf("Host rule detected into %s but no domain parsed.", route.Rule)
+								continue
+							}
 							s.globalConfiguration.ACME.LoadCertificateForDomains(domains)
 						}
 					}

--- a/server/server.go
+++ b/server/server.go
@@ -673,19 +673,18 @@ func (s *Server) postLoadConfiguration() {
 				if acmeEnabled {
 					for _, route := range frontend.Routes {
 						rules := rules.Rules{}
-						isHostRule, domains, err := rules.ParseDomains(route.Rule)
+						domains, err := rules.ParseDomains(route.Rule)
 						if err != nil {
 							log.Errorf("Error parsing domains: %v", err)
 							continue
 						}
 
-						if isHostRule {
-							if len(domains) == 0 {
-								log.Errorf("Host rule detected into %s but no domain parsed.", route.Rule)
-								continue
-							}
-							s.globalConfiguration.ACME.LoadCertificateForDomains(domains)
+						if len(domains) == 0 {
+							log.Debugf("No domain parsed in rule %q", route.Rule)
+							continue
 						}
+
+						s.globalConfiguration.ACME.LoadCertificateForDomains(domains)
 					}
 				}
 			}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This PR allows users to know if a `Host` rule is malformed by returning a `bool` to prevent that a `Host` Rule has been detected.

Thus if a `Host` rule is detected and no domain are returned, a specific error message can be created.

### Motivation

<!-- What inspired you to submit this pull request? -->

User reported that ACME has not created domains with the error message `Error getting valid domain: unable to generate a certificate when no domain is given.`.

The error has came from his `Host` rule but the message has not indicated it.

The PR improves the error management.

### More

- [x] Added/updated tests
