### PR TITLE
Add a "Security Consideration" section in the Docker's backend section of the documentation

### DIFF
--- a/docs/configuration/backends/docker.md
+++ b/docs/configuration/backends/docker.md
@@ -57,9 +57,9 @@ watch = true
 exposedByDefault = true
 
 # Use the IP address from the binded port instead of the inner network one.
-# 
-# In case no IP address is attached to the binded port (or in case 
-# there is no bind), the inner network one will be used as a fallback.     
+#
+# In case no IP address is attached to the binded port (or in case
+# there is no bind), the inner network one will be used as a fallback.
 #
 # Optional
 # Default: false
@@ -337,26 +337,26 @@ Labels can be used on containers to override default behavior.
 | `traefik.frontend.whiteList.sourceRange=RANGE`                      | Sets a list of IP-Ranges which are allowed to access.<br>An unset or empty list allows all Source-IPs to access.<br>If one of the Net-Specifications are invalid, the whole list is invalid and allows all Source-IPs to access. |
 | `traefik.frontend.whiteList.useXForwardedFor=true`                  | Uses `X-Forwarded-For` header as valid source of IP for the white list.                                                                                                                                                          |
 
-[1] `traefik.docker.network`:  
-If a container is linked to several networks, be sure to set the proper network name (you can check with `docker inspect <container_id>`) otherwise it will randomly pick one (depending on how docker is returning them).  
+[1] `traefik.docker.network`:
+If a container is linked to several networks, be sure to set the proper network name (you can check with `docker inspect <container_id>`) otherwise it will randomly pick one (depending on how docker is returning them).
 For instance when deploying docker `stack` from compose files, the compose defined networks will be prefixed with the `stack` name.
 Or if your service references external network use it's name instead.
 
-[2] `traefik.frontend.auth.basic.users=EXPR `:  
-To create `user:password` pair, it's possible to use this command:  
-`echo $(htpasswd -nb user password) | sed -e s/\\$/\\$\\$/g`.  
+[2] `traefik.frontend.auth.basic.users=EXPR`:
+To create `user:password` pair, it's possible to use this command:
+`echo $(htpasswd -nb user password) | sed -e s/\\$/\\$\\$/g`.
 The result will be `user:$$apr1$$9Cv/OMGj$$ZomWQzuQbL.3TRCS81A1g/`, note additional symbol `$` makes escaping.
 
-[3] `traefik.backend.loadbalancer.swarm`:  
+[3] `traefik.backend.loadbalancer.swarm`:
 If you enable this option, Traefik will use the virtual IP provided by docker swarm instead of the containers IPs.
-Which means that Traefik will not perform any kind of load balancing and will delegate this task to swarm.  
+Which means that Traefik will not perform any kind of load balancing and will delegate this task to swarm.
 It also means that Traefik will manipulate only one backend, not one backend per container.
 
 #### Custom Headers
 
 | Label                                                 | Description                                                                                                                                                                         |
 |-------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `traefik.frontend.headers.customRequestHeaders=EXPR ` | Provides the container with custom request headers that will be appended to each request forwarded to the container.<br>Format: <code>HEADER:value&vert;&vert;HEADER2:value2</code> |
+| `traefik.frontend.headers.customRequestHeaders=EXPR` | Provides the container with custom request headers that will be appended to each request forwarded to the container.<br>Format: <code>HEADER:value&vert;&vert;HEADER2:value2</code> |
 | `traefik.frontend.headers.customResponseHeaders=EXPR` | Appends the headers to each response returned by the container, before forwarding the response to the client.<br>Format: <code>HEADER:value&vert;&vert;HEADER2:value2</code>        |
 
 #### Security Headers
@@ -371,7 +371,7 @@ It also means that Traefik will manipulate only one backend, not one backend per
 | `traefik.frontend.headers.customFrameOptionsValue=VALUE` | Overrides the `X-Frame-Options` header with the custom value.                                                                                                                                       |
 | `traefik.frontend.headers.forceSTSHeader=false`          | Adds the STS  header to non-SSL requests.                                                                                                                                                           |
 | `traefik.frontend.headers.frameDeny=false`               | Adds the `X-Frame-Options` header with the value of `DENY`.                                                                                                                                         |
-| `traefik.frontend.headers.hostsProxyHeaders=EXPR `       | Provides a list of headers that the proxied hostname may be stored.<br>Format: `HEADER1,HEADER2`                                                                                                    |
+| `traefik.frontend.headers.hostsProxyHeaders=EXPR`       | Provides a list of headers that the proxied hostname may be stored.<br>Format: `HEADER1,HEADER2`                                                                                                    |
 | `traefik.frontend.headers.isDevelopment=false`           | This will cause the `AllowedHosts`, `SSLRedirect`, and `STSSeconds`/`STSIncludeSubdomains` options to be ignored during development.<br>When deploying to production, be sure to set this to false. |
 | `traefik.frontend.headers.publicKey=VALUE`               | Adds HPKP header.                                                                                                                                                                                   |
 | `traefik.frontend.headers.referrerPolicy=VALUE`          | Adds referrer policy  header.                                                                                                                                                                       |
@@ -448,7 +448,7 @@ Segment labels override the default behavior.
 
 | Label                                                                | Description                                              |
 |----------------------------------------------------------------------|----------------------------------------------------------|
-| `traefik.<segment_name>.frontend.headers.customRequestHeaders=EXPR ` | Same as `traefik.frontend.headers.customRequestHeaders`  |
+| `traefik.<segment_name>.frontend.headers.customRequestHeaders=EXPR` | Same as `traefik.frontend.headers.customRequestHeaders`  |
 | `traefik.<segment_name>.frontend.headers.customResponseHeaders=EXPR` | Same as `traefik.frontend.headers.customResponseHeaders` |
 
 #### Security Headers

--- a/docs/configuration/backends/docker.md
+++ b/docs/configuration/backends/docker.md
@@ -191,7 +191,7 @@ by watching the Docker API through this socket.
 
 As explained on the Docker documentation: ([Docker Daemon Attack Surface page](https://docs.docker.com/engine/security/security/#docker-daemon-attack-surface)):
 
-```[...] only **trusted** users should be allowed to control your Docker daemon [...]'```
+`[...] only **trusted** users should be allowed to control your Docker daemon [...]`
 
 If the Traefik processes (handling requests from the outside world) is attacked,
 then the attacker can access the Docker (or Swarm Mode) backend.

--- a/docs/configuration/backends/docker.md
+++ b/docs/configuration/backends/docker.md
@@ -58,8 +58,8 @@ exposedByDefault = true
 
 # Use the IP address from the binded port instead of the inner network one.
 #
-# In case no IP address is attached to the binded port (or in case
-# there is no bind), the inner network one will be used as a fallback.    
+# In case no IP address is attached to the binded port (or in case 
+# there is no bind), the inner network one will be used as a fallback.     
 #
 # Optional
 # Default: false

--- a/docs/configuration/backends/docker.md
+++ b/docs/configuration/backends/docker.md
@@ -59,7 +59,7 @@ exposedByDefault = true
 # Use the IP address from the binded port instead of the inner network one.
 #
 # In case no IP address is attached to the binded port (or in case
-# there is no bind), the inner network one will be used as a fallback.
+# there is no bind), the inner network one will be used as a fallback.    
 #
 # Optional
 # Default: false
@@ -337,19 +337,19 @@ Labels can be used on containers to override default behavior.
 | `traefik.frontend.whiteList.sourceRange=RANGE`                      | Sets a list of IP-Ranges which are allowed to access.<br>An unset or empty list allows all Source-IPs to access.<br>If one of the Net-Specifications are invalid, the whole list is invalid and allows all Source-IPs to access. |
 | `traefik.frontend.whiteList.useXForwardedFor=true`                  | Uses `X-Forwarded-For` header as valid source of IP for the white list.                                                                                                                                                          |
 
-[1] `traefik.docker.network`:
-If a container is linked to several networks, be sure to set the proper network name (you can check with `docker inspect <container_id>`) otherwise it will randomly pick one (depending on how docker is returning them).
+[1] `traefik.docker.network`:  
+If a container is linked to several networks, be sure to set the proper network name (you can check with `docker inspect <container_id>`) otherwise it will randomly pick one (depending on how docker is returning them).  
 For instance when deploying docker `stack` from compose files, the compose defined networks will be prefixed with the `stack` name.
 Or if your service references external network use it's name instead.
 
-[2] `traefik.frontend.auth.basic.users=EXPR`:
-To create `user:password` pair, it's possible to use this command:
-`echo $(htpasswd -nb user password) | sed -e s/\\$/\\$\\$/g`.
+[2] `traefik.frontend.auth.basic.users=EXPR`:  
+To create `user:password` pair, it's possible to use this command:  
+`echo $(htpasswd -nb user password) | sed -e s/\\$/\\$\\$/g`.  
 The result will be `user:$$apr1$$9Cv/OMGj$$ZomWQzuQbL.3TRCS81A1g/`, note additional symbol `$` makes escaping.
 
-[3] `traefik.backend.loadbalancer.swarm`:
+[3] `traefik.backend.loadbalancer.swarm`:  
 If you enable this option, Traefik will use the virtual IP provided by docker swarm instead of the containers IPs.
-Which means that Traefik will not perform any kind of load balancing and will delegate this task to swarm.
+Which means that Traefik will not perform any kind of load balancing and will delegate this task to swarm.  
 It also means that Traefik will manipulate only one backend, not one backend per container.
 
 #### Custom Headers

--- a/docs/configuration/backends/docker.md
+++ b/docs/configuration/backends/docker.md
@@ -356,7 +356,7 @@ It also means that Traefik will manipulate only one backend, not one backend per
 
 | Label                                                 | Description                                                                                                                                                                         |
 |-------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `traefik.frontend.headers.customRequestHeaders=EXPR` | Provides the container with custom request headers that will be appended to each request forwarded to the container.<br>Format: <code>HEADER:value&vert;&vert;HEADER2:value2</code> |
+| `traefik.frontend.headers.customRequestHeaders=EXPR`  | Provides the container with custom request headers that will be appended to each request forwarded to the container.<br>Format: <code>HEADER:value&vert;&vert;HEADER2:value2</code> |
 | `traefik.frontend.headers.customResponseHeaders=EXPR` | Appends the headers to each response returned by the container, before forwarding the response to the client.<br>Format: <code>HEADER:value&vert;&vert;HEADER2:value2</code>        |
 
 #### Security Headers
@@ -371,7 +371,7 @@ It also means that Traefik will manipulate only one backend, not one backend per
 | `traefik.frontend.headers.customFrameOptionsValue=VALUE` | Overrides the `X-Frame-Options` header with the custom value.                                                                                                                                       |
 | `traefik.frontend.headers.forceSTSHeader=false`          | Adds the STS  header to non-SSL requests.                                                                                                                                                           |
 | `traefik.frontend.headers.frameDeny=false`               | Adds the `X-Frame-Options` header with the value of `DENY`.                                                                                                                                         |
-| `traefik.frontend.headers.hostsProxyHeaders=EXPR`       | Provides a list of headers that the proxied hostname may be stored.<br>Format: `HEADER1,HEADER2`                                                                                                    |
+| `traefik.frontend.headers.hostsProxyHeaders=EXPR`        | Provides a list of headers that the proxied hostname may be stored.<br>Format: `HEADER1,HEADER2`                                                                                                    |
 | `traefik.frontend.headers.isDevelopment=false`           | This will cause the `AllowedHosts`, `SSLRedirect`, and `STSSeconds`/`STSIncludeSubdomains` options to be ignored during development.<br>When deploying to production, be sure to set this to false. |
 | `traefik.frontend.headers.publicKey=VALUE`               | Adds HPKP header.                                                                                                                                                                                   |
 | `traefik.frontend.headers.referrerPolicy=VALUE`          | Adds referrer policy  header.                                                                                                                                                                       |
@@ -392,63 +392,63 @@ You can define as many segments as ports exposed in a container.
 
 Segment labels override the default behavior.
 
-| Label                                                                              | Description                                                            |
-|------------------------------------------------------------------------------------|------------------------------------------------------------------------|
-| `traefik.<segment_name>.backend=BACKEND`                                           | Same as `traefik.backend`                                              |
-| `traefik.<segment_name>.domain=DOMAIN`                                             | Same as `traefik.domain`                                               |
-| `traefik.<segment_name>.port=PORT`                                                 | Same as `traefik.port`                                                 |
-| `traefik.<segment_name>.protocol=http`                                             | Same as `traefik.protocol`                                             |
-| `traefik.<segment_name>.weight=10`                                                 | Same as `traefik.weight`                                               |
-| `traefik.<segment_name>.frontend.auth.basic=EXPR`                                  | Same as `traefik.frontend.auth.basic`                                  |
-| `traefik.<segment_name>.frontend.auth.basic.removeHeader=true`                     | Same as `traefik.frontend.auth.basic.removeHeader`                     |
-| `traefik.<segment_name>.frontend.auth.basic.users=EXPR`                            | Same as `traefik.frontend.auth.basic.users`                            |
-| `traefik.<segment_name>.frontend.auth.basic.usersFile=/path/.htpasswd`             | Same as `traefik.frontend.auth.basic.usersFile`                        |
-| `traefik.<segment_name>.frontend.auth.digest.removeHeader=true`                    | Same as `traefik.frontend.auth.digest.removeHeader`                    |
-| `traefik.<segment_name>.frontend.auth.digest.users=EXPR`                           | Same as `traefik.frontend.auth.digest.users`                           |
-| `traefik.<segment_name>.frontend.auth.digest.usersFile=/path/.htdigest`            | Same as `traefik.frontend.auth.digest.usersFile`                       |
-| `traefik.<segment_name>.frontend.auth.forward.address=https://example.com`         | Same as `traefik.frontend.auth.forward.address`                        |
-| `traefik.<segment_name>.frontend.auth.forward.authResponseHeaders=EXPR`            | Same as `traefik.frontend.auth.forward.authResponseHeaders`            |
-| `traefik.<segment_name>.frontend.auth.forward.tls.ca=/path/ca.pem`                 | Same as `traefik.frontend.auth.forward.tls.ca`                         |
-| `traefik.<segment_name>.frontend.auth.forward.tls.caOptional=true`                 | Same as `traefik.frontend.auth.forward.tls.caOptional`                 |
-| `traefik.<segment_name>.frontend.auth.forward.tls.cert=/path/server.pem`           | Same as `traefik.frontend.auth.forward.tls.cert`                       |
-| `traefik.<segment_name>.frontend.auth.forward.tls.insecureSkipVerify=true`         | Same as `traefik.frontend.auth.forward.tls.insecureSkipVerify`         |
-| `traefik.<segment_name>.frontend.auth.forward.tls.key=/path/server.key`            | Same as `traefik.frontend.auth.forward.tls.key`                        |
-| `traefik.<segment_name>.frontend.auth.forward.trustForwardHeader=true`             | Same as `traefik.frontend.auth.forward.trustForwardHeader`             |
-| `traefik.<segment_name>.frontend.auth.headerField=X-WebAuth-User`                  | Same as `traefik.frontend.auth.headerField`                            |
-| `traefik.<segment_name>.frontend.entryPoints=https`                                | Same as `traefik.frontend.entryPoints`                                 |
-| `traefik.<segment_name>.frontend.errors.<name>.backend=NAME`                       | Same as `traefik.frontend.errors.<name>.backend`                       |
-| `traefik.<segment_name>.frontend.errors.<name>.query=PATH`                         | Same as `traefik.frontend.errors.<name>.query`                         |
-| `traefik.<segment_name>.frontend.errors.<name>.status=RANGE`                       | Same as `traefik.frontend.errors.<name>.status`                        |
-| `traefik.<segment_name>.frontend.passHostHeader=true`                              | Same as `traefik.frontend.passHostHeader`                              |
-| `traefik.<segment_name>.frontend.passTLSClientCert.infos.notAfter=true`            | Same as `traefik.frontend.passTLSClientCert.infos.notAfter`            |
-| `traefik.<segment_name>.frontend.passTLSClientCert.infos.notBefore=true`           | Same as `traefik.frontend.passTLSClientCert.infos.notBefore`           |
-| `traefik.<segment_name>.frontend.passTLSClientCert.infos.sans=true`                | Same as `traefik.frontend.passTLSClientCert.infos.sans`                |
-| `traefik.<segment_name>.frontend.passTLSClientCert.infos.subject.commonName=true`  | Same as `traefik.frontend.passTLSClientCert.infos.subject.commonName`  |
-| `traefik.<segment_name>.frontend.passTLSClientCert.infos.subject.country=true`     | Same as `traefik.frontend.passTLSClientCert.infos.subject.country`     |
-| `traefik.<segment_name>.frontend.passTLSClientCert.infos.subject.locality=true`    | Same as `traefik.frontend.passTLSClientCert.infos.subject.locality`    |
-| `traefik.<segment_name>.frontend.passTLSClientCert.infos.subject.organization=true`| Same as `traefik.frontend.passTLSClientCert.infos.subject.organization`|
-| `traefik.<segment_name>.frontend.passTLSClientCert.infos.subject.province=true`    | Same as `traefik.frontend.passTLSClientCert.infos.subject.province`    |
-| `traefik.<segment_name>.frontend.passTLSClientCert.infos.subject.serialNumber=true`| Same as `traefik.frontend.passTLSClientCert.infos.subject.serialNumber`|
-| `traefik.<segment_name>.frontend.passTLSClientCert.pem=true`                       | Same as `traefik.frontend.passTLSClientCert.infos.pem`                 |
-| `traefik.<segment_name>.frontend.passTLSCert=true`                                 | Same as `traefik.frontend.passTLSCert`                                 |
-| `traefik.<segment_name>.frontend.priority=10`                                      | Same as `traefik.frontend.priority`                                    |
-| `traefik.<segment_name>.frontend.rateLimit.extractorFunc=EXP`                      | Same as `traefik.frontend.rateLimit.extractorFunc`                     |
-| `traefik.<segment_name>.frontend.rateLimit.rateSet.<name>.period=6`                | Same as `traefik.frontend.rateLimit.rateSet.<name>.period`             |
-| `traefik.<segment_name>.frontend.rateLimit.rateSet.<name>.average=6`               | Same as `traefik.frontend.rateLimit.rateSet.<name>.average`            |
-| `traefik.<segment_name>.frontend.rateLimit.rateSet.<name>.burst=6`                 | Same as `traefik.frontend.rateLimit.rateSet.<name>.burst`              |
-| `traefik.<segment_name>.frontend.redirect.entryPoint=https`                        | Same as `traefik.frontend.redirect.entryPoint`                         |
-| `traefik.<segment_name>.frontend.redirect.regex=^http://localhost/(.*)`            | Same as `traefik.frontend.redirect.regex`                              |
-| `traefik.<segment_name>.frontend.redirect.replacement=http://mydomain/$1`          | Same as `traefik.frontend.redirect.replacement`                        |
-| `traefik.<segment_name>.frontend.redirect.permanent=true`                          | Same as `traefik.frontend.redirect.permanent`                          |
-| `traefik.<segment_name>.frontend.rule=EXP`                                         | Same as `traefik.frontend.rule`                                        |
-| `traefik.<segment_name>.frontend.whiteList.sourceRange=RANGE`                      | Same as `traefik.frontend.whiteList.sourceRange`                       |
-| `traefik.<segment_name>.frontend.whiteList.useXForwardedFor=true`                  | Same as `traefik.frontend.whiteList.useXForwardedFor`                  |
+| Label                                                                               | Description                                                             |
+|-------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
+| `traefik.<segment_name>.backend=BACKEND`                                            | Same as `traefik.backend`                                               |
+| `traefik.<segment_name>.domain=DOMAIN`                                              | Same as `traefik.domain`                                                |
+| `traefik.<segment_name>.port=PORT`                                                  | Same as `traefik.port`                                                  |
+| `traefik.<segment_name>.protocol=http`                                              | Same as `traefik.protocol`                                              |
+| `traefik.<segment_name>.weight=10`                                                  | Same as `traefik.weight`                                                |
+| `traefik.<segment_name>.frontend.auth.basic=EXPR`                                   | Same as `traefik.frontend.auth.basic`                                   |
+| `traefik.<segment_name>.frontend.auth.basic.removeHeader=true`                      | Same as `traefik.frontend.auth.basic.removeHeader`                      |
+| `traefik.<segment_name>.frontend.auth.basic.users=EXPR`                             | Same as `traefik.frontend.auth.basic.users`                             |
+| `traefik.<segment_name>.frontend.auth.basic.usersFile=/path/.htpasswd`              | Same as `traefik.frontend.auth.basic.usersFile`                         |
+| `traefik.<segment_name>.frontend.auth.digest.removeHeader=true`                     | Same as `traefik.frontend.auth.digest.removeHeader`                     |
+| `traefik.<segment_name>.frontend.auth.digest.users=EXPR`                            | Same as `traefik.frontend.auth.digest.users`                            |
+| `traefik.<segment_name>.frontend.auth.digest.usersFile=/path/.htdigest`             | Same as `traefik.frontend.auth.digest.usersFile`                        |
+| `traefik.<segment_name>.frontend.auth.forward.address=https://example.com`          | Same as `traefik.frontend.auth.forward.address`                         |
+| `traefik.<segment_name>.frontend.auth.forward.authResponseHeaders=EXPR`             | Same as `traefik.frontend.auth.forward.authResponseHeaders`             |
+| `traefik.<segment_name>.frontend.auth.forward.tls.ca=/path/ca.pem`                  | Same as `traefik.frontend.auth.forward.tls.ca`                          |
+| `traefik.<segment_name>.frontend.auth.forward.tls.caOptional=true`                  | Same as `traefik.frontend.auth.forward.tls.caOptional`                  |
+| `traefik.<segment_name>.frontend.auth.forward.tls.cert=/path/server.pem`            | Same as `traefik.frontend.auth.forward.tls.cert`                        |
+| `traefik.<segment_name>.frontend.auth.forward.tls.insecureSkipVerify=true`          | Same as `traefik.frontend.auth.forward.tls.insecureSkipVerify`          |
+| `traefik.<segment_name>.frontend.auth.forward.tls.key=/path/server.key`             | Same as `traefik.frontend.auth.forward.tls.key`                         |
+| `traefik.<segment_name>.frontend.auth.forward.trustForwardHeader=true`              | Same as `traefik.frontend.auth.forward.trustForwardHeader`              |
+| `traefik.<segment_name>.frontend.auth.headerField=X-WebAuth-User`                   | Same as `traefik.frontend.auth.headerField`                             |
+| `traefik.<segment_name>.frontend.entryPoints=https`                                 | Same as `traefik.frontend.entryPoints`                                  |
+| `traefik.<segment_name>.frontend.errors.<name>.backend=NAME`                        | Same as `traefik.frontend.errors.<name>.backend`                        |
+| `traefik.<segment_name>.frontend.errors.<name>.query=PATH`                          | Same as `traefik.frontend.errors.<name>.query`                          |
+| `traefik.<segment_name>.frontend.errors.<name>.status=RANGE`                        | Same as `traefik.frontend.errors.<name>.status`                         |
+| `traefik.<segment_name>.frontend.passHostHeader=true`                               | Same as `traefik.frontend.passHostHeader`                               |
+| `traefik.<segment_name>.frontend.passTLSClientCert.infos.notAfter=true`             | Same as `traefik.frontend.passTLSClientCert.infos.notAfter`             |
+| `traefik.<segment_name>.frontend.passTLSClientCert.infos.notBefore=true`            | Same as `traefik.frontend.passTLSClientCert.infos.notBefore`            |
+| `traefik.<segment_name>.frontend.passTLSClientCert.infos.sans=true`                 | Same as `traefik.frontend.passTLSClientCert.infos.sans`                 |
+| `traefik.<segment_name>.frontend.passTLSClientCert.infos.subject.commonName=true`   | Same as `traefik.frontend.passTLSClientCert.infos.subject.commonName`   |
+| `traefik.<segment_name>.frontend.passTLSClientCert.infos.subject.country=true`      | Same as `traefik.frontend.passTLSClientCert.infos.subject.country`      |
+| `traefik.<segment_name>.frontend.passTLSClientCert.infos.subject.locality=true`     | Same as `traefik.frontend.passTLSClientCert.infos.subject.locality`     |
+| `traefik.<segment_name>.frontend.passTLSClientCert.infos.subject.organization=true` | Same as `traefik.frontend.passTLSClientCert.infos.subject.organization` |
+| `traefik.<segment_name>.frontend.passTLSClientCert.infos.subject.province=true`     | Same as `traefik.frontend.passTLSClientCert.infos.subject.province`     |
+| `traefik.<segment_name>.frontend.passTLSClientCert.infos.subject.serialNumber=true` | Same as `traefik.frontend.passTLSClientCert.infos.subject.serialNumber` |
+| `traefik.<segment_name>.frontend.passTLSClientCert.pem=true`                        | Same as `traefik.frontend.passTLSClientCert.infos.pem`                  |
+| `traefik.<segment_name>.frontend.passTLSCert=true`                                  | Same as `traefik.frontend.passTLSCert`                                  |
+| `traefik.<segment_name>.frontend.priority=10`                                       | Same as `traefik.frontend.priority`                                     |
+| `traefik.<segment_name>.frontend.rateLimit.extractorFunc=EXP`                       | Same as `traefik.frontend.rateLimit.extractorFunc`                      |
+| `traefik.<segment_name>.frontend.rateLimit.rateSet.<name>.period=6`                 | Same as `traefik.frontend.rateLimit.rateSet.<name>.period`              |
+| `traefik.<segment_name>.frontend.rateLimit.rateSet.<name>.average=6`                | Same as `traefik.frontend.rateLimit.rateSet.<name>.average`             |
+| `traefik.<segment_name>.frontend.rateLimit.rateSet.<name>.burst=6`                  | Same as `traefik.frontend.rateLimit.rateSet.<name>.burst`               |
+| `traefik.<segment_name>.frontend.redirect.entryPoint=https`                         | Same as `traefik.frontend.redirect.entryPoint`                          |
+| `traefik.<segment_name>.frontend.redirect.regex=^http://localhost/(.*)`             | Same as `traefik.frontend.redirect.regex`                               |
+| `traefik.<segment_name>.frontend.redirect.replacement=http://mydomain/$1`           | Same as `traefik.frontend.redirect.replacement`                         |
+| `traefik.<segment_name>.frontend.redirect.permanent=true`                           | Same as `traefik.frontend.redirect.permanent`                           |
+| `traefik.<segment_name>.frontend.rule=EXP`                                          | Same as `traefik.frontend.rule`                                         |
+| `traefik.<segment_name>.frontend.whiteList.sourceRange=RANGE`                       | Same as `traefik.frontend.whiteList.sourceRange`                        |
+| `traefik.<segment_name>.frontend.whiteList.useXForwardedFor=true`                   | Same as `traefik.frontend.whiteList.useXForwardedFor`                   |
 
 #### Custom Headers
 
 | Label                                                                | Description                                              |
 |----------------------------------------------------------------------|----------------------------------------------------------|
-| `traefik.<segment_name>.frontend.headers.customRequestHeaders=EXPR` | Same as `traefik.frontend.headers.customRequestHeaders`  |
+| `traefik.<segment_name>.frontend.headers.customRequestHeaders=EXPR`  | Same as `traefik.frontend.headers.customRequestHeaders`  |
 | `traefik.<segment_name>.frontend.headers.customResponseHeaders=EXPR` | Same as `traefik.frontend.headers.customResponseHeaders` |
 
 #### Security Headers


### PR DESCRIPTION
### What does this PR do?

It adds a section "Security Consideration" in the Docker backend's configuration section, in the documentation.

### Motivation

This new documentation section about Security relates to #4174 , to explains the risk and the ways to leverage or compensate.

It also provides a way to achieve Traefik container's scheduling on worker node with Swarm mode.

### More

- ~[ ] Added/updated tests~
- [x] Added/updated documentation

### Additional Notes

Nope
