### PR TITLE
Fix Kubernetes backend detection with empty serviceport name or endpointport name

### DIFF
--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -751,37 +751,37 @@ func TestModifierType(t *testing.T) {
 		expectedModifierRule      string
 	}{
 		{
-			desc: "Request modifier annotation missing",
+			desc:                      "Request modifier annotation missing",
 			requestModifierAnnotation: "",
 			expectedModifierRule:      "",
 		},
 		{
-			desc: "AddPrefix modifier annotation",
+			desc:                      "AddPrefix modifier annotation",
 			requestModifierAnnotation: " AddPrefix: /foo",
 			expectedModifierRule:      "AddPrefix:/foo",
 		},
 		{
-			desc: "ReplacePath modifier annotation",
+			desc:                      "ReplacePath modifier annotation",
 			requestModifierAnnotation: " ReplacePath: /foo",
 			expectedModifierRule:      "ReplacePath:/foo",
 		},
 		{
-			desc: "ReplacePathRegex modifier annotation",
+			desc:                      "ReplacePathRegex modifier annotation",
 			requestModifierAnnotation: " ReplacePathRegex: /foo /bar",
 			expectedModifierRule:      "ReplacePathRegex:/foo /bar",
 		},
 		{
-			desc: "AddPrefix modifier annotation",
+			desc:                      "AddPrefix modifier annotation",
 			requestModifierAnnotation: "AddPrefix:/foo",
 			expectedModifierRule:      "AddPrefix:/foo",
 		},
 		{
-			desc: "ReplacePath modifier annotation",
+			desc:                      "ReplacePath modifier annotation",
 			requestModifierAnnotation: "ReplacePath:/foo",
 			expectedModifierRule:      "ReplacePath:/foo",
 		},
 		{
-			desc: "ReplacePathRegex modifier annotation",
+			desc:                      "ReplacePathRegex modifier annotation",
 			requestModifierAnnotation: "ReplacePathRegex:/foo /bar",
 			expectedModifierRule:      "ReplacePathRegex:/foo /bar",
 		},
@@ -843,23 +843,23 @@ func TestModifierFails(t *testing.T) {
 		requestModifierAnnotation string
 	}{
 		{
-			desc: "Request modifier missing part of annotation",
+			desc:                      "Request modifier missing part of annotation",
 			requestModifierAnnotation: "AddPrefix: ",
 		},
 		{
-			desc: "Request modifier full of spaces annotation",
+			desc:                      "Request modifier full of spaces annotation",
 			requestModifierAnnotation: "    ",
 		},
 		{
-			desc: "Request modifier missing both parts of annotation",
+			desc:                      "Request modifier missing both parts of annotation",
 			requestModifierAnnotation: "  :  ",
 		},
 		{
-			desc: "Request modifier using unknown rule",
+			desc:                      "Request modifier using unknown rule",
 			requestModifierAnnotation: "Foo: /bar",
 		},
 		{
-			desc: "Missing Rule",
+			desc:                      "Missing Rule",
 			requestModifierAnnotation: " : /bar",
 		},
 	}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This PR fixes the Kubernetes provider by implementing the `optional` behavior of [`endpointPort name`](https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#endpointport-v1-core) and [`servicePort name`](https://v1-9.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#serviceport-v1-core).

Thus, as described in the Kubernetes specification, users can specified a `endpointPort` with no name and Traefik will be able to match it with a `servicePort` if the port is the same even if the the `servicePort` name is not empty.

In the same way, users will be able specified a `servicePort` with no name and Traefik will be able to match it with a `endpointPort` if the port is the same even if the the `endpointPort` name is not empty.

### Motivation

<!-- What inspired you to submit this pull request? -->
Implement the Kubernetes specifications.
Fixes #4193 

### More

- [x] Added/updated tests

### Additional Notes

The bug is only present in Traefik versions 1.7.0 to 1.7.4.
