### PR TITLE
Don't challenge ACME when host rule on another entry point

### DIFF
--- a/provider/acme/provider.go
+++ b/provider/acme/provider.go
@@ -323,12 +323,24 @@ func (p *Provider) initAccount() (*Account, error) {
 	return p.account, nil
 }
 
+func contains(entryPoints []string, acmeEntryPoint string) bool {
+	for _, entryPoint := range entryPoints {
+		if entryPoint == acmeEntryPoint {
+			return true
+		}
+	}
+	return false
+}
+
 func (p *Provider) watchNewDomains() {
 	p.pool.Go(func(stop chan bool) {
 		for {
 			select {
 			case config := <-p.configFromListenerChan:
 				for _, frontend := range config.Frontends {
+					if !contains(frontend.EntryPoints, p.EntryPoint) {
+						continue
+					}
 					for _, route := range frontend.Routes {
 						domainRules := rules.Rules{}
 						domains, err := domainRules.ParseDomains(route.Rule)


### PR DESCRIPTION
### What does this PR do?
Verify that the `Host` in `onHostRule` is on the ACME EntryPoint.

### Motivation
Fixes #3918 