### PR TITLE
app-root on non-explicit path include "/" in the redirect

### DIFF
--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -945,8 +945,12 @@ func getFrontendRedirect(i *extensionsv1beta1.Ingress, baseName, path string) *t
 	permanent := getBoolValue(i.Annotations, annotationKubernetesRedirectPermanent, false)
 
 	if appRoot := getStringValue(i.Annotations, annotationKubernetesAppRoot, ""); appRoot != "" && (path == "/" || path == "") {
+		regex := fmt.Sprintf("%s$", baseName)
+		if path == "" {
+			regex = fmt.Sprintf("%s/$", baseName)
+		}
 		return &types.Redirect{
-			Regex:       fmt.Sprintf("%s$", baseName),
+			Regex:       regex,
 			Replacement: fmt.Sprintf("%s/%s", strings.TrimRight(baseName, "/"), strings.TrimLeft(appRoot, "/")),
 			Permanent:   permanent,
 		}

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -1686,7 +1686,7 @@ rateset:
 			),
 			frontend("root3",
 				passHostHeader(),
-				redirectRegex("root3$", "root3/root"),
+				redirectRegex("root3/$", "root3/root"),
 				routes(
 					route("root3", "Host:root3"),
 				),


### PR DESCRIPTION
### What does this PR do?

Fixes #4427 , 
When the path is empty, the basepath does not contains a slash.
The slash must be added in the redirect matching regex.


### Motivation

Given the [RFC 2616 sec. 3.2.2](https://tools.ietf.org/html/rfc2616#section-3.2.2) : 

> the abs_path is not present in the URL, it MUST be given as "/" when
   used as a Request-URI for a resource  

Which mean that the current matching regex for the redirect rule of the "appRoot" annotation of an ingress without given path will not work.


### More

- [x] Added/updated tests
- [x] Added/updated documentation - not needed, intended behaviour

### Additional Notes

This is my First PR, sorry If I missed something.
