### PR TITLE
warning should not be a fail status

### DIFF
--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -111,6 +111,7 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 	defaultConsulCatalog.Prefix = "traefik"
 	defaultConsulCatalog.FrontEndRule = "Host:{{.ServiceName}}.{{.Domain}}"
 	defaultConsulCatalog.Stale = false
+	defaultConsulCatalog.WarningIsCritical = true
 
 	// default Etcd
 	var defaultEtcd etcd.Provider

--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -111,7 +111,7 @@ func NewTraefikDefaultPointersConfiguration() *TraefikConfiguration {
 	defaultConsulCatalog.Prefix = "traefik"
 	defaultConsulCatalog.FrontEndRule = "Host:{{.ServiceName}}.{{.Domain}}"
 	defaultConsulCatalog.Stale = false
-	defaultConsulCatalog.WarningIsCritical = true
+	defaultConsulCatalog.StrictChecks = true
 
 	// default Etcd
 	var defaultEtcd etcd.Provider

--- a/docs/configuration/backends/consulcatalog.md
+++ b/docs/configuration/backends/consulcatalog.md
@@ -37,6 +37,13 @@ stale = false
 #
 domain = "consul.localhost"
 
+# Removes a Consul node from all backends on any check in Warning on this node.
+#
+# Optional
+# Default: true
+#
+WarningIsCritical = true
+
 # Prefix for Consul catalog tags.
 #
 # Optional

--- a/docs/configuration/backends/consulcatalog.md
+++ b/docs/configuration/backends/consulcatalog.md
@@ -37,12 +37,14 @@ stale = false
 #
 domain = "consul.localhost"
 
-# Removes a Consul node from all backends on any check in Warning on this node.
+# Keep a Consul node only if all checks status are passing
+# If true, only the Consul nodes with checks status 'passing' will be kept.
+# if false, only the Consul nodes with checks status 'passing' or 'warning' will be kept.
 #
 # Optional
 # Default: true
 #
-WarningIsCritical = true
+strictChecks = true
 
 # Prefix for Consul catalog tags.
 #

--- a/provider/consulcatalog/consul_catalog.go
+++ b/provider/consulcatalog/consul_catalog.go
@@ -492,7 +492,7 @@ func getServiceAddresses(services []*api.CatalogService) []string {
 
 func (p *Provider) healthyNodes(service string) (catalogUpdate, error) {
 	health := p.client.Health()
-	// You can't filter with assing only here, nodeFilter will do this later
+	// You can't filter with assigning passingOnly here, nodeFilter will do this later
 	data, _, err := health.Service(service, "", false, &api.QueryOptions{AllowStale: p.Stale})
 	if err != nil {
 		log.WithError(err).Errorf("Failed to fetch details of %s", service)

--- a/provider/consulcatalog/consul_catalog.go
+++ b/provider/consulcatalog/consul_catalog.go
@@ -299,7 +299,7 @@ func (p *Provider) watchHealthState(stopCh <-chan struct{}, watchCh chan<- map[s
 				for _, healthy := range healthyState {
 					key := fmt.Sprintf("%s-%s", healthy.Node, healthy.ServiceID)
 					_, failing := currentFailing[key]
-					if healthy.Status == "passing" && !failing {
+					if (healthy.Status == "passing" || healthy.Status == "warning") && !failing {
 						current[key] = append(current[key], healthy.Node)
 					} else if strings.HasPrefix(healthy.CheckID, "_service_maintenance") || strings.HasPrefix(healthy.CheckID, "_node_maintenance") {
 						maintenance = append(maintenance, healthy.CheckID)


### PR DESCRIPTION
I would like to have a behavior like the DNS provider of consul.
Even if the service is warning, It is considered as UP.

Moreover, another difference is that if any service not served by traefik is in warning state, traefik remove it from consul catalog.

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

Change failure detection for consul catalog

### Motivation

A warning on a service on a node disable all frontends of this node on consul

### More

- Not Added/updated tests
- Not Added/updated documentation

### Additional Notes

I have tested it manualy, I don't know what test I could write.
related to #4536 