### PR TITLE
Don't remove static certs from config when cluster mode

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -480,18 +480,17 @@ func (s *Server) createTLSConfig(entryPointName string, tlsOption *traefiktls.TL
 		}
 	} else {
 		config.GetCertificate = s.serverEntryPoints[entryPointName].getCertificate
-	}
+		if len(config.Certificates) != 0 {
+			certMap := s.buildNameOrIPToCertificate(config.Certificates)
 
-	if len(config.Certificates) != 0 {
-		certMap := s.buildNameOrIPToCertificate(config.Certificates)
-
-		if s.entryPoints[entryPointName].CertificateStore != nil {
-			s.entryPoints[entryPointName].CertificateStore.StaticCerts.Set(certMap)
+			if s.entryPoints[entryPointName].CertificateStore != nil {
+				s.entryPoints[entryPointName].CertificateStore.StaticCerts.Set(certMap)
+			}
 		}
-	}
 
-	// Remove certs from the TLS config object
-	config.Certificates = []tls.Certificate{}
+		// Remove certs from the TLS config object
+		config.Certificates = []tls.Certificate{}
+	}
 
 	// Set the minimum TLS version if set in the config TOML
 	if minConst, exists := traefiktls.MinVersion[s.entryPoints[entryPointName].Configuration.TLS.MinVersion]; exists {


### PR DESCRIPTION
### What does this PR do?
Remove certs from tls config only if we're not in cluster mode.

### Motivation
Fixes #3939
