### PR TITLE
Cherry pick v1.7 into master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,7 @@ before_deploy:
         make -j${N_MAKE_JOBS} crossbinary-parallel;
         tar cfz dist/traefik-${VERSION}.src.tar.gz --exclude-vcs --exclude dist .;
       fi;
-      curl -sI https://github.com/containous/structor/releases/latest | grep -Fi Location  | tr -d '\r' | sed "s/tag/download/g" | awk -F " " '{ print $2 "/structor_linux-amd64"}' | wget --output-document=$GOPATH/bin/structor -i -;
-      chmod +x $GOPATH/bin/structor;
+      curl -sfL https://raw.githubusercontent.com/containous/structor/master/godownloader.sh | bash -s -- -b "${GOPATH}/bin" v1.4.0
       structor -o containous -r traefik --dockerfile-url="https://raw.githubusercontent.com/containous/traefik/master/docs.Dockerfile" --menu.js-url="https://raw.githubusercontent.com/containous/structor/master/traefik-menu.js.gotmpl" --rqts-url="https://raw.githubusercontent.com/containous/structor/master/requirements-override.txt" --exp-branch=master --debug;
     fi
 deploy:


### PR DESCRIPTION
### What does this PR do?

Cherry pick v1.7 into master:
- [x] Update Structor to  v1.4.0 [#4508](https://github.com/containous/traefik/pull/4508)

Skip:
- [x] Applies new goimports recommendations. [#4499](https://github.com/containous/traefik/pull/4499)

### Motivation

Be sync.

### More

- ~~[ ] Added/updated tests~~
- ~~[ ] Added/updated documentation~~