### PR TITLE
Fixes docker swarm mode refresh second for KV.

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -235,6 +235,10 @@ func (gc *GlobalConfiguration) SetEffectiveConfiguration(configFile string) {
 		} else {
 			gc.Docker.TemplateVersion = 2
 		}
+
+		if gc.Docker.SwarmModeRefreshSeconds <= 0 {
+			gc.Docker.SwarmModeRefreshSeconds = 15
+		}
 	}
 
 	if gc.Marathon != nil {


### PR DESCRIPTION

### What does this PR do?

fix: docker swarm mode refresh second for KV.

### Motivation

```
time="2019-01-22T20:27:38Z" level=error msg="Error in Go routine: non-positive interval for NewTicker"
time="2019-01-22T20:27:38Z" level=error msg="Stack: goroutine 82 [running]:\nruntime/debug.Stack(0x26a5d88, 0x17, 0xc000c51e90)\n\t/usr/local/go/src/runtime/debug/stack.go:24 +0xa7\ngithub.com/containous/traefik/safe.defaultRecoverGoroutine(0x21b9300, 0xc000c51e80)\n\t/go/src/github.com/containous/traefik/safe/routine.go:148 +0x89\ngithub.com/containous/traefik/safe.OperationWithRecover.func1.1(0xc0036c9e20)\n\t/go/src/github.com/containous/traefik/safe/routine.go:156 +0x56\npanic(0x21b9300, 0xc000c51e80)\n\t/usr/local/go/src/runtime/panic.go:513 +0x1b9\ntime.NewTicker(0x0, 0x0)\n\t/usr/local/go/src/time/tick.go:23 +0x18f\ngithub.com/containous/traefik/provider/docker.(*Provider).Provide.func1.1(0x0, 0x0)\n\t/go/src/github.com/containous/traefik/provider/docker/docker.go:167 +0xb7b\ngithub.com/containous/traefik/safe.OperationWithRecover.func1(0x0, 0x0)\n\t/go/src/github.com/containous/traefik/safe/routine.go:160 +0x62\ngithub.com/containous/traefik/vendor/github.com/cenk/backoff.RetryNotify(0xc000376010, 0x29a0fc0, 0xc0001ea1a0, 0x275d030, 0xc0001ea1a0, 0xc000836040)\n\t/go/src/github.com/containous/traefik/vendor/github.com/cenk/backoff/retry.go:37 +0xa2\ngithub.com/containous/traefik/provider/docker.(*Provider).Provide.func1(0x29c1980, 0xc00032a100)\n\t/go/src/github.com/containous/traefik/provider/docker/docker.go:252 +0x1bb\ngithub.com/containous/traefik/safe.(*Pool).GoCtx.func1()\n\t/go/src/github.com/containous/traefik/safe/routine.go:62 +0x40\ngithub.com/containous/traefik/safe.GoWithRecover.func1(0x275d300, 0xc0001ea080)\n\t/go/src/github.com/containous/traefik/safe/routine.go:142 +0x4d\ncreated by github.com/containous/traefik/safe.GoWithRecover\n\t/go/src/github.com/containous/traefik/safe/routine.go:136 +0x49\n"
time="2019-01-22T20:27:38Z" level=error msg="Provider connection error panic in operation: %!s(<nil>), retrying in 13.980940352s"
```
```
Stack: goroutine 82 [running]:
runtime/debug.Stack(0x26a5d88, 0x17, 0xc000c51e90)
	/usr/local/go/src/runtime/debug/stack.go:24 +0xa7
github.com/containous/traefik/safe.defaultRecoverGoroutine(0x21b9300, 0xc000c51e80)
	/go/src/github.com/containous/traefik/safe/routine.go:148 +0x89
github.com/containous/traefik/safe.OperationWithRecover.func1.1(0xc0036c9e20)
	/go/src/github.com/containous/traefik/safe/routine.go:156 +0x56
panic(0x21b9300, 0xc000c51e80)
	/usr/local/go/src/runtime/panic.go:513 +0x1b9
time.NewTicker(0x0, 0x0)
	/usr/local/go/src/time/tick.go:23 +0x18f
github.com/containous/traefik/provider/docker.(*Provider).Provide.func1.1(0x0, 0x0)
	/go/src/github.com/containous/traefik/provider/docker/docker.go:167 +0xb7b
github.com/containous/traefik/safe.OperationWithRecover.func1(0x0, 0x0)
	/go/src/github.com/containous/traefik/safe/routine.go:160 +0x62
github.com/containous/traefik/vendor/github.com/cenk/backoff.RetryNotify(0xc000376010, 0x29a0fc0, 0xc0001ea1a0, 0x275d030, 0xc0001ea1a0, 0xc000836040)
	/go/src/github.com/containous/traefik/vendor/github.com/cenk/backoff/retry.go:37 +0xa2
github.com/containous/traefik/provider/docker.(*Provider).Provide.func1(0x29c1980, 0xc00032a100)
	/go/src/github.com/containous/traefik/provider/docker/docker.go:252 +0x1bb
github.com/containous/traefik/safe.(*Pool).GoCtx.func1()
	/go/src/github.com/containous/traefik/safe/routine.go:62 +0x40
github.com/containous/traefik/safe.GoWithRecover.func1(0x275d300, 0xc0001ea080)
	/go/src/github.com/containous/traefik/safe/routine.go:142 +0x4d
created by github.com/containous/traefik/safe.GoWithRecover
	/go/src/github.com/containous/traefik/safe/routine.go:136 +0x49
```

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Ping @MichaelErmer 
