### PR TITLE
Check for anchors (hashes) for external links on the documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,6 +236,14 @@ $ make docs-clean docs-verify
 ...
 ```
 
+Please note that verification can be disabled by setting the environment variable `DOCS_VERIFY_SKIP` to `true`:
+
+```shell
+DOCS_VERIFY_SKIP=true make docs-verify
+...
+DOCS_LINT_SKIP is true: no linting done.
+```
+
 ## How to Write a Good Issue
 
 Please keep in mind that the GitHub issue tracker is not intended as a general support forum, but for reporting bugs and feature requests.

--- a/docs/user-guide/swarm-mode.md
+++ b/docs/user-guide/swarm-mode.md
@@ -7,7 +7,7 @@ The cluster consists of:
 - 3 servers
 - 1 manager
 - 2 workers
-- 1 [overlay](https://docs.docker.com/engine/userguide/networking/dockernetworks/#an-overlay-network) network (multi-host networking)
+- 1 [overlay](https://docs.docker.com/network/overlay/) network (multi-host networking)
 
 
 ## Prerequisites

--- a/docs/user-guide/swarm.md
+++ b/docs/user-guide/swarm.md
@@ -7,7 +7,7 @@ The cluster consists of:
 - 2 servers
 - 1 swarm master
 - 2 swarm nodes
-- 1 [overlay](https://docs.docker.com/engine/userguide/networking/dockernetworks/#an-overlay-network) network (multi-host networking)
+- 1 [overlay](https://docs.docker.com/network/overlay/) network (multi-host networking)
 
 ## Prerequisites
 

--- a/script/docs-verify-docker-image/validate.sh
+++ b/script/docs-verify-docker-image/validate.sh
@@ -20,7 +20,7 @@ find "${PATH_TO_SITE}" -type f -not -path "/app/site/theme/*" \
   --check-html \
   --check_external_hash \
   --alt_ignore="/traefik.logo.png/" \
-  --url-ignore "/localhost:/,/127.0.0.1:/,/fonts.gstatic.com/,/.minikube/,/github.com\/containous\/traefik\/*edit*/,/github.com\/containous\/traefik\/$/" \
+  --url-ignore "/https://groups.google.com/a/traefik.io/forum/#!forum/security/,/localhost:/,/127.0.0.1:/,/fonts.gstatic.com/,/.minikube/,/github.com\/containous\/traefik\/*edit*/,/github.com\/containous\/traefik\/$/" \
   '{}'
 ## HTML-proofer options at https://github.com/gjtorikian/html-proofer#configuration
 

--- a/script/docs-verify-docker-image/validate.sh
+++ b/script/docs-verify-docker-image/validate.sh
@@ -20,6 +20,7 @@ find "${PATH_TO_SITE}" -type f -not -path "/app/site/theme/*" \
   --check-html \
   --check_external_hash \
   --alt_ignore="/traefik.logo.png/" \
+  --http_status_ignore="0,500,501,503" \
   --url-ignore "/https://groups.google.com/a/traefik.io/forum/#!forum/security/,/localhost:/,/127.0.0.1:/,/fonts.gstatic.com/,/.minikube/,/github.com\/containous\/traefik\/*edit*/,/github.com\/containous\/traefik\/$/" \
   '{}'
 ## HTML-proofer options at https://github.com/gjtorikian/html-proofer#configuration

--- a/script/docs-verify-docker-image/validate.sh
+++ b/script/docs-verify-docker-image/validate.sh
@@ -18,7 +18,7 @@ find "${PATH_TO_SITE}" -type f -not -path "/app/site/theme/*" \
 | xargs -0 -r -P "${NUMBER_OF_CPUS}" -I '{}' \
   htmlproofer \
   --check-html \
-  --only_4xx \
+  --check_external_hash \
   --alt_ignore="/traefik.logo.png/" \
   --url-ignore "/localhost:/,/127.0.0.1:/,/fonts.gstatic.com/,/.minikube/,/github.com\/containous\/traefik\/*edit*/,/github.com\/containous\/traefik\/$/" \
   '{}'


### PR DESCRIPTION
### What does this PR do?

This PR adds a check for hashes (HTML anchor) on the documentation links on external pages.
It also adds a kill switch for documentation to avoid breaking the build (see below).

### Motivation

We want our documentation to have valid link to external resources.

 #4289  shows that we had a broken link, without the actual verify system able to detect it.
A few more dead links (because of changed anchors) where detected and fixed in the current PR.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

- The option `--only_4xx` had been removed, because it excludes the option `--check_external_hashes` : 
  * Please note this `--only_4xx` option was added here: https://github.com/containous/traefik/commit/37aa902cef1c46beb8b3af03dabf36ba8e5eb38c . it was to unblock a 301 redirect breaking the whole build.

=> Since we need a way to disable the verification (reason why the `--only_4xx` was initially added), when a release requires to cut edges, this PR is also adding a kill switch, documented in `CONTRIBUTING.md`. If the environment variable `DOCS_VERIFY_SKIP` is set to `true`, then the verify phase is skipped with a message on the stdout:

```shell
DOCS_VERIFY_SKIP=true make docs-verify
...
DOCS_LINT_SKIP is true: no linting done.
```

=> The following error code are ignored, to avoid transient errors to break the verification: `0` (means timeout or no DNS resolution), `5xx`