### PR TITLE
Support Datadog tracer priority sampling

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1619,8 +1619,8 @@
     "ddtrace/opentracer",
     "ddtrace/tracer"
   ]
-  revision = "48eeff27357376bcb31a15674dc4be9078de88b3"
-  version = "v1.5.0"
+  revision = "7fb2bce4b1ed6ab61f7a9e1be30dea56de19db7c"
+  version = "v1.8.0"
 
 [[projects]]
   name = "gopkg.in/fsnotify.v1"
@@ -1879,6 +1879,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "cc7d0f3f860a91ce8fdcc6465d3f54a566716fe828340ec73900779fd844214f"
+  inputs-digest = "781857167b93ec784d40c7c093a46c4d817f2d47b0dbc1f08fe3ec8ffc562cf9"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -263,4 +263,4 @@
 
 [[constraint]]
   name = "gopkg.in/DataDog/dd-trace-go.v1"
-  version = "1.5.0"
+  version = "1.7.0"

--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -239,6 +239,8 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 			LocalAgentHostPort: "localhost:8126",
 			GlobalTag:          "",
 			Debug:              false,
+			PrioritySampling:   false,
+
 		},
 	}
 

--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -240,7 +240,6 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 			GlobalTag:          "",
 			Debug:              false,
 			PrioritySampling:   false,
-
 		},
 	}
 

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -368,6 +368,7 @@ func (gc *GlobalConfiguration) initTracing() {
 					LocalAgentHostPort: "localhost:8126",
 					GlobalTag:          "",
 					Debug:              false,
+					PrioritySampling:   false,
 				}
 			}
 			if gc.Tracing.Zipkin != nil {

--- a/docs/configuration/tracing.md
+++ b/docs/configuration/tracing.md
@@ -156,4 +156,10 @@ Traefik supports three tracing backends: Jaeger, Zipkin and DataDog.
     #
     globalTag = ""
 
+    # Enable priority sampling. When using distributed tracing, this option must be enabled in order
+    # to get all the parts of a distributed trace sampled.
+    #
+    # Default: false
+    #
+    prioritySampling = false
 ```

--- a/middlewares/tracing/datadog/datadog.go
+++ b/middlewares/tracing/datadog/datadog.go
@@ -18,6 +18,8 @@ type Config struct {
 	LocalAgentHostPort string `description:"Set datadog-agent's host:port that the reporter will used. Defaults to localhost:8126" export:"false"`
 	GlobalTag          string `description:"Key:Value tag to be set on all the spans." export:"true"`
 	Debug              bool   `description:"Enable DataDog debug." export:"true"`
+	PrioritySampling   bool   `description:"Enable priority sampling. When using distributed tracing, this option must be enabled in order to get all the parts of a distributed trace sampled."`
+
 }
 
 // Setup sets up the tracer
@@ -29,12 +31,16 @@ func (c *Config) Setup(serviceName string) (opentracing.Tracer, io.Closer, error
 		value = tag[1]
 	}
 
-	tracer := ddtracer.New(
+	opts := []datadog.StartOption{
 		datadog.WithAgentAddr(c.LocalAgentHostPort),
 		datadog.WithServiceName(serviceName),
 		datadog.WithGlobalTag(tag[0], value),
 		datadog.WithDebugMode(c.Debug),
-	)
+	}
+	if c.PrioritySampling {
+		opts = append(opts, datadog.WithPrioritySampling())
+	}
+	tracer := ddtracer.New(opts...)
 
 	// Without this, child spans are getting the NOOP tracer
 	opentracing.SetGlobalTracer(tracer)

--- a/middlewares/tracing/datadog/datadog.go
+++ b/middlewares/tracing/datadog/datadog.go
@@ -19,7 +19,6 @@ type Config struct {
 	GlobalTag          string `description:"Key:Value tag to be set on all the spans." export:"true"`
 	Debug              bool   `description:"Enable DataDog debug." export:"true"`
 	PrioritySampling   bool   `description:"Enable priority sampling. When using distributed tracing, this option must be enabled in order to get all the parts of a distributed trace sampled."`
-
 }
 
 // Setup sets up the tracer

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/sampler.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/sampler.go
@@ -1,10 +1,13 @@
 package tracer
 
 import (
+	"encoding/json"
+	"io"
 	"math"
 	"sync"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 )
 
 // Sampler is the generic interface of any sampler. It must be safe for concurrent use.
@@ -59,14 +62,83 @@ const knuthFactor = uint64(1111111111111111111)
 
 // Sample returns true if the given span should be sampled.
 func (r *rateSampler) Sample(spn ddtrace.Span) bool {
+	if r.rate == 1 {
+		// fast path
+		return true
+	}
 	s, ok := spn.(*span)
 	if !ok {
 		return false
 	}
 	r.RLock()
 	defer r.RUnlock()
-	if r.rate < 1 {
-		return s.TraceID*knuthFactor < uint64(r.rate*math.MaxUint64)
+	return sampledByRate(s.TraceID, r.rate)
+}
+
+// sampledByRate verifies if the number n should be sampled at the specified
+// rate.
+func sampledByRate(n uint64, rate float64) bool {
+	if rate < 1 {
+		return n*knuthFactor < uint64(rate*math.MaxUint64)
 	}
 	return true
+}
+
+// prioritySampler holds a set of per-service sampling rates and applies
+// them to spans.
+type prioritySampler struct {
+	mu          sync.RWMutex
+	rates       map[string]float64
+	defaultRate float64
+}
+
+func newPrioritySampler() *prioritySampler {
+	return &prioritySampler{
+		rates:       make(map[string]float64),
+		defaultRate: 1.,
+	}
+}
+
+// readRatesJSON will try to read the rates as JSON from the given io.ReadCloser.
+func (ps *prioritySampler) readRatesJSON(rc io.ReadCloser) error {
+	var payload struct {
+		Rates map[string]float64 `json:"rate_by_service"`
+	}
+	if err := json.NewDecoder(rc).Decode(&payload); err != nil {
+		return err
+	}
+	rc.Close()
+	const defaultRateKey = "service:,env:"
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	ps.rates = payload.Rates
+	if v, ok := ps.rates[defaultRateKey]; ok {
+		ps.defaultRate = v
+		delete(ps.rates, defaultRateKey)
+	}
+	return nil
+}
+
+// getRate returns the sampling rate to be used for the given span. Callers must
+// guard the span.
+func (ps *prioritySampler) getRate(spn *span) float64 {
+	key := "service:" + spn.Service + ",env:" + spn.Meta[ext.Environment]
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
+	if rate, ok := ps.rates[key]; ok {
+		return rate
+	}
+	return ps.defaultRate
+}
+
+// apply applies sampling priority to the given span. Caller must ensure it is safe
+// to modify the span.
+func (ps *prioritySampler) apply(spn *span) {
+	rate := ps.getRate(spn)
+	if sampledByRate(spn.TraceID, rate) {
+		spn.SetTag(ext.SamplingPriority, ext.PriorityAutoKeep)
+	} else {
+		spn.SetTag(ext.SamplingPriority, ext.PriorityAutoReject)
+	}
+	spn.SetTag(samplingPriorityRateKey, rate)
 }

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/span.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/span.go
@@ -201,8 +201,8 @@ func (s *span) finish(finishTime int64) {
 	}
 	s.finished = true
 
-	if !s.context.sampled {
-		// not sampled
+	if s.context.drop {
+		// not sampled by local sampler
 		return
 	}
 	s.context.finish()
@@ -235,4 +235,7 @@ func (s *span) String() string {
 	return strings.Join(lines, "\n")
 }
 
-const samplingPriorityKey = "_sampling_priority_v1"
+const (
+	samplingPriorityKey     = "_sampling_priority_v1"
+	samplingPriorityRateKey = "_sampling_priority_rate_v1"
+)

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/textmap.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/textmap.go
@@ -175,11 +175,11 @@ func (p *propagator) extractTextMap(reader TextMapReader) (ddtrace.SpanContext, 
 				return ErrSpanContextCorrupted
 			}
 		case p.cfg.PriorityHeader:
-			ctx.priority, err = strconv.Atoi(v)
+			priority, err := strconv.Atoi(v)
 			if err != nil {
 				return ErrSpanContextCorrupted
 			}
-			ctx.hasPriority = true
+			ctx.setSamplingPriority(priority)
 		default:
 			if strings.HasPrefix(key, p.cfg.BaggagePrefix) {
 				ctx.setBaggageItem(strings.TrimPrefix(key, p.cfg.BaggagePrefix), v)


### PR DESCRIPTION
This is #4321 rebased to v1.7.

### What does this PR do?

Add an option to enable [priority sampling](https://docs.datadoghq.com/tracing/advanced_usage/?tab=java#priority-sampling) to the Datadog tracer. This prevents trace sampling from removing segments of a distributed trace (i.e. ensures completeness).

The first commit updates the dd-trace-go dependency to version 1.7.0, because that is the version the functionality appeared in. The second commit exposes the functionality in the configuration.

This pull request fixes #4296.

### Motivation

When using Traefik as an ingress router, it is important to include it in distributed Datadog traces of incoming requests.

### More

- [ ] Added/updated tests
- [X] Added/updated documentation

The Datadog tracer did not include tests. If tests are required for this change, I would appreciate some pointers. (I have been running this code for a week without problems.)

### Additional Notes

This is my second ever Go language pull request. Some changes were done based on pattern recognition. All comments are welcome, including stylistic and nit-picking ones. :slightly_smiling_face: