### PR TITLE
Filter ECS tasks by LastStatus before adding to list of service tasks

### DIFF
--- a/provider/ecs/ecs.go
+++ b/provider/ecs/ecs.go
@@ -240,7 +240,9 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 					log.Errorf("Unable to describe tasks for %v", page.TaskArns)
 				} else {
 					for _, t := range resp.Tasks {
-						tasks[aws.StringValue(t.TaskArn)] = t
+						lastStatus = aws.StringValue(t.LastStatus):
+                        if t.LastStatus == ecs.DesiredStatusRunning:
+						    tasks[aws.StringValue(t.TaskArn)] = t
 					}
 				}
 			}

--- a/provider/ecs/ecs.go
+++ b/provider/ecs/ecs.go
@@ -240,9 +240,9 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 					log.Errorf("Unable to describe tasks for %v", page.TaskArns)
 				} else {
 					for _, t := range resp.Tasks {
-						lastStatus = aws.StringValue(t.LastStatus):
-                        if t.LastStatus == ecs.DesiredStatusRunning:
-						    tasks[aws.StringValue(t.TaskArn)] = t
+						if aws.StringValue(t.LastStatus) == ecs.DesiredStatusRunning {
+							tasks[aws.StringValue(t.TaskArn)] = t
+						}
 					}
 				}
 			}


### PR DESCRIPTION
### What does this PR do?

Filters ECS tasks by their LastStatus, only adding them to the list of tasks if they are RUNNING

### Motivation

Fixes https://github.com/containous/traefik/issues/4249


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
