### PR TITLE
Nil request body with retry

### DIFF
--- a/healthcheck/healthcheck.go
+++ b/healthcheck/healthcheck.go
@@ -71,7 +71,7 @@ func (b *BackendConfig) newRequest(serverURL *url.URL) (*http.Request, error) {
 
 	u.Path += b.Path
 
-	return http.NewRequest(http.MethodGet, u.String(), nil)
+	return http.NewRequest(http.MethodGet, u.String(), http.NoBody)
 }
 
 // this function adds additional http headers and hostname to http.request

--- a/middlewares/auth/forward.go
+++ b/middlewares/auth/forward.go
@@ -40,7 +40,7 @@ func Forward(config *types.Forward, w http.ResponseWriter, r *http.Request, next
 		}
 	}
 
-	forwardReq, err := http.NewRequest(http.MethodGet, config.Address, nil)
+	forwardReq, err := http.NewRequest(http.MethodGet, config.Address, http.NoBody)
 	tracing.LogRequest(tracing.GetSpan(r), forwardReq)
 	if err != nil {
 		tracing.SetErrorAndDebugLog(r, "Error calling %s. Cause %s", config.Address, err)

--- a/middlewares/errorpages/error_pages.go
+++ b/middlewares/errorpages/error_pages.go
@@ -120,7 +120,7 @@ func newRequest(baseURL string) (*http.Request, error) {
 		return nil, fmt.Errorf("error pages: error when parse URL: %v", err)
 	}
 
-	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	req, err := http.NewRequest(http.MethodGet, u.String(), http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("error pages: error when create query: %v", err)
 	}

--- a/middlewares/retry.go
+++ b/middlewares/retry.go
@@ -35,6 +35,9 @@ func (retry *Retry) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	// cf https://github.com/containous/traefik/issues/1008
 	if retry.attempts > 1 {
 		body := r.Body
+		if body == nil {
+			body = http.NoBody
+		}
 		defer body.Close()
 		r.Body = ioutil.NopCloser(body)
 	}


### PR DESCRIPTION
### What does this PR do?

Nil request body with retry.

### Motivation

Fixes #4013

```
github.com/containous/traefik/middlewares.recoverFunc(0x7fc743112078, 0xc000efa090, 0xc00114ea00)
	/go/src/github.com/containous/traefik/middlewares/recover.go:40 +0x1b7
panic(0x21d58a0, 0x4530f40)
	/usr/local/go/src/runtime/panic.go:513 +0x1b9
github.com/containous/traefik/middlewares.(*Retry).ServeHTTP(0xc000cbf860, 0x7fc743112168, 0xc000efa0c0, 0xc00114f500)
	/go/src/github.com/containous/traefik/middlewares/retry.go:38 +0x5e8
github.com/containous/traefik/middlewares/tracing.(*HTTPHandlerWrapper).ServeHTTP(0xc000cbf890, 0x7fc743112168, 0xc000efa0c0, 0xc00114f500)
	/go/src/github.com/containous/traefik/middlewares/tracing/wrapper.go:63 +0xd5
github.com/containous/traefik/middlewares/errorpages.(*Handler).ServeHTTP(0xc0003898f0, 0x7fc743112078, 0xc000efa0a8, 0xc00114ef00, 0xc00130d100)
	/go/src/github.com/containous/traefik/middlewares/errorpages/error_pages.go:102 +0x867
github.com/containous/traefik/vendor/github.com/urfave/negroni.middleware.ServeHTTP(0x2935200, 0xc0003898f0, 0xc0010e0960, 0x7fc743112078, 0xc000efa0a8, 0xc00114ef00)
	/go/src/github.com/containous/traefik/vendor/github.com/urfave/negroni/negroni.go:33 +0x9c
github.com/containous/traefik/vendor/github.com/urfave/negroni.(*Negroni).ServeHTTP(0xc000cbff20, 0x7fc743112118, 0xc000920d00, 0xc00114ef00)
	/go/src/github.com/containous/traefik/vendor/github.com/urfave/negroni/negroni.go:81 +0xee
github.com/containous/traefik/vendor/github.com/containous/mux.(*Router).ServeHTTP(0xc0007c8300, 0x7fc743112118, 0xc000920d00, 0xc00114ef00)
	/go/src/github.com/containous/traefik/vendor/github.com/containous/mux/mux.go:133 +0xf1
github.com/containous/traefik/middlewares.(*HandlerSwitcher).ServeHTTP(0xc00000c008, 0x7fc743112118, 0xc000920d00, 0xc00114ed00)
	/go/src/github.com/containous/traefik/middlewares/handlerSwitcher.go:24 +0x6f
github.com/containous/traefik/vendor/github.com/urfave/negroni.Wrap.func1(0x7fc743112118, 0xc000920d00, 0xc00114ed00, 0xc00130d0e0)
	/go/src/github.com/containous/traefik/vendor/github.com/urfave/negroni/negroni.go:41 +0x4d
github.com/containous/traefik/vendor/github.com/urfave/negroni.HandlerFunc.ServeHTTP(0xc000962600, 0x7fc743112118, 0xc000920d00, 0xc00114ed00, 0xc00130d0e0)
	/go/src/github.com/containous/traefik/vendor/github.com/urfave/negroni/negroni.go:24 +0x4e
github.com/containous/traefik/vendor/github.com/urfave/negroni.middleware.ServeHTTP(0x2939e00, 0xc000962600, 0xc000962700, 0x7fc743112118, 0xc000920d00, 0xc00114ed00)
	/go/src/github.com/containous/traefik/vendor/github.com/urfave/negroni/negroni.go:33 +0x9c
github.com/containous/traefik/vendor/github.com/urfave/negroni.middleware.ServeHTTP-fm(0x7fc743112118, 0xc000920d00, 0xc00114ed00)
	/go/src/github.com/containous/traefik/vendor/github.com/urfave/negroni/negroni.go:33
```

### More

- [-] Added/updated tests
- [-] Added/updated documentation
