### PR TITLE
Loop through service ports for global backend

### DIFF
--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -517,7 +517,6 @@ func (p *Provider) addGlobalBackend(cl Client, i *extensionsv1beta1.Ingress, tem
 		for _, subset := range endpoints.Subsets {
 			endpointPort := endpointPortNumber(port, subset.Ports)
 			if endpointPort == 0 {
-				log.Errorf("Endpoint subset ports %v don't match service port: %v ", subset.Ports, port)
 				// endpoint port does not match service.
 				continue
 			}

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -502,39 +502,42 @@ func (p *Provider) addGlobalBackend(cl Client, i *extensionsv1beta1.Ingress, tem
 	templateObjects.Backends[defaultBackendName].Buffering = getBuffering(service)
 	templateObjects.Backends[defaultBackendName].ResponseForwarding = getResponseForwarding(service)
 
-	endpoints, exists, err := cl.GetEndpoints(service.Namespace, service.Name)
-	if err != nil {
-		return fmt.Errorf("error retrieving endpoint information from k8s API %s/%s: %v", service.Namespace, service.Name, err)
-	}
-	if !exists {
-		return fmt.Errorf("endpoints not found for %s/%s", service.Namespace, service.Name)
-	}
-	if len(endpoints.Subsets) == 0 {
-		return fmt.Errorf("endpoints not available for %s/%s", service.Namespace, service.Name)
-	}
-
-	for _, subset := range endpoints.Subsets {
-		endpointPort := endpointPortNumber(corev1.ServicePort{Protocol: "TCP", Port: int32(i.Spec.Backend.ServicePort.IntValue())}, subset.Ports)
-		if endpointPort == 0 {
-			// endpoint port does not match service.
-			continue
+	for _, port := range service.Spec.Ports {
+		endpoints, exists, err := cl.GetEndpoints(service.Namespace, service.Name)
+		if err != nil {
+			return fmt.Errorf("error retrieving endpoint information from k8s API %s/%s: %v", service.Namespace, service.Name, err)
+		}
+		if !exists {
+			return fmt.Errorf("endpoints not found for %s/%s", service.Namespace, service.Name)
+		}
+		if len(endpoints.Subsets) == 0 {
+			return fmt.Errorf("endpoints not available for %s/%s", service.Namespace, service.Name)
 		}
 
-		protocol := "http"
-		for _, address := range subset.Addresses {
-			if endpointPort == 443 || strings.HasPrefix(i.Spec.Backend.ServicePort.String(), "https") {
-				protocol = "https"
+		for _, subset := range endpoints.Subsets {
+			endpointPort := endpointPortNumber(port, subset.Ports)
+			if endpointPort == 0 {
+				log.Errorf("Endpoint subset ports %v don't match service port: %v ", subset.Ports, port)
+				// endpoint port does not match service.
+				continue
 			}
 
-			url := fmt.Sprintf("%s://%s", protocol, net.JoinHostPort(address.IP, strconv.FormatInt(int64(endpointPort), 10)))
-			name := url
-			if address.TargetRef != nil && address.TargetRef.Name != "" {
-				name = address.TargetRef.Name
-			}
+			protocol := "http"
+			for _, address := range subset.Addresses {
+				if endpointPort == 443 || strings.HasPrefix(i.Spec.Backend.ServicePort.String(), "https") {
+					protocol = "https"
+				}
 
-			templateObjects.Backends[defaultBackendName].Servers[name] = types.Server{
-				URL:    url,
-				Weight: label.DefaultWeight,
+				url := fmt.Sprintf("%s://%s", protocol, net.JoinHostPort(address.IP, strconv.FormatInt(int64(endpointPort), 10)))
+				name := url
+				if address.TargetRef != nil && address.TargetRef.Name != "" {
+					name = address.TargetRef.Name
+				}
+
+				templateObjects.Backends[defaultBackendName].Servers[name] = types.Server{
+					URL:    url,
+					Weight: label.DefaultWeight,
+				}
 			}
 		}
 	}

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -374,7 +374,7 @@ func TestLoadGlobalIngressWithHttpsPortNames(t *testing.T) {
 			eUID("1"),
 			subset(
 				eAddresses(eAddress("10.10.0.1")),
-				ePorts(ePort(8080, ""))),
+				ePorts(ePort(8080, "https-global"))),
 		),
 	}
 


### PR DESCRIPTION
### What does this PR do?

This PR resolves an issue where service ports and endpoint ports mismatch on global backends, despite both being correct, and correctly named. This was due to the matching logic used on multiport services, and services that are named/not named.

This PR also updates the test for named endpoint ports, since the original case in the tests could not have happened (non-named endpoint port with named service port).


### Motivation

Fixes #4465 

### More

- [x] Added/updated tests
- [x] Added/updated documentation - None needed
