### PR TITLE
Multiple kubernetes ingress definitions may cause flapping frontend

### DIFF
--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -242,7 +242,10 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 					continue
 				}
 
-				if _, exists := templateObjects.Frontends[baseName]; !exists {
+				var frontend *types.Frontend
+				if fe, exists := templateObjects.Frontends[baseName]; exists {
+					frontend = fe
+				} else {
 					auth, err := getAuthConfig(i, k8sClient)
 					if err != nil {
 						log.Errorf("Failed to retrieve auth configuration for ingress %s/%s: %s", i.Namespace, i.Name, err)
@@ -253,7 +256,7 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 					passTLSCert := getBoolValue(i.Annotations, annotationKubernetesPassTLSCert, p.EnablePassTLSCert)
 					entryPoints := getSliceStringValue(i.Annotations, annotationKubernetesFrontendEntryPoints)
 
-					templateObjects.Frontends[baseName] = &types.Frontend{
+					frontend = &types.Frontend{
 						Backend:        baseName,
 						PassHostHeader: passHostHeader,
 						PassTLSCert:    passTLSCert,
@@ -269,26 +272,6 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 					}
 				}
 
-				if len(r.Host) > 0 {
-					if _, exists := templateObjects.Frontends[baseName].Routes[r.Host]; !exists {
-						templateObjects.Frontends[baseName].Routes[r.Host] = types.Route{
-							Rule: getRuleForHost(r.Host),
-						}
-					}
-				}
-
-				rule, err := getRuleForPath(pa, i)
-				if err != nil {
-					log.Errorf("Failed to get rule for ingress %s/%s: %s", i.Namespace, i.Name, err)
-					delete(templateObjects.Frontends, baseName)
-					continue
-				}
-				if rule != "" {
-					templateObjects.Frontends[baseName].Routes[pa.Path] = types.Route{
-						Rule: rule,
-					}
-				}
-
 				service, exists, err := k8sClient.GetService(i.Namespace, pa.Backend.ServiceName)
 				if err != nil {
 					log.Errorf("Error while retrieving service information from k8s API %s/%s: %v", i.Namespace, pa.Backend.ServiceName, err)
@@ -297,10 +280,30 @@ func (p *Provider) loadIngresses(k8sClient Client) (*types.Configuration, error)
 
 				if !exists {
 					log.Errorf("Service not found for %s/%s", i.Namespace, pa.Backend.ServiceName)
-					delete(templateObjects.Frontends, baseName)
 					continue
 				}
 
+				rule, err := getRuleForPath(pa, i)
+				if err != nil {
+					log.Errorf("Failed to get rule for ingress %s/%s: %s", i.Namespace, i.Name, err)
+					continue
+				}
+
+				if rule != "" {
+					frontend.Routes[pa.Path] = types.Route{
+						Rule: rule,
+					}
+				}
+
+				if len(r.Host) > 0 {
+					if _, exists := frontend.Routes[r.Host]; !exists {
+						frontend.Routes[r.Host] = types.Route{
+							Rule: getRuleForHost(r.Host),
+						}
+					}
+				}
+
+				templateObjects.Frontends[baseName] = frontend
 				templateObjects.Backends[baseName].CircuitBreaker = getCircuitBreaker(service)
 				templateObjects.Backends[baseName].LoadBalancer = getLoadBalancer(service)
 				templateObjects.Backends[baseName].MaxConn = getMaxConn(service)

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -1519,6 +1519,13 @@ rateset:
 					route("/whitelist-source-range", "PathPrefix:/whitelist-source-range"),
 					route("test", "Host:test")),
 			),
+			frontend("root2/",
+				passHostHeader(),
+				redirectRegex("root2/$", "root2/root2"),
+				routes(
+					route("/", "PathPrefix:/;ReplacePathRegex: ^/(.*) /abc$1"),
+					route("root2", "Host:root2")),
+			),
 			frontend("test/whitelist-remote-addr",
 				passHostHeader(),
 				whiteList(


### PR DESCRIPTION
### What does this PR do?

If multiple ingress objects define the same frontend (host + path) and one of the ingresses is broken (e.g. referenced service does not exist) then the frontend will be flapping (appear, disappear, ...).

### Motivation

We found this in production and I've extracted the problem into a testcase...

Given 2 ingresses:
```
- apiVersion: extensions/v1beta1
  kind: Ingress
  metadata:
    namespace: testing
    name: web-a
  spec:
    rules:
    - host: host-a
      http:
        paths:
        - backend:
            serviceName: service1
            servicePort: 80
- apiVersion: extensions/v1beta1
  kind: Ingress
  metadata:
    namespace: testing
    name: web-b
  spec:
    rules:
    - host: host-a
      http:
        paths:
        - backend:
            serviceName: missing
            servicePort: 80
```

The `missing` service will cause the whole `host-a` frontend to disappear if the ingress objects are processed in order `[ingress/web-a, ingress/web-b]`. We have seen in production that the ordering can be random, thus causing the frontend to become unavailable.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Instead if writing to the `Frontends` map directly this patch checks out the current `frontend` and writes it to the map only if basic validations pass.

There was a second test-failure after applying this patch. The `root2` testcase has 2 ingress definitions, one of those is broken.
The behavior now changed to accept the valid one and keep the frontend.