### PR TITLE
Document the default accessLog format

### DIFF
--- a/docs/configuration/logs.md
+++ b/docs/configuration/logs.md
@@ -60,12 +60,14 @@ For more information about the CLI, see the documentation about [Traefik command
 By default the Traefik log is written to stdout in text format.
 
 To write the logs into a log file specify the `filePath`:
+
 ```toml
 [traefikLog]
   filePath = "/path/to/traefik.log"
 ```
 
 To write JSON format logs, specify `json` as the format:
+
 ```toml
 [traefikLog]
   filePath = "/path/to/traefik.log"
@@ -90,6 +92,7 @@ traefikLogsFile = "log/traefik.log"
 ```
 
 To customize the log level:
+
 ```toml
 # Log level
 #
@@ -108,23 +111,21 @@ logLevel = "ERROR"
 Access logs are written when `[accessLog]` is defined.
 By default it will write to stdout and produce logs in the textual Common Log Format (CLF), extended with additional fields.
 
-Default access log format
-```
-ClientHost - ClientUsername [Timestamp] "RequestMethod RequestPath RequestProtocol" OriginStatus OriginContentSize "RequestReferer" "RequestUserAgent" RequestCount "FrontendName" "BackendURL" ElapsedMillisecondsms\n
-```
-
 To enable access logs using the default settings just add the `[accessLog]` entry:
+
 ```toml
 [accessLog]
 ```
 
 To write the logs into a log file specify the `filePath`:
+
 ```toml
 [accessLog]
 filePath = "/path/to/access.log"
 ```
 
 To write JSON format logs, specify `json` as the format:
+
 ```toml
 [accessLog]
 filePath = "/path/to/access.log"
@@ -132,6 +133,7 @@ format = "json"
 ```
 
 To write the logs in async, specify `bufferingSize` as the format (must be >0):
+
 ```toml
 [accessLog]
 filePath = "/path/to/access.log"
@@ -146,6 +148,7 @@ bufferingSize = 100
 ```
 
 To filter logs you can specify a set of filters which are logically "OR-connected". Thus, specifying multiple filters will keep more access logs than specifying only one:
+
 ```toml
 [accessLog]
 filePath = "/path/to/access.log"
@@ -176,6 +179,7 @@ format = "json"
 ```
 
 To customize logs format:
+
 ```toml
 [accessLog]
 filePath = "/path/to/access.log"
@@ -223,7 +227,8 @@ format = "json"
       # ...
 ```
 
-#### List of all available fields
+
+### List of all available fields
 
 ```ini
 StartUTC
@@ -270,6 +275,15 @@ Deprecated way (before 1.4):
 #
 accessLogsFile = "log/access.log"
 ```
+
+### CLF - Common Log Format
+
+By default, Træfik use the CLF (`common`) as access log format.
+
+```html
+<remote IP address> - <client user name (if available)> [<timestamp>] "<request method> <request path> <request protocol>" <origin server HTTP status> <origin server content size> <request referrer> <request user agent> <number of requests received since Traefik started> <Traefik frontend name> <Traefik backend URL> <request duration in ms> 
+```
+
 
 ## Log Rotation
 

--- a/docs/configuration/logs.md
+++ b/docs/configuration/logs.md
@@ -108,6 +108,11 @@ logLevel = "ERROR"
 Access logs are written when `[accessLog]` is defined.
 By default it will write to stdout and produce logs in the textual Common Log Format (CLF), extended with additional fields.
 
+Default access log format
+```
+ClientHost - ClientUsername [Timestamp] "RequestMethod RequestPath RequestProtocol" OriginStatus OriginContentSize "RequestReferer" "RequestUserAgent" RequestCount "FrontendName" "BackendURL" ElapsedMillisecondsms\n
+```
+
 To enable access logs using the default settings just add the `[accessLog]` entry:
 ```toml
 [accessLog]

--- a/docs/configuration/logs.md
+++ b/docs/configuration/logs.md
@@ -281,7 +281,7 @@ accessLogsFile = "log/access.log"
 By default, Træfik use the CLF (`common`) as access log format.
 
 ```html
-<remote IP address> - <client user name (if available)> [<timestamp>] "<request method> <request path> <request protocol>" <origin server HTTP status> <origin server content size> <request referrer> <request user agent> <number of requests received since Traefik started> <Traefik frontend name> <Traefik backend URL> <request duration in ms> 
+<remote IP address> - <client user name (if available)> [<timestamp>] "<request method> <request path> <request protocol>" <origin server HTTP status> <origin server content size> <request referrer> <request user agent> <number of requests received since Traefik started> <Traefik frontend name> <Traefik backend URL> <request duration in ms>ms 
 ```
 
 

--- a/docs/configuration/logs.md
+++ b/docs/configuration/logs.md
@@ -281,7 +281,7 @@ accessLogsFile = "log/access.log"
 By default, Træfik use the CLF (`common`) as access log format.
 
 ```html
-<remote IP address> - <client user name (if available)> [<timestamp>] "<request method> <request path> <request protocol>" <origin server HTTP status> <origin server content size> <request referrer> <request user agent> <number of requests received since Traefik started> <Traefik frontend name> <Traefik backend URL> <request duration in ms>ms 
+<remote_IP_address> - <client_user_name_if_available> [<timestamp>] "<request_method> <request_path> <request_protocol>" <origin_server_HTTP_status> <origin_server_content_size> "<request_referrer>" "<request_user_agent>" <number_of_requests_received_since_Traefik_started> "<Traefik_frontend_name>" "<Traefik_backend_URL>" <request_duration_in_ms>ms 
 ```
 
 


### PR DESCRIPTION
### What does this PR do?

Add documentation for the default accessLog format on the logs doc. 

### Motivation

I wanted to know what the access log format was so I could parse and label the fields correctly in my centralized logger. Ex:
```
111.111.133.18 - - [27/Sep/2018:18:25:09 +0000] "GET / HTTP/1.1" 200 1022 "-" "Scalyr-monitor; https://www.scalyr.com/help/monitors" 1234 "frontend" "http://192.168.10.10:8080" 2ms
```

I had to read the code to see what the different values were. https://github.com/containous/traefik/blob/5acd43efaf076ae2204285e750e41976c29069f2/middlewares/accesslog/logger_formatters.go#L34

