### PR TITLE
Skip TLS section with no secret in Kubernetes ingress

### DIFF
--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -644,6 +644,11 @@ func getTLS(ingress *extensionsv1beta1.Ingress, k8sClient Client, tlsConfigs map
 	for _, t := range ingress.Spec.TLS {
 		newEntryPoints := getSliceStringValue(ingress.Annotations, annotationKubernetesFrontendEntryPoints)
 
+		if t.SecretName == "" {
+			log.Debugf("Skipping TLS sub-section for ingress %s/%s: No secret name provided", ingress.Namespace, ingress.Name)
+			continue
+		}
+
 		configKey := ingress.Namespace + "/" + t.SecretName
 		if tlsConfig, tlsExists := tlsConfigs[configKey]; tlsExists {
 			for _, entryPoint := range newEntryPoints {

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -642,12 +642,12 @@ func getRuleForHost(host string) string {
 
 func getTLS(ingress *extensionsv1beta1.Ingress, k8sClient Client, tlsConfigs map[string]*tls.Configuration) error {
 	for _, t := range ingress.Spec.TLS {
-		newEntryPoints := getSliceStringValue(ingress.Annotations, annotationKubernetesFrontendEntryPoints)
-
 		if t.SecretName == "" {
 			log.Debugf("Skipping TLS sub-section for ingress %s/%s: No secret name provided", ingress.Namespace, ingress.Name)
 			continue
 		}
+
+		newEntryPoints := getSliceStringValue(ingress.Annotations, annotationKubernetesFrontendEntryPoints)
 
 		configKey := ingress.Namespace + "/" + t.SecretName
 		if tlsConfig, tlsExists := tlsConfigs[configKey]; tlsExists {

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -2824,6 +2824,16 @@ func TestGetTLS(t *testing.T) {
 		),
 	)
 
+	testIngressWithoutSecret := buildIngress(
+		iNamespace("testing"),
+		iRules(
+			iRule(iHost("ep1.example.com")),
+		),
+		iTLSes(
+			iTLS("", "foo.com"),
+		),
+	)
+
 	testCases := []struct {
 		desc      string
 		ingress   *extensionsv1beta1.Ingress
@@ -2949,6 +2959,12 @@ func TestGetTLS(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			desc:    "return nil when no secret is defined",
+			ingress: testIngressWithoutSecret,
+			client:  clientMock{},
+			result:  map[string]*tls.Configuration{},
 		},
 		{
 			desc: "pass the endpoints defined in the annotation to the certificate",


### PR DESCRIPTION
### What does this PR do?

Checks to see if a secret is defined in the `TLS` block of an ingress before attempting to load the secret. Logs a debug message if TLS section is skipped.

### Motivation

Fixes #4280.

### More

- [x] Added/updated tests
- [x] Added/updated documentation - None needed, intended behavior
