### PR TITLE
Fix file provider to watch event in subdirectories

### DIFF
--- a/provider/file/file.go
+++ b/provider/file/file.go
@@ -65,7 +65,7 @@ func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *s
 // and returns a 'Configuration' object
 func (p *Provider) BuildConfiguration() (*types.Configuration, error) {
 	if len(p.Directory) > 0 {
-		return p.loadFileConfigFromDirectory(p.Directory, nil)
+		return p.loadFileConfigFromDirectory(p.Directory), nil
 	}
 
 	if len(p.Filename) > 0 {
@@ -188,34 +188,32 @@ func (p *Provider) loadFileConfig(filename string, parseTemplate bool) (*types.C
 	return configuration, err
 }
 
-func (p *Provider) loadFileConfigFromDirectory(directory string, configuration *types.Configuration) *types.Configuration {
+func (p *Provider) loadFileConfigFromDirectory(directory string) *types.Configuration {
+	configuration := &types.Configuration{
+		Frontends: make(map[string]*types.Frontend),
+		Backends:  make(map[string]*types.Backend),
+	}
+
 	fileList, err := ioutil.ReadDir(directory)
 	if err != nil {
 		log.Errorf("Unable to read directory %s: %v", directory, err)
 		return configuration
 	}
 
-	if configuration == nil {
-		configuration = &types.Configuration{
-			Frontends: make(map[string]*types.Frontend),
-			Backends:  make(map[string]*types.Backend),
-		}
-	}
-
 	configTLSMaps := make(map[*tls.Configuration]struct{})
 	for _, item := range fileList {
+		var c *types.Configuration
+
 		if item.IsDir() {
-			configuration = p.loadFileConfigFromDirectory(filepath.Join(directory, item.Name()), configuration)
-			continue
+			c = p.loadFileConfigFromDirectory(filepath.Join(directory, item.Name()))
 		} else if !strings.HasSuffix(item.Name(), ".toml") && !strings.HasSuffix(item.Name(), ".tmpl") {
 			continue
-		}
-
-		var c *types.Configuration
-		c, err = p.loadFileConfig(path.Join(directory, item.Name()), true)
-		if err != nil {
-			log.Errorf("Unable to load content configuration from file %s: %v", item, err)
-			continue
+		} else {
+			c, err = p.loadFileConfig(path.Join(directory, item.Name()), true)
+			if err != nil {
+				log.Errorf("Unable to load content configuration from file %s: %v", item, err)
+				continue
+			}
 		}
 
 		for backendName, backend := range c.Backends {

--- a/provider/file/file_test.go
+++ b/provider/file/file_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"testing"
 	"time"
 
@@ -13,46 +12,6 @@ import (
 	"github.com/containous/traefik/types"
 	"github.com/stretchr/testify/assert"
 )
-
-// createRandomFile Helper
-func createRandomFile(t *testing.T, tempDir string, contents ...string) *os.File {
-	return createFile(t, tempDir, fmt.Sprintf("temp%d.toml", time.Now().UnixNano()), contents...)
-}
-
-// createFile Helper
-func createFile(t *testing.T, tempDir string, name string, contents ...string) *os.File {
-	t.Helper()
-	fileName := path.Join(tempDir, name)
-
-	tempFile, err := os.Create(fileName)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for _, content := range contents {
-		_, err := tempFile.WriteString(content)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	err = tempFile.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return tempFile
-}
-
-// createTempDir Helper
-func createTempDir(t *testing.T, dir string) string {
-	t.Helper()
-	d, err := ioutil.TempDir("", dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return d
-}
 
 // createFrontendConfiguration Helper
 func createFrontendConfiguration(n int) string {

--- a/provider/file/watcher.go
+++ b/provider/file/watcher.go
@@ -1,0 +1,125 @@
+package file
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/containous/traefik/log"
+	"github.com/containous/traefik/safe"
+	"gopkg.in/fsnotify.v1"
+)
+
+type watcher struct {
+	*fsnotify.Watcher
+	Events      chan fsnotify.Event
+	done        chan struct{}
+	directories map[string]struct{}
+}
+
+func newWatcher() (*watcher, error) {
+	fsWatcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("error creating file watcher: %v", err)
+	}
+
+	newWatcher := &watcher{
+		Watcher:     fsWatcher,
+		done:        make(chan struct{}),
+		Events:      make(chan fsnotify.Event),
+		directories: make(map[string]struct{}),
+	}
+
+	newWatcher.handleRecursiveEvent()
+
+	return newWatcher, nil
+}
+
+func (w *watcher) handleRecursiveEvent() {
+	safe.Go(func() {
+		defer func() {
+			err := w.Watcher.Close()
+			if err != nil {
+				log.Debugf("Unable to close watcher: %v", err)
+			}
+		}()
+
+		for {
+			select {
+			case evt := <-w.Watcher.Events:
+				if evt.Op == fsnotify.Remove || evt.Op == fsnotify.Rename {
+					w.removeRecursive(evt.Name)
+				} else if evt.Op == fsnotify.Create {
+					w.addRecursive(evt.Name)
+				}
+				w.Events <- evt
+			case <-w.done:
+				return
+			}
+		}
+	})
+}
+
+func (w *watcher) Close() error {
+	close(w.done)
+	return nil
+}
+
+func (w *watcher) removeRecursive(rootDir string) {
+	for dir := range w.directories {
+		if strings.HasPrefix(dir, rootDir) {
+			err := w.Remove(dir)
+			if err != nil {
+				log.Errorf("Unable to remove %s from watcher: %v", dir, err)
+				continue
+			}
+			delete(w.directories, dir)
+		}
+	}
+}
+
+func (w *watcher) addRecursive(rootDir string) error {
+	directories := getDirectoriesRecursive(rootDir)
+
+	for dir := range directories {
+		err := w.Add(dir)
+		if err != nil {
+			log.Errorf("Unable to add file watcher on directory %q: %v", dir, err)
+		} else {
+			w.directories[dir] = struct{}{}
+		}
+	}
+
+	return nil
+}
+
+func getDirectoriesRecursive(rootDir string) map[string]struct{} {
+	rootDirInfo, err := os.Stat(rootDir)
+	if err != nil {
+		log.Errorf("unable to stat %q: %v", rootDir, err)
+		return nil
+	}
+
+	if !rootDirInfo.IsDir() {
+		return nil
+	}
+
+	directories := map[string]struct{}{
+		rootDir: {},
+	}
+
+	fileList, err := ioutil.ReadDir(rootDir)
+	if err != nil {
+		log.Errorf("unable to initialize sub-directories list from directory %s: %v", rootDir, err)
+		return nil
+	}
+
+	for _, item := range fileList {
+		for dir := range getDirectoriesRecursive(strings.TrimSuffix(rootDir, "/") + "/" + item.Name()) {
+			directories[dir] = struct{}{}
+		}
+	}
+
+	return directories
+}

--- a/provider/file/watcher_test.go
+++ b/provider/file/watcher_test.go
@@ -1,0 +1,148 @@
+package file
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/fsnotify.v1"
+)
+
+// createRandomFile Helper
+func createRandomFile(t *testing.T, tempDir string, contents ...string) *os.File {
+	return createFile(t, tempDir, fmt.Sprintf("temp%d.toml", time.Now().UnixNano()), contents...)
+}
+
+// createFile Helper
+func createFile(t *testing.T, tempDir string, name string, contents ...string) *os.File {
+	t.Helper()
+	fileName := path.Join(tempDir, name)
+
+	tempFile, err := os.Create(fileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, content := range contents {
+		_, err := tempFile.WriteString(content)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	err = tempFile.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return tempFile
+}
+
+// createTempDir Helper
+func createTempDir(t *testing.T, dir string) string {
+	t.Helper()
+	d, err := ioutil.TempDir("", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+// createDir Helper
+func createDir(t *testing.T, parentDir string, name string) string {
+	t.Helper()
+	dirPath := path.Join(parentDir, name)
+	err := os.MkdirAll(dirPath, os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return dirPath
+}
+
+// I want test create/remove/rename file
+func TestWatchFileInWatchedDir(t *testing.T) {
+	watcher, err := newWatcher()
+	assert.Nil(t, err)
+	defer watcher.Close()
+
+	dirToWatch := createTempDir(t, "watcheddir")
+	watcher.addRecursive(dirToWatch)
+
+	name := "foo.toml"
+	originalPath := path.Join(dirToWatch, name)
+	renamedPath := path.Join(dirToWatch, "bar.toml")
+
+	createFile(t, dirToWatch, name)
+	evt := <-watcher.Events
+	assert.Equal(t, evt.Name, originalPath)
+	assert.Equal(t, evt.Op, fsnotify.Create)
+	_, exists := watcher.directories[originalPath]
+	assert.False(t, exists)
+
+	os.Rename(originalPath, renamedPath)
+	evt = <-watcher.Events
+	assert.Equal(t, evt.Name, originalPath)
+	assert.Equal(t, evt.Op, fsnotify.Rename)
+
+	evt = <-watcher.Events
+	assert.Equal(t, evt.Name, renamedPath)
+	assert.Equal(t, evt.Op, fsnotify.Create)
+
+	os.Remove(renamedPath)
+	evt = <-watcher.Events
+	assert.Equal(t, evt.Name, renamedPath)
+	assert.Equal(t, evt.Op, fsnotify.Remove)
+}
+
+func TestWatchSubdirInWatchedDir(t *testing.T) {
+	watcher, err := newWatcher()
+	assert.Nil(t, err)
+	defer watcher.Close()
+
+	dirToWatch := createTempDir(t, "watcheddir")
+	watcher.addRecursive(dirToWatch)
+
+	renamedPath := path.Join(dirToWatch, "bar")
+
+	originalPath := createDir(t, dirToWatch, "foo")
+	evt := <-watcher.Events
+	assert.Equal(t, evt.Name, originalPath)
+	assert.Equal(t, evt.Op, fsnotify.Create)
+	_, exists := watcher.directories[originalPath]
+	assert.True(t, exists)
+
+	err = os.Rename(originalPath, renamedPath)
+	assert.Nil(t, err)
+
+	evt = <-watcher.Events
+	assert.Equal(t, evt.Name, originalPath)
+	assert.Equal(t, evt.Op, fsnotify.Rename)
+	_, exists = watcher.directories[originalPath]
+	assert.False(t, exists)
+
+	evt = <-watcher.Events
+	assert.Equal(t, evt.Name, renamedPath)
+	assert.Equal(t, evt.Op, fsnotify.Create)
+	_, exists = watcher.directories[renamedPath]
+	assert.True(t, exists)
+
+	os.Remove(renamedPath)
+	evt = <-watcher.Events
+	assert.Equal(t, evt.Name, renamedPath)
+	assert.Equal(t, evt.Op, fsnotify.Remove)
+	_, exists = watcher.directories[renamedPath]
+	assert.False(t, exists)
+}
+
+// I want test create subdir + create/remove/rename file in subdir
+
+// I want test removerecursive but not delete real subdir modify its contents
+
+// I want test rename dir
+
+// I want test create sub-subdir + file + modify


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

This PR allows watching recursively the events launched by the subdirectories of the `directory` set in the file provider configuration.

### Motivation

<!-- What inspired you to submit this pull request? -->
Fixes #3986 

### More

- [ ] Added/updated tests