### PR TITLE
Cache exising task definitions to avoid rate limiting

### DIFF
--- a/provider/ecs/ecs.go
+++ b/provider/ecs/ecs.go
@@ -23,6 +23,7 @@ import (
 
 var _ provider.Provider = (*Provider)(nil)
 var existingTaskDef = make(map[string]*ecs.TaskDefinition)
+
 // Provider holds configurations of the provider.
 type Provider struct {
 	provider.BaseProvider `mapstructure:",squash" export:"true"`


### PR DESCRIPTION
### What does this PR do?

Stores existing task definitions to avoid rate limiting of the AWS describeTask API.  If there is an existing definition, use instead of making another API call.


### Motivation

Deployments taking hours instead of minutes. Due to using multiple instances of Traefik, each making frequent desribeTask API calls, and quickly hitting AWS's rate limit.


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

