### PR TITLE
Removed repeated entryPoints.http from grpc.md

### DIFF
--- a/docs/user-guide/grpc.md
+++ b/docs/user-guide/grpc.md
@@ -14,7 +14,6 @@ defaultEntryPoints = ["https"]
 [entryPoints]
   [entryPoints.http]
   address = ":80"
-    [entryPoints.http]
 
 [api]
 


### PR DESCRIPTION
The TOML config was invalid with a second `[entryPoints.http]`. Removed.

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

GRPC docs for Traefik contain an invalid config, with a repeated `[entryPoints.http]`.


### Motivation

<!-- What inspired you to submit this pull request? -->
Observed the issue, checked if already existing issue, couldn't find one, so created PR since its an easy fix to docs.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes
This is only a documentation change, from my limited knowledge of TOML. Feel free to ignore if its already correct.
<!-- Anything else we should know when reviewing? -->
