### PR TITLE
Properly check request context for secure middleware

### DIFF
--- a/middlewares/secure.go
+++ b/middlewares/secure.go
@@ -1,37 +1,75 @@
 package middlewares
 
 import (
+	"net/http"
+	"strings"
+
 	"github.com/containous/traefik/types"
 	"github.com/unrolled/secure"
 )
 
+type SecureConfig struct {
+	Secure *secure.Secure
+}
+
 // NewSecure constructs a new Secure instance with supplied options.
-func NewSecure(headers *types.Headers) *secure.Secure {
+func NewSecure(headers *types.Headers) *SecureConfig {
 	if headers == nil || !headers.HasSecureHeadersDefined() {
 		return nil
 	}
 
-	opt := secure.Options{
-		AllowedHosts:            headers.AllowedHosts,
-		HostsProxyHeaders:       headers.HostsProxyHeaders,
-		SSLRedirect:             headers.SSLRedirect,
-		SSLTemporaryRedirect:    headers.SSLTemporaryRedirect,
-		SSLHost:                 headers.SSLHost,
-		SSLForceHost:            headers.SSLForceHost,
-		SSLProxyHeaders:         headers.SSLProxyHeaders,
-		STSSeconds:              headers.STSSeconds,
-		STSIncludeSubdomains:    headers.STSIncludeSubdomains,
-		STSPreload:              headers.STSPreload,
-		ForceSTSHeader:          headers.ForceSTSHeader,
-		FrameDeny:               headers.FrameDeny,
-		CustomFrameOptionsValue: headers.CustomFrameOptionsValue,
-		ContentTypeNosniff:      headers.ContentTypeNosniff,
-		BrowserXssFilter:        headers.BrowserXSSFilter,
-		CustomBrowserXssValue:   headers.CustomBrowserXSSValue,
-		ContentSecurityPolicy:   headers.ContentSecurityPolicy,
-		PublicKey:               headers.PublicKey,
-		ReferrerPolicy:          headers.ReferrerPolicy,
-		IsDevelopment:           headers.IsDevelopment,
+	return &SecureConfig{
+		Secure: secure.New(secure.Options{
+			AllowedHosts:            headers.AllowedHosts,
+			HostsProxyHeaders:       headers.HostsProxyHeaders,
+			SSLRedirect:             headers.SSLRedirect,
+			SSLTemporaryRedirect:    headers.SSLTemporaryRedirect,
+			SSLHost:                 headers.SSLHost,
+			SSLForceHost:            headers.SSLForceHost,
+			SSLProxyHeaders:         headers.SSLProxyHeaders,
+			STSSeconds:              headers.STSSeconds,
+			STSIncludeSubdomains:    headers.STSIncludeSubdomains,
+			STSPreload:              headers.STSPreload,
+			ForceSTSHeader:          headers.ForceSTSHeader,
+			FrameDeny:               headers.FrameDeny,
+			CustomFrameOptionsValue: headers.CustomFrameOptionsValue,
+			ContentTypeNosniff:      headers.ContentTypeNosniff,
+			BrowserXssFilter:        headers.BrowserXSSFilter,
+			CustomBrowserXssValue:   headers.CustomBrowserXSSValue,
+			ContentSecurityPolicy:   headers.ContentSecurityPolicy,
+			PublicKey:               headers.PublicKey,
+			ReferrerPolicy:          headers.ReferrerPolicy,
+			IsDevelopment:           headers.IsDevelopment,
+		}),
 	}
-	return secure.New(opt)
+}
+
+// HandlerFuncWithNextForRequestOnlyWithContextCheck is a special wrapper for Traefik that checks the context for stripped/modified paths.
+// Note that this is for requests only and will not write any headers.
+func (s *SecureConfig) HandlerFuncWithNextForRequestOnlyWithContextCheck(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	requestURL := r.URL
+
+	if stripPrefix, stripPrefixOk := r.Context().Value(StripPrefixKey).(string); stripPrefixOk {
+		if len(stripPrefix) > 0 {
+			requestURL.Path = stripPrefix
+		}
+	}
+
+	if addPrefix, addPrefixOk := r.Context().Value(AddPrefixKey).(string); addPrefixOk {
+		if len(addPrefix) > 0 {
+			requestURL.Path = strings.Replace(requestURL.Path, addPrefix, "", 1)
+		}
+	}
+
+	if replacePath, replacePathOk := r.Context().Value(ReplacePathKey).(string); replacePathOk {
+		if len(replacePath) > 0 {
+			requestURL.Path = replacePath
+		}
+	}
+
+	r.URL = requestURL
+	// make sure the request URI corresponds the rewritten URL
+	r.RequestURI = r.URL.RequestURI()
+
+	s.Secure.HandlerFuncWithNextForRequestOnly(w, r, next)
 }

--- a/middlewares/secure.go
+++ b/middlewares/secure.go
@@ -8,6 +8,7 @@ import (
 	"github.com/unrolled/secure"
 )
 
+// SecureConfig is a wrapper for a Secure instance to allow extension.
 type SecureConfig struct {
 	Secure *secure.Secure
 }

--- a/middlewares/secure_test.go
+++ b/middlewares/secure_test.go
@@ -8,14 +8,13 @@ import (
 	"github.com/containous/traefik/testhelpers"
 	"github.com/containous/traefik/types"
 	"github.com/stretchr/testify/assert"
-	"github.com/unrolled/secure"
 )
 
 func TestSSLForceHost(t *testing.T) {
 	testCases := []struct {
 		desc             string
 		host             string
-		secureMiddleware *secure.Secure
+		secureMiddleware *SecureConfig
 		expected         int
 	}{
 		{
@@ -88,7 +87,7 @@ func TestSSLForceHost(t *testing.T) {
 			}
 
 			rw := httptest.NewRecorder()
-			test.secureMiddleware.HandlerFuncWithNextForRequestOnly(rw, req, next)
+			test.secureMiddleware.HandlerFuncWithNextForRequestOnlyWithContextCheck(rw, req, next)
 
 			assert.Equal(t, test.expected, rw.Result().StatusCode)
 		})

--- a/server/server_middlewares.go
+++ b/server/server_middlewares.go
@@ -95,7 +95,7 @@ func (s *Server) buildMiddlewares(frontendName string, frontend *types.Frontend,
 	if secureMiddleware != nil {
 		log.Debugf("Adding secure middleware for frontend %s", frontendName)
 
-		handler := negroni.HandlerFunc(secureMiddleware.HandlerFuncWithNextForRequestOnly)
+		handler := negroni.HandlerFunc(secureMiddleware.HandlerFuncWithNextForRequestOnlyWithContextCheck)
 		middle = append(middle, handler)
 	}
 
@@ -335,10 +335,10 @@ func (s *Server) wrapHTTPHandlerWithAccessLog(handler http.Handler, frontendName
 	return handler
 }
 
-func buildModifyResponse(secure *secure.Secure, header *middlewares.HeaderStruct) func(res *http.Response) error {
+func buildModifyResponse(secure *middlewares.SecureConfig, header *middlewares.HeaderStruct) func(res *http.Response) error {
 	return func(res *http.Response) error {
 		if secure != nil {
-			if err := secure.ModifyResponseHeaders(res); err != nil {
+			if err := secure.Secure.ModifyResponseHeaders(res); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
### What does this PR do?

Wraps the secure middleware to extend the handler functions to enable context checking.

### Motivation

Fixes #4085 

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation
