### PR TITLE
Update swarm mode endpoint

### DIFF
--- a/docs/configuration/backends/docker.md
+++ b/docs/configuration/backends/docker.md
@@ -112,7 +112,7 @@ To enable constraints see [provider-specific constraints section](/configuration
 #
 # swarm classic (1.12-)
 # endpoint = "tcp://127.0.0.1:2375"
-# swarm intergated (1.12+)
+# docker swarm mode (1.12+)
 endpoint = "tcp://127.0.0.1:2377"
 
 # Default base domain used for the frontend rules.

--- a/docs/configuration/backends/docker.md
+++ b/docs/configuration/backends/docker.md
@@ -110,7 +110,10 @@ To enable constraints see [provider-specific constraints section](/configuration
 # Required
 # Default: "unix:///var/run/docker.sock"
 #
-endpoint = "tcp://127.0.0.1:2375"
+# swarm classic (1.12-)
+# endpoint = "tcp://127.0.0.1:2375"
+# swarm intergated (1.12+)
+endpoint = "tcp://127.0.0.1:2377"
 
 # Default base domain used for the frontend rules.
 # Can be overridden by setting the "traefik.domain" label on a services.


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

According to docker's doc, https://docs.docker.com/engine/swarm/swarm-tutorial/#the-ip-address-of-the-manager-machine, port 2375 is replaced by 2377 for cluster management communications

### Motivation

<!-- What inspired you to submit this pull request? -->

Use port 2375 simply does not work with the new swarm the doc needs an update

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

`endpoint = "tcp://127.0.0.1:2377"` is only usable when launching traefik directly on the host. In a dockerized environment, `endpoint = "unix:///var/run/docker.sock"` should be used with a mounted volume `/var/run/docker.sock:/var/run/docker.sock`
