### PR TITLE
Additional EntryPoints can use ACME certificates

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -226,7 +226,7 @@ func runCmd(globalConfiguration *configuration.GlobalConfiguration, configFile s
 				entryPoint.CertificateStore = acmeCertificateStore
 				acmeprovider.SetCertificateStore(acmeCertificateStore)
 				log.Debugf("Setting Acme Certificate store from Entrypoint: %s", entryPointName)
-			} else if config.TLS != nil && config.TLS.ACME {
+			} else if config.TLS != nil && config.TLS.UseACME {
 				entryPoint.CertificateStore = acmeCertificateStore
 				log.Debugf("Using Acme Certificates for Entrypoint: %s", entryPointName)
 			}

--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -200,6 +200,7 @@ func runCmd(globalConfiguration *configuration.GlobalConfiguration, configFile s
 	}
 
 	entryPoints := map[string]server.EntryPoint{}
+	acmeCertificateStore := traefiktls.NewCertificateStore()
 	for entryPointName, config := range globalConfiguration.EntryPoints {
 
 		entryPoint := server.EntryPoint{
@@ -222,9 +223,12 @@ func runCmd(globalConfiguration *configuration.GlobalConfiguration, configFile s
 			}
 
 			if entryPointName == acmeprovider.EntryPoint {
-				entryPoint.CertificateStore = traefiktls.NewCertificateStore()
-				acmeprovider.SetCertificateStore(entryPoint.CertificateStore)
+				entryPoint.CertificateStore = acmeCertificateStore
+				acmeprovider.SetCertificateStore(acmeCertificateStore)
 				log.Debugf("Setting Acme Certificate store from Entrypoint: %s", entryPointName)
+			} else if config.TLS != nil && config.TLS.ACME {
+				entryPoint.CertificateStore = acmeCertificateStore
+				log.Debugf("Using Acme Certificates for Entrypoint: %s", entryPointName)
 			}
 		}
 

--- a/configuration/entrypoints.go
+++ b/configuration/entrypoints.go
@@ -247,6 +247,10 @@ func makeEntryPointTLS(result map[string]string) (*tls.TLS, error) {
 			configTLS.MinVersion = result["tls_minversion"]
 		}
 
+		if len(result["tls_useacme"]) > 0 {
+			configTLS.UseACME = toBool(result, "tls_useacme")
+		}
+
 		if len(result["tls_ciphersuites"]) > 0 {
 			configTLS.CipherSuites = strings.Split(result["tls_ciphersuites"], ",")
 		}

--- a/configuration/entrypoints_test.go
+++ b/configuration/entrypoints_test.go
@@ -22,6 +22,7 @@ func Test_parseEntryPointsConfiguration(t *testing.T) {
 				"TLS:goo,gii " +
 				"TLS " +
 				"TLS.MinVersion:VersionTLS11 " +
+				"TLS.UseACME:true " +
 				"TLS.CipherSuites:TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA " +
 				"CA:car " +
 				"CA.Optional:true " +
@@ -77,6 +78,7 @@ func Test_parseEntryPointsConfiguration(t *testing.T) {
 				"tls_acme":                            "TLS",
 				"tls_ciphersuites":                    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
 				"tls_minversion":                      "VersionTLS11",
+				"tls_useacme":                         "true",
 				"whitelistsourcerange":                "10.42.0.0/16,152.89.1.33/32,afed:be44::/16",
 				"whitelist_sourcerange":               "10.42.0.0/16,152.89.1.33/32,afed:be44::/16",
 				"whitelist_usexforwardedfor":          "true",
@@ -183,6 +185,7 @@ func TestEntryPoints_Set(t *testing.T) {
 				"TLS:goo,gii;foo,fii " +
 				"TLS " +
 				"TLS.MinVersion:VersionTLS11 " +
+				"TLS.UseAcme:true " +
 				"TLS.CipherSuites:TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA " +
 				"CA:car " +
 				"CA.Optional:true " +
@@ -214,6 +217,7 @@ func TestEntryPoints_Set(t *testing.T) {
 				Address: ":8000",
 				TLS: &tls.TLS{
 					MinVersion:   "VersionTLS11",
+					UseACME:      true,
 					CipherSuites: []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA384", "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"},
 					Certificates: tls.Certificates{
 						{
@@ -299,6 +303,7 @@ func TestEntryPoints_Set(t *testing.T) {
 				"tls:goo,gii;foo,fii " +
 				"tls " +
 				"tls.minversion:VersionTLS11 " +
+				"tls.useacme:true " +
 				"tls.ciphersuites:TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA " +
 				"ca:car " +
 				"ca.Optional:true " +
@@ -326,6 +331,7 @@ func TestEntryPoints_Set(t *testing.T) {
 				Address: ":8000",
 				TLS: &tls.TLS{
 					MinVersion:   "VersionTLS11",
+					UseACME:      true,
 					CipherSuites: []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA384", "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"},
 					Certificates: tls.Certificates{
 						{

--- a/docs/configuration/acme.md
+++ b/docs/configuration/acme.md
@@ -12,6 +12,10 @@ See [Let's Encrypt examples](/user-guide/examples/#lets-encrypt-support) and [Do
   [entryPoints.https]
   address = ":443"
     [entryPoints.https.tls]
+  [entryPoints.https_other]
+  address = ":8443"
+    [entryPoints.https_other.tls]
+    useAcme = true
 ```
 
 ```toml
@@ -245,6 +249,36 @@ defaultEntryPoints = ["http", "https"]
 
 !!! note
     `acme.httpChallenge.entryPoint` has to be reachable through port 80. It's a Let's Encrypt limitation as described on the [community forum](https://community.letsencrypt.org/t/support-for-ports-other-than-80-and-443/3419/72).
+
+#### `ACME Certificate on other entryPoints`
+
+You can specify additional entryPoints to use the acme certificates by setting `useAcme = true` under the entryPoints tls settings.
+This allows you to use, for example, a wildcard certificate to secure internal only entryPoints. In the example below, the entrypoint `https`
+is used to obtain the acme certificate and the entryPoints `https_int` also uses the acme certificate. The `useAcme` option is not required
+on the entrypoint specified under the `acme` settings.
+
+```toml
+defaultEntryPoints = ["http", "https"]
+
+[entryPoints]
+  [entryPoints.http]
+  address = ":80"
+  [entryPoints.https]
+  address = ":443"
+    [entryPoints.https.tls]
+  [entryPoints.https_int]
+  address = ":8443"
+    [entryPoints.https_int.tls]
+    useAcme = true
+# ...
+
+[acme]
+  # ...
+  entryPoint = "https"
+  [acme.httpChallenge]
+    entryPoint = "http"
+```
+
 
 #### `dnsChallenge`
 

--- a/docs/configuration/entrypoints.md
+++ b/docs/configuration/entrypoints.md
@@ -25,6 +25,7 @@ defaultEntryPoints = ["http", "https"]
         "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
         "TLS_RSA_WITH_AES_256_GCM_SHA384"
        ]
+      useAcme = true
       [[entryPoints.http.tls.certificates]]
         certFile = "path/to/my.cert"
         keyFile = "path/to/my.key"
@@ -117,6 +118,7 @@ Address::80
 TLS:/my/path/foo.cert,/my/path/foo.key;/my/path/goo.cert,/my/path/goo.key;/my/path/hoo.cert,/my/path/hoo.key
 TLS
 TLS.MinVersion:VersionTLS11
+TLS.UseACME:true
 TLS.CipherSuites:TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA384
 TLS.SniStrict:true
 TLS.DefaultCertificate.Cert:path/to/foo.cert

--- a/tls/tls.go
+++ b/tls/tls.go
@@ -29,6 +29,7 @@ type TLS struct {
 	ClientCA           ClientCA
 	DefaultCertificate *Certificate
 	SniStrict          bool `export:"true"`
+	ACME               bool `export:"true"`
 }
 
 // FilesOrContents hold the CA we want to have in root

--- a/tls/tls.go
+++ b/tls/tls.go
@@ -29,7 +29,7 @@ type TLS struct {
 	ClientCA           ClientCA
 	DefaultCertificate *Certificate
 	SniStrict          bool `export:"true"`
-	ACME               bool `export:"true"`
+	UseACME            bool `export:"true"`
 }
 
 // FilesOrContents hold the CA we want to have in root


### PR DESCRIPTION
### What does this PR do?
This adds the setting under entryPoint.name.tls `useAcme = true` to use the acme obtained certificates for that entrypoint. It re-assigns the entryPoints certificate store to the same one used for acme. The specified entrypoint should be use to obtain the cert and any additional entrypoints tagged with this setting can use the certs also.

### Motivation
I use acme to obtain a wildcard certificate for my domain. I expose a small handful of services to the internet for which I want valid certs. I also use another entrypoint to expose many other services on another entrypoint internally. I want to be able to use the same wildcard certificate on the internal entrpoint. 

### More

- [X] Added/updated tests
- [X] Added/updated documentation
