### PR TITLE
Do not copy hop-by-hop headers to forward auth request

### DIFF
--- a/middlewares/auth/forward.go
+++ b/middlewares/auth/forward.go
@@ -105,6 +105,7 @@ func Forward(config *types.Forward, w http.ResponseWriter, r *http.Request, next
 
 func writeHeader(req *http.Request, forwardReq *http.Request, trustForwardHeader bool) {
 	utils.CopyHeaders(forwardReq.Header, req.Header)
+	utils.RemoveHeaders(forwardReq.Header, forward.HopHeaders...)
 
 	if clientIP, _, err := net.SplitHostPort(req.RemoteAddr); err == nil {
 		if trustForwardHeader {


### PR DESCRIPTION
### What does this PR do?

Hop-By-Hop headers aren't passed over to the auth backend anymore.

### Motivation

Copying over Hop-By-Hop header might result in a wrong behaviour, e.g. if a websocket is requested, the auth backend request fails and a HTTP 500 error code is returned. Therefore websocket don't work anymore when a forward auth backend is enabled.

Fixes #3039 

### More

- [x] Added/updated tests
- [ ] Added/updated documentation
