### PR TITLE
Allow Træfik to update Ingress status

### DIFF
--- a/examples/k8s/traefik-rbac.yaml
+++ b/examples/k8s/traefik-rbac.yaml
@@ -22,6 +22,12 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+    - extensions
+    resources:
+    - ingresses/status
+    verbs:
+    - update
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
This PR updates the manifest of the example ClusterRole for Træfik 1.7 and allows updating the status after successfully provisioning the Ingress. Fixes: #3377 