### PR TITLE
Allow empty path with App-root annotation

### DIFF
--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -939,7 +939,7 @@ func loadAuthTLSSecret(namespace, secretName string, k8sClient Client) (string, 
 func getFrontendRedirect(i *extensionsv1beta1.Ingress, baseName, path string) *types.Redirect {
 	permanent := getBoolValue(i.Annotations, annotationKubernetesRedirectPermanent, false)
 
-	if appRoot := getStringValue(i.Annotations, annotationKubernetesAppRoot, ""); appRoot != "" && path == "/" {
+	if appRoot := getStringValue(i.Annotations, annotationKubernetesAppRoot, ""); appRoot != "" && (path == "/" || path == "") {
 		return &types.Redirect{
 			Regex:       fmt.Sprintf("%s$", baseName),
 			Replacement: fmt.Sprintf("%s/%s", strings.TrimRight(baseName, "/"), strings.TrimLeft(appRoot, "/")),

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -1301,6 +1301,18 @@ rateset:
 		),
 		buildIngress(
 			iNamespace("testing"),
+			iAnnotation(annotationKubernetesAppRoot, "/root"),
+			iRules(
+				iRule(
+					iHost("root3"),
+					iPaths(
+						onePath(iBackend("service1", intstr.FromInt(80))),
+					),
+				),
+			),
+		),
+		buildIngress(
+			iNamespace("testing"),
 			iAnnotation(annotationKubernetesIngressClass, "traefik"),
 			iAnnotation(annotationKubernetesCustomRequestHeaders, "Access-Control-Allow-Methods:POST,GET,OPTIONS || Content-type: application/json; charset=utf-8"),
 			iAnnotation(annotationKubernetesCustomResponseHeaders, "Access-Control-Allow-Methods:POST,GET,OPTIONS || Content-type: application/json; charset=utf-8"),
@@ -1503,6 +1515,11 @@ rateset:
 				servers(),
 				lbMethod("wrr"),
 			),
+			backend("root3",
+				servers(
+					server("http://example.com", weight(1))),
+				lbMethod("wrr"),
+			),
 			backend("protocol/valid",
 				servers(
 					server("h2c://example.com", weight(1)),
@@ -1656,6 +1673,13 @@ rateset:
 				routes(
 					route("/root1", "PathPrefix:/root1"),
 					route("root", "Host:root"),
+				),
+			),
+			frontend("root3",
+				passHostHeader(),
+				redirectRegex("root3$", "root3/root"),
+				routes(
+					route("root3", "Host:root3"),
 				),
 			),
 			frontend("protocol/valid",


### PR DESCRIPTION
### What does this PR do?

Modifies logic to allow empty paths when used with the app-root annotation


### Motivation

Fixes #4322 

### More

- [x] Added/updated tests
- [x] Added/updated documentation - Not needed, intended behavior
