### PR TITLE
Case insensitive host rule 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -291,7 +291,7 @@
   branch = "master"
   name = "github.com/containous/mux"
   packages = ["."]
-  revision = "06ccd3e75091eb659b1d720cda0e16bc7057954c"
+  revision = "c33f32e268983f989290677351b871b65da75ba5"
 
 [[projects]]
   name = "github.com/containous/staert"
@@ -819,6 +819,7 @@
   revision = "9b66602d496a139e4722bdde32f0f1ac1c12d4a8"
 
 [[projects]]
+  branch = "master"
   name = "github.com/jjcollinge/servicefabric"
   packages = ["."]
   revision = "8eebe170fa1ba25d3dfb928b3f86a7313b13b9fe"

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -53,10 +53,10 @@ func (r *Rules) host(hosts ...string) *mux.Route {
 	})
 }
 
-func (r *Rules) hostRegexp(hosts ...string) *mux.Route {
+func (r *Rules) hostRegexp(hostPatterns ...string) *mux.Route {
 	router := r.Route.Route.Subrouter()
-	for _, host := range hosts {
-		router.Host(strings.ToLower(host))
+	for _, hostPattern := range hostPatterns {
+		router.Host(strings.ToLower(hostPattern))
 	}
 	return r.Route.Route
 }

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -56,7 +56,7 @@ func (r *Rules) host(hosts ...string) *mux.Route {
 func (r *Rules) hostRegexp(hostPatterns ...string) *mux.Route {
 	router := r.Route.Route.Subrouter()
 	for _, hostPattern := range hostPatterns {
-		router.Host(strings.ToLower(hostPattern))
+		router.Host(hostPattern)
 	}
 	return r.Route.Route
 }

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -196,8 +196,30 @@ func TestHostRegexp(t *testing.T) {
 			},
 		},
 		{
-			desc:    "uppercased hostnames in request",
+			desc:    "regex insensitive",
 			hostExp: "{dummy:[A-Za-z-]+\\.bar\\.com}",
+			urls: map[string]bool{
+				"http://FOO.bar.com": true,
+				"http://foo.bar.com": true,
+				"http://fooubar.com": false,
+				"http://barucom":     false,
+				"http://barcom":      false,
+			},
+		},
+		{
+			desc:    "insensitive host",
+			hostExp: "{dummy:[a-z-]+\\.bar\\.com}",
+			urls: map[string]bool{
+				"http://FOO.bar.com": true,
+				"http://foo.bar.com": true,
+				"http://fooubar.com": false,
+				"http://barucom":     false,
+				"http://barcom":      false,
+			},
+		},
+		{
+			desc:    "insensitive host simple",
+			hostExp: "foo.bar.com",
 			urls: map[string]bool{
 				"http://FOO.bar.com": true,
 				"http://foo.bar.com": true,
@@ -223,7 +245,7 @@ func TestHostRegexp(t *testing.T) {
 
 			for testURL, match := range test.urls {
 				req := testhelpers.MustNewRequest(http.MethodGet, testURL, nil)
-				assert.Equal(t, match, rt.Match(req, &mux.RouteMatch{}))
+				assert.Equal(t, match, rt.Match(req, &mux.RouteMatch{}), testURL)
 			}
 		})
 	}

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -195,6 +195,17 @@ func TestHostRegexp(t *testing.T) {
 				"http://barcom":      false,
 			},
 		},
+		{
+			desc:    "uppercased hostnames in request",
+			hostExp: "{dummy:[A-Za-z-]+\\.bar\\.com}",
+			urls: map[string]bool{
+				"http://FOO.bar.com": true,
+				"http://foo.bar.com": true,
+				"http://fooubar.com": false,
+				"http://barucom":     false,
+				"http://barcom":      false,
+			},
+		},
 	}
 
 	for _, test := range testCases {

--- a/vendor/github.com/containous/mux/regexp.go
+++ b/vendor/github.com/containous/mux/regexp.go
@@ -53,6 +53,12 @@ func newRouteRegexp(tpl string, matchHost, matchPrefix, matchQuery, strictSlash,
 	varsN := make([]string, len(idxs)/2)
 	varsR := make([]*regexp.Regexp, len(idxs)/2)
 	pattern := bytes.NewBufferString("")
+
+	// Host matching is case insensitive
+	if matchHost {
+		fmt.Fprint(pattern, "(?i)")
+	}
+
 	pattern.WriteByte('^')
 	reverse := bytes.NewBufferString("")
 	var end int


### PR DESCRIPTION

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

This PR introduces a failing test for issue #3930.

Here we also rename parameters and variables in the `hostRegexp()` function to better reflect what is actually handled. Indeed, this function is written as if it was manipulating plain hostnames, whereas it actually handles host patterns that might include regular expressions.


### Motivation

<!-- What inspired you to submit this pull request? -->
I wanted to demonstrate the issue #3930, and also address a misnaming that was pointed out while analyzing that issue.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
Relates to #3930.