### PR TITLE
Improve the CLI help (Update of the Flaeg dependency)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -283,8 +283,8 @@
     ".",
     "parse"
   ]
-  revision = "b4c2f060875361c070ed2bc300c5929b82f5fa2e"
-  version = "v1.1.2"
+  revision = "aad81c7ac7f49671a59b9ede8ab22436e132a302"
+  version = "v1.3.0"
 
 [[projects]]
   branch = "master"
@@ -1818,6 +1818,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b75bf0ae5b8c1ae1ba578fe5a58dfc4cd4270e02f5ea3b9f0d5a92972a36e9b2"
+  inputs-digest = "059f9d29d78e7a800b676c529197fd627de968837b01c663a8a00ee72c36271b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -54,7 +54,7 @@
 
 [[constraint]]
   name = "github.com/containous/flaeg"
-  version = "1.0.1"
+  version = "1.3.0"
 
 [[constraint]]
   branch = "master"

--- a/script/prune-dep.sh
+++ b/script/prune-dep.sh
@@ -32,7 +32,7 @@ find vendor -type f  \( ! -iname 'licen[cs]e*' \
  -a ! -iname '*.hxx' \
  -a ! -iname '*.s' \) -exec rm -f {} +
 
-find -type d \( -iname '*Godeps*' \) -exec rm -rf {} +
+find . -type d \( -iname '*Godeps*' \) -exec rm -rf {} +
 
 find vendor -type l  \( ! -iname 'licen[cs]e*' \
  -a ! -iname '*notice*' \

--- a/vendor/github.com/containous/flaeg/flaeg.go
+++ b/vendor/github.com/containous/flaeg/flaeg.go
@@ -396,6 +396,7 @@ type Command struct {
 	DefaultPointersConfig interface{} // TODO: case DefaultPointersConfig is nil
 	Run                   func() error
 	Metadata              map[string]string
+	HideHelp              bool
 }
 
 // LoadWithCommand initializes config : struct fields given by reference, with args : arguments.
@@ -437,13 +438,16 @@ func PrintHelpWithCommand(flagMap map[string]reflect.StructField, defaultValMap 
 	// Using POSXE STD : http://pubs.opengroup.org/onlinepubs/9699919799/
 	const helper = `{{if .ProgDescription}}{{.ProgDescription}}
 
-{{end}}Usage: {{.ProgName}} [--flag=flag_argument] [-f[flag_argument]] ...     set flag_argument to flag(s)
-   or: {{.ProgName}} [--flag[=true|false| ]] [-f[true|false| ]] ...     set true/false to boolean flag(s)
+{{end}}Usage: {{.ProgName}} [flags] <command> [<arguments>]
+
+Use "{{.ProgName}} <command> --help" for help on any command.
 {{if .SubCommands}}
-Available Commands:{{range $subCmdName, $subCmdDesc := .SubCommands}}
+Commands:{{range $subCmdName, $subCmdDesc := .SubCommands}}
 {{printf "\t%-50s %s" $subCmdName $subCmdDesc}}{{end}}
-Use "{{.ProgName}} [command] --help" for more information about a command.
 {{end}}
+Flag's usage: {{.ProgName}} [--flag=flag_argument] [-f[flag_argument]] ...     set flag_argument to flag(s)
+          or: {{.ProgName}} [--flag[=true|false| ]] [-f[true|false| ]] ...     set true/false to boolean flag(s)
+
 Flags:
 `
 	// Use a struct to give data to template
@@ -453,13 +457,15 @@ Flags:
 		SubCommands     map[string]string
 	}
 	tempStruct := TempStruct{}
-	if cmd != nil {
+	if cmd != nil && !cmd.HideHelp {
 		tempStruct.ProgName = cmd.Name
 		tempStruct.ProgDescription = cmd.Description
 		tempStruct.SubCommands = map[string]string{}
 		if len(subCmd) > 1 && cmd == subCmd[0] {
 			for _, c := range subCmd[1:] {
-				tempStruct.SubCommands[c.Name] = c.Description
+				if !c.HideHelp {
+					tempStruct.SubCommands[c.Name] = c.Description
+				}
 			}
 		}
 	} else {
@@ -528,7 +534,7 @@ func printFlagsDescriptionsDefaultValues(flagMap map[string]reflect.StructField,
 		}
 	}
 
-	//add help flag
+	// add help flag
 	shortFlagsWithDash = append(shortFlagsWithDash, "-h,")
 	flagsWithDash = append(flagsWithDash, "--help")
 	descriptions = append(descriptions, "Print Help (this message) and exit")
@@ -536,6 +542,7 @@ func printFlagsDescriptionsDefaultValues(flagMap map[string]reflect.StructField,
 
 	return displayTab(output, shortFlagsWithDash, flagsWithDash, descriptions, defaultValues)
 }
+
 func split(str string, width int) []string {
 	if len(str) > width {
 		index := strings.LastIndex(str[:width], " ")
@@ -584,7 +591,7 @@ func PrintErrorWithCommand(err error, flagMap map[string]reflect.StructField, de
 // a map of custom parsers could be use
 type Flaeg struct {
 	calledCommand *Command
-	commands      []*Command ///rootCommand is th fist one in this slice
+	commands      []*Command // rootCommand is th fist one in this slice
 	args          []string
 	commandArgs   []string
 	customParsers map[reflect.Type]parse.Parser
@@ -654,7 +661,7 @@ func (f *Flaeg) findCommandWithCommandArgs() (*Command, []string, error) {
 	commandName, f.commandArgs = splitArgs(f.args)
 	if len(commandName) > 0 {
 		for _, command := range f.commands {
-			if commandName == command.Name {
+			if commandName == command.Name && !command.HideHelp {
 				f.calledCommand = command
 				return f.calledCommand, f.commandArgs, nil
 			}


### PR DESCRIPTION
### What does this PR do?

This PR introduces the following changes:

* For end-users: It improves the clarity of the `traefik --help` command line (CLI) output
* For maintainers and contributors: Update of the dependency Flaeg to the version `1.3.0`
* For maintainers and contributors: It allows the commands `make dep-ensure` and `make dep-prune` to be run on macOS and BSD

### Motivation

The current state of the `traefik --help` is very confusing: if you are getting started, you don't know where to put commands: before, after flags?

When updating dependencies on my mac, I also was facing an error message when running `make dep-ensure`. it was a simple fix so it has been smoothly added into the scope of this PR.

### More

- [-] Added/updated tests
- [-] Added/updated documentation

### Additional Notes

Example of the new output:

```
$ ./traefik --help
traefik is a modern HTTP reverse proxy and load balancer made to deploy microservices with ease.
Complete documentation is available at https://traefik.io

Usage: traefik [flags] <command> [<arguments>]

Use "traefik <command> --help" for help on any command.

Commands:
        bug                                                Report an issue on Traefik bugtracker
        healthcheck                                        Calls traefik /ping to check health (web provider must be enabled)
        storeconfig                                        Store the static traefik configuration into a Key-value stores. Traefik will not start.
        version                                            Print version

Flag's usage: traefik [--flag=flag_argument] [-f[flag_argument]] ...     set flag_argument to flag(s)
          or: traefik [--flag[=true|false| ]] [-f[true|false| ]] ...     set true/false to boolean flag(s)

Flags:
...
```
