### PR TITLE
usebindportip can fall back on the container ip / port

### DIFF
--- a/docs/configuration/backends/docker.md
+++ b/docs/configuration/backends/docker.md
@@ -435,7 +435,7 @@ Segment labels override the default behavior.
 The default behavior of Træfik is to route requests to the IP/Port of the matching container.
 When setting `usebindportip` to true, you tell Træfik to use the IP/Port attached to the container's binding instead of the inner network IP/Port.
 
-When used in conjunction with `traefik.port` (that tells Traefik to route requests to a specific port), Traefik tries to find a binding with `traefik.port` port to select the container. If it can't find such a binding, Traefik falls back on the internal network IP of the container, but still uses the `traefik.port` that is set in the label.
+When used in conjunction with `traefik.port` (that tells Træfik to route requests to a specific port), Træfik tries to find a binding with `traefik.port` port to select the container. If it can't find such a binding, Træfik falls back on the internal network IP of the container, but still uses the `traefik.port` that is set in the label.
 
 Below is a recap of the behavior of `usebindportip` in different situations.
 

--- a/docs/configuration/backends/docker.md
+++ b/docs/configuration/backends/docker.md
@@ -439,15 +439,15 @@ When used in conjunction with `traefik.port` (that tells Traefik to route reques
 
 Below is a recap of the behavior of `usebindportip` in different situations.
 
-| traefik.port label | Container's binding     | Routes to       |
-|--------------------|-------------------------|-----------------|
-|          -         |           -             | IntIP:IntPort   |
-|          -         | ExtPort:IntPort         | IntIP:IntPort   |
-|          -         | ExtIp:ExtPort:IntPort   | ExtIp:ExtPort   |
-| LblPort            |           -             | IntIp:LblPort   |
-| LblPort            | ExtIp:ExtPort:LblPort   | ExtIp:ExtPort   |
-| LblPort            | ExtIp:ExtPort:OtherPort | IntIp:LblPort   |
-| LblPort            | ExtIp1:ExtPort1:IntPort1 & ExtIp2:LblPort:IntPort2   | ExtIp2:LblPort |
+| traefik.port label | Container's binding                                | Routes to      |
+|--------------------|----------------------------------------------------|----------------|
+|          -         |           -                                        | IntIP:IntPort  |
+|          -         | ExtPort:IntPort                                    | IntIP:IntPort  |
+|          -         | ExtIp:ExtPort:IntPort                              | ExtIp:ExtPort  |
+| LblPort            |           -                                        | IntIp:LblPort  |
+| LblPort            | ExtIp:ExtPort:LblPort                              | ExtIp:ExtPort  |
+| LblPort            | ExtIp:ExtPort:OtherPort                            | IntIp:LblPort  |
+| LblPort            | ExtIp1:ExtPort1:IntPort1 & ExtIp2:LblPort:IntPort2 | ExtIp2:LblPort |
 
 !!! note
     In the above table, ExtIp stands for "external IP found in the binding", IntIp stands for "internal network container's IP", ExtPort stands for "external Port found in the binding", and IntPort stands for "internal network container's port."

--- a/docs/configuration/backends/docker.md
+++ b/docs/configuration/backends/docker.md
@@ -435,7 +435,7 @@ Segment labels override the default behavior.
 The default behavior of Træfik is to route requests to the IP/Port of the matching container.
 When setting `usebindportip` to true, you tell Træfik to use the IP/Port attached to the container's binding instead of the inner network IP/Port.
 
-When used in conjunction with `traefik.port` (that tells Træfik to route requests to a specific port), Træfik tries to find a binding with `traefik.port` port to select the container. If it can't find such a binding, Træfik falls back on the internal network IP of the container, but still uses the `traefik.port` that is set in the label.
+When used in conjunction with the `traefik.port` label (that tells Træfik to route requests to a specific port), Træfik tries to find a binding with `traefik.port` port to select the container. If it can't find such a binding, Træfik falls back on the internal network IP of the container, but still uses the `traefik.port` that is set in the label.
 
 Below is a recap of the behavior of `usebindportip` in different situations.
 

--- a/provider/docker/config.go
+++ b/provider/docker/config.go
@@ -337,21 +337,22 @@ func (p *Provider) getPortBinding(container dockerData) (*nat.PortBinding, error
 
 func (p *Provider) getIPPort(container dockerData) (string, string, error) {
 	var ip, port string
+	usedBound := false
 
 	if p.UseBindPortIP {
 		portBinding, err := p.getPortBinding(container)
 		if err != nil {
-			return "", "", fmt.Errorf("unable to find a binding for the container %q: ignoring server", container.Name)
+			log.Infof("Unable to find a binding for container %q, falling back on its internal IP/Port.", container.Name)
+		} else if (portBinding.HostIP == "0.0.0.0") || (len(portBinding.HostIP) == 0) {
+			log.Infof("Cannot determine the IP address (got %q) for %q's binding, falling back on its internal IP/Port.", portBinding.HostIP, container.Name)
+		} else {
+			ip = portBinding.HostIP
+			port = portBinding.HostPort
+			usedBound = true
 		}
+	}
 
-		if portBinding.HostIP == "0.0.0.0" {
-			return "", "", fmt.Errorf("cannot determine the IP address (got 0.0.0.0) for the container %q: ignoring server", container.Name)
-		}
-
-		ip = portBinding.HostIP
-		port = portBinding.HostPort
-
-	} else {
+	if !usedBound {
 		ip = p.getIPAddress(container)
 		port = getPort(container)
 	}
@@ -359,6 +360,7 @@ func (p *Provider) getIPPort(container dockerData) (string, string, error) {
 	if len(ip) == 0 {
 		return "", "", fmt.Errorf("unable to find the IP address for the container %q: the server is ignored", container.Name)
 	}
+
 	return ip, port, nil
 }
 


### PR DESCRIPTION
### What does this PR do?

Changes the behaviour of the usebindportip so it can fallback on the container ip/port when the binding doesn't specify the IP.

**Changes Recap**

| label                  | Binding      | Routed to (before) | Routes to (after) |
|----------------|------------|-----------|-----------|
| `traefik.port` not set | `IP_E1:P_E1:P_I1` | `IP_E1:P_E1` | `IP_E1:P_E1`
| `traefik.port` not set | `P_E1:P_I1` | Warning & Ignored (cannot route to `0.0.0.0`) | ContainerIP:ContainerPort |
| `traefik.port` not set | None | Warning & Ignored (Binding is missing) |  ContainerIP:ContainerPort |
| `traefik.port=P_E1` | `IP_E1:P_E1:P_I1` | `IP_E1:P_E1` | `IP_E1:P_E1` |
| `traefik.port=P_E2` | `IP_E1:P_E1:P_I1` | Warning  & Ignored (cannot find binding for `XX:P_E2:XX`) | ContainerIP:P_E2 |
| `traefik.port=P_E2`  | `IP_E1:P_E1:P_I1` & `IP_E2:P_E2:P_I2` | `IP_E2:P_E2` | `IP_E2:P_E2` |
| `traefik.port=P_E1`  | None | Warning & Ignored (Binding is missing) | ContainerIP:P_E1 |

### Motivation

#3960 and #3943 

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Related to #3622 
