### PR TITLE
Test and exit for jq error before domain loop

### DIFF
--- a/contrib/scripts/dumpcerts.sh
+++ b/contrib/scripts/dumpcerts.sh
@@ -155,7 +155,7 @@ echo -e "-----BEGIN RSA PRIVATE KEY-----\n${priv}\n-----END RSA PRIVATE KEY-----
    | openssl rsa -inform pem -out "${pdir}/letsencrypt.key"
 
 # Process the certificates for each of the domains in acme.json
-domains=$(jq -r '.Certificates[].Domain.Main' ${acmefile}) || bad_adme
+domains=$(jq -r '.Certificates[].Domain.Main' ${acmefile}) || bad_acme
 for domain in $domains; do
 	# Traefik stores a cert bundle for each domain.  Within this cert
 	# bundle there is both proper the certificate and the Let's Encrypt CA

--- a/contrib/scripts/dumpcerts.sh
+++ b/contrib/scripts/dumpcerts.sh
@@ -155,7 +155,8 @@ echo -e "-----BEGIN RSA PRIVATE KEY-----\n${priv}\n-----END RSA PRIVATE KEY-----
    | openssl rsa -inform pem -out "${pdir}/letsencrypt.key"
 
 # Process the certificates for each of the domains in acme.json
-for domain in $(jq -r '.Certificates[].Domain.Main' ${acmefile}); do
+domains=$(jq -r '.Certificates[].Domain.Main' ${acmefile}) || bad_adme
+for domain in $domains; do
 	# Traefik stores a cert bundle for each domain.  Within this cert
 	# bundle there is both proper the certificate and the Let's Encrypt CA
 	echo "Extracting cert bundle for ${domain}"


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
In `contrib/scripts/dumpcerts.sh`: Test and exit for `jq` error before domain loop

### Motivation

<!-- What inspired you to submit this pull request? -->
In an automated (inotify) environment, there are cases where this script gets executed before Traefik actually finishes all writes to `acme.json`. This can result in `jq` errors when it's called in the the `domain` loop. The script did not check the `jq` return code and subsequently exited with return code `0`.

Original jq error:
```
jq: error (at /traefik/acme.json:18): Cannot iterate over null (null)
```

### More

Test and docs are not applicable in this case.

### Additional Notes

Nope

