### PR TITLE
Added support for configuring trace headers for DataDog tracing

### DIFF
--- a/middlewares/tracing/datadog/datadog.go
+++ b/middlewares/tracing/datadog/datadog.go
@@ -19,7 +19,7 @@ type Config struct {
 	GlobalTag                  string `description:"Key:Value tag to be set on all the spans." export:"true"`
 	Debug                      bool   `description:"Enable DataDog debug." export:"true"`
 	PrioritySampling           bool   `description:"Enable priority sampling. When using distributed tracing, this option must be enabled in order to get all the parts of a distributed trace sampled."`
-	TraceIDHeaderName          string `description:"Specifies the header name that will be used to store the trace ID.." export:"true"`
+	TraceIDHeaderName          string `description:"Specifies the header name that will be used to store the trace ID." export:"true"`
 	ParentIDHeaderName         string `description:"Specifies the header name that will be used to store the parent ID." export:"true"`
 	SamplingPriorityHeaderName string `description:"Specifies the header name that will be used to store the sampling priority." export:"true"`
 	BagagePrefixHeaderName     string `description:"specifies the header name prefix that will be used to store baggage items in a map." export:"true"`

--- a/middlewares/tracing/datadog/datadog.go
+++ b/middlewares/tracing/datadog/datadog.go
@@ -15,10 +15,14 @@ const Name = "datadog"
 
 // Config provides configuration settings for a datadog tracer
 type Config struct {
-	LocalAgentHostPort string `description:"Set datadog-agent's host:port that the reporter will used. Defaults to localhost:8126" export:"false"`
-	GlobalTag          string `description:"Key:Value tag to be set on all the spans." export:"true"`
-	Debug              bool   `description:"Enable DataDog debug." export:"true"`
-	PrioritySampling   bool   `description:"Enable priority sampling. When using distributed tracing, this option must be enabled in order to get all the parts of a distributed trace sampled."`
+	LocalAgentHostPort         string `description:"Set datadog-agent's host:port that the reporter will used. Defaults to localhost:8126" export:"false"`
+	GlobalTag                  string `description:"Key:Value tag to be set on all the spans." export:"true"`
+	Debug                      bool   `description:"Enable DataDog debug." export:"true"`
+	PrioritySampling           bool   `description:"Enable priority sampling. When using distributed tracing, this option must be enabled in order to get all the parts of a distributed trace sampled."`
+	TraceIDHeaderName          string `description:"Specifies the header name that will be used to store the trace ID.." export:"true"`
+	ParentIDHeaderName         string `description:"Specifies the header name that will be used to store the parent ID." export:"true"`
+	SamplingPriorityHeaderName string `description:"Specifies the header name that will be used to store the sampling priority." export:"true"`
+	BagagePrefixHeaderName     string `description:"specifies the header name prefix that will be used to store baggage items in a map." export:"true"`
 }
 
 // Setup sets up the tracer
@@ -35,6 +39,12 @@ func (c *Config) Setup(serviceName string) (opentracing.Tracer, io.Closer, error
 		datadog.WithServiceName(serviceName),
 		datadog.WithGlobalTag(tag[0], value),
 		datadog.WithDebugMode(c.Debug),
+		datadog.WithPropagator(datadog.NewPropagator(&datadog.PropagatorConfig{
+			TraceHeader:    c.TraceIDHeaderName,
+			ParentHeader:   c.ParentIDHeaderName,
+			PriorityHeader: c.SamplingPriorityHeaderName,
+			BaggagePrefix:  c.BagagePrefixHeaderName,
+		})),
 	}
 	if c.PrioritySampling {
 		opts = append(opts, datadog.WithPrioritySampling())


### PR DESCRIPTION
Provide ability to configure Trace Header name overrides to enable integration of DataDog tracer with other OpenTracing compliant systems like Zipkin, Jaeger, Haystack and others.