### PR TITLE
kubernetes: sort and uniq TLS secrets

### DIFF
--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -2912,13 +2912,13 @@ func TestGetTLS(t *testing.T) {
 				},
 			},
 			result: map[string]*tls.Configuration{
-				"test-secret": {
+				"testing/test-secret": {
 					Certificate: &tls.Certificate{
 						CertFile: tls.FileOrContent("tls-crt"),
 						KeyFile:  tls.FileOrContent("tls-key"),
 					},
 				},
-				"test-secret2": {
+				"testing/test-secret2": {
 					Certificate: &tls.Certificate{
 						CertFile: tls.FileOrContent("tls-crt"),
 						KeyFile:  tls.FileOrContent("tls-key"),
@@ -2949,7 +2949,7 @@ func TestGetTLS(t *testing.T) {
 				},
 			},
 			result: map[string]*tls.Configuration{
-				"test-secret": {
+				"testing/test-secret": {
 					EntryPoints: []string{"api-secure", "https"},
 					Certificate: &tls.Certificate{
 						CertFile: tls.FileOrContent("tls-crt"),


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

This PR sorts and de-dups the set of TLS certs that come from Kubernetes Ingress objects. When not sorted consistently, Traefik believes the config has changed and unnecessarily reloads the server configuration.

Fixes #4187. Note that the issue is simply 2+ Ingress-referenced TLS certs which just happens to be common when using wildcards. Wildcards are not the actual issue.
Fixes #4245.

### Motivation

Fixing a bug. 😄 

### More

- [x] Added/updated tests

### Additional Notes

Background: Kubernetes returns the list of Ingress objects in varied order. Traefik processes the frontends and backends according to named keys (a standard dict/hash), which avoids any ordering issue.

In contrast, Traefik looks up the TLS secrets and simply appends them to an array. Because the Ingresses vary in order, so does the array of TLS secrets. This only applies to TLS certs referenced as part of an Ingress, since it's all local to the Kubernetes provider.

Further, if a given secret is referenced by more than one Ingress (typical when using wildcard or SAN certs), the cert is appended to the TLS array multiple times. This results in unnecessary warnings "Into EntryPoint https, try to add certificate for domains which already have this certificate ...". 

This PR sorts and de-dups the TLS certs by the Secret name. To accommodate configurations where Ingresses have different entrypoint lists, it also merges (and sorts) those.

It has been tested on our staging server which has a rather complex set of Ingresses. So far, all unnecessary reloads are gone.