### PR TITLE
Retry middleware : store headers per attempts and propagate them when responding.

### DIFF
--- a/middlewares/retry_test.go
+++ b/middlewares/retry_test.go
@@ -1,8 +1,10 @@
 package middlewares
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httptrace"
 	"strings"
 	"testing"
 
@@ -254,5 +256,47 @@ func TestRetryWithFlush(t *testing.T) {
 
 	if responseRecorder.Body.String() != "FULL DATA" {
 		t.Errorf("Wrong body %q want %q", responseRecorder.Body.String(), "FULL DATA")
+	}
+}
+
+func TestMultipleRetriesShouldNotLooseHeaders(t *testing.T) {
+	attempt := 0
+	expectedHeaderName := "X-Foo-Test-2"
+	expectedHeaderValue := "bar"
+
+	next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		headerName := fmt.Sprintf("X-Foo-Test-%d", attempt)
+		rw.Header().Add(headerName, expectedHeaderValue)
+		if attempt < 2 {
+			attempt++
+			return
+		}
+
+		// Request has been successfully written to backend
+		trace := httptrace.ContextClientTrace(req.Context())
+		trace.WroteHeaders()
+
+		// And we decide to answer to client
+		rw.WriteHeader(http.StatusNoContent)
+	})
+
+	retry := NewRetry(3, next, &countingRetryListener{})
+	responseRecorder := httptest.NewRecorder()
+	retry.ServeHTTP(responseRecorder, &http.Request{})
+
+	headerValue := responseRecorder.Header().Get(expectedHeaderName)
+
+	// Validate if we have the correct header
+	if headerValue != expectedHeaderValue {
+		t.Errorf("Expected to have %s for header %s, got %s", expectedHeaderValue, expectedHeaderName, headerValue)
+	}
+
+	// Validate that we don't have headers from previous attempts
+	for i := 0; i < attempt; i++ {
+		headerName := fmt.Sprintf("X-Foo-Test-%d", i)
+		headerValue = responseRecorder.Header().Get("headerName")
+		if headerValue != "" {
+			t.Errorf("Expected no value for header %s, got %s", headerName, headerValue)
+		}
 	}
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

Make the `retryResponseWriter` store headers written during the attempt only write them when the attempt is successful. 

Fixes #3975 

### Motivation

<!-- What inspired you to submit this pull request? -->
The retry middleware was loosing response headers written before the request was actually sent to the backend.
This behaviour is caused by [this](https://github.com/containous/traefik/blob/v1.7/middlewares/retry.go#L124) line. 

This is what was happening when sticking a request to a backend for instance (see [here](https://github.com/containous/traefik/blob/ae1569514e87c42f7d5652f8bf1b98cf9d67afa2/vendor/github.com/vulcand/oxy/roundrobin/rebalancer.go#L205)).

To fix that, we make the `retryResponseWriter` carry a header map which represent the
headers gathered for the attempt. Then we propagate this header map to the response if only we decide to respond to the client. 

### More

- [x] Added/updated tests
- [ ] Added/updated documentation (not relevant)