### PR TITLE
Verify ctx when we send configuration message in docker provider

### DIFF
--- a/provider/docker/docker.go
+++ b/provider/docker/docker.go
@@ -210,10 +210,15 @@ func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *s
 						}
 						configuration := p.buildConfiguration(containers)
 						if configuration != nil {
-							configurationChan <- types.ConfigMessage{
+							message := types.ConfigMessage{
 								ProviderName:  "docker",
 								Configuration: configuration,
 							}
+							select {
+							case configurationChan <- message:
+							case <-ctx.Done():
+							}
+
 						}
 					}
 


### PR DESCRIPTION
### What does this PR do?
Add a select when we want to send configuration message to be sure the ctx is not done

### Motivation
Fix a goroutine leak that can stuck the provider shutdown