### PR TITLE
fix broken links in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,12 @@ Pointing Træfik at your orchestrator should be the _only_ configuration step yo
 **[Supported backends](#supported-backends)** .
 **[Quickstart](#quickstart)** .
 **[Web UI](#web-ui)** .
-**[Test it](#test-it)** .
 **[Documentation](#documentation)** .
 
 . **[Support](#support)** .
 **[Release cycle](#release-cycle)** .
 **[Contributing](#contributing)** .
 **[Maintainers](#maintainers)** .
-**[Plumbing](#plumbing)** .
 **[Credits](#credits)** .
 
 ---


### PR DESCRIPTION
### What does this PR do?

There are a couple if links on the main readme.md that lead to no longer existing sections. These are "Test It" and "Plumbing" links. This PR remove these now defunct links.


### Motivation

Talked this through with Ludovic on slack, and he suggested a PR.

