### PR TITLE
Fix label segmentation when using custom prefix

### DIFF
--- a/provider/consulcatalog/consul_catalog.go
+++ b/provider/consulcatalog/consul_catalog.go
@@ -578,7 +578,7 @@ func (p *Provider) generateFrontends(service *serviceUpdate) []*serviceUpdate {
 	})
 
 	// loop over children of <prefix>.frontends.*
-	for _, frontend := range getSegments(p.Prefix+".frontends", p.Prefix, service.TraefikLabels) {
+	for _, frontend := range getSegments(label.Prefix+"frontends", label.Prefix, service.TraefikLabels) {
 		frontends = append(frontends, &serviceUpdate{
 			ServiceName:       service.ServiceName + "-" + frontend.Name,
 			ParentServiceName: service.ServiceName,
@@ -589,6 +589,7 @@ func (p *Provider) generateFrontends(service *serviceUpdate) []*serviceUpdate {
 
 	return frontends
 }
+
 func getSegments(path string, prefix string, tree map[string]string) []*frontendSegment {
 	segments := make([]*frontendSegment, 0)
 	// find segment names
@@ -598,13 +599,12 @@ func getSegments(path string, prefix string, tree map[string]string) []*frontend
 			segmentNames[strings.SplitN(strings.TrimPrefix(key, path+"."), ".", 2)[0]] = true
 		}
 	}
-
 	// get labels for each segment found
 	for segment := range segmentNames {
 		labels := make(map[string]string)
 		for key, value := range tree {
 			if strings.HasPrefix(key, path+"."+segment) {
-				labels[prefix+".frontend"+strings.TrimPrefix(key, path+"."+segment)] = value
+				labels[prefix+"frontend"+strings.TrimPrefix(key, path+"."+segment)] = value
 			}
 		}
 		segments = append(segments, &frontendSegment{


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

This fixes a bug with the consul catalog label segmentation when using a custom prefix (other than `traefik`). I found this on our QA system when implementing a second traefik cluster for internal traffic. 


### Motivation

I never realised that Provider.label is actually being reset to the standard one: https://github.com/containous/traefik/blob/v1.7/provider/consulcatalog/convert_types.go#L22

### More

- Added a test to reflect this use case

### Additional Notes

<!-- Anything else we should know when reviewing? -->
