### PR TITLE
Remove X-Forwarded-Uri and X-Forwarded-Method from untrusted IP

### DIFF
--- a/server/header_rewriter.go
+++ b/server/header_rewriter.go
@@ -7,6 +7,12 @@ import (
 	"github.com/containous/traefik/log"
 	"github.com/containous/traefik/whitelist"
 	"github.com/vulcand/oxy/forward"
+	"github.com/vulcand/oxy/utils"
+)
+
+const (
+	xForwardedURI    = "X-Forwarded-Uri"
+	xForwardedMethod = "X-Forwarded-Method"
 )
 
 // NewHeaderRewriter Create a header rewriter
@@ -45,6 +51,8 @@ func (h *headerRewriter) Rewrite(req *http.Request) {
 	err := h.ips.IsAuthorized(req)
 	if err != nil {
 		log.Debug(err)
+		// Remove additional X-Forwarded Headers which are used by the forward authentication
+		utils.RemoveHeaders(req.Header, xForwardedURI, xForwardedMethod)
 		h.secureRewriter.Rewrite(req)
 		return
 	}

--- a/server/header_rewriter_test.go
+++ b/server/header_rewriter_test.go
@@ -23,8 +23,10 @@ func TestHeaderRewriter_Rewrite(t *testing.T) {
 			trustedIPs: []string{"10.10.10.10"},
 			insecure:   false,
 			expected: map[string]string{
-				"X-Foo":           "bar",
-				"X-Forwarded-For": "30.30.30.30",
+				"X-Foo":              "bar",
+				"X-Forwarded-For":    "30.30.30.30",
+				"X-Forwarded-Uri":    "/bar",
+				"X-Forwarded-Method": "GET",
 			},
 		},
 		{
@@ -33,8 +35,10 @@ func TestHeaderRewriter_Rewrite(t *testing.T) {
 			trustedIPs: []string{"10.10.10.10"},
 			insecure:   false,
 			expected: map[string]string{
-				"X-Foo":           "bar",
-				"X-Forwarded-For": "",
+				"X-Foo":              "bar",
+				"X-Forwarded-For":    "",
+				"X-Forwarded-Uri":    "",
+				"X-Forwarded-Method": "",
 			},
 		},
 		{
@@ -43,8 +47,10 @@ func TestHeaderRewriter_Rewrite(t *testing.T) {
 			trustedIPs: []string{"10.10.10.10"},
 			insecure:   false,
 			expected: map[string]string{
-				"X-Foo":           "bar",
-				"X-Forwarded-For": "",
+				"X-Foo":              "bar",
+				"X-Forwarded-For":    "",
+				"X-Forwarded-Uri":    "",
+				"X-Forwarded-Method": "",
 			},
 		},
 		{
@@ -53,8 +59,10 @@ func TestHeaderRewriter_Rewrite(t *testing.T) {
 			trustedIPs: []string{"10.10.10.10"},
 			insecure:   true,
 			expected: map[string]string{
-				"X-Foo":           "bar",
-				"X-Forwarded-For": "30.30.30.30",
+				"X-Foo":              "bar",
+				"X-Forwarded-For":    "30.30.30.30",
+				"X-Forwarded-Uri":    "/bar",
+				"X-Forwarded-Method": "GET",
 			},
 		},
 		{
@@ -63,8 +71,10 @@ func TestHeaderRewriter_Rewrite(t *testing.T) {
 			trustedIPs: []string{"10.10.10.10"},
 			insecure:   true,
 			expected: map[string]string{
-				"X-Foo":           "bar",
-				"X-Forwarded-For": "30.30.30.30",
+				"X-Foo":              "bar",
+				"X-Forwarded-For":    "30.30.30.30",
+				"X-Forwarded-Uri":    "/bar",
+				"X-Forwarded-Method": "GET",
 			},
 		},
 		{
@@ -73,8 +83,10 @@ func TestHeaderRewriter_Rewrite(t *testing.T) {
 			trustedIPs: []string{"10.10.10.10"},
 			insecure:   true,
 			expected: map[string]string{
-				"X-Foo":           "bar",
-				"X-Forwarded-For": "30.30.30.30",
+				"X-Foo":              "bar",
+				"X-Forwarded-For":    "30.30.30.30",
+				"X-Forwarded-Uri":    "/bar",
+				"X-Forwarded-Method": "GET",
 			},
 		},
 	}
@@ -93,6 +105,8 @@ func TestHeaderRewriter_Rewrite(t *testing.T) {
 
 			req.Header.Set("X-Foo", "bar")
 			req.Header.Set("X-Forwarded-For", "30.30.30.30")
+			req.Header.Set("X-Forwarded-Uri", "/bar")
+			req.Header.Set("X-Forwarded-Method", "GET")
 
 			rewriter.Rewrite(req)
 


### PR DESCRIPTION
### What does this PR do?

Remove X-Forwarded-Uri and X-Forwarded-Method headers if a request
comes from an untrusted IP.

### Motivation

Failing to do so would result in an inconsistent and insecure behaviour
for the forward authentication. If TrustForwardHeader is active in the
forward auth, the auth endpoint receives these two headers if they
have been sent from an untrusted IP. Whereas other X-Forward headers
have been removed in the request and are safe to use in the auth
endpoint.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
