### PR TITLE
Harden Traefik systemd service

### DIFF
--- a/contrib/systemd/traefik.service
+++ b/contrib/systemd/traefik.service
@@ -1,11 +1,41 @@
 [Unit]
 Description=Traefik
+Documentation=https://docs.traefik.io
+After=network-online.target
+AssertFileIsExecutable=/usr/bin/traefik
+AssertPathExists=/etc/traefik/traefik.toml
 
 [Service]
+# Run traefik as its own user (create new user with: useradd -r -s /bin/false -U -M traefik)
+#User=traefik
+#AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+# configure service behavior
 Type=notify
-ExecStart=/usr/bin/traefik --configFile=/etc/traefik.toml
+ExecStart=/usr/bin/traefik --configFile=/etc/traefik/traefik.toml
 Restart=always
 WatchdogSec=1s
+
+# lock down system access
+# prohibit any operating system and configuration modification
+ProtectSystem=strict
+# create separate, new (and empty) /tmp and /var/tmp filesystems
+PrivateTmp=true
+# make /home directories inaccessible
+ProtectHome=true
+# turns off access to physical devices (/dev/...)
+PrivateDevices=true
+# make kernel settings (procfs and sysfs) read-only
+ProtectKernelTunables=true
+# make cgroups /sys/fs/cgroup read-only
+ProtectControlGroups=true
+
+# allow writing of acme.json
+ReadWritePaths=/etc/traefik/acme.json
+# depending on log and entrypoint configuration, you may need to allow writing to other paths, too
+
+# limit number of processes in this unit
+LimitNPROC=1
 
 [Install]
 WantedBy=multi-user.target

--- a/contrib/systemd/traefik.service
+++ b/contrib/systemd/traefik.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=Traefik
 Documentation=https://docs.traefik.io
-After=network-online.target
-AssertFileIsExecutable=/usr/bin/traefik
-AssertPathExists=/etc/traefik/traefik.toml
+#After=network-online.target
+#AssertFileIsExecutable=/usr/bin/traefik
+#AssertPathExists=/etc/traefik/traefik.toml
 
 [Service]
 # Run traefik as its own user (create new user with: useradd -r -s /bin/false -U -M traefik)
@@ -12,30 +12,30 @@ AssertPathExists=/etc/traefik/traefik.toml
 
 # configure service behavior
 Type=notify
-ExecStart=/usr/bin/traefik --configFile=/etc/traefik/traefik.toml
+#ExecStart=/usr/bin/traefik --configFile=/etc/traefik/traefik.toml
 Restart=always
 WatchdogSec=1s
 
 # lock down system access
 # prohibit any operating system and configuration modification
-ProtectSystem=strict
+#ProtectSystem=strict
 # create separate, new (and empty) /tmp and /var/tmp filesystems
-PrivateTmp=true
+#PrivateTmp=true
 # make /home directories inaccessible
-ProtectHome=true
+#ProtectHome=true
 # turns off access to physical devices (/dev/...)
-PrivateDevices=true
+#PrivateDevices=true
 # make kernel settings (procfs and sysfs) read-only
-ProtectKernelTunables=true
+#ProtectKernelTunables=true
 # make cgroups /sys/fs/cgroup read-only
-ProtectControlGroups=true
+#ProtectControlGroups=true
 
 # allow writing of acme.json
-ReadWritePaths=/etc/traefik/acme.json
+#ReadWritePaths=/etc/traefik/acme.json
 # depending on log and entrypoint configuration, you may need to allow writing to other paths, too
 
 # limit number of processes in this unit
-LimitNPROC=1
+#LimitNPROC=1
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Since Traefik is running as root on the system, it makes sense to
apply various lock down measures to keep the system as safe as possible.

Includes mounting most of the directories as read-only or even making them
inaccessible, restricting kernel modifications and limiting the number of
processes the unit may spawn.

Also add checks at service startup to ensure all required files are present.