### PR TITLE
Global configuration log at start

### DIFF
--- a/anonymize/anonymize_config_test.go
+++ b/anonymize/anonymize_config_test.go
@@ -2,12 +2,15 @@ package anonymize
 
 import (
 	"crypto/tls"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/containous/flaeg"
 	"github.com/containous/traefik/acme"
+	"github.com/containous/traefik/api"
 	"github.com/containous/traefik/configuration"
+	"github.com/containous/traefik/middlewares"
 	"github.com/containous/traefik/provider"
 	acmeprovider "github.com/containous/traefik/provider/acme"
 	"github.com/containous/traefik/provider/boltdb"
@@ -25,8 +28,11 @@ import (
 	"github.com/containous/traefik/provider/mesos"
 	"github.com/containous/traefik/provider/rancher"
 	"github.com/containous/traefik/provider/zk"
+	"github.com/containous/traefik/safe"
 	traefiktls "github.com/containous/traefik/tls"
 	"github.com/containous/traefik/types"
+	"github.com/elazarl/go-bindata-assetfs"
+	"github.com/thoas/stats"
 )
 
 func TestDo_globalConfiguration(t *testing.T) {
@@ -187,6 +193,35 @@ func TestDo_globalConfiguration(t *testing.T) {
 	}
 	config.HealthCheck = &configuration.HealthCheckConfig{
 		Interval: flaeg.Duration(666 * time.Second),
+	}
+	config.API = &api.Handler{
+		EntryPoint:            "traefik",
+		Dashboard:             true,
+		Debug:                 true,
+		CurrentConfigurations: &safe.Safe{},
+		Statistics: &types.Statistics{
+			RecentErrors: 666,
+		},
+		Stats: &stats.Stats{
+			Uptime:              time.Now(),
+			Pid:                 666,
+			ResponseCounts:      map[string]int{"foo": 1},
+			TotalResponseCounts: map[string]int{"bar": 1},
+			TotalResponseTime:   time.Now(),
+		},
+		StatsRecorder: &middlewares.StatsRecorder{},
+		DashboardAssets: &assetfs.AssetFS{
+			Asset: func(path string) ([]byte, error) {
+				return nil, nil
+			},
+			AssetDir: func(path string) ([]string, error) {
+				return nil, nil
+			},
+			AssetInfo: func(path string) (os.FileInfo, error) {
+				return nil, nil
+			},
+			Prefix: "fii",
+		},
 	}
 	config.RespondingTimeouts = &configuration.RespondingTimeouts{
 		ReadTimeout:  flaeg.Duration(666 * time.Second),

--- a/api/handler.go
+++ b/api/handler.go
@@ -23,7 +23,7 @@ type Handler struct {
 	Statistics            *types.Statistics          `description:"Enable more detailed statistics" export:"true"`
 	Stats                 *thoas_stats.Stats         `json:"-"`
 	StatsRecorder         *middlewares.StatsRecorder `json:"-"`
-	DashboardAssets       *assetfs.AssetFS
+	DashboardAssets       *assetfs.AssetFS           `json:"-"`
 }
 
 var (

--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -165,20 +165,25 @@ func runCmd(globalConfiguration *configuration.GlobalConfiguration, configFile s
 	globalConfiguration.SetEffectiveConfiguration(configFile)
 	globalConfiguration.ValidateConfiguration()
 
+	log.Infof("Traefik version %s built on %s", version.Version, version.BuildDate)
+
+	jsonConf, err := json.Marshal(globalConfiguration)
+	if err != nil {
+		log.Error(err)
+		log.Debugf("Global configuration loaded [struct] %+v", globalConfiguration)
+	} else {
+		log.Debugf("Global configuration loaded %s", string(jsonConf))
+	}
+
 	if globalConfiguration.API != nil && globalConfiguration.API.Dashboard {
 		globalConfiguration.API.DashboardAssets = &assetfs.AssetFS{Asset: genstatic.Asset, AssetInfo: genstatic.AssetInfo, AssetDir: genstatic.AssetDir, Prefix: "static"}
 	}
-
-	jsonConf, _ := json.Marshal(globalConfiguration)
-	log.Infof("Traefik version %s built on %s", version.Version, version.BuildDate)
 
 	if globalConfiguration.CheckNewVersion {
 		checkNewVersion()
 	}
 
 	stats(globalConfiguration)
-
-	log.Debugf("Global configuration loaded %s", string(jsonConf))
 
 	providerAggregator := configuration.NewProviderAggregator(globalConfiguration)
 

--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -170,7 +170,7 @@ func runCmd(globalConfiguration *configuration.GlobalConfiguration, configFile s
 	jsonConf, err := json.Marshal(globalConfiguration)
 	if err != nil {
 		log.Error(err)
-		log.Debugf("Global configuration loaded [struct] %+v", globalConfiguration)
+		log.Debugf("Global configuration loaded [struct] %#v", globalConfiguration)
 	} else {
 		log.Debugf("Global configuration loaded %s", string(jsonConf))
 	}


### PR DESCRIPTION
### What does this PR do?

Fix a regression on the global configuration log at the start of Traefik

before this PR:
```
time="2018-09-29T10:58:34Z" level=debug msg="Global configuration loaded "
```

after this PR (same behavior as Træfik <v1.7):
```
time="2018-09-29T10:58:34Z" level=debug msg="Global configuration loaded {\"LifeCycle\":{\"RequestAcceptGraceTimeout\":0,\"GraceTimeOut\":10000000000},\"GraceTimeOut\":0,\"Debug\":false,\"CheckNewVersion\":true,\"SendAnonymousUsage\":false,\"AccessLogsFile\":\"\",\"AccessLog\":null,\"TraefikLogsFile\":\"\",\"TraefikLog\":{\"format\":\"common\"},\"Tracing\":null,\"LogLevel\":\"DEBUG\",\"EntryPoints\":{\"http\":{\"Address\":\":80\",\"TLS\":null,\"Redirect\":{\"entryPoint\":\"https\"},\"Auth\":null,\"WhitelistSourceRange\":null,\"WhiteList\":null,\"Compress\":false,\"ProxyProtocol\":null,\"ForwardedHeaders\":{\"Insecure\":true,\"TrustedIPs\":null}},\"https\":{\"Address\":\":443\",\"TLS\":{\"MinVersion\":\"\",\"CipherSuites\":null,\"Certificates\":[],\"ClientCAFiles\":null,\"ClientCA\":{\"Files\":null,\"Optional\":false},\"DefaultCertificate\":null,\"SniStrict\":false},\"Redirect\":null,\"Auth\":null,\"WhitelistSourceRange\":null,\"WhiteList\":null,\"Compress\":false,\"ProxyProtocol\":null,\"ForwardedHeaders\":{\"Insecure\":true,\"TrustedIPs\":null}},\"traefik\":{\"Address\":\":8080\",\"TLS\":{\"MinVersion\":\"\",\"CipherSuites\":null,\"Certificates\":[],\"ClientCAFiles\":null,\"ClientCA\":{\"Files\":null,\"Optional\":false},\"DefaultCertificate\":null,\"SniStrict\":false},\"Redirect\":null,\"Auth\":null,\"WhitelistSourceRange\":null,\"WhiteList\":null,\"Compress\":false,\"ProxyProtocol\":null,\"ForwardedHeaders\":{\"Insecure\":true,\"TrustedIPs\":null}}},\"Cluster\":null,\"Constraints\":[],\"ACME\":{\"Email\":\"test@traefik.io\",\"Domains\":null,\"Storage\":\"/tmp/acme.json\",\"StorageFile\":\"\",\"OnDemand\":false,\"OnHostRule\":true,\"CAServer\":\"https://172.17.0.3:14000/dir\",\"EntryPoint\":\"https\",\"KeyType\":\"\",\"DNSChallenge\":null,\"HTTPChallenge\":{\"EntryPoint\":\"http\"},\"TLSChallenge\":null,\"DNSProvider\":\"\",\"DelayDontCheckDNS\":0,\"ACMELogging\":true,\"OverrideCertificates\":false,\"TLSConfig\":null},\"DefaultEntryPoints\":[\"http\",\"https\"],\"ProvidersThrottleDuration\":2000000000,\"MaxIdleConnsPerHost\":200,\"IdleTimeout\":0,\"InsecureSkipVerify\":false,\"RootCAs\":null,\"Retry\":null,\"HealthCheck\":{\"Interval\":30000000000},\"RespondingTimeouts\":null,\"ForwardingTimeouts\":null,\"AllowMinWeightZero\":false,\"Web\":null,\"Docker\":null,\"File\":{\"Watch\":true,\"Filename\":\"\",\"Constraints\":null,\"Trace\":false,\"TemplateVersion\":0,\"DebugLogGeneratedTemplate\":false,\"Directory\":\"\",\"TraefikFile\":\"/go/src/github.com/containous/traefik/integration/fixtures/acme/acme_base.toml218962287\"},\"Marathon\":null,\"Consul\":null,\"ConsulCatalog\":null,\"Etcd\":null,\"Zookeeper\":null,\"Boltdb\":null,\"Kubernetes\":null,\"Mesos\":null,\"Eureka\":null,\"ECS\":null,\"Rancher\":null,\"DynamoDB\":null,\"ServiceFabric\":null,\"Rest\":null,\"API\":{\"EntryPoint\":\"traefik\",\"Dashboard\":true,\"Debug\":false,\"CurrentConfigurations\":null,\"Statistics\":null,\"DashboardAssets\":null},\"Metrics\":null,\"Ping\":null,\"HostResolver\":null}"
```

### Motivation

Fix a regression from #3386

### More

- [x] Added/updated tests
