### PR TITLE
insecureSkipVerify for the passTLSCert transport

### DIFF
--- a/server/server_loadbalancer.go
+++ b/server/server_loadbalancer.go
@@ -211,6 +211,7 @@ func (s *Server) getRoundTripper(entryPointName string, passTLSCert bool, tls *t
 		if err != nil {
 			return nil, fmt.Errorf("failed to create TLSClientConfig: %v", err)
 		}
+		tlsConfig.InsecureSkipVerify = s.globalConfiguration.InsecureSkipVerify
 
 		transport, err := createHTTPTransport(s.globalConfiguration)
 		if err != nil {


### PR DESCRIPTION

### What does this PR do?

Apply the global InsecureSkipVerify Configuration to the passTLSCert transport.

### Motivation

Allow to apply insecure skip verify between Traefik and the backend

### More

- ~[ ] Added/updated tests~
- ~[ ] Added/updated documentation~
