### PR TITLE
Fix html-proofer and nokogiri version

### DIFF
--- a/script/docs-verify-docker-image/Dockerfile
+++ b/script/docs-verify-docker-image/Dockerfile
@@ -7,9 +7,9 @@ RUN apk --no-cache --no-progress add \
     ruby-bigdecimal \
     ruby-ffi \
     ruby-json \
-    ruby-nokogiri \
+    ruby-nokogiri=1.8.3-r0 \
     tini \
-  && gem install --no-document html-proofer
+  && gem install --no-document html-proofer -v 3.9.3
 
 COPY ./validate.sh /validate.sh
 


### PR DESCRIPTION

### What does this PR do?

This PR fix issue since new versions of html-proofer and nokogiri has been released.

https://rubygems.org/gems/html-proofer/versions/3.10.0
and 
https://rubygems.org/gems/nokogiri/versions/1.10.0

```console
ERROR:  Error installing html-proofer:
	ERROR: Failed to build gem native extension.

    current directory: /usr/lib/ruby/gems/2.5.0/gems/nokogiri-1.10.0/ext/nokogiri
/usr/bin/ruby -r ./siteconf20190107-18-1lqbb25.rb extconf.rb
mkmf.rb can't find header files for ruby at /usr/lib/ruby/include/ruby.h

extconf failed, exit code 1

Gem files will remain installed in /usr/lib/ruby/gems/2.5.0/gems/nokogiri-1.10.0 for inspection.
```


### Motivation

Working build ;)
