### PR TITLE
Rule parsing error.

### DIFF
--- a/rules/rules.go
+++ b/rules/rules.go
@@ -269,6 +269,9 @@ func (r *Rules) Parse(expression string) (*mux.Route, error) {
 			if r.err != nil {
 				return r.err
 			}
+			if resultRoute == nil {
+				return fmt.Errorf("invalid expression: %s", expression)
+			}
 			if resultRoute.GetError() != nil {
 				return resultRoute.GetError()
 			}

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -218,11 +218,17 @@ func TestHostRegexp(t *testing.T) {
 	}
 }
 
-type fakeHandler struct {
-	name string
-}
+func TestParseInvalidSyntax(t *testing.T) {
+	router := mux.NewRouter()
+	router.StrictSlash(true)
 
-func (h *fakeHandler) ServeHTTP(http.ResponseWriter, *http.Request) {}
+	rules := &Rules{Route: &types.ServerRoute{Route: router.NewRoute()}}
+	expression01 := "Path: /path1;Query:param_one=true, /path2"
+
+	routeFoo, err := rules.Parse(expression01)
+	require.Error(t, err)
+	assert.Nil(t, routeFoo)
+}
 
 func TestPathPrefix(t *testing.T) {
 	testCases := []struct {
@@ -287,3 +293,9 @@ func TestPathPrefix(t *testing.T) {
 		})
 	}
 }
+
+type fakeHandler struct {
+	name string
+}
+
+func (h *fakeHandler) ServeHTTP(http.ResponseWriter, *http.Request) {}


### PR DESCRIPTION
### What does this PR do?

Don't panic when parsing some invalid rules.

### Motivation

```
time="2018-10-03T20:06:12Z" level=error msg="Error in Go routine: runtime error: invalid memory address or nil pointer dereference"
goroutine 77 [running]:
runtime/debug.Stack(0x73e23f, 0xc4200bc2d0, 0x245bb01)
	/usr/local/go/src/runtime/debug/stack.go:24 +0xa7
runtime/debug.PrintStack()
	/usr/local/go/src/runtime/debug/stack.go:16 +0x22
github.com/containous/traefik/safe.defaultRecoverGoroutine(0x200c4e0, 0x3a3b0c0)
	/go/src/github.com/containous/traefik/safe/routine.go:148 +0x73
github.com/containous/traefik/safe.GoWithRecover.func1.1(0x2501428)
	/go/src/github.com/containous/traefik/safe/routine.go:139 +0x57
panic(0x200c4e0, 0x3a3b0c0)
	/usr/local/go/src/runtime/panic.go:502 +0x229
github.com/containous/traefik/vendor/github.com/containous/mux.(*Route).GetError(...)
	/go/src/github.com/containous/traefik/vendor/github.com/containous/mux/route.go:102
github.com/containous/traefik/rules.(*Rules).Parse.func1(0xc4205a6e1d, 0x5, 0x1eb5ce0, 0xc4204e7840, 0xc4203a0d00, 0x2, 0x2, 0x1, 0x0)
	/go/src/github.com/containous/traefik/rules/rules.go:273 +0x22b
github.com/containous/traefik/rules.(*Rules).parseRules(0xc4203a0ae0, 0xc4205a6e10, 0x29, 0xc42068f1f8, 0xc4208d6c60, 0x3a489b0)
	/go/src/github.com/containous/traefik/rules/rules.go:250 +0xb8d
github.com/containous/traefik/rules.(*Rules).Parse(0xc4203a0ae0, 0xc4205a6e10, 0x29, 0xc42040e360, 0x2, 0xc4204e7750)
	/go/src/github.com/containous/traefik/rules/rules.go:262 +0x77
github.com/containous/traefik/server.buildServerRoute(0xc42049ea00, 0xc420428e40, 0x30, 0xc420206640, 0x0, 0xc4202599e0, 0x13, 0xc420259a60)
	/go/src/github.com/containous/traefik/server/server_configuration.go:273 +0x343
github.com/containous/traefik/server.(*Server).loadFrontendConfig(0xc42033f600, 0x243af7e, 0x6, 0xc420428e40, 0x30, 0xc4208d6030, 0xc4205c4a50, 0xc4205c4a80, 0xc4205c4cf0, 0xc4205c4d20, ...)
	/go/src/github.com/containous/traefik/server/server_configuration.go:208 +0x7b6
github.com/containous/traefik/server.(*Server).loadConfig(0xc42033f600, 0xc4205c4a20, 0xc42044a9c0, 0x0, 0x100, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/go/src/github.com/containous/traefik/server/server_configuration.go:96 +0x1e7
github.com/containous/traefik/server.(*Server).loadConfiguration(0xc42033f600, 0x243af7e, 0x6, 0xc4208d6030)
	/go/src/github.com/containous/traefik/server/server_configuration.go:44 +0x234
github.com/containous/traefik/server.(*Server).listenConfigurations(0xc42033f600, 0xc420572380)
	/go/src/github.com/containous/traefik/server/server_configuration.go:421 +0x51
github.com/containous/traefik/server.(*Server).Start.func2(0xc420572380)
	/go/src/github.com/containous/traefik/server/server.go:152 +0x34
github.com/containous/traefik/safe.(*Pool).Go.func1()
	/go/src/github.com/containous/traefik/safe/routine.go:78 +0x3a
github.com/containous/traefik/safe.GoWithRecover.func1(0x2501428, 0xc4203cf470)
	/go/src/github.com/containous/traefik/safe/routine.go:142 +0x4d
created by github.com/containous/traefik/safe.GoWithRecover
	/go/src/github.com/containous/traefik/safe/routine.go:136 +0x49
```


### More

- [x] Added/updated tests

### Additional Notes

To reproduce:
```yml
version: '3'

services:
  reverse_proxy:
    image: traefik:v1.6
    command: --api --docker
    ports:
      - "80:80"
      - "8080:8080"
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock

  whoami:
    image: containous/whoami
    labels:
      - "traefik.frontend.rule=Path: /path1;Query:param_one=true, /path2"
```
