### PR TITLE
Log configuration errors from providers and keeps listening

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -356,10 +356,14 @@ func (s *Server) listenProviders(stop chan bool) {
 		case <-stop:
 			return
 		case configMsg, ok := <-s.configurationChan:
-			if !ok || configMsg.Configuration == nil {
+			if !ok {
 				return
 			}
-			s.preLoadConfiguration(configMsg)
+			if configMsg.Configuration != nil {
+				s.preLoadConfiguration(configMsg)
+			} else {
+				log.Debugf("Received nil configuration from provider %q, skipping.", configMsg.ProviderName)
+			}
 		}
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Fixes the fact that traefik used to stop listening for configuration from providers after having received a nil Configuration message.

### Additional Notes

Fixes #3974 
