### PR TITLE
Consul Catalog backend: separate backend servers by common tags.

### DIFF
--- a/autogen/gentemplates/gen.go
+++ b/autogen/gentemplates/gen.go
@@ -110,8 +110,8 @@ var _templatesConsul_catalogTmpl = []byte(`[backends]
 
 {{end}}
 {{range $index, $node := .Nodes}}
-  {{ $server := getServer $node }}
-  [backends."backend-{{ getNodeBackendName $node }}".servers."{{ getServerName $node $index }}"]
+  {{ $server := getServer ($node.ServiceEntry) }}
+  [backends."backend-{{ $node.BackendName }}".servers."{{ getServerName ($node.ServiceEntry) $index }}"]
     url = "{{ $server.URL }}"
     weight = {{ $server.Weight }}
 

--- a/provider/consulcatalog/consul_catalog_test.go
+++ b/provider/consulcatalog/consul_catalog_test.go
@@ -12,185 +12,227 @@ import (
 func TestNodeSorter(t *testing.T) {
 	testCases := []struct {
 		desc     string
-		nodes    []*api.ServiceEntry
-		expected []*api.ServiceEntry
+		nodes    []serverItem
+		expected []serverItem
 	}{
 		{
 			desc:     "Should sort nothing",
-			nodes:    []*api.ServiceEntry{},
-			expected: []*api.ServiceEntry{},
+			nodes:    []serverItem{},
+			expected: []serverItem{},
 		},
 		{
 			desc: "Should sort by node address",
-			nodes: []*api.ServiceEntry{
+			nodes: []serverItem{
 				{
-					Service: &api.AgentService{
-						Service: "foo",
-						Address: "127.0.0.1",
-						Port:    80,
-					},
-					Node: &api.Node{
-						Node:    "localhost",
-						Address: "127.0.0.1",
+					BackendName: "foo",
+					ServiceEntry: &api.ServiceEntry{
+						Service: &api.AgentService{
+							Service: "foo",
+							Address: "127.0.0.1",
+							Port:    80,
+						},
+						Node: &api.Node{
+							Node:    "localhost",
+							Address: "127.0.0.1",
+						},
 					},
 				},
 			},
-			expected: []*api.ServiceEntry{
+			expected: []serverItem{
 				{
-					Service: &api.AgentService{
-						Service: "foo",
-						Address: "127.0.0.1",
-						Port:    80,
-					},
-					Node: &api.Node{
-						Node:    "localhost",
-						Address: "127.0.0.1",
+					BackendName: "foo",
+					ServiceEntry: &api.ServiceEntry{
+						Service: &api.AgentService{
+							Service: "foo",
+							Address: "127.0.0.1",
+							Port:    80,
+						},
+						Node: &api.Node{
+							Node:    "localhost",
+							Address: "127.0.0.1",
+						},
 					},
 				},
 			},
 		},
 		{
 			desc: "Should sort by service name",
-			nodes: []*api.ServiceEntry{
+			nodes: []serverItem{
 				{
-					Service: &api.AgentService{
-						Service: "foo",
-						Address: "127.0.0.2",
-						Port:    80,
-					},
-					Node: &api.Node{
-						Node:    "localhost",
-						Address: "127.0.0.2",
+					BackendName: "foo",
+					ServiceEntry: &api.ServiceEntry{
+						Service: &api.AgentService{
+							Service: "foo",
+							Address: "127.0.0.2",
+							Port:    80,
+						},
+						Node: &api.Node{
+							Node:    "localhost",
+							Address: "127.0.0.2",
+						},
 					},
 				},
 				{
-					Service: &api.AgentService{
-						Service: "bar",
-						Address: "127.0.0.2",
-						Port:    81,
-					},
-					Node: &api.Node{
-						Node:    "localhost",
-						Address: "127.0.0.2",
-					},
-				},
-				{
-					Service: &api.AgentService{
-						Service: "foo",
-						Address: "127.0.0.1",
-						Port:    80,
-					},
-					Node: &api.Node{
-						Node:    "localhost",
-						Address: "127.0.0.1",
+					BackendName: "foo",
+					ServiceEntry: &api.ServiceEntry{
+						Service: &api.AgentService{
+							Service: "bar",
+							Address: "127.0.0.2",
+							Port:    81,
+						},
+						Node: &api.Node{
+							Node:    "localhost",
+							Address: "127.0.0.2",
+						},
 					},
 				},
 				{
-					Service: &api.AgentService{
-						Service: "bar",
-						Address: "127.0.0.2",
-						Port:    80,
+					BackendName: "foo",
+					ServiceEntry: &api.ServiceEntry{
+						Service: &api.AgentService{
+							Service: "foo",
+							Address: "127.0.0.1",
+							Port:    80,
+						},
+						Node: &api.Node{
+							Node:    "localhost",
+							Address: "127.0.0.1",
+						},
 					},
-					Node: &api.Node{
-						Node:    "localhost",
-						Address: "127.0.0.2",
+				},
+				{
+					BackendName: "foo",
+					ServiceEntry: &api.ServiceEntry{
+						Service: &api.AgentService{
+							Service: "bar",
+							Address: "127.0.0.2",
+							Port:    80,
+						},
+						Node: &api.Node{
+							Node:    "localhost",
+							Address: "127.0.0.2",
+						},
 					},
 				},
 			},
-			expected: []*api.ServiceEntry{
+			expected: []serverItem{
 				{
-					Service: &api.AgentService{
-						Service: "bar",
-						Address: "127.0.0.2",
-						Port:    80,
-					},
-					Node: &api.Node{
-						Node:    "localhost",
-						Address: "127.0.0.2",
+					BackendName: "foo",
+					ServiceEntry: &api.ServiceEntry{
+						Service: &api.AgentService{
+							Service: "bar",
+							Address: "127.0.0.2",
+							Port:    80,
+						},
+						Node: &api.Node{
+							Node:    "localhost",
+							Address: "127.0.0.2",
+						},
 					},
 				},
 				{
-					Service: &api.AgentService{
-						Service: "bar",
-						Address: "127.0.0.2",
-						Port:    81,
-					},
-					Node: &api.Node{
-						Node:    "localhost",
-						Address: "127.0.0.2",
-					},
-				},
-				{
-					Service: &api.AgentService{
-						Service: "foo",
-						Address: "127.0.0.1",
-						Port:    80,
-					},
-					Node: &api.Node{
-						Node:    "localhost",
-						Address: "127.0.0.1",
+					BackendName: "foo",
+					ServiceEntry: &api.ServiceEntry{
+						Service: &api.AgentService{
+							Service: "bar",
+							Address: "127.0.0.2",
+							Port:    81,
+						},
+						Node: &api.Node{
+							Node:    "localhost",
+							Address: "127.0.0.2",
+						},
 					},
 				},
 				{
-					Service: &api.AgentService{
-						Service: "foo",
-						Address: "127.0.0.2",
-						Port:    80,
+					BackendName: "foo",
+					ServiceEntry: &api.ServiceEntry{
+						Service: &api.AgentService{
+							Service: "foo",
+							Address: "127.0.0.1",
+							Port:    80,
+						},
+						Node: &api.Node{
+							Node:    "localhost",
+							Address: "127.0.0.1",
+						},
 					},
-					Node: &api.Node{
-						Node:    "localhost",
-						Address: "127.0.0.2",
+				},
+				{
+					BackendName: "foo",
+					ServiceEntry: &api.ServiceEntry{
+						Service: &api.AgentService{
+							Service: "foo",
+							Address: "127.0.0.2",
+							Port:    80,
+						},
+						Node: &api.Node{
+							Node:    "localhost",
+							Address: "127.0.0.2",
+						},
 					},
 				},
 			},
 		},
 		{
 			desc: "Should sort by node address",
-			nodes: []*api.ServiceEntry{
+			nodes: []serverItem{
 				{
-					Service: &api.AgentService{
-						Service: "foo",
-						Address: "",
-						Port:    80,
-					},
-					Node: &api.Node{
-						Node:    "localhost",
-						Address: "127.0.0.2",
+					BackendName: "foo",
+					ServiceEntry: &api.ServiceEntry{
+						Service: &api.AgentService{
+							Service: "foo",
+							Address: "",
+							Port:    80,
+						},
+						Node: &api.Node{
+							Node:    "localhost",
+							Address: "127.0.0.2",
+						},
 					},
 				},
 				{
-					Service: &api.AgentService{
-						Service: "foo",
-						Address: "",
-						Port:    80,
-					},
-					Node: &api.Node{
-						Node:    "localhost",
-						Address: "127.0.0.1",
+					BackendName: "foo",
+					ServiceEntry: &api.ServiceEntry{
+						Service: &api.AgentService{
+							Service: "foo",
+							Address: "",
+							Port:    80,
+						},
+						Node: &api.Node{
+							Node:    "localhost",
+							Address: "127.0.0.1",
+						},
 					},
 				},
 			},
-			expected: []*api.ServiceEntry{
+			expected: []serverItem{
 				{
-					Service: &api.AgentService{
-						Service: "foo",
-						Address: "",
-						Port:    80,
-					},
-					Node: &api.Node{
-						Node:    "localhost",
-						Address: "127.0.0.1",
+					BackendName: "foo",
+					ServiceEntry: &api.ServiceEntry{
+						Service: &api.AgentService{
+							Service: "foo",
+							Address: "",
+							Port:    80,
+						},
+						Node: &api.Node{
+							Node:    "localhost",
+							Address: "127.0.0.1",
+						},
 					},
 				},
 				{
-					Service: &api.AgentService{
-						Service: "foo",
-						Address: "",
-						Port:    80,
-					},
-					Node: &api.Node{
-						Node:    "localhost",
-						Address: "127.0.0.2",
+					BackendName: "foo",
+					ServiceEntry: &api.ServiceEntry{
+						Service: &api.AgentService{
+							Service: "foo",
+							Address: "",
+							Port:    80,
+						},
+						Node: &api.Node{
+							Node:    "localhost",
+							Address: "127.0.0.2",
+						},
 					},
 				},
 			},

--- a/provider/consulcatalog/convert_types.go
+++ b/provider/consulcatalog/convert_types.go
@@ -1,6 +1,9 @@
 package consulcatalog
 
 import (
+	"crypto/sha1"
+	"encoding/base64"
+	"sort"
 	"strings"
 
 	"github.com/containous/traefik/provider/label"
@@ -26,4 +29,27 @@ func tagsToNeutralLabels(tags []string, prefix string) map[string]string {
 	}
 
 	return labels
+}
+
+func tagsWithPrefix(tags []string, prefix string) []string {
+	var selectedTags []string
+	for _, tag := range tags {
+		if strings.HasPrefix(tag, prefix) {
+			selectedTags = append(selectedTags, tag)
+		}
+	}
+	return selectedTags
+}
+
+func tagsToGroupId(tags []string, prefix string) string {
+	selectedTags := tagsWithPrefix(tags, prefix)
+
+	hash := sha1.New()
+	sort.Strings(selectedTags)
+	for _, tag := range selectedTags {
+		hash.Write([]byte(tag))
+		hash.Write([]byte{0})
+	}
+
+	return base64.URLEncoding.EncodeToString(hash.Sum(nil))
 }

--- a/templates/consul_catalog.tmpl
+++ b/templates/consul_catalog.tmpl
@@ -54,8 +54,8 @@
 
 {{end}}
 {{range $index, $node := .Nodes}}
-  {{ $server := getServer $node }}
-  [backends."backend-{{ getNodeBackendName $node }}".servers."{{ getServerName $node $index }}"]
+  {{ $server := getServer ($node.ServiceEntry) }}
+  [backends."backend-{{ $node.BackendName }}".servers."{{ getServerName ($node.ServiceEntry) $index }}"]
     url = "{{ $server.URL }}"
     weight = {{ $server.Weight }}
 


### PR DESCRIPTION
Fix #3882. This commit separate each backend server based on common
traefik tags. If two servers have different tags, they are grouped in
two separate backends.

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

See https://github.com/containous/traefik/issues/3882

When two consul services that share the same service name but have different tags, those tags were merged together and formed a unique backend.

In some cases, it's not desirable as different services might have different tags that are incompatible with each other. This can be the case for blue/green deployment with Consul and Nomad where the blue instances have a set of tags, and the green instances have another set.

It makes much more sense to split backends with similar tags, that's what this PR does.
### Motivation

<!-- What inspired you to submit this pull request? -->
Support blue/green deployments with Consul and Nomad

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
