### PR TITLE
Adds default rule system on Docker provider.

### DIFF
--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -155,6 +155,7 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 	defaultDocker.Endpoint = "unix:///var/run/docker.sock"
 	defaultDocker.SwarmMode = false
 	defaultDocker.SwarmModeRefreshSeconds = 15
+	defaultDocker.DefaultRule = docker.DefaultTemplateRule
 
 	// default Rest
 	var defaultRest rest.Provider

--- a/integration/docker_compose_test.go
+++ b/integration/docker_compose_test.go
@@ -45,7 +45,7 @@ func (s *DockerComposeSuite) TestComposeScale(c *check.C) {
 		DefaultRule string
 	}{
 		DockerHost:  s.getDockerHost(),
-		DefaultRule: "{{ normalize .Name }}.docker.localhost",
+		DefaultRule: "Host:{{ normalize .Name }}.docker.localhost",
 	}
 	file := s.adaptFile(c, "fixtures/docker/minimal.toml", tempObjects)
 	defer os.Remove(file)

--- a/integration/docker_compose_test.go
+++ b/integration/docker_compose_test.go
@@ -40,7 +40,14 @@ func (s *DockerComposeSuite) TestComposeScale(c *check.C) {
 
 	s.composeProject.Scale(c, composeService, serviceCount)
 
-	file := s.adaptFileForHost(c, "fixtures/docker/minimal.toml")
+	tempObjects := struct {
+		DockerHost  string
+		DefaultRule string
+	}{
+		DockerHost:  s.getDockerHost(),
+		DefaultRule: "{{ normalize .Name }}.docker.localhost",
+	}
+	file := s.adaptFile(c, "fixtures/docker/minimal.toml", tempObjects)
 	defer os.Remove(file)
 
 	cmd, display := s.traefikCmd(withConfigFile(file))

--- a/integration/docker_test.go
+++ b/integration/docker_test.go
@@ -79,11 +79,19 @@ func (s *DockerSuite) SetUpSuite(c *check.C) {
 }
 
 func (s *DockerSuite) TearDownTest(c *check.C) {
-	s.project.Clean(c, os.Getenv("CIRCLECI") != "")
+	s.project.Clean(c, os.Getenv("CIRCLECI") != "") // FIXME
 }
 
 func (s *DockerSuite) TestSimpleConfiguration(c *check.C) {
-	file := s.adaptFileForHost(c, "fixtures/docker/simple.toml")
+	tempObjects := struct {
+		DockerHost  string
+		DefaultRule string
+	}{
+		DockerHost:  s.getDockerHost(),
+		DefaultRule: "{{ normalize .Name }}.docker.localhost",
+	}
+
+	file := s.adaptFile(c, "fixtures/docker/simple.toml", tempObjects)
 	defer os.Remove(file)
 
 	cmd, display := s.traefikCmd(withConfigFile(file))
@@ -99,7 +107,15 @@ func (s *DockerSuite) TestSimpleConfiguration(c *check.C) {
 }
 
 func (s *DockerSuite) TestDefaultDockerContainers(c *check.C) {
-	file := s.adaptFileForHost(c, "fixtures/docker/simple.toml")
+	tempObjects := struct {
+		DockerHost  string
+		DefaultRule string
+	}{
+		DockerHost:  s.getDockerHost(),
+		DefaultRule: "{{ normalize .Name }}.docker.localhost",
+	}
+
+	file := s.adaptFile(c, "fixtures/docker/simple.toml", tempObjects)
 	defer os.Remove(file)
 
 	name := s.startContainer(c, "swarm:1.0.0", "manage", "token://blablabla")
@@ -129,7 +145,15 @@ func (s *DockerSuite) TestDefaultDockerContainers(c *check.C) {
 }
 
 func (s *DockerSuite) TestDockerContainersWithLabels(c *check.C) {
-	file := s.adaptFileForHost(c, "fixtures/docker/simple.toml")
+	tempObjects := struct {
+		DockerHost  string
+		DefaultRule string
+	}{
+		DockerHost:  s.getDockerHost(),
+		DefaultRule: "{{ normalize .Name }}.docker.localhost",
+	}
+
+	file := s.adaptFile(c, "fixtures/docker/simple.toml", tempObjects)
 	defer os.Remove(file)
 
 	// Start a container with some labels
@@ -177,7 +201,15 @@ func (s *DockerSuite) TestDockerContainersWithLabels(c *check.C) {
 }
 
 func (s *DockerSuite) TestDockerContainersWithOneMissingLabels(c *check.C) {
-	file := s.adaptFileForHost(c, "fixtures/docker/simple.toml")
+	tempObjects := struct {
+		DockerHost  string
+		DefaultRule string
+	}{
+		DockerHost:  s.getDockerHost(),
+		DefaultRule: "{{ normalize .Name }}.docker.localhost",
+	}
+
+	file := s.adaptFile(c, "fixtures/docker/simple.toml", tempObjects)
 	defer os.Remove(file)
 
 	// Start a container with some labels
@@ -205,7 +237,15 @@ func (s *DockerSuite) TestDockerContainersWithOneMissingLabels(c *check.C) {
 }
 
 func (s *DockerSuite) TestRestartDockerContainers(c *check.C) {
-	file := s.adaptFileForHost(c, "fixtures/docker/simple.toml")
+	tempObjects := struct {
+		DockerHost  string
+		DefaultRule string
+	}{
+		DockerHost:  s.getDockerHost(),
+		DefaultRule: "{{ normalize .Name }}.docker.localhost",
+	}
+
+	file := s.adaptFile(c, "fixtures/docker/simple.toml", tempObjects)
 	defer os.Remove(file)
 
 	// Start a container with some labels

--- a/integration/docker_test.go
+++ b/integration/docker_test.go
@@ -88,7 +88,7 @@ func (s *DockerSuite) TestSimpleConfiguration(c *check.C) {
 		DefaultRule string
 	}{
 		DockerHost:  s.getDockerHost(),
-		DefaultRule: "{{ normalize .Name }}.docker.localhost",
+		DefaultRule: "Host:{{ normalize .Name }}.docker.localhost",
 	}
 
 	file := s.adaptFile(c, "fixtures/docker/simple.toml", tempObjects)
@@ -112,7 +112,7 @@ func (s *DockerSuite) TestDefaultDockerContainers(c *check.C) {
 		DefaultRule string
 	}{
 		DockerHost:  s.getDockerHost(),
-		DefaultRule: "{{ normalize .Name }}.docker.localhost",
+		DefaultRule: "Host:{{ normalize .Name }}.docker.localhost",
 	}
 
 	file := s.adaptFile(c, "fixtures/docker/simple.toml", tempObjects)
@@ -150,7 +150,7 @@ func (s *DockerSuite) TestDockerContainersWithLabels(c *check.C) {
 		DefaultRule string
 	}{
 		DockerHost:  s.getDockerHost(),
-		DefaultRule: "{{ normalize .Name }}.docker.localhost",
+		DefaultRule: "Host:{{ normalize .Name }}.docker.localhost",
 	}
 
 	file := s.adaptFile(c, "fixtures/docker/simple.toml", tempObjects)
@@ -206,7 +206,7 @@ func (s *DockerSuite) TestDockerContainersWithOneMissingLabels(c *check.C) {
 		DefaultRule string
 	}{
 		DockerHost:  s.getDockerHost(),
-		DefaultRule: "{{ normalize .Name }}.docker.localhost",
+		DefaultRule: "Host:{{ normalize .Name }}.docker.localhost",
 	}
 
 	file := s.adaptFile(c, "fixtures/docker/simple.toml", tempObjects)
@@ -231,7 +231,7 @@ func (s *DockerSuite) TestDockerContainersWithOneMissingLabels(c *check.C) {
 
 	// FIXME Need to wait than 500 milliseconds more (for swarm or traefik to boot up ?)
 	// TODO validate : run on 80
-	// Expected a 404 as we did not comfigure anything
+	// Expected a 404 as we did not configure anything
 	err = try.Request(req, 1500*time.Millisecond, try.StatusCodeIs(http.StatusNotFound))
 	c.Assert(err, checker.IsNil)
 }
@@ -242,7 +242,7 @@ func (s *DockerSuite) TestRestartDockerContainers(c *check.C) {
 		DefaultRule string
 	}{
 		DockerHost:  s.getDockerHost(),
-		DefaultRule: "{{ normalize .Name }}.docker.localhost",
+		DefaultRule: "Host:{{ normalize .Name }}.docker.localhost",
 	}
 
 	file := s.adaptFile(c, "fixtures/docker/simple.toml", tempObjects)

--- a/integration/error_pages_test.go
+++ b/integration/error_pages_test.go
@@ -26,7 +26,6 @@ func (s *ErrorPagesSuite) SetUpSuite(c *check.C) {
 }
 
 func (s *ErrorPagesSuite) TestSimpleConfiguration(c *check.C) {
-
 	file := s.adaptFile(c, "fixtures/error_pages/simple.toml", struct {
 		Server1 string
 		Server2 string

--- a/integration/fixtures/access_log_config.toml
+++ b/integration/fixtures/access_log_config.toml
@@ -25,5 +25,5 @@ checkNewVersion = false
 [providers]
    [providers.docker]
      exposedByDefault = false
-     domain = "docker.local"
+     defaultRule = "{{ normalize .Name }}.docker.local"
      watch = true

--- a/integration/fixtures/docker/minimal.toml
+++ b/integration/fixtures/docker/minimal.toml
@@ -10,6 +10,6 @@ logLevel = "DEBUG"
 
 [providers]
    [providers.docker]
-      endpoint = "{{.DockerHost}}"
-      defaultRule = "{{ normalize .Name }}.docker.localhost"
+      endpoint = "{{ .DockerHost }}"
+      defaultRule = "{{ .DefaultRule }}"
       exposedByDefault = false

--- a/integration/fixtures/docker/minimal.toml
+++ b/integration/fixtures/docker/minimal.toml
@@ -11,5 +11,5 @@ logLevel = "DEBUG"
 [providers]
    [providers.docker]
       endpoint = "{{.DockerHost}}"
-      domain = "docker.localhost"
+      defaultRule = "{{ normalize .Name }}.docker.localhost"
       exposedByDefault = false

--- a/integration/fixtures/docker/simple.toml
+++ b/integration/fixtures/docker/simple.toml
@@ -10,5 +10,5 @@ logLevel = "DEBUG"
 [providers]
    [providers.docker]
        endpoint = "{{.DockerHost}}"
-       domain = "docker.localhost"
+       defaultRule = "{{ normalize .Name }}.docker.localhost"
        exposedByDefault = true

--- a/integration/fixtures/docker/simple.toml
+++ b/integration/fixtures/docker/simple.toml
@@ -9,6 +9,6 @@ logLevel = "DEBUG"
 
 [providers]
    [providers.docker]
-       endpoint = "{{.DockerHost}}"
-       defaultRule = "{{ normalize .Name }}.docker.localhost"
+      endpoint = "{{ .DockerHost }}"
+      defaultRule = "{{ .DefaultRule }}"
        exposedByDefault = true

--- a/integration/fixtures/error_pages/error.toml
+++ b/integration/fixtures/error_pages/error.toml
@@ -10,11 +10,9 @@ logLevel = "DEBUG"
 
 [routers]
   [routers.router1]
-      middlewares = ["error"]
-      service = "service1"
-
-  [routers.router1.routes.test_1]
-      rule = "Host:test.local"
+    rule = "Host:test.local"
+    service = "service1"
+    middlewares = ["error"]
 
 [middlewares]
     [middlewares.error.errors]

--- a/integration/fixtures/error_pages/simple.toml
+++ b/integration/fixtures/error_pages/simple.toml
@@ -10,11 +10,9 @@ logLevel = "DEBUG"
 
 [routers]
   [routers.router1]
-      middlewares = ["error"]
-      service = "service1"
-
-  [routers.router1.routes.test_1]
       rule = "Host:test.local"
+      service = "service1"
+      middlewares = ["error"]
 
 [middlewares]
     [middlewares.error.errors]

--- a/integration/fixtures/simple_hostresolver.toml
+++ b/integration/fixtures/simple_hostresolver.toml
@@ -10,7 +10,7 @@ logLevel = "DEBUG"
 [providers]
    [providers.docker]
       exposedByDefault = false
-      domain = "docker.local"
+      defaultRule = "{{ normalize .Name }}.docker.local"
       watch = true
 
 [hostResolver]

--- a/integration/fixtures/traefik_log_config.toml
+++ b/integration/fixtures/traefik_log_config.toml
@@ -21,5 +21,5 @@ checkNewVersion = false
 [providers]
    [providers.docker]
      exposedByDefault = false
-     domain = "docker.local"
+     defaultRule = "{{ normalize .Name }}.docker.local"
      watch = true

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -142,14 +142,13 @@ func (s *BaseSuite) displayTraefikLog(c *check.C, output *bytes.Buffer) {
 	}
 }
 
-func (s *BaseSuite) adaptFileForHost(c *check.C, path string) string {
+func (s *BaseSuite) getDockerHost() string {
 	dockerHost := os.Getenv("DOCKER_HOST")
 	if dockerHost == "" {
 		// Default docker socket
 		dockerHost = "unix:///var/run/docker.sock"
 	}
-	tempObjects := struct{ DockerHost string }{dockerHost}
-	return s.adaptFile(c, path, tempObjects)
+	return dockerHost
 }
 
 func (s *BaseSuite) adaptFile(c *check.C, path string, tempObjects interface{}) string {

--- a/provider/base_provider.go
+++ b/provider/base_provider.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"strings"
 	"text/template"
-	"unicode"
 
 	"github.com/BurntSushi/toml"
 	"github.com/Masterminds/sprig"
@@ -46,15 +45,6 @@ func (p *BaseProvider) MatchConstraints(tags []string) (bool, *types.Constraint)
 
 	// If no constraint or every constraints matching
 	return true, nil
-}
-
-// GetConfiguration returns the provider configuration from default template (file or content) or overrode template file.
-func (p *BaseProvider) GetConfiguration(defaultTemplate string, funcMap template.FuncMap, templateObjects interface{}) (*config.Configuration, error) {
-	tmplContent, err := p.getTemplateContent(defaultTemplate)
-	if err != nil {
-		return nil, err
-	}
-	return p.CreateConfiguration(tmplContent, funcMap, templateObjects)
 }
 
 // CreateConfiguration creates a provider configuration from content using templating.
@@ -120,21 +110,4 @@ func (p *BaseProvider) getTemplateContent(defaultTemplateFile string) (string, e
 
 func split(sep, s string) []string {
 	return strings.Split(s, sep)
-}
-
-// Normalize transforms a string that work with the rest of traefik.
-// Replace '.' with '-' in quoted keys because of this issue https://github.com/BurntSushi/toml/issues/78
-func Normalize(name string) string {
-	fargs := func(c rune) bool {
-		return !unicode.IsLetter(c) && !unicode.IsNumber(c)
-	}
-	// get function
-	return strings.Join(strings.FieldsFunc(name, fargs), "-")
-}
-
-// ReverseStringSlice inverts the order of the given slice of string.
-func ReverseStringSlice(slice *[]string) {
-	for i, j := 0, len(*slice)-1; i < j; i, j = i+1, j-1 {
-		(*slice)[i], (*slice)[j] = (*slice)[j], (*slice)[i]
-	}
 }

--- a/provider/configuration.go
+++ b/provider/configuration.go
@@ -119,7 +119,8 @@ func AddMiddleware(configuration *config.Configuration, middlewareName string, m
 	return reflect.DeepEqual(configuration.Middlewares[middlewareName], middleware)
 }
 
-func BuildDefaultRuleTemplate(defaultRule string, funcMap template.FuncMap) (*template.Template, error) {
+// MakeDefaultRuleTemplate Creates the default rule template.
+func MakeDefaultRuleTemplate(defaultRule string, funcMap template.FuncMap) (*template.Template, error) {
 	defaultFuncMap := sprig.TxtFuncMap()
 	defaultFuncMap["normalize"] = Normalize
 
@@ -130,7 +131,8 @@ func BuildDefaultRuleTemplate(defaultRule string, funcMap template.FuncMap) (*te
 	return template.New("defaultRule").Funcs(defaultFuncMap).Parse(defaultRule)
 }
 
-func BuildRouterConfiguration(ctx context.Context, configuration *config.Configuration, name string, defaultRuleTpl *template.Template, model interface{}) {
+// BuildRouterConfiguration Builds a router configuration.
+func BuildRouterConfiguration(ctx context.Context, configuration *config.Configuration, defaultRouterName string, defaultRuleTpl *template.Template, model interface{}) {
 	logger := log.FromContext(ctx)
 
 	if len(configuration.Routers) == 0 {
@@ -138,7 +140,7 @@ func BuildRouterConfiguration(ctx context.Context, configuration *config.Configu
 			log.FromContext(ctx).Info("Could not create a router for the container: too many services")
 		} else {
 			configuration.Routers = make(map[string]*config.Router)
-			configuration.Routers[name] = &config.Router{}
+			configuration.Routers[defaultRouterName] = &config.Router{}
 		}
 	}
 
@@ -175,7 +177,7 @@ func BuildRouterConfiguration(ctx context.Context, configuration *config.Configu
 	}
 }
 
-// Normalize Replace all special chars with `-`
+// Normalize Replace all special chars with `-`.
 func Normalize(name string) string {
 	fargs := func(c rune) bool {
 		return !unicode.IsLetter(c) && !unicode.IsNumber(c)

--- a/provider/configuration.go
+++ b/provider/configuration.go
@@ -162,7 +162,7 @@ func BuildRouterConfiguration(ctx context.Context, configuration *config.Configu
 			}
 		}
 
-		if router.Service == "" {
+		if len(router.Service) == 0 {
 			if len(configuration.Services) > 1 {
 				delete(configuration.Routers, routerName)
 				loggerRouter.

--- a/provider/docker/docker.go
+++ b/provider/docker/docker.go
@@ -31,8 +31,9 @@ import (
 )
 
 const (
-	// SwarmAPIVersion is a constant holding the version of the Provider API traefik will use
-	SwarmAPIVersion     = "1.24"
+	// SwarmAPIVersion is a constant holding the version of the Provider API traefik will use.
+	SwarmAPIVersion = "1.24"
+	// DefaultTemplateRule The default template for the default rule.
 	DefaultTemplateRule = "Host:{{ normalize .Name }}"
 )
 
@@ -52,9 +53,9 @@ type Provider struct {
 	defaultRuleTpl          *template.Template
 }
 
-// Init the provider
+// Init the provider.
 func (p *Provider) Init() error {
-	defaultRuleTpl, err := provider.BuildDefaultRuleTemplate(p.DefaultRule, nil)
+	defaultRuleTpl, err := provider.MakeDefaultRuleTemplate(p.DefaultRule, nil)
 	if err != nil {
 		return fmt.Errorf("error while parsing default rule: %v", err)
 	}
@@ -63,7 +64,7 @@ func (p *Provider) Init() error {
 	return p.BaseProvider.Init()
 }
 
-// dockerData holds the need data to the Provider p
+// dockerData holds the need data to the provider.
 type dockerData struct {
 	ID              string
 	ServiceName     string
@@ -75,14 +76,14 @@ type dockerData struct {
 	ExtraConf       configuration
 }
 
-// NetworkSettings holds the networks data to the Provider p
+// NetworkSettings holds the networks data to the provider.
 type networkSettings struct {
 	NetworkMode dockercontainertypes.NetworkMode
 	Ports       nat.PortMap
 	Networks    map[string]*networkData
 }
 
-// Network holds the network data to the Provider p
+// Network holds the network data to the provider.
 type networkData struct {
 	Name     string
 	Addr     string
@@ -131,8 +132,7 @@ func (p *Provider) createClient() (client.APIClient, error) {
 	return client.NewClient(p.Endpoint, apiVersion, httpClient, httpHeaders)
 }
 
-// Provide allows the docker provider to provide configurations to traefik
-// using the given configuration channel.
+// Provide allows the docker provider to provide configurations to traefik using the given configuration channel.
 func (p *Provider) Provide(configurationChan chan<- config.Message, pool *safe.Pool) error {
 	pool.GoCtx(func(routineCtx context.Context) {
 		ctxLog := log.With(routineCtx, log.Str(log.ProviderName, "docker"))

--- a/provider/docker/label.go
+++ b/provider/docker/label.go
@@ -15,7 +15,6 @@ const (
 type configuration struct {
 	Enable bool
 	Tags   []string
-	Domain string
 	Docker specificConfiguration
 }
 
@@ -27,13 +26,12 @@ type specificConfiguration struct {
 func (p *Provider) getConfiguration(container dockerData) (configuration, error) {
 	conf := configuration{
 		Enable: p.ExposedByDefault,
-		Domain: p.Domain,
 		Docker: specificConfiguration{
 			Network: p.Network,
 		},
 	}
 
-	err := label.Decode(container.Labels, &conf, "traefik.docker.", "traefik.domain", "traefik.enable", "traefik.tags")
+	err := label.Decode(container.Labels, &conf, "traefik.docker.", "traefik.enable", "traefik.tags")
 	if err != nil {
 		return configuration{}, err
 	}

--- a/server/router/rules.go
+++ b/server/router/rules.go
@@ -17,6 +17,10 @@ func addRoute(ctx context.Context, router *mux.Router, rule string, priority int
 		return err
 	}
 
+	if len(matchers) == 0 {
+		return fmt.Errorf("invalid rule: %s", rule)
+	}
+
 	if priority == 0 {
 		priority = len(rule)
 	}

--- a/server/router/rules_test.go
+++ b/server/router/rules_test.go
@@ -15,16 +15,20 @@ import (
 
 func Test_addRoute(t *testing.T) {
 	testCases := []struct {
-		desc     string
-		rule     string
-		headers  map[string]string
-		expected map[string]int
+		desc          string
+		rule          string
+		headers       map[string]string
+		expected      map[string]int
+		expectedError bool
 	}{
 		{
-			desc: "no rule",
-			expected: map[string]int{
-				"http://localhost/foo": http.StatusOK,
-			},
+			desc:          "no rule",
+			expectedError: true,
+		},
+		{
+			desc:          "Rule with no matcher",
+			rule:          "rulewithnotmatcher",
+			expectedError: true,
 		},
 		{
 			desc: "PathPrefix",
@@ -217,23 +221,27 @@ func Test_addRoute(t *testing.T) {
 			router.SkipClean(true)
 
 			err := addRoute(context.Background(), router, test.rule, 0, handler)
-			require.NoError(t, err)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 
-			// RequestDecorator is necessary for the host rule
-			reqHost := requestdecorator.New(nil)
+				// RequestDecorator is necessary for the host rule
+				reqHost := requestdecorator.New(nil)
 
-			results := make(map[string]int)
-			for calledURL := range test.expected {
-				w := httptest.NewRecorder()
+				results := make(map[string]int)
+				for calledURL := range test.expected {
+					w := httptest.NewRecorder()
 
-				req := testhelpers.MustNewRequest(http.MethodGet, calledURL, nil)
-				for key, value := range test.headers {
-					req.Header.Set(key, value)
+					req := testhelpers.MustNewRequest(http.MethodGet, calledURL, nil)
+					for key, value := range test.headers {
+						req.Header.Set(key, value)
+					}
+					reqHost.ServeHTTP(w, req, router.ServeHTTP)
+					results[calledURL] = w.Code
 				}
-				reqHost.ServeHTTP(w, req, router.ServeHTTP)
-				results[calledURL] = w.Code
+				assert.Equal(t, test.expected, results)
 			}
-			assert.Equal(t, test.expected, results)
 
 		})
 	}

--- a/server/router/rules_test.go
+++ b/server/router/rules_test.go
@@ -242,7 +242,6 @@ func Test_addRoute(t *testing.T) {
 				}
 				assert.Equal(t, test.expected, results)
 			}
-
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

- Adds default rule system on Docker provider
- Removes `domain` from static configuration
- Removes `traefik.domain` from labels

### Motivation

Be simpler to define default rules.

### More

- [x] Added/updated tests
~- [ ] Added/updated documentation~

### Additional Notes

Co-authored-by: Julien Salleyron <julien@containo.us>
