### PR TITLE
Update Structor to  v1.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,7 @@ before_deploy:
         make -j${N_MAKE_JOBS} crossbinary-parallel;
         tar cfz dist/traefik-${VERSION}.src.tar.gz --exclude-vcs --exclude dist .;
       fi;
-      curl -sI https://github.com/containous/structor/releases/latest | grep -Fi Location  | tr -d '\r' | sed "s/tag/download/g" | awk -F " " '{ print $2 "/structor_linux-amd64"}' | wget --output-document=$GOPATH/bin/structor -i -;
-      chmod +x $GOPATH/bin/structor;
+      curl -sfL https://raw.githubusercontent.com/containous/structor/master/godownloader.sh | bash -s -- -b "${GOPATH}/bin" v1.4.0
       structor -o containous -r traefik --dockerfile-url="https://raw.githubusercontent.com/containous/traefik/master/docs.Dockerfile" --menu.js-url="https://raw.githubusercontent.com/containous/structor/master/traefik-menu.js.gotmpl" --rqts-url="https://raw.githubusercontent.com/containous/structor/master/requirements-override.txt" --exp-branch=master --debug;
     fi
 deploy:


### PR DESCRIPTION
Signed-off-by: Damien DUPORTAL <damien.duportal@gmail.com>

### What does this PR do?

This PR changes the behavior for getting [structor](https://github.com/containous/structor) for generating versioned documentation in Travis:

- Using [godownloader script](https://github.com/goreleaser/godownloader), added in latest release of structor
- Fix the structor version, instead of getting "latest" release all the time, to have a constant behavior. 
- Update structor version from `1.3.2` to `1.4.0`

### Motivation

- Better automation and release management
- Constant behavior of builds for future releases
- Get latest structor changes

### More

- ~[ ] Added/updated tests~
- ~[ ] Added/updated documentation~

### Additional Notes

👋 
