### PR TITLE
Cherry pick v1.7 into master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_deploy:
         tar cfz dist/traefik-${VERSION}.src.tar.gz --exclude-vcs --exclude dist .;
       fi;
       curl -sfL https://raw.githubusercontent.com/containous/structor/master/godownloader.sh | bash -s -- -b "${GOPATH}/bin" v1.4.0
-      structor -o containous -r traefik --dockerfile-url="https://raw.githubusercontent.com/containous/traefik/master/docs.Dockerfile" --menu.js-url="https://raw.githubusercontent.com/containous/structor/master/traefik-menu.js.gotmpl" --rqts-url="https://raw.githubusercontent.com/containous/structor/master/requirements-override.txt" --exp-branch=master --debug;
+      structor -o containous -r traefik --dockerfile-url="https://raw.githubusercontent.com/containous/traefik/v1.7/docs.Dockerfile" --menu.js-url="https://raw.githubusercontent.com/containous/structor/master/traefik-menu.js.gotmpl" --rqts-url="https://raw.githubusercontent.com/containous/structor/master/requirements-override.txt" --exp-branch=master --debug;
     fi
 deploy:
   - provider: releases

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -222,7 +222,7 @@ func loadService(client Client, namespace string, backend v1beta1.IngressBackend
 			}
 
 			protocol := "http"
-			if port == 443 || portName == "https" {
+			if port == 443 || strings.HasPrefix(portName, "https") {
 				protocol = "https"
 			}
 


### PR DESCRIPTION
### What does this PR do?

Cherry pick v1.7 into master:
 - [x] Travis: switch fallback dockerfile for structor [#4538](https://github.com/containous/traefik/pull/4538)

Skip
- [x] Loop through service ports for global backend [#4486](https://github.com/containous/traefik/pull/4486) 

### Motivation

Be sync.

### More

- ~~[ ] Added/updated tests~~
- ~~[ ] Added/updated documentation~~
