### PR TITLE
Route priorities: document minimum priority value

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -236,7 +236,8 @@ The following rules are both `Matchers` and `Modifiers`, so the `Matcher` portio
 #### Priorities
 
 By default, routes will be sorted (in descending order) using rules length (to avoid path overlap):
-`PathPrefix:/foo;Host:foo.com` (length == 28) will be matched before `PathPrefixStrip:/foobar` (length == 23) will be matched before `PathPrefix:/foo,/bar` (length == 20).
+`PathPrefix:/foo;Host:foo.com` (length == 28) will be matched before `PathPrefixStrip:/foobar` (length == 23) will be matched before `PathPrefix:/foo,/bar` (length == 20).  
+The minimum priority is 1. A priority value of zero will be ignored.
 
 You can customize priority by frontend. The priority value override the rule length during sorting:
 

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -236,8 +236,8 @@ The following rules are both `Matchers` and `Modifiers`, so the `Matcher` portio
 #### Priorities
 
 By default, routes will be sorted (in descending order) using rules length (to avoid path overlap):
-`PathPrefix:/foo;Host:foo.com` (length == 28) will be matched before `PathPrefixStrip:/foobar` (length == 23) will be matched before `PathPrefix:/foo,/bar` (length == 20).  
-The minimum priority is 1. A priority value of zero will be ignored.
+- `PathPrefix:/foo;Host:foo.com` (length == 28) will be matched before `PathPrefixStrip:/foobar` (length == 23) will be matched before `PathPrefix:/foo,/bar` (length == 20).  
+- A priority value of 0 will be ignored, so the default value will be calculated (rules length).
 
 You can customize priority by frontend. The priority value override the rule length during sorting:
 


### PR DESCRIPTION
### What does this PR do?

document minimum priority value


### Motivation

I had the case that i needed a rule to be matched after all other rules and it was not until i started reading the source code (https://github.com/containous/traefik/blob/master/server/router/rules.go#L20) that i realized a value of zero will not place the route to the end of the list.
It would have saved me some time, had the documentation already contained this line.


### More

- [ ] Added/updated tests
- [x] Added/updated documentation
