### PR TITLE
Add missing tmp directory to scratch image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM scratch
 COPY script/ca-certificates.crt /etc/ssl/certs/
 COPY dist/traefik /
+RUN mdir -p /tmp
 EXPOSE 80
 ENTRYPOINT ["/traefik"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM scratch
 COPY script/ca-certificates.crt /etc/ssl/certs/
 COPY dist/traefik /
-RUN mdir -p /tmp
+ WORKDIR /tmp
+ WORKDIR /
 EXPOSE 80
 ENTRYPOINT ["/traefik"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM scratch
+WORKDIR /tmp
+WORKDIR /
 COPY script/ca-certificates.crt /etc/ssl/certs/
 COPY dist/traefik /
- WORKDIR /tmp
- WORKDIR /
 EXPOSE 80
 ENTRYPOINT ["/traefik"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM scratch
-WORKDIR /tmp
-WORKDIR /
 COPY script/ca-certificates.crt /etc/ssl/certs/
 COPY dist/traefik /
 EXPOSE 80
+VOLUME ["/tmp"]
 ENTRYPOINT ["/traefik"]


### PR DESCRIPTION
### What does this PR do?

Fixes buffering by re-adding the missing `/tmp` directory.


### Motivation

Closes #4064 
