### PR TITLE
Support external name service on global default backend

### DIFF
--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -284,6 +284,59 @@ func TestLoadIngresses(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestLoadGlobalIngressWithExternalName(t *testing.T) {
+	ingresses := []*extensionsv1beta1.Ingress{
+		buildIngress(
+			iNamespace("testing"),
+			iSpecBackends(iSpecBackend(iIngressBackend("service1", intstr.FromInt(80)))),
+		),
+	}
+
+	services := []*corev1.Service{
+		buildService(
+			sName("service1"),
+			sNamespace("testing"),
+			sUID("1"),
+			sSpec(
+				sType("ExternalName"),
+				sExternalName("some-external-name"),
+				sPorts(sPort(80, ""))),
+		),
+	}
+
+	watchChan := make(chan interface{})
+	client := clientMock{
+		ingresses: ingresses,
+		services:  services,
+		watchChan: watchChan,
+	}
+	provider := Provider{}
+
+	actual, err := provider.loadIngresses(client)
+	require.NoError(t, err, "error loading ingresses")
+
+	expected := buildConfiguration(
+		backends(
+			backend("global-default-backend",
+				lbMethod("wrr"),
+				servers(
+					server("http://some-external-name", weight(1)),
+				),
+			),
+		),
+		frontends(
+			frontend("global-default-backend",
+				frontendName("global-default-frontend"),
+				passHostHeader(),
+				routes(
+					route("/", "PathPrefix:/"),
+				),
+			),
+		),
+	)
+	assert.Equal(t, expected, actual)
+}
+
 func TestLoadGlobalIngressWithPortNumbers(t *testing.T) {
 	ingresses := []*extensionsv1beta1.Ingress{
 		buildIngress(


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

This PR adds support for global backends pointing to an ExternalName services. This is accomplished by checking the service type when adding the global default backend. If the service type is an ExternalName service, the backend is mapped to the ExternalName service's url. This is basically a copy paste of what is done with normal backends. 

### Motivation

It would be useful in my environment (and others I'm sure) for the Kubernetes provider to support a global default backend that's points to an ExternalName service. This is already supported for regular backends so I imagine not supporting it here was an oversight.

### More

- [X] Added/updated tests

### Additional Notes

None