### PR TITLE
Avoid goroutine leak in server

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -248,7 +248,9 @@ func (s *Server) Start() {
 		s.listenConfigurations(stop)
 	})
 	s.startProvider()
-	go s.listenSignals()
+	s.routinesPool.Go(func(stop chan bool) {
+		s.listenSignals(stop)
+	})
 }
 
 // StartWithContext starts the server and Stop/Close it when context is Done

--- a/server/server_configuration.go
+++ b/server/server_configuration.go
@@ -447,8 +447,10 @@ func (s *Server) throttleProviderConfigReload(throttle time.Duration, publish ch
 			case <-stop:
 				return
 			case nextConfig := <-ring.Out():
-				publish <- nextConfig.(types.ConfigMessage)
-				time.Sleep(throttle)
+				if nextConfig != nil {
+					publish <- nextConfig.(types.ConfigMessage)
+					time.Sleep(throttle)
+				}
 			}
 		}
 	})


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
The PR allows the goroutine `ListenSignals` to listen to the server context.
Thus, this goroutine will be stopped when the server is stopped.

### Motivation

<!-- What inspired you to submit this pull request? -->
Improve the quality of the code by making it more robust.

### Additional Notes

<!-- Anything else we should know when reviewing? -->
The PR contains a test on the configMessage in the ThrottleChan to avoid a possible `panic` when the cast is done on a nil referenced object.