### PR TITLE
[docker backend] - Add config flag to set refreshSeconds for swarmmode ticker

### DIFF
--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -46,7 +46,7 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 	defaultDocker.ExposedByDefault = true
 	defaultDocker.Endpoint = "unix:///var/run/docker.sock"
 	defaultDocker.SwarmMode = false
-	defaultDocker.SwarmRefreshPeriod = 15
+	defaultDocker.SwarmModeRefreshSeconds = 15
 
 	// default File
 	var defaultFile file.Provider

--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -46,7 +46,7 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 	defaultDocker.ExposedByDefault = true
 	defaultDocker.Endpoint = "unix:///var/run/docker.sock"
 	defaultDocker.SwarmMode = false
-	defaultDocker.RefreshSeconds = 15
+	defaultDocker.SwarmRefreshPeriod = 15
 
 	// default File
 	var defaultFile file.Provider

--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -46,6 +46,7 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 	defaultDocker.ExposedByDefault = true
 	defaultDocker.Endpoint = "unix:///var/run/docker.sock"
 	defaultDocker.SwarmMode = false
+	defaultDocker.RefreshSeconds = 15
 
 	// default File
 	var defaultFile file.Provider

--- a/docs/configuration/backends/docker.md
+++ b/docs/configuration/backends/docker.md
@@ -73,6 +73,13 @@ usebindportip = true
 #
 swarmMode = false
 
+# Polling interval (in seconds) for Swarm Mode.
+#
+# Optional
+# Default: 15
+#
+swarmModeRefreshSeconds = 15
+
 # Define a default docker network to use for connections to all containers.
 # Can be overridden by the traefik.docker.network label.
 #

--- a/provider/docker/docker.go
+++ b/provider/docker/docker.go
@@ -44,7 +44,7 @@ type Provider struct {
 	UseBindPortIP         bool             `description:"Use the ip address from the bound port, rather than from the inner network" export:"true"`
 	SwarmMode             bool             `description:"Use Docker on Swarm Mode" export:"true"`
 	Network               string           `description:"Default Docker network used" export:"true"`
-	RefreshSeconds        int              `description:"Polling interval for swarm mode (in seconds)" export:"true"`
+	SwarmRefreshPeriod    int              `description:"Polling interval for swarm mode (in seconds)" export:"true"`
 }
 
 // Init the provider

--- a/provider/docker/docker.go
+++ b/provider/docker/docker.go
@@ -30,8 +30,6 @@ import (
 const (
 	// SwarmAPIVersion is a constant holding the version of the Provider API traefik will use
 	SwarmAPIVersion = "1.24"
-	// SwarmDefaultWatchTime is the duration of the interval when polling docker
-	SwarmDefaultWatchTime = 15 * time.Second
 )
 
 var _ provider.Provider = (*Provider)(nil)
@@ -46,6 +44,7 @@ type Provider struct {
 	UseBindPortIP         bool             `description:"Use the ip address from the bound port, rather than from the inner network" export:"true"`
 	SwarmMode             bool             `description:"Use Docker on Swarm Mode" export:"true"`
 	Network               string           `description:"Default Docker network used" export:"true"`
+	RefreshSeconds        int              `description:"Polling interval for swarm mode (in seconds)" export:"true"`
 }
 
 // Init the provider
@@ -162,7 +161,7 @@ func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *s
 				if p.SwarmMode {
 					errChan := make(chan error)
 					// TODO: This need to be change. Linked to Swarm events docker/docker#23827
-					ticker := time.NewTicker(SwarmDefaultWatchTime)
+					ticker := time.NewTicker(time.Second * time.Duration(p.SwarmRefreshPeriod))
 					pool.GoCtx(func(ctx context.Context) {
 						defer close(errChan)
 						for {


### PR DESCRIPTION
### What does this PR do?

This PR allow user to set a custom refresh interval for polling swarm mode socket for docker backend
The default value is 15
The new flag to set in config is `--docker.refreshSeconds`