### PR TITLE
Fix Marathon config load on connection error

### DIFF
--- a/provider/marathon/marathon.go
+++ b/provider/marathon/marathon.go
@@ -143,10 +143,31 @@ func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *s
 		}
 
 		configuration := p.getConfiguration()
-		configurationChan <- types.ConfigMessage{
-			ProviderName:  "marathon",
-			Configuration: configuration,
+		if configuration != nil {
+			configurationChan <- types.ConfigMessage{
+				ProviderName:  "marathon",
+				Configuration: configuration,
+			}
+		} else if p.Watch {
+			pool.Go(func(stop chan bool) {
+				for {
+					select {
+					case <-stop:
+						return
+					case <-time.After(5 * time.Second):
+						configuration := p.getConfiguration()
+						if configuration != nil {
+							configurationChan <- types.ConfigMessage{
+								ProviderName:  "marathon",
+								Configuration: configuration,
+							}
+							return
+						}
+					}
+				}
+			})
 		}
+
 		return nil
 	}
 


### PR DESCRIPTION
    If Traefik can't load the configuration when starting it will give
up doing so until a new Marathon event gets fired. If no new event is
fired then no configuration will ever be loaded, no matter if the watch
is true or not.

fix #3974 for Traefik 1.6
