### PR TITLE
Implement SkipVerify for entrypoint ClientCA

### DIFF
--- a/configuration/entrypoints.go
+++ b/configuration/entrypoints.go
@@ -237,9 +237,11 @@ func makeEntryPointTLS(result map[string]string) (*tls.TLS, error) {
 			files := tls.FilesOrContents{}
 			files.Set(result["ca"])
 			optional := toBool(result, "ca_optional")
+			skipVerify := toBool(result, "ca_skipverify")
 			configTLS.ClientCA = tls.ClientCA{
-				Files:    files,
-				Optional: optional,
+				Files:      files,
+				Optional:   optional,
+				SkipVerify: skipVerify,
 			}
 		}
 

--- a/server/server.go
+++ b/server/server.go
@@ -17,7 +17,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/armon/go-proxyproto"
+	proxyproto "github.com/armon/go-proxyproto"
 	"github.com/containous/mux"
 	"github.com/containous/traefik/cluster"
 	"github.com/containous/traefik/configuration"
@@ -461,9 +461,17 @@ func (s *Server) createTLSConfig(entryPointName string, tlsOption *traefiktls.TL
 		}
 		config.ClientCAs = pool
 		if tlsOption.ClientCA.Optional {
-			config.ClientAuth = tls.VerifyClientCertIfGiven
+			if tlsOption.ClientCA.SkipVerify {
+				config.ClientAuth = tls.RequestClientCert
+			} else {
+				config.ClientAuth = tls.VerifyClientCertIfGiven
+			}
 		} else {
-			config.ClientAuth = tls.RequireAndVerifyClientCert
+			if tlsOption.ClientCA.SkipVerify {
+				config.ClientAuth = tls.RequireAnyClientCert
+			} else {
+				config.ClientAuth = tls.RequireAndVerifyClientCert
+			}
 		}
 	}
 

--- a/tls/tls.go
+++ b/tls/tls.go
@@ -16,8 +16,9 @@ const (
 // ClientCA defines traefik CA files for a entryPoint
 // and it indicates if they are mandatory or have just to be analyzed if provided
 type ClientCA struct {
-	Files    FilesOrContents
-	Optional bool
+	Files      FilesOrContents
+	Optional   bool
+	SkipVerify bool
 }
 
 // TLS configures TLS for an entry point


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Added an option to skip client certificate verification on a TLS entrypoint.

### Motivation

<!-- What inspired you to submit this pull request? -->

When passing through client certificates over HTTP headers, it is assumed that some form of client certificate validation happens on the back-end. In some organizations, these back-ends might belong to multiple groups/teams that manage their own PKI infrastructure, and don't necessarily have permission to manage trusted roots on the load balancer.

This patch allows the administrator to skip verification of the client certificate and fully delegate that task to the back-end. Installing a 'dummy' root certificate is still necessary with this patch, something I would like to be able to omit. For example, only specifying the following configs:

- `entryPoints.https.tls.ClientCA.optional = true`
- `entryPoints.https.tls.ClientCA.skipVerify = true`

In my ideal scenario, this would pass an empty cert pool, request the client to provide a certificate, skip verification, and pass the urlized PEM to the designated back-end. Not having this is fine, however.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Before committing to writing tests, I would like some input about whether or not this is an acceptable solution, and whether or not everything in this change set is necessary. I've touched both `struct types.ClientTLS` and `struct tls.ClientCA`, and I'm not sure yet which one is redundant. I have a feeling `types` is used for the Auth back-end, and my change there doesn't make sense.

Also, looking at master, I see all of this code changed significantly, but I'd be interested in contributing the same feature in 2.0 as well.