### PR TITLE
fix missing trailers with retry

### DIFF
--- a/integration/fixtures/grpc/config_retry.toml
+++ b/integration/fixtures/grpc/config_retry.toml
@@ -1,0 +1,31 @@
+defaultEntryPoints = ["https"]
+
+rootCAs = [ """{{ .CertContent }}""" ]
+
+[retry]
+
+[entryPoints]
+  [entryPoints.https]
+  address = ":4443"
+    [entryPoints.https.tls]
+     [[entryPoints.https.tls.certificates]]
+     certFile = """{{ .CertContent }}"""
+     keyFile  = """{{ .KeyContent }}"""
+
+
+[api]
+
+[file]
+
+[backends]
+  [backends.backend1]
+    [backends.backend1.servers.server1]
+    url = "https://127.0.0.1:{{ .GRPCServerPort }}"
+    weight = 1
+
+
+[frontends]
+  [frontends.frontend1]
+  backend = "backend1"
+    [frontends.frontend1.routes.test_1]
+    rule = "Host:127.0.0.1"

--- a/integration/grpc_test.go
+++ b/integration/grpc_test.go
@@ -417,3 +417,45 @@ func (s *GRPCSuite) TestGRPCBufferWithFlushInterval(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 }
+
+func (s *GRPCSuite) TestGRPCWithRetry(c *check.C) {
+	lis, err := net.Listen("tcp", ":0")
+	_, port, err := net.SplitHostPort(lis.Addr().String())
+	c.Assert(err, check.IsNil)
+
+	go func() {
+		err := startGRPCServer(lis, &myserver{})
+		c.Log(err)
+		c.Assert(err, check.IsNil)
+	}()
+
+	file := s.adaptFile(c, "fixtures/grpc/config_retry.toml", struct {
+		CertContent    string
+		KeyContent     string
+		GRPCServerPort string
+	}{
+		CertContent:    string(LocalhostCert),
+		KeyContent:     string(LocalhostKey),
+		GRPCServerPort: port,
+	})
+
+	defer os.Remove(file)
+	cmd, display := s.traefikCmd(withConfigFile(file))
+	defer display(c)
+
+	err = cmd.Start()
+	c.Assert(err, check.IsNil)
+	defer cmd.Process.Kill()
+
+	// wait for Traefik
+	err = try.GetRequest("http://127.0.0.1:8080/api/providers", 1*time.Second, try.BodyContains("Host:127.0.0.1"))
+	c.Assert(err, check.IsNil)
+
+	var response string
+	err = try.Do(1*time.Second, func() error {
+		response, err = callHelloClientGRPC("World", true)
+		return err
+	})
+	c.Assert(err, check.IsNil)
+	c.Assert(response, check.Equals, "Hello World")
+}

--- a/middlewares/retry.go
+++ b/middlewares/retry.go
@@ -110,6 +110,7 @@ type retryResponseWriterWithoutCloseNotify struct {
 	responseWriter http.ResponseWriter
 	headers        http.Header
 	shouldRetry    bool
+	writed         bool
 }
 
 func (rr *retryResponseWriterWithoutCloseNotify) ShouldRetry() bool {
@@ -121,6 +122,9 @@ func (rr *retryResponseWriterWithoutCloseNotify) DisableRetries() {
 }
 
 func (rr *retryResponseWriterWithoutCloseNotify) Header() http.Header {
+	if rr.writed {
+		return rr.responseWriter.Header()
+	}
 	return rr.headers
 }
 
@@ -155,6 +159,7 @@ func (rr *retryResponseWriterWithoutCloseNotify) WriteHeader(code int) {
 	}
 
 	rr.responseWriter.WriteHeader(code)
+	rr.writed = true
 }
 
 func (rr *retryResponseWriterWithoutCloseNotify) Hijack() (net.Conn, *bufio.ReadWriter, error) {

--- a/middlewares/retry.go
+++ b/middlewares/retry.go
@@ -110,7 +110,7 @@ type retryResponseWriterWithoutCloseNotify struct {
 	responseWriter http.ResponseWriter
 	headers        http.Header
 	shouldRetry    bool
-	writed         bool
+	written         bool
 }
 
 func (rr *retryResponseWriterWithoutCloseNotify) ShouldRetry() bool {
@@ -122,7 +122,7 @@ func (rr *retryResponseWriterWithoutCloseNotify) DisableRetries() {
 }
 
 func (rr *retryResponseWriterWithoutCloseNotify) Header() http.Header {
-	if rr.writed {
+	if rr.written {
 		return rr.responseWriter.Header()
 	}
 	return rr.headers
@@ -159,7 +159,7 @@ func (rr *retryResponseWriterWithoutCloseNotify) WriteHeader(code int) {
 	}
 
 	rr.responseWriter.WriteHeader(code)
-	rr.writed = true
+	rr.written = true
 }
 
 func (rr *retryResponseWriterWithoutCloseNotify) Hijack() (net.Conn, *bufio.ReadWriter, error) {

--- a/middlewares/retry.go
+++ b/middlewares/retry.go
@@ -110,7 +110,7 @@ type retryResponseWriterWithoutCloseNotify struct {
 	responseWriter http.ResponseWriter
 	headers        http.Header
 	shouldRetry    bool
-	written         bool
+	written        bool
 }
 
 func (rr *retryResponseWriterWithoutCloseNotify) ShouldRetry() bool {


### PR DESCRIPTION
### What does this PR do?
When the retry middleware has already sent the headers, use the original headers map to be able to send trailers.

### Motivation
Fix trailers and Grpc issues.
Fixes #4433 

### More

- [x] Added/updated tests
