### PR TITLE
Lower casing the certificate domain name

### DIFF
--- a/tls/certificate_store.go
+++ b/tls/certificate_store.go
@@ -117,6 +117,8 @@ func (c CertificateStore) ResetCache() {
 
 // MatchDomain return true if a domain match the cert domain
 func MatchDomain(domain string, certDomain string) bool {
+	certDomain = strings.ToLower(strings.TrimSpace(certDomain))
+
 	if domain == certDomain {
 		return true
 	}


### PR DESCRIPTION
Update for lower casing the certificate domain name in case the same is not set to lower case.

Example Scenario:

certificate generated for LocalNet.com
domain to be checked LocalNet.com

while checking the domain to be checked is lower cased, but the certificate domain name is not set to lower case.

updated the code for the same

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
