### PR TITLE
Disable zoom on the web ui

### DIFF
--- a/webui/src/index.html
+++ b/webui/src/index.html
@@ -4,7 +4,8 @@
   <meta charset="utf-8">
   <title>Traefik</title>
   <base href="./">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <link rel="icon" type="image/x-icon" href="./assets/images/traefik.icon.png">
 </head>
 <body>


### PR DESCRIPTION
Update index.html of the web ui for more compatibility with web browsers.

### What does this PR do?

Thanks to this modification, it is no longer possible to zoom in on the web interface when viewed on a small screen.

### Motivation

Fix bug on web ui.