### PR TITLE
chore(webui): ignore target/dependencies in docker copy

### DIFF
--- a/webui/.dockerignore
+++ b/webui/.dockerignore
@@ -1,0 +1,5 @@
+# compiled output
+/dist
+
+# dependencies
+/node_modules


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

- add `.dockerignore` file
- ignore target builded files during docker image build
- ignore dependencies during docker image build
 
### Motivation

<!-- What inspired you to submit this pull request? -->

It is consider a bad practice to copy dependencies and target in a docker "build pattern" image.
This won't affect current build, but it will protect contributors to locally image building latency.

