### PR TITLE
Update default value in docs of buckets for Prometheus

### DIFF
--- a/docs/configuration/metrics.md
+++ b/docs/configuration/metrics.md
@@ -20,7 +20,7 @@
     # Buckets for latency metrics
     #
     # Optional
-    # Default: [0.1, 0.3, 1.2, 5]
+    # Default: [0.1, 0.3, 1.2, 5.0]
     #
     buckets = [0.1,0.3,1.2,5.0]
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

Updated default value if buckets for Prometheus metrics. It should be homogeneous so the last value had a missing decimal place.


### Motivation

I've got an error: `Array contains values of type 'Float' and 'Integer', but arrays must be homogeneous` after coping default value from the documentation.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

