### PR TITLE
Fix partial declaration of authentication.

### DIFF
--- a/provider/label/partial.go
+++ b/provider/label/partial.go
@@ -109,6 +109,8 @@ func GetAuth(labels map[string]string) *types.Auth {
 		auth.Digest = getAuthDigest(labels)
 	} else if HasPrefix(labels, TraefikFrontendAuthForward) {
 		auth.Forward = getAuthForward(labels)
+	} else {
+		return nil
 	}
 
 	return auth

--- a/provider/label/partial_test.go
+++ b/provider/label/partial_test.go
@@ -733,6 +733,13 @@ func TestGetAuth(t *testing.T) {
 			expected: nil,
 		},
 		{
+			desc: "should return nil when no real auth",
+			labels: map[string]string{
+				TraefikFrontendAuthHeaderField: "myHeaderField",
+			},
+			expected: nil,
+		},
+		{
 			desc: "should return a basic auth",
 			labels: map[string]string{
 				TraefikFrontendAuthHeaderField:       "myHeaderField",


### PR DESCRIPTION
### What does this PR do?

Now, when the partial/invalid auth label is defined (eg. `traefik.frontend.auth.foobar`) the auth is skipped.

### Motivation

Fixes #4211

```go
Stack: goroutine 36 [running]:
github.com/containous/traefik/middlewares.recoverFunc(0x7f0ebb409540, 0xc00000c978, 0xc000117200)
	/go/src/github.com/containous/traefik/middlewares/recover.go:40 +0x1b7
panic(0x21e5ca0, 0x4551d40)
	/usr/local/go/src/runtime/panic.go:513 +0x1b9
github.com/containous/traefik/middlewares/auth.(*Authenticator).ServeHTTP(0xc0003ed820, 0x7f0ebb409540, 0xc00000c980, 0xc000117800, 0xc0003eddc0)
	/go/src/github.com/containous/traefik/middlewares/auth/authenticator.go:161 +0x29
github.com/containous/traefik/vendor/github.com/urfave/negroni.middleware.ServeHTTP(0x2949220, 0xc0003ed820, 0xc0003edae0, 0x7f0ebb409540, 0xc00000c980, 0xc000117800)
	/go/src/github.com/containous/traefik/vendor/github.com/urfave/negroni/negroni.go:33 +0x9c
github.com/containous/traefik/vendor/github.com/urfave/negroni.(*Negroni).ServeHTTP(0xc00018e060, 0x7f0ebb409540, 0xc00000c978, 0xc000117800)
	/go/src/github.com/containous/traefik/vendor/github.com/urfave/negroni/negroni.go:81 +0xee
github.com/containous/traefik/vendor/github.com/containous/mux.(*Router).ServeHTTP(0xc0006708a0, 0x7f0ebb409540, 0xc00000c978, 0xc000117800)
	/go/src/github.com/containous/traefik/vendor/github.com/containous/mux/mux.go:133 +0xf1
github.com/containous/traefik/middlewares.(*HandlerSwitcher).ServeHTTP(0xc0003055c0, 0x7f0ebb409540, 0xc00000c978, 0xc000117300)
	/go/src/github.com/containous/traefik/middlewares/handlerSwitcher.go:24 +0x6f
github.com/containous/traefik/vendor/github.com/urfave/negroni.Wrap.func1(0x7f0ebb409540, 0xc00000c978, 0xc000117300, 0xc0003edda0)
	/go/src/github.com/containous/traefik/vendor/github.com/urfave/negroni/negroni.go:41 +0x4d
github.com/containous/traefik/vendor/github.com/urfave/negroni.HandlerFunc.ServeHTTP(0xc00054b9a0, 0x7f0ebb409540, 0xc00000c978, 0xc000117300, 0xc0003edda0)
	/go/src/github.com/containous/traefik/vendor/github.com/urfave/negroni/negroni.go:24 +0x4e
github.com/containous/traefik/vendor/github.com/urfave/negroni.middleware.ServeHTTP(0x294dee0, 0xc00054b9a0, 0xc00054ba00, 0x7f0ebb409540, 0xc00000c978, 0xc000117300)
	/go/src/github.com/containous/traefik/vendor/github.com/urfave/negroni/negroni.go:33 +0x9c
github.com/containous/traefik/vendor/github.com/urfave/negroni.middleware.ServeHTTP-fm(0x7f0ebb409540, 0xc00000c978, 0xc000117300)
	/go/src/github.com/containous/traefik/vendor/github.com/urfave/negroni/negroni.go:33 +0x60
net/http.HandlerFunc.ServeHTTP(0xc0003edd80, 0x7f0ebb409540, 0xc00000c978, 0xc000117300)
	/usr/local/go/src/net/http/server.go:1964 +0x44
github.com/containous/traefik/middlewares.(*RequestHost).ServeHTTP(0x4592118, 0x7f0ebb409540, 0xc00000c978, 0xc000117200, 0xc0003edd80)
	/go/src/github.com/containous/traefik/middlewares/request_host.go:20 +0x1ec
github.com/containous/traefik/vendor/github.com/urfave/negroni.middleware.ServeHTTP(0x2949020, 0x4592118, 0xc00054b9e0, 0x7f0ebb409540, 0xc00000c978, 0xc000117200)
	/go/src/github.com/containous/traefik/vendor/github.com/urfave/negroni/negroni.go:33 +0x9c
github.com/containous/traefik/vendor/github.com/urfave/negroni.middleware.ServeHTTP-fm(0x7f0ebb409540, 0xc00000c978, 0xc000117200)
	/go/src/github.com/containous/traefik/vendor/github.com/urfave/negroni/negroni.go:33 +0x60
net/http.HandlerFunc.ServeHTTP(0xc0003edd60, 0x7f0ebb409540, 0xc00000c978, 0xc000117200)
	/usr/local/go/src/net/http/server.go:1964 +0x44
github.com/containous/traefik/middlewares.NegroniRecoverHandler.func1(0x7f0ebb409540, 0xc00000c978, 0xc000117200, 0xc0003edd60)
	/go/src/github.com/containous/traefik/middlewares/recover.go:24 +0x87
github.com/containous/traefik/vendor/github.com/urfave/negroni.HandlerFunc.ServeHTTP(0x27143e0, 0x7f0ebb409540, 0xc00000c978, 0xc000117200, 0xc0003edd60)
	/go/src/github.com/containous/traefik/vendor/github.com/urfave/negroni/negroni.go:24 +0x4e
github.com/containous/traefik/vendor/github.com/urfave/negroni.middleware.ServeHTTP(0x294dee0, 0x27143e0, 0xc00054b9c0, 0x7f0ebb409540, 0xc00000c978, 0xc000117200)
	/go/src/github.com/containous/traefik/vendor/github.com/urfave/negroni/negroni.go:33 +0x9c
github.com/containous/traefik/vendor/github.com/urfave/negroni.(*Negroni).ServeHTTP(0xc00058a030, 0x296fe60, 0xc00017ca80, 0xc000117200)
	/go/src/github.com/containous/traefik/vendor/github.com/urfave/negroni/negroni.go:81 +0xee
github.com/containous/traefik/vendor/github.com/containous/mux.(*Router).ServeHTTP(0xc000397d40, 0x296fe60, 0xc00017ca80, 0xc000117200)
	/go/src/github.com/containous/traefik/vendor/github.com/containous/mux/mux.go:133 +0xf1
github.com/containous/traefik/h2c.Server.Serve.func1(0x296fe60, 0xc00017ca80, 0xc000116f00)
	/go/src/github.com/containous/traefik/h2c/h2c.go:78 +0x409
net/http.HandlerFunc.ServeHTTP(0xc00054bc00, 0x296fe60, 0xc00017ca80, 0xc000116f00)
	/usr/local/go/src/net/http/server.go:1964 +0x44
net/http.serverHandler.ServeHTTP(0xc00002b1e0, 0x296fe60, 0xc00017ca80, 0xc000116f00)
	/usr/local/go/src/net/http/server.go:2741 +0xab
net/http.(*conn).serve(0xc0002d1360, 0x2972360, 0xc0004d3500)
	/usr/local/go/src/net/http/server.go:1847 +0x646
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:2851 +0x2f5
```

### More

- [x] Added/updated tests
- [-] Added/updated documentation
