### PR TITLE
ReplacePathRegex: Support adding query parameters in replacement path

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -88,7 +88,7 @@ Following is the list of existing modifier rules:
 
 - `AddPrefix: /products`: Add path prefix to the existing request path prior to forwarding the request to the backend.
 - `ReplacePath: /serverless-path`: Replaces the path and adds the old path to the `X-Replaced-Path` header. Useful for mapping to AWS Lambda or Google Cloud Functions.
-- `ReplacePathRegex: ^/api/v2/(.*) /api/$1`: Replaces the path with a regular expression and adds the old path to the `X-Replaced-Path` header. Separate the regular expression and the replacement by a space.
+- `ReplacePathRegex: ^/api/v3/(.*) /api/$1`: Replaces the path with a regular expression and adds the old path to the `X-Replaced-Path` header. Separate the regular expression and the replacement by a space. Query parameters can also be replaced, for example `/api/$1?foo=bar`. The original query parameters can be retained using `%{QUERY_STRING}`, for example `/api/$1?%{QUERY_STRING}&foo=bar`.
 
 #### Matchers
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Support adding/replacing query parameters for `ReplacePathRegex` modifier.

### Motivation

<!-- What inspired you to submit this pull request? -->
https://stackoverflow.com/questions/48545586/traefik-how-to-append-parameters-to-path/52489528

> There is no way to do what you want. (@ldez)

So naturally I had no choice but to do it ;)

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

