### PR TITLE
Fix tracing duplicated headers

### DIFF
--- a/middlewares/tracing/carrier.go
+++ b/middlewares/tracing/carrier.go
@@ -1,0 +1,25 @@
+package tracing
+
+import "net/http"
+
+// HTTPHeadersCarrier custom implementation to fix duplicated headers
+// It has been fixed in https://github.com/opentracing/opentracing-go/pull/191
+type HTTPHeadersCarrier http.Header
+
+// Set conforms to the TextMapWriter interface.
+func (c HTTPHeadersCarrier) Set(key, val string) {
+	h := http.Header(c)
+	h.Set(key, val)
+}
+
+// ForeachKey conforms to the TextMapReader interface.
+func (c HTTPHeadersCarrier) ForeachKey(handler func(key, val string) error) error {
+	for k, vals := range c {
+		for _, v := range vals {
+			if err := handler(k, v); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/middlewares/tracing/entrypoint.go
+++ b/middlewares/tracing/entrypoint.go
@@ -24,7 +24,7 @@ func (t *Tracing) NewEntryPoint(name string) negroni.Handler {
 func (e *entryPointMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	opNameFunc := generateEntryPointSpanName
 
-	ctx, _ := e.Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(r.Header))
+	ctx, _ := e.Extract(opentracing.HTTPHeaders, HTTPHeadersCarrier(r.Header))
 	span := e.StartSpan(opNameFunc(r, e.entryPoint, e.SpanNameLimit), ext.RPCServerOption(ctx))
 	ext.Component.Set(span, e.ServiceName)
 	LogRequest(span, r)

--- a/middlewares/tracing/tracing.go
+++ b/middlewares/tracing/tracing.go
@@ -125,7 +125,7 @@ func InjectRequestHeaders(r *http.Request) {
 		err := opentracing.GlobalTracer().Inject(
 			span.Context(),
 			opentracing.HTTPHeaders,
-			opentracing.HTTPHeadersCarrier(r.Header))
+			HTTPHeadersCarrier(r.Header))
 		if err != nil {
 			log.Error(err)
 		}


### PR DESCRIPTION
### What does this PR do?

This PR fix duplicated header in Tracing.

### Motivation

When an incoming request arrives with a tracing header, Træfik should used this header to create the new tracing headers and keep only the last one.

### Additional Notes

Closes #3854 

It is an issue in [opentracing/opentracing-go](https://github.com/opentracing/opentracing-go) ant it has been fixed by https://github.com/opentracing/opentracing-go/pull/191 but for now we are not able to upgrade this dependency