### PR TITLE
Replaces emilevauge/whoami by containous/whoami in the documentation

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -15,7 +15,7 @@ I used 4 VMs for the tests with the following configuration:
 
 1. One VM used to launch the benchmarking tool [wrk](https://github.com/wg/wrk)
 2. One VM for Traefik (v1.0.0-beta.416) / nginx (v1.4.6)
-3. Two VMs for 2 backend servers in go [whoami](https://github.com/emilevauge/whoamI/)
+3. Two VMs for 2 backend servers in go [whoami](https://github.com/containous/whoami/)
 
 Each VM has been tuned using the following limits:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -109,7 +109,7 @@ Edit your `docker-compose.yml` file and add the following at the end of your fil
 ```yaml
 # ...
   whoami:
-    image: emilevauge/whoami # A container that exposes an API to show its IP address
+    image: containous/whoami # A container that exposes an API to show its IP address
     labels:
       - "traefik.frontend.rule=Host:whoami.docker.localhost"
 ```

--- a/docs/user-guide/kv-config.md
+++ b/docs/user-guide/kv-config.md
@@ -24,7 +24,7 @@ The Traefik global configuration will be retrieved from a [Consul](https://consu
 
 First we have to launch Consul in a container.
 
-The [docker-compose file](https://docs.docker.com/compose/compose-file/) allows us to launch Consul and four instances of the trivial app [emilevauge/whoamI](https://github.com/emilevauge/whoamI) :
+The [docker-compose file](https://docs.docker.com/compose/compose-file/) allows us to launch Consul and four instances of the trivial app [containous/whoami](https://github.com/containous/whoami) :
 
 ```yaml
 consul:
@@ -42,16 +42,16 @@ consul:
     - "8302/udp"
 
 whoami1:
-  image: emilevauge/whoami
+  image: containous/whoami
 
 whoami2:
-  image: emilevauge/whoami
+  image: containous/whoami
 
 whoami3:
-  image: emilevauge/whoami
+  image: containous/whoami
 
 whoami4:
-  image: emilevauge/whoami
+  image: containous/whoami
 ```
 
 ### Upload the configuration in the Key-value store

--- a/docs/user-guide/swarm-mode.md
+++ b/docs/user-guide/swarm-mode.md
@@ -107,7 +107,7 @@ Let's explain this command:
 
 ## Deploy your apps
 
-We can now deploy our app on the cluster, here [whoami](https://github.com/emilevauge/whoami), a simple web server in Go.
+We can now deploy our app on the cluster, here [whoami](https://github.com/containous/whoami), a simple web server in Go.
 We start 2 services, on the `traefik-net` network.
 
 ```shell
@@ -115,14 +115,14 @@ docker-machine ssh manager "docker service create \
 	--name whoami0 \
 	--label traefik.port=80 \
 	--network traefik-net \
-	emilevauge/whoami"
+	containous/whoami"
 
 docker-machine ssh manager "docker service create \
 	--name whoami1 \
 	--label traefik.port=80 \
 	--network traefik-net \
 	--label traefik.backend.loadbalancer.sticky=true \
-	emilevauge/whoami"
+	containous/whoami"
 ```
 
 !!! note
@@ -140,8 +140,8 @@ docker-machine ssh manager "docker service ls"
 ```
 ID            NAME     MODE        REPLICAS  IMAGE                     PORTS
 moq3dq4xqv6t  traefik  replicated  1/1       traefik:latest            *:80->80/tcp,*:8080->8080/tcp
-ysil6oto1wim  whoami0  replicated  1/1       emilevauge/whoami:latest
-z9re2mnl34k4  whoami1  replicated  1/1       emilevauge/whoami:latest
+ysil6oto1wim  whoami0  replicated  1/1       containous/whoami:latest
+z9re2mnl34k4  whoami1  replicated  1/1       containous/whoami:latest
 ```
 
 
@@ -243,8 +243,8 @@ docker-machine ssh manager "docker service ls"
 ```
 ID            NAME     MODE        REPLICAS  IMAGE                     PORTS
 moq3dq4xqv6t  traefik  replicated  1/1       traefik:latest            *:80->80/tcp,*:8080->8080/tcp
-ysil6oto1wim  whoami0  replicated  5/5       emilevauge/whoami:latest
-z9re2mnl34k4  whoami1  replicated  5/5       emilevauge/whoami:latest
+ysil6oto1wim  whoami0  replicated  5/5       containous/whoami:latest
+z9re2mnl34k4  whoami1  replicated  5/5       containous/whoami:latest
 ```
 
 ## Access to your `whoami0` through Traefik multiple times.

--- a/docs/user-guide/swarm.md
+++ b/docs/user-guide/swarm.md
@@ -112,12 +112,12 @@ Let's explain this command:
 
 ## Deploy your apps
 
-We can now deploy our app on the cluster, here [whoami](https://github.com/emilevauge/whoami), a simple web server in GO, on the network `my-net`:
+We can now deploy our app on the cluster, here [whoami](https://github.com/containous/whoami), a simple web server in GO, on the network `my-net`:
 
 ```shell
 eval $(docker-machine env --swarm mhs-demo0)
-docker run -d --name=whoami0 --net=my-net --env="constraint:node==mhs-demo0" emilevauge/whoami
-docker run -d --name=whoami1 --net=my-net --env="constraint:node==mhs-demo1" emilevauge/whoami
+docker run -d --name=whoami0 --net=my-net --env="constraint:node==mhs-demo0" containous/whoami
+docker run -d --name=whoami1 --net=my-net --env="constraint:node==mhs-demo1" containous/whoami
 ```
 
 Check that everything is started:
@@ -127,8 +127,8 @@ docker ps
 ```
 ```
 CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                                                      NAMES
-ba2c21488299        emilevauge/whoami   "/whoamI"                8 seconds ago       Up 9 seconds        80/tcp                                                     mhs-demo1/whoami1
-8147a7746e7a        emilevauge/whoami   "/whoamI"                19 seconds ago      Up 20 seconds       80/tcp                                                     mhs-demo0/whoami0
+ba2c21488299        containous/whoami   "/whoamI"                8 seconds ago       Up 9 seconds        80/tcp                                                     mhs-demo1/whoami1
+8147a7746e7a        containous/whoami   "/whoamI"                19 seconds ago      Up 20 seconds       80/tcp                                                     mhs-demo0/whoami0
 8fbc39271b4c        traefik             "/traefik -l DEBUG -c"   36 seconds ago      Up 37 seconds       192.168.99.101:80->80/tcp, 192.168.99.101:8080->8080/tcp   mhs-demo0/serene_bhabha
 ```
 


### PR DESCRIPTION
### What does this PR do?

Since the project emilevauge/whoami moved to containous/whoami, the PR updates the documentation accordingly.

### More

- [x] Added/updated documentation

### Additional Notes

I haven't updated the integration tests 