### PR TITLE
Not allow ACME provider initialization if storage is empty

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -187,11 +187,13 @@ func runCmd(globalConfiguration *configuration.GlobalConfiguration, configFile s
 
 	providerAggregator := configuration.NewProviderAggregator(globalConfiguration)
 
-	acmeprovider := globalConfiguration.InitACMEProvider()
-	if acmeprovider != nil {
-		err := providerAggregator.AddProvider(acmeprovider)
+	acmeprovider, err := globalConfiguration.InitACMEProvider()
+	if err != nil {
+		log.Errorf("Unable to initialize ACME provider: %v", err)
+	} else if acmeprovider != nil {
+		err = providerAggregator.AddProvider(acmeprovider)
 		if err != nil {
-			log.Errorf("Error initializing provider ACME: %v", err)
+			log.Errorf("Unable to add ACME provider to the providers list: %v", err)
 			acmeprovider = nil
 		}
 	}

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -33,6 +33,7 @@ import (
 	"github.com/containous/traefik/provider/zk"
 	"github.com/containous/traefik/tls"
 	"github.com/containous/traefik/types"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -419,8 +420,13 @@ func (gc *GlobalConfiguration) initACMEProvider() {
 }
 
 // InitACMEProvider create an acme provider from the ACME part of globalConfiguration
-func (gc *GlobalConfiguration) InitACMEProvider() *acmeprovider.Provider {
+func (gc *GlobalConfiguration) InitACMEProvider() (*acmeprovider.Provider, error) {
 	if gc.ACME != nil {
+		if len(gc.ACME.Storage) == 0 {
+			// Delete the ACME configuration to avoid starting ACME in cluster mode
+			gc.ACME = nil
+			return nil, errors.New("unable to initialize ACME provider with no storage location for the certificates")
+		}
 		// TODO: Remove when Provider ACME will replace totally ACME
 		// If provider file, use Provider ACME instead of ACME
 		if gc.Cluster == nil {
@@ -444,10 +450,10 @@ func (gc *GlobalConfiguration) InitACMEProvider() *acmeprovider.Provider {
 			provider.Store = store
 			acme.ConvertToNewFormat(provider.Storage)
 			gc.ACME = nil
-			return provider
+			return provider, nil
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 func getSafeACMECAServer(caServerSrc string) string {

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -5,10 +5,12 @@ import (
 	"time"
 
 	"github.com/containous/flaeg"
+	"github.com/containous/traefik/acme"
 	"github.com/containous/traefik/middlewares/tracing"
 	"github.com/containous/traefik/middlewares/tracing/jaeger"
 	"github.com/containous/traefik/middlewares/tracing/zipkin"
 	"github.com/containous/traefik/provider"
+	acmeprovider "github.com/containous/traefik/provider/acme"
 	"github.com/containous/traefik/provider/file"
 	"github.com/stretchr/testify/assert"
 )
@@ -212,6 +214,55 @@ func TestSetEffectiveConfigurationTracing(t *testing.T) {
 			gc.SetEffectiveConfiguration(defaultConfigFile)
 
 			assert.Equal(t, test.expected, gc.Tracing)
+		})
+	}
+}
+
+func TestInitACMEProvider(t *testing.T) {
+	testCases := []struct {
+		desc                  string
+		acmeConfiguration     *acme.ACME
+		expectedConfiguration *acmeprovider.Provider
+		noError               bool
+	}{
+		{
+			desc:                  "No ACME configuration",
+			acmeConfiguration:     nil,
+			expectedConfiguration: nil,
+			noError:               true,
+		},
+		{
+			desc:                  "ACME configuration with storage",
+			acmeConfiguration:     &acme.ACME{Storage: "foo/acme.json"},
+			expectedConfiguration: &acmeprovider.Provider{Configuration: &acmeprovider.Configuration{Storage: "foo/acme.json"}},
+			noError:               true,
+		},
+		{
+			desc:                  "ACME configuration with no storage",
+			acmeConfiguration:     &acme.ACME{},
+			expectedConfiguration: nil,
+			noError:               false,
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			gc := &GlobalConfiguration{
+				ACME: test.acmeConfiguration,
+			}
+
+			configuration, err := gc.InitACMEProvider()
+
+			assert.True(t, (err == nil) == test.noError)
+
+			if test.expectedConfiguration == nil {
+				assert.Nil(t, configuration)
+			} else {
+				assert.Equal(t, test.expectedConfiguration.Storage, configuration.Storage)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

This PR adds a test on the `acme.storage` option in the way to initialize ACME provider **only if** this option is provided.

### Motivation

<!-- What inspired you to submit this pull request? -->
Have a more explicit error message.

### More

- [X] Added/updated tests
