### PR TITLE
Fix recover from panic handler

### DIFF
--- a/middlewares/recover.go
+++ b/middlewares/recover.go
@@ -27,7 +27,16 @@ func NegroniRecoverHandler() negroni.Handler {
 
 func recoverFunc(w http.ResponseWriter) {
 	if err := recover(); err != nil {
-		log.Errorf("Recovered from panic in http handler: %+v", err)
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		if shouldLogPanic(err) {
+			log.Errorf("Recovered from panic in http handler: %+v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		} else {
+			log.Debugf("HTTP handler has been aborted: %v", err)
+		}
 	}
+}
+
+// https://github.com/golang/go/blob/c33153f7b416c03983324b3e8f869ce1116d84bc/src/net/http/httputil/reverseproxy.go#L284
+func shouldLogPanic(panicValue interface{}) bool {
+	return panicValue != nil && panicValue != http.ErrAbortHandler
 }


### PR DESCRIPTION
### What does this PR do?

Since go 1.11, http/reverseproxy.go can generate some panic

https://github.com/golang/go/blob/c33153f7b416c03983324b3e8f869ce1116d84bc/src/net/http/httputil/reverseproxy.go#L274-L285

Its can be justify by his piece of code:

https://github.com/golang/go/blob/a0d6420d8be2ae7164797051ec74fa2a2df466a1/src/net/http/server.go#L1761-L1775

### Motivation

Avoid to have this error message

```console
Recovered from panic in http handler: net/http: abort Handler
```