### PR TITLE
chore(webui): update docker node version

### DIFF
--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -1,14 +1,7 @@
-FROM node:6.9.1
+FROM node:8.15.0
 
 ENV WEBUI_DIR /src/webui
 RUN mkdir -p $WEBUI_DIR
-
-RUN apt-get -yq update \
-&& apt-get -yq --no-install-suggests --no-install-recommends --force-yes install apt-transport-https \
-&& curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-&& echo "deb https://dl.yarnpkg.com/debian/ stable main" |  tee /etc/apt/sources.list.d/yarn.list \
-&& apt-get -yq update && apt-get -yq --no-install-suggests --no-install-recommends --force-yes install yarn \
-&& rm -fr /var/lib/apt/lists/
 
 COPY package.json $WEBUI_DIR/
 COPY yarn.lock $WEBUI_DIR/


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- Update webui docker image to Node Carbon (a compatible version of Node and with LTS until dec/2019)
- Remove `yarn` JS package manager from image layers because it is now already installed in Node official image 

### Motivation

<!-- What inspired you to submit this pull request? -->
- Maintain webui up to date :tada: 

### Additional Notes

<!-- Anything else we should know when reviewing? -->

- [Release schedule of NodeJS](https://github.com/nodejs/Release)
- [Yarn install in Node official image](https://github.com/nodejs/docker-node/blob/86b9618674b01fc5549f83696a90d5bc21f38af0/8/stretch/Dockerfile#L47)
