### PR TITLE
Add RequestPathRaw and RequestQuery

### DIFF
--- a/docs/configuration/logs.md
+++ b/docs/configuration/logs.md
@@ -213,38 +213,41 @@ format = "json"
 
 ### List of all available fields
 
-```ini
-StartUTC
-StartLocal
-Duration
-FrontendName
-BackendName
-BackendURL
-BackendAddr
-ClientAddr
-ClientHost
-ClientPort
-ClientUsername
-RequestAddr
-RequestHost
-RequestPort
-RequestMethod
-RequestPath
-RequestProtocol
-RequestLine
-RequestContentSize
-OriginDuration
-OriginContentSize
-OriginStatus
-OriginStatusLine
-DownstreamStatus
-DownstreamStatusLine
-DownstreamContentSize
-RequestCount
-GzipRatio
-Overhead
-RetryAttempts
-```
+|   Field   |   Description |
+|-----------|---------------|
+|   StartUTC    |   StartUTC is the map key used for the time at which request processing started.  |
+|   StartLocal  |   StartLocal is the map key used for the local time at which request processing started.  |
+|   Duration    |   Duration is the map key used for the total time taken by processing the response, including the origin server's time but not the log writing time.  |
+|   FrontendName    |   FrontendName is the map key used for the name of the Traefik frontend.  |
+|   BackendName |   BackendName is the map key used for the name of the Traefik backend.    |
+|   BackendURL  |   BackendURL is the map key used for the URL of the Traefik backend.  |
+|   BackendAddr |   BackendAddr is the map key used for the IP:port of the Traefik backend (extracted from BackendURL)  |
+|   ClientAddr  |   ClientAddr is the map key used for the remote address in its original form (usually IP:port).   |
+|   ClientHost  |   ClientHost is the map key used for the remote IP address from which the client request was received.    |
+|   ClientPort  |   ClientPort is the map key used for the remote TCP port from which the client request was received.  |
+|   ClientUsername  |   ClientUsername is the map key used for the username provided in the URL, if present.    |
+|   RequestAddr |   RequestAddr is the map key used for the HTTP Host header (usually IP:port). This is treated as not a header by the Go API.  |
+|   RequestHost |   RequestHost is the map key used for the HTTP Host server name (not including port). |
+|   RequestPort |   RequestPort is the map key used for the TCP port from the HTTP Host.    |
+|   RequestMethod   |   RequestMethod is the map key used for the HTTP method.  |
+|   RequestPath |   RequestPath is the map key used for the HTTP request URI, not including the scheme, host or port.   |
+|   RequestPathRaw  |   RequestPathRaw is the map key used for the HTTP request path, without any others URI parts. |
+|   RequestQuery    |   RequestQuery is the map key used for the HTTP request query, without any others URI parts.  |
+|   RequestProtocol |   RequestProtocol is the map key used for the version of HTTP requested.  |
+|   RequestLine |   RequestMethod + RequestPath + RequestProtocol   |
+|   RequestContentSize  |   RequestContentSize is the map key used for the number of bytes in the request entity (a.k.a. body) sent by the client.     |
+|   OriginDuration  |   OriginDuration is the map key used for the time taken by the origin server ('upstream') to return its response. |
+|   OriginContentSize   |   OriginContentSize is the map key used for the content length specified by the origin server, or 0 if unspecified.   |
+|   OriginStatus    |   OriginStatus is the map key used for the HTTP status code returned by the origin server. If the request was handled by this Traefik instance (e.g. with a redirect), then this value will be absent.    |
+|   OriginStatusLine    |   OriginStatus + Status code explanation  |
+|   DownstreamStatus    |   DownstreamStatus is the map key used for the HTTP status code returned to the client.   |
+|   DownstreamStatusLine    |   DownstreamStatus + Status code explanation  |
+|   DownstreamContentSize   |   DownstreamContentSize is the map key used for the number of bytes in the response entity returned to the client. This is in addition to the "Content-Length" header, which may be present in the origin response.   |
+|   RequestCount    |   RequestCount is the map key used for the number of requests received since the Traefik instance started.    |
+|   GzipRatio   |   GzipRatio is the map key used for the response body compression ratio achieved. |
+|   Overhead    |   Overhead is the map key used for the processing time overhead caused by Traefik.    |
+|   RetryAttempts   |   RetryAttempts is the map key used for the amount of attempts the request was retried.   |
+
 
 ### CLF - Common Log Format
 

--- a/middlewares/accesslog/logdata.go
+++ b/middlewares/accesslog/logdata.go
@@ -38,6 +38,10 @@ const (
 	RequestMethod = "RequestMethod"
 	// RequestPath is the map key used for the HTTP request URI, not including the scheme, host or port.
 	RequestPath = "RequestPath"
+	// RequestPathRaw is the map key used for the HTTP request path, without any others URI parts.
+	RequestPathRaw = "RequestPathRaw"
+	// RequestQuery is the map key used for the HTTP request query, without any others URI parts.
+	RequestQuery = "RequestQuery"
 	// RequestProtocol is the map key used for the version of HTTP requested.
 	RequestProtocol = "RequestProtocol"
 	// RequestContentSize is the map key used for the number of bytes in the request entity (a.k.a. body) sent by the client.
@@ -82,6 +86,8 @@ var defaultCoreKeys = [...]string{
 	RequestPort,
 	RequestMethod,
 	RequestPath,
+	RequestPathRaw,
+	RequestQuery,
 	RequestProtocol,
 	RequestContentSize,
 	OriginDuration,

--- a/middlewares/accesslog/logger.go
+++ b/middlewares/accesslog/logger.go
@@ -163,6 +163,9 @@ func (l *LogHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request, next h
 		ForceQuery: req.URL.ForceQuery,
 		Fragment:   req.URL.Fragment,
 	}
+	core[RequestPathRaw] = req.URL.Path
+	core[RequestQuery] = req.URL.RawQuery
+
 	urlCopyString := urlCopy.String()
 	core[RequestMethod] = req.Method
 	core[RequestPath] = urlCopyString

--- a/middlewares/accesslog/logger_test.go
+++ b/middlewares/accesslog/logger_test.go
@@ -31,6 +31,7 @@ var (
 	testHostname            = "TestHost"
 	testUsername            = "TestUser"
 	testPath                = "testpath"
+	testQuery               = "foo=bar"
 	testPort                = 8181
 	testProto               = "HTTP/0.0"
 	testMethod              = http.MethodPost
@@ -129,7 +130,7 @@ func TestLoggerCLF(t *testing.T) {
 	logData, err := ioutil.ReadFile(logFilePath)
 	require.NoError(t, err)
 
-	expectedLog := ` TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath HTTP/0.0" 123 12 "testReferer" "testUserAgent" 1 "testFrontend" "http://127.0.0.1/testBackend" 1ms`
+	expectedLog := ` TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath?foo=bar HTTP/0.0" 123 12 "testReferer" "testUserAgent" 1 "testFrontend" "http://127.0.0.1/testBackend" 1ms`
 	assertValidLogData(t, expectedLog, logData)
 }
 
@@ -144,7 +145,7 @@ func TestAsyncLoggerCLF(t *testing.T) {
 	logData, err := ioutil.ReadFile(logFilePath)
 	require.NoError(t, err)
 
-	expectedLog := ` TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath HTTP/0.0" 123 12 "testReferer" "testUserAgent" 1 "testFrontend" "http://127.0.0.1/testBackend" 1ms`
+	expectedLog := ` TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath?foo=bar HTTP/0.0" 123 12 "testReferer" "testUserAgent" 1 "testFrontend" "http://127.0.0.1/testBackend" 1ms`
 	assertValidLogData(t, expectedLog, logData)
 }
 
@@ -196,7 +197,9 @@ func TestLoggerJSON(t *testing.T) {
 				RequestHost:               assertString(testHostname),
 				RequestAddr:               assertString(testHostname),
 				RequestMethod:             assertString(testMethod),
-				RequestPath:               assertString(testPath),
+				RequestPathRaw:            assertString(testPath),
+				RequestQuery:              assertString(testQuery),
+				RequestPath:               assertString(testPath + "?" + testQuery),
 				RequestProtocol:           assertString(testProto),
 				RequestPort:               assertString("-"),
 				DownstreamStatus:          assertFloat64(float64(testStatus)),
@@ -349,7 +352,7 @@ func TestNewLogHandlerOutputStdout(t *testing.T) {
 				FilePath: "",
 				Format:   CommonFormat,
 			},
-			expectedLog: `TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testFrontend" "http://127.0.0.1/testBackend" 1ms`,
+			expectedLog: `TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath?foo=bar HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testFrontend" "http://127.0.0.1/testBackend" 1ms`,
 		},
 		{
 			desc: "default config with empty filters",
@@ -358,7 +361,7 @@ func TestNewLogHandlerOutputStdout(t *testing.T) {
 				Format:   CommonFormat,
 				Filters:  &types.AccessLogFilters{},
 			},
-			expectedLog: `TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testFrontend" "http://127.0.0.1/testBackend" 1ms`,
+			expectedLog: `TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath?foo=bar HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testFrontend" "http://127.0.0.1/testBackend" 1ms`,
 		},
 		{
 			desc: "Status code filter not matching",
@@ -380,7 +383,7 @@ func TestNewLogHandlerOutputStdout(t *testing.T) {
 					StatusCodes: []string{"123"},
 				},
 			},
-			expectedLog: `TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testFrontend" "http://127.0.0.1/testBackend" 1ms`,
+			expectedLog: `TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath?foo=bar HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testFrontend" "http://127.0.0.1/testBackend" 1ms`,
 		},
 		{
 			desc: "Duration filter not matching",
@@ -402,7 +405,7 @@ func TestNewLogHandlerOutputStdout(t *testing.T) {
 					MinDuration: parse.Duration(1 * time.Millisecond),
 				},
 			},
-			expectedLog: `TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testFrontend" "http://127.0.0.1/testBackend" 1ms`,
+			expectedLog: `TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath?foo=bar HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testFrontend" "http://127.0.0.1/testBackend" 1ms`,
 		},
 		{
 			desc: "Retry attempts filter matching",
@@ -413,7 +416,7 @@ func TestNewLogHandlerOutputStdout(t *testing.T) {
 					RetryAttempts: true,
 				},
 			},
-			expectedLog: `TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testFrontend" "http://127.0.0.1/testBackend" 1ms`,
+			expectedLog: `TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath?foo=bar HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testFrontend" "http://127.0.0.1/testBackend" 1ms`,
 		},
 		{
 			desc: "Default mode keep",
@@ -424,7 +427,7 @@ func TestNewLogHandlerOutputStdout(t *testing.T) {
 					DefaultMode: "keep",
 				},
 			},
-			expectedLog: `TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testFrontend" "http://127.0.0.1/testBackend" 1ms`,
+			expectedLog: `TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath?foo=bar HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testFrontend" "http://127.0.0.1/testBackend" 1ms`,
 		},
 		{
 			desc: "Default mode keep with override",
@@ -438,7 +441,7 @@ func TestNewLogHandlerOutputStdout(t *testing.T) {
 					},
 				},
 			},
-			expectedLog: `- - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testFrontend" "http://127.0.0.1/testBackend" 1ms`,
+			expectedLog: `- - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath?foo=bar HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testFrontend" "http://127.0.0.1/testBackend" 1ms`,
 		},
 		{
 			desc: "Default mode drop",
@@ -618,7 +621,8 @@ func doLogging(t *testing.T, config *types.AccessLog) {
 		Method:     testMethod,
 		RemoteAddr: fmt.Sprintf("%s:%d", testHostname, testPort),
 		URL: &url.URL{
-			Path: testPath,
+			Path:     testPath,
+			RawQuery: testQuery,
 		},
 	}
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
1) Two new fields in accesses logs `RequestPathRaw` and `RequestQuery`
2) Corresponded edits in documentations
3) Coping accesses logs descriptions from sources to documentation

### Motivation

<!-- What inspired you to submit this pull request? -->
This pr is addressing to #4142 I want to make log processing as simple as possible, and for this I want to introduce two addition fields in accesses logs `RequestPathRaw` and `RequestQuery` that split `RequestPath` on path and query respectively. The best solution would be to extract query from `RequestPath` but it would introduce breaking change. But if it acceptable I will rewrite pr. 

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
![](http://img.parcsis.net/i/dcd232ced37a9235572b8d28349e07e2.png)