### PR TITLE
Fix access log field parsing

### DIFF
--- a/types/logs.go
+++ b/types/logs.go
@@ -88,6 +88,11 @@ func (f *FieldNames) Get() interface{} {
 // Set's argument is a string to be parsed to set the flag.
 // It's a space-separated list, so we split it.
 func (f *FieldNames) Set(value string) error {
+	// When arguments are passed through YAML, escaped double quotes
+	// might be added to this string, and they would break the last
+	// key/value pair. This ensures the string is clean.
+	value = strings.Replace(value, "\"", "", -1)
+
 	fields := strings.Fields(value)
 
 	for _, field := range fields {
@@ -123,6 +128,11 @@ func (f *FieldHeaderNames) Get() interface{} {
 // Set's argument is a string to be parsed to set the flag.
 // It's a space-separated list, so we split it.
 func (f *FieldHeaderNames) Set(value string) error {
+	// When arguments are passed through YAML, escaped double quotes
+	// might be added to this string, and they would break the last
+	// key/value pair. This ensures the string is clean.
+	value = strings.Replace(value, "\"", "", -1)
+
 	fields := strings.Fields(value)
 
 	for _, field := range fields {

--- a/types/logs.go
+++ b/types/logs.go
@@ -91,7 +91,7 @@ func (f *FieldNames) Set(value string) error {
 	// When arguments are passed through YAML, escaped double quotes
 	// might be added to this string, and they would break the last
 	// key/value pair. This ensures the string is clean.
-	value = strings.Replace(value, "\"", "", -1)
+	value = strings.Trim(value, "\"")
 
 	fields := strings.Fields(value)
 
@@ -131,7 +131,7 @@ func (f *FieldHeaderNames) Set(value string) error {
 	// When arguments are passed through YAML, escaped double quotes
 	// might be added to this string, and they would break the last
 	// key/value pair. This ensures the string is clean.
-	value = strings.Replace(value, "\"", "", -1)
+	value = strings.Trim(value, "\"")
 
 	fields := strings.Fields(value)
 

--- a/types/logs_test.go
+++ b/types/logs_test.go
@@ -301,6 +301,14 @@ func TestFieldsHeadersNamesSet(t *testing.T) {
 				"X-HEADER-2": "bar",
 			},
 		},
+		{
+			desc:  "Two values separated by space with escaped double quotes should return FieldNames of size 2",
+			value: "\"X-HEADER-1=foo X-HEADER-2=bar\"",
+			expected: &FieldHeaderNames{
+				"X-HEADER-1": "foo",
+				"X-HEADER-2": "bar",
+			},
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
### What does this PR do?

This PR fixes #3841 and adds a unit test to cover the specific case that was causing it.

Basically, when using a YAML file to pass arguments, they are passed with escaped backquotes if  backquotes are present in the input YAML file.

For example:

```
args:
        - --accessLog.fields.names="Username=drop Hostname=drop ClientUsername=drop ClientHost=drop"
```

Would be received by the flaeg parser as `"Username=drop Hostname=drop ClientUsername=drop ClientHost=drop"`. The parser then used to break it down into key value pairs and store it in a map. What happened was that for the last key (here `ClientHost` in this example, the value had a backquote at the end of it (`drop"` in this case), which didn't match with either `drop`, `keep` or `redact`. It was then replaced by the default value.

Removing the backquotes in the YAML file was a workaround for this, but it definitely isn't intuitive, so a fix was needed in the parser itself to handle that case.

No documentation change should be needed.

### Motivation

Fixing #3841 

### More

- [x] Added/updated tests
- [ ] Added/updated documentation