### PR TITLE
Trimming whitespace in XFF for IP whitelisting

### DIFF
--- a/whitelist/ip.go
+++ b/whitelist/ip.go
@@ -63,7 +63,8 @@ func (ip *IP) IsAuthorized(req *http.Request) error {
 			for _, xFF := range xFFs {
 				xffs := strings.Split(xFF, ",")
 				for _, xff := range xffs {
-					ok, err := ip.contains(parseHost(xff))
+					xffTrimmed := strings.TrimSpace(xff)
+					ok, err := ip.contains(parseHost(xffTrimmed))
 					if err != nil {
 						return err
 					}
@@ -72,7 +73,7 @@ func (ip *IP) IsAuthorized(req *http.Request) error {
 						return nil
 					}
 
-					invalidMatches = append(invalidMatches, xff)
+					invalidMatches = append(invalidMatches, xffTrimmed)
 				}
 			}
 		}

--- a/whitelist/ip_test.go
+++ b/whitelist/ip_test.go
@@ -32,7 +32,7 @@ func TestIsAuthorized(t *testing.T) {
 			whiteList:           []string{"1.2.3.4/24"},
 			allowXForwardedFor:  true,
 			remoteAddr:          "10.2.3.1:123",
-			xForwardedForValues: []string{"1.2.3.1, 10.2.3.1"},
+			xForwardedForValues: []string{"10.2.3.1, 1.2.3.1"},
 			authorized:          true,
 		},
 		{


### PR DESCRIPTION
### What does this PR do?
Trims whitespace from `X-Forwarded-For` header values.
 
### Motivation
In case there are multiple comma-separated values for the XFF header, there might be trailing whitespace after the comma e.g.

```
X-Forwarded-For: 1.2.3.4, 1.1.1.1, 8.8.8.8
``` 
If that's the case, then `net.parseIP` will return `nil` and the whitelist check will fail.

This situation was not caught by the test since the fixture:

```
{
	desc:                "allow UseXForwardedFor, remoteAddr not in range, UseXForwardedFor in range (compact XFF)",
	whiteList:           []string{"1.2.3.4/24"},
	allowXForwardedFor:  true,
	remoteAddr:          "10.2.3.1:123",
	xForwardedForValues: []string{"1.2.3.1, 10.2.3.1"},
	authorized:          true,
},
```

listed the matching IP as the first value in the comma separated value, hence not testing the second value (`10.2.3.1`) which contains the whitespace.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
