### PR TITLE
Use the first static certificate as a fallback when no default is given

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -207,6 +207,11 @@ func (gc *GlobalConfiguration) SetEffectiveConfiguration(configFile string) {
 				entryPoint.WhitelistSourceRange = nil
 			}
 		}
+
+		if entryPoint.TLS != nil && entryPoint.TLS.DefaultCertificate == nil && len(entryPoint.TLS.Certificates) > 0 {
+			log.Infof("No tls.defaultCertificate given for %s: using the first item in tls.certificates as a fallback.", entryPointName)
+			entryPoint.TLS.DefaultCertificate = &entryPoint.TLS.Certificates[0]
+		}
 	}
 
 	// Make sure LifeCycle isn't nil to spare nil checks elsewhere.

--- a/integration/etcd_test.go
+++ b/integration/etcd_test.go
@@ -315,13 +315,13 @@ func (s *EtcdSuite) TestCertificatesContentWithSNIConfigHandshake(c *check.C) {
 	snitestOrgKey, err := ioutil.ReadFile("fixtures/https/snitest.org.key")
 	c.Assert(err, checker.IsNil)
 
-	globalConfig := map[string]string{
-		"/traefik/entrypoints/https/address":                     ":4443",
-		"/traefik/entrypoints/https/tls/certificates/0/certfile": string(snitestComCert),
-		"/traefik/entrypoints/https/tls/certificates/0/keyfile":  string(snitestComKey),
-		"/traefik/entrypoints/https/tls/certificates/1/certfile": string(snitestOrgCert),
-		"/traefik/entrypoints/https/tls/certificates/1/keyfile":  string(snitestOrgKey),
-		"/traefik/defaultentrypoints/0":                          "https",
+	globalConfig := map[string][]byte{
+		"/traefik/entrypoints/https/address":                     []byte(":4443"),
+		"/traefik/entrypoints/https/tls/certificates/0/certfile": snitestComCert,
+		"/traefik/entrypoints/https/tls/certificates/0/keyfile":  snitestComKey,
+		"/traefik/entrypoints/https/tls/certificates/1/certfile": snitestOrgCert,
+		"/traefik/entrypoints/https/tls/certificates/1/keyfile":  snitestOrgKey,
+		"/traefik/defaultentrypoints/0":                          []byte("https"),
 	}
 
 	backend1 := map[string]string{
@@ -351,7 +351,7 @@ func (s *EtcdSuite) TestCertificatesContentWithSNIConfigHandshake(c *check.C) {
 		"/traefik/frontends/frontend2/routes/test_2/rule": "Host:snitest.org",
 	}
 	for key, value := range globalConfig {
-		err := s.kv.Put(key, []byte(value), nil)
+		err := s.kv.Put(key, value, nil)
 		c.Assert(err, checker.IsNil)
 	}
 	for key, value := range backend1 {

--- a/server/server_configuration.go
+++ b/server/server_configuration.go
@@ -590,13 +590,17 @@ func (s *Server) buildServerEntryPoints() map[string]*serverEntryPoint {
 			serverEntryPoints[entryPointName].certs.SniStrict = entryPoint.Configuration.TLS.SniStrict
 
 			if entryPoint.Configuration.TLS.DefaultCertificate != nil {
-				cert, err := tls.LoadX509KeyPair(entryPoint.Configuration.TLS.DefaultCertificate.CertFile.String(), entryPoint.Configuration.TLS.DefaultCertificate.KeyFile.String())
+				cert, err := buildDefaultCertificate(entryPoint.Configuration.TLS.DefaultCertificate)
 				if err != nil {
+					log.Error(err)
+					continue
 				}
-				serverEntryPoints[entryPointName].certs.DefaultCertificate = &cert
+				serverEntryPoints[entryPointName].certs.DefaultCertificate = cert
 			} else {
 				cert, err := generate.DefaultCertificate()
 				if err != nil {
+					log.Errorf("failed to generate default certificate: %v", err)
+					continue
 				}
 				serverEntryPoints[entryPointName].certs.DefaultCertificate = cert
 			}
@@ -609,6 +613,24 @@ func (s *Server) buildServerEntryPoints() map[string]*serverEntryPoint {
 		}
 	}
 	return serverEntryPoints
+}
+
+func buildDefaultCertificate(defaultCertificate *traefiktls.Certificate) (*tls.Certificate, error) {
+	certFile, err := defaultCertificate.CertFile.Read()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cert file content: %v", err)
+	}
+
+	keyFile, err := defaultCertificate.KeyFile.Read()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get key file content: %v", err)
+	}
+
+	cert, err := tls.X509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load X509 key pair: %v", err)
+	}
+	return &cert, nil
 }
 
 func (s *Server) buildDefaultHTTPRouter() *mux.Router {


### PR DESCRIPTION
### What does this PR do?
When DefaultCertificate is not defined, we use the first certificate from tls.Certificates.

### Motivation
Fixes #3935 