### PR TITLE
Native kubernetes ACME storage

### DIFF
--- a/acme/acme.go
+++ b/acme/acme.go
@@ -45,6 +45,7 @@ type ACME struct {
 	Domains               []types.Domain              `description:"SANs (alternative domains) to each main domain using format: --acme.domains='main.com,san1.com,san2.com' --acme.domains='main.net,san1.net,san2.net'"`
 	Storage               string                      `description:"File or key used for certificates storage."`
 	StorageFile           string                      // Deprecated
+	Kubernetes            *acmeprovider.Kubernetes    `description:"Activate native Kubernetes storage for ACME data."`
 	OnDemand              bool                        `description:"(Deprecated) Enable on demand certificate generation. This will request a certificate from Let's Encrypt during the first TLS handshake for a hostname that does not yet have a certificate."` // Deprecated
 	OnHostRule            bool                        `description:"Enable certificate generation on frontends Host rules."`
 	CAServer              string                      `description:"CA server to use."`

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -283,8 +283,12 @@ func (gc *GlobalConfiguration) InitACMEProvider() *acmeprovider.Provider {
 				EntryPoint:    gc.ACME.EntryPoint,
 			}
 
-			store := acmeprovider.NewLocalStore(provider.Storage)
-			provider.Store = store
+			if gc.ACME.Kubernetes != nil {
+				provider.Store = acmeprovider.NewKubernetesStore(gc.ACME.Kubernetes.Namespace)
+			} else {
+				provider.Store = acmeprovider.NewLocalStore(provider.Storage)
+			}
+
 			acme.ConvertToNewFormat(provider.Storage)
 			gc.ACME = nil
 			return provider


### PR DESCRIPTION
### What does this PR do?

This PR is an attempt to contribute towards the ideas in #2542 

Currently, this PR implements a very naive approach to storing the ACME information in native k8s objects, it simply takes the entire `acme.StoredData` struct and saves it in a secret called `traefik-acme-storage`.

Here are some discussion points that i'd love some input from others in the community (or even help to implement if anyone has time):
- concurrency/safety
    - we could implement a distributed lock using annotations on the secret to ensure safe concurrent access
    - we could break up the storage into many config-maps and secrets as mentioned in the original issue #2542 
        - probably still requires distributed locking
- automatic configuration reloading
    - i'm not very familiar with the codebase but i'm sure nodes will need to make use of k8s watch apis to reload ACME data when other nodes write
    - i'm not sure how this push based reloading works in the broader context of the codebase

I assume with safe concurrent access to the storage (be it 1 or many objects) using a lock + automatic configuration reloading we'll be able to have a fairly robust implementation where any node can participate in the acme challenge.

It'd be great for others to raise their own ideas on the implementation of this feature so we can get this moving! I think it will be a very useful feature for many use-cases of traefik.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Here's the configuration to use the Kubernetes storage implementation.

```toml
[acme]
# ...
[acme.kubernetes]
  namespace = "default"
```