### PR TITLE
acme: prevent some malformed errors.

### DIFF
--- a/acme/acme.go
+++ b/acme/acme.go
@@ -692,16 +692,25 @@ func searchUncheckedDomains(domains []string, certs map[string]*tls.Certificate)
 }
 
 func (a *ACME) getDomainsCertificates(domains []string) (*Certificate, error) {
-	domains = fun.Map(types.CanonicalDomain, domains).([]string)
-	log.Debugf("Loading ACME certificates %s...", domains)
+	var cleanDomains []string
+	for _, domain := range domains {
+		canonicalDomain := types.CanonicalDomain(domain)
+		cleanDomain := acme.UnFqdn(canonicalDomain)
+		if canonicalDomain != cleanDomain {
+			log.Warnf("FQDN detected, please remove the trailing dot: %s", canonicalDomain)
+		}
+		cleanDomains = append(cleanDomains, cleanDomain)
+	}
+
+	log.Debugf("Loading ACME certificates %s...", cleanDomains)
 	bundle := true
 
-	certificate, err := a.client.ObtainCertificate(domains, bundle, nil, OSCPMustStaple)
+	certificate, err := a.client.ObtainCertificate(cleanDomains, bundle, nil, OSCPMustStaple)
 	if err != nil {
 		return nil, fmt.Errorf("cannot obtain certificates: %+v", err)
 	}
 
-	log.Debugf("Loaded ACME certificates %s", domains)
+	log.Debugf("Loaded ACME certificates %s", cleanDomains)
 	return &Certificate{
 		Domain:        certificate.Domain,
 		CertURL:       certificate.CertURL,

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -34,6 +34,7 @@ import (
 	"github.com/containous/traefik/tls"
 	"github.com/containous/traefik/types"
 	"github.com/pkg/errors"
+	lego "github.com/xenolf/lego/acme"
 )
 
 const (
@@ -400,6 +401,17 @@ func (gc *GlobalConfiguration) initACMEProvider() {
 		if gc.ACME.HTTPChallenge != nil && gc.ACME.TLSChallenge != nil {
 			log.Warn("Unable to use HTTP challenge and TLS challenge at the same time. Fallback to TLS challenge.")
 			gc.ACME.HTTPChallenge = nil
+		}
+
+		for _, domain := range gc.ACME.Domains {
+			if domain.Main != lego.UnFqdn(domain.Main) {
+				log.Warnf("FQDN detected, please remove the trailing dot: %s", domain.Main)
+			}
+			for _, san := range domain.SANs {
+				if san != lego.UnFqdn(san) {
+					log.Warnf("FQDN detected, please remove the trailing dot: %s", san)
+				}
+			}
 		}
 
 		// TODO: to remove in the future

--- a/provider/acme/provider.go
+++ b/provider/acme/provider.go
@@ -770,6 +770,7 @@ func (p *Provider) getValidDomains(domain types.Domain, wildcardAllowed bool) ([
 		}
 		cleanDomains = append(cleanDomains, cleanDomain)
 	}
+
 	return cleanDomains, nil
 }
 

--- a/provider/acme/provider.go
+++ b/provider/acme/provider.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/BurntSushi/ty/fun"
 	"github.com/cenk/backoff"
 	"github.com/containous/flaeg"
 	"github.com/containous/traefik/log"
@@ -762,8 +761,16 @@ func (p *Provider) getValidDomains(domain types.Domain, wildcardAllowed bool) ([
 		}
 	}
 
-	domains = fun.Map(types.CanonicalDomain, domains).([]string)
-	return domains, nil
+	var cleanDomains []string
+	for _, domain := range domains {
+		canonicalDomain := types.CanonicalDomain(domain)
+		cleanDomain := acme.UnFqdn(canonicalDomain)
+		if canonicalDomain != cleanDomain {
+			log.Warnf("FQDN detected, please remove the trailing dot: %s", canonicalDomain)
+		}
+		cleanDomains = append(cleanDomains, cleanDomain)
+	}
+	return cleanDomains, nil
 }
 
 func isDomainAlreadyChecked(domainToCheck string, existentDomains []string) bool {


### PR DESCRIPTION
### What does this PR do?

Prevent some malformed errors.

### Motivation

Not being a dominant source of malformed errors in Let's Encrypt logs.

Fixes #4011

### More

- [-] Added/updated tests
- [-] Added/updated documentation
