### PR TITLE
Add new modifier: ReplaceQueryRegex

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -89,6 +89,7 @@ Following is the list of existing modifier rules:
 - `AddPrefix: /products`: Add path prefix to the existing request path prior to forwarding the request to the backend.
 - `ReplacePath: /serverless-path`: Replaces the path and adds the old path to the `X-Replaced-Path` header. Useful for mapping to AWS Lambda or Google Cloud Functions.
 - `ReplacePathRegex: ^/api/v2/(.*) /api/$1`: Replaces the path with a regular expression and adds the old path to the `X-Replaced-Path` header. Separate the regular expression and the replacement by a space.
+- `ReplaceQueryRegex: ^/item/([0-9]+)/view\\?(.*) id=$1&$2`: Modifies the query parameters. The regular expression is matched against the path AND query parameters. The regular expression must match the full path otherwise parts of the unmatched path will appear in the resulting query parameter.
 
 #### Matchers
 
@@ -224,12 +225,13 @@ The following rules are both `Matchers` and `Modifiers`, so the `Matcher` portio
 
 `Modifiers` will be applied in a pre-determined order regardless of their order in the `rule` configuration section.
 
-1. `PathStrip`
-2. `PathPrefixStrip`
-3. `PathStripRegex`
-4. `PathPrefixStripRegex`
-5. `AddPrefix`
-6. `ReplacePath`
+1. `ReplaceQueryRegex`
+2. `PathStrip`
+3. `PathPrefixStrip`
+4. `PathStripRegex`
+5. `PathPrefixStripRegex`
+6. `AddPrefix`
+7. `ReplacePath`
 
 #### Priorities
 

--- a/middlewares/replace_query_regex.go
+++ b/middlewares/replace_query_regex.go
@@ -1,0 +1,46 @@
+package middlewares
+
+import (
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/containous/traefik/log"
+)
+
+// ReplaceQueryRegex is a middleware used to replace the query of a URL request with a regular expression
+type ReplaceQueryRegex struct {
+	Handler     http.Handler
+	Regexp      *regexp.Regexp
+	Replacement string
+}
+
+// NewReplaceQueryRegexHandler returns a new ReplaceQueryRegex
+func NewReplaceQueryRegexHandler(regex string, replacement string, handler http.Handler) http.Handler {
+	re, err := regexp.Compile(strings.TrimSpace(regex))
+	if err != nil {
+		log.Errorf("Error compiling regular expression %s: %s", regex, err)
+	}
+	return &ReplaceQueryRegex{
+		Regexp:      re,
+		Replacement: strings.TrimSpace(replacement),
+		Handler:     handler,
+	}
+}
+
+func (s *ReplaceQueryRegex) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if s.Regexp != nil && s.Regexp.MatchString(r.RequestURI) {
+		replacement := s.Regexp.ReplaceAllString(r.RequestURI, s.Replacement)
+		path := strings.SplitN(r.RequestURI, "?", 2)[0]
+		if replacement != "" {
+			path = path + "?" + replacement
+		}
+		if u, err := r.URL.Parse(path); err != nil {
+			log.Errorf("bad replacement %s: %s", replacement, err)
+		} else {
+			r.URL = u
+			r.RequestURI = u.RequestURI()
+		}
+	}
+	s.Handler.ServeHTTP(w, r)
+}

--- a/middlewares/replace_query_regex_test.go
+++ b/middlewares/replace_query_regex_test.go
@@ -1,0 +1,91 @@
+package middlewares
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReplaceQueryRegex(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		target        string
+		regex         string
+		replacement   string
+		expectedQuery string
+	}{
+		{
+			desc:          "add query parameter",
+			target:        "/foo",
+			regex:         `.*`,
+			replacement:   "bar=baz",
+			expectedQuery: "bar=baz",
+		},
+		{
+			desc:          "remove query parameter",
+			target:        "/foo?remove=yes",
+			regex:         `.*(.*)`, // greedy leaves nothing
+			replacement:   "$1",
+			expectedQuery: "",
+		},
+		{
+			desc:          "overwrite query parameters",
+			target:        "/foo?dropped=yes",
+			regex:         `.*`,
+			replacement:   "bar=baz",
+			expectedQuery: "bar=baz",
+		},
+		{
+			desc:          "append query parameter",
+			target:        "/foo?keep=yes",
+			regex:         `^/foo\?(.*)$`,
+			replacement:   "$1&bar=baz",
+			expectedQuery: "keep=yes&bar=baz",
+		},
+		{
+			desc:          "modify query parameter",
+			target:        "/foo?a=a",
+			regex:         `^/foo\?a=a$`,
+			replacement:   "a=A",
+			expectedQuery: "a=A",
+		},
+		{
+			desc:          "use path component as new query parameters",
+			target:        "/foo/animal/CAT/food/FISH?keep=no",
+			regex:         `^/foo/animal/([^/]+)/food/([^?]+)(\?.*)?$`,
+			replacement:   "animal=$1&food=$2",
+			expectedQuery: "animal=CAT&food=FISH",
+		},
+		{
+			desc:          "use path component as new query parameters, keep existing query params",
+			target:        "/foo/animal/CAT/food/FISH?keep=yes",
+			regex:         `^/foo/animal/([^/]+)/food/([^/]+)\?(.*)$`,
+			replacement:   "$3&animal=$1&food=$2",
+			expectedQuery: "keep=yes&animal=CAT&food=FISH",
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			var actualQuery string
+			handler := NewReplaceQueryRegexHandler(
+				test.regex,
+				test.replacement,
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					actualQuery = r.URL.RawQuery
+				}),
+			)
+
+			req := httptest.NewRequest(http.MethodGet, test.target, nil)
+
+			handler.ServeHTTP(nil, req)
+
+			assert.Equal(t, test.expectedQuery, actualQuery, "Unespected request query")
+		})
+	}
+}

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -137,6 +137,13 @@ func (r *Rules) replacePathRegex(paths ...string) *mux.Route {
 	return r.Route.Route
 }
 
+func (r *Rules) replaceQueryRegex(paths ...string) *mux.Route {
+	for _, path := range paths {
+		r.Route.ReplaceQueryRegex = path
+	}
+	return r.Route.Route
+}
+
 func (r *Rules) addPrefix(paths ...string) *mux.Route {
 	for _, path := range paths {
 		r.Route.AddPrefix = path
@@ -201,6 +208,7 @@ func (r *Rules) parseRules(expression string, onRule func(functionName string, f
 		"AddPrefix":            r.addPrefix,
 		"ReplacePath":          r.replacePath,
 		"ReplacePathRegex":     r.replacePathRegex,
+		"ReplaceQueryRegex":    r.replaceQueryRegex,
 		"Query":                r.query,
 	}
 

--- a/server/server_configuration.go
+++ b/server/server_configuration.go
@@ -488,6 +488,16 @@ func buildMatcherMiddlewares(serverRoute *types.ServerRoute, handler http.Handle
 		handler = middlewares.NewStripPrefixRegex(handler, serverRoute.StripPrefixesRegex)
 	}
 
+	if len(serverRoute.ReplaceQueryRegex) > 0 {
+		sp := strings.Split(serverRoute.ReplaceQueryRegex, " ")
+		if len(sp) == 2 {
+			handler = middlewares.NewReplaceQueryRegexHandler(sp[0], sp[1], handler)
+		} else {
+			log.Warnf("Invalid syntax for ReplaceQueryRegex: %s. Separate the regular expression and the replacement by a space.", serverRoute.ReplaceQueryRegex)
+		}
+
+	}
+
 	return handler
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -98,6 +98,7 @@ type ServerRoute struct {
 	AddPrefix          string
 	ReplacePath        string
 	ReplacePathRegex   string
+	ReplaceQueryRegex  string
 }
 
 // ErrorPage holds custom error page configuration


### PR DESCRIPTION
### What does this PR do?

Allows manipulation of query parameters using regular expression

A new modifier `ReplaceQueryRegex` matches against the path and query parameters ("origin-form" in rfc7230 section 5.3.1 (`net/http.Request.RequestURI`)). The result of the regular expression replacement executed against the incoming `net/http.Request.RequestURI` replaces the existing query parameters  in the request.

### Motivation

It was not possible to modify the query parameters (or add new ones) to backends.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

This pull request obsoletes https://github.com/containous/traefik/pull/3928. The changes here are in response to the review comments there.