### PR TITLE
Allow multiple ingress classes

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -69,6 +69,7 @@ Complete documentation is available at https://traefik.io`,
 	f.AddParser(reflect.TypeOf(traefiktls.FilesOrContents{}), &traefiktls.FilesOrContents{})
 	f.AddParser(reflect.TypeOf(types.Constraints{}), &types.Constraints{})
 	f.AddParser(reflect.TypeOf(kubernetes.Namespaces{}), &kubernetes.Namespaces{})
+	f.AddParser(reflect.TypeOf(kubernetes.IngressClasses{}), &kubernetes.IngressClasses{})
 	f.AddParser(reflect.TypeOf(ecs.Clusters{}), &ecs.Clusters{})
 	f.AddParser(reflect.TypeOf([]types.Domain{}), &types.Domains{})
 	f.AddParser(reflect.TypeOf(types.Buckets{}), &types.Buckets{})

--- a/provider/kubernetes/ingressclasses.go
+++ b/provider/kubernetes/ingressclasses.go
@@ -1,7 +1,7 @@
 package kubernetes
 
 import (
-       "fmt"
+	"fmt"
 )
 
 // IngressClasses holds kubernetes ingressClass annotation values
@@ -10,8 +10,8 @@ type IngressClasses []string
 //Set adds strings elem into the the parser
 //it splits str on , and ;
 func (ic *IngressClasses) Set(str string) error {
-       *ic = append(*ic, str)
-       return nil
+	*ic = append(*ic, str)
+	return nil
 }
 
 //Get []string
@@ -22,5 +22,5 @@ func (ic *IngressClasses) String() string { return fmt.Sprintf("%v", *ic) }
 
 //SetValue sets []string into the parser
 func (ic *IngressClasses) SetValue(val interface{}) {
-       *ic = val.(IngressClasses)
+	*ic = val.(IngressClasses)
 }

--- a/provider/kubernetes/ingressclasses.go
+++ b/provider/kubernetes/ingressclasses.go
@@ -1,0 +1,26 @@
+package kubernetes
+
+import (
+       "fmt"
+)
+
+// IngressClasses holds kubernetes ingressClass annotation values
+type IngressClasses []string
+
+//Set adds strings elem into the the parser
+//it splits str on , and ;
+func (ic *IngressClasses) Set(str string) error {
+       *ic = append(*ic, str)
+       return nil
+}
+
+//Get []string
+func (ic *IngressClasses) Get() interface{} { return *ic }
+
+//String return slice in a string
+func (ic *IngressClasses) String() string { return fmt.Sprintf("%v", *ic) }
+
+//SetValue sets []string into the parser
+func (ic *IngressClasses) SetValue(val interface{}) {
+       *ic = val.(IngressClasses)
+}

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -1787,7 +1787,7 @@ func TestIngressClassAnnotation(t *testing.T) {
 		},
 		{
 			desc:     "Provided IngressClass annotation",
-			provider: Provider{IngressClass: traefikDefaultRealm + "-other"},
+			provider: Provider{IngressClass: IngressClasses{traefikDefaultRealm + "-other"}},
 			expected: buildConfiguration(
 				backends(
 					backend("foo/bar",
@@ -1808,7 +1808,7 @@ func TestIngressClassAnnotation(t *testing.T) {
 		},
 		{
 			desc:     "Provided IngressClass annotation",
-			provider: Provider{IngressClass: "custom"},
+			provider: Provider{IngressClass: IngressClasses{"custom"}},
 			expected: buildConfiguration(
 				backends(
 					backend("foo/bar",


### PR DESCRIPTION
### What does this PR do?

Allow more than one ingress class to be specified. Why?
1. The default ingress matching for traefik is `["", "traefik"]` which is currently not configurable
2. Advanced setups may have traefik instances that handle a superset of another ingress (e.g. in our case an ingress controller that handles the `internal` and `public` ingress classes)

### Motivation

This is the last custom patch we are running in production. It is a rather small change that might be useful to others. I am also a fan of defaults that can be expressed through configuration.

Our use-case is a setup where we run 2 ingress pools for our applications: a public pool for external traffic and an internal one for internal traffic (often tools for humans).
However the internal one does route the external names, too. This is needed as some services go through the internal ingress infrastructure as a shortcut.

### More

- [x] Updated tests
- [ ] Added tests
- [ ] Added/updated documentation

### Additional Notes

I expect this PR to need more tests and a docs update but I wanted to get the idea out (for discussion).