### PR TITLE
Redirection status codes for methods different than GET

### DIFF
--- a/docs/configuration/ping.md
+++ b/docs/configuration/ping.md
@@ -27,7 +27,7 @@ The `/ping` health-check URL is enabled with the command-line `--ping` or config
 Thus, if you have a regular path for `/foo` and an entrypoint on `:80`, you would access them as follows:
 
 * Regular path: `http://hostname:80/foo`
-* Dashboard: `http://hostname:8080/`
+* Admin panel: `http://hostname:8080/`
 * Ping URL: `http://hostname:8080/ping`
 
 However, for security reasons, you may want to be able to expose the `/ping` health-check URL to outside health-checkers, e.g. an Internet service or cloud load-balancer, _without_ exposing your dashboard's port.

--- a/middlewares/redirect/redirect.go
+++ b/middlewares/redirect/redirect.go
@@ -125,8 +125,15 @@ type moveHandler struct {
 func (m *moveHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	rw.Header().Set("Location", m.location.String())
 	status := http.StatusFound
+	if req.Method != http.MethodGet {
+		status = http.StatusTemporaryRedirect
+	}
+
 	if m.permanent {
 		status = http.StatusMovedPermanently
+		if req.Method != http.MethodGet {
+			status = http.StatusPermanentRedirect
+		}
 	}
 	rw.WriteHeader(status)
 	rw.Write([]byte(http.StatusText(status)))


### PR DESCRIPTION
For HTTP methods different than GET on redirection status codes should be:
 * 307 temporary (https://tools.ietf.org/html/rfc7231#section-6.4.7)
 * 308 permanent (https://tools.ietf.org/html/rfc7538)
in order to keep requested HTTP method.

#4040 #hacktoberfest #greywizard


