### PR TITLE
Allow user to configure traefik log

### DIFF
--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -64,9 +64,9 @@ type Configuration struct {
 	Ping    *ping.Handler  `description:"Enable ping" export:"true"`
 	// Rest    *rest.Provider `description:"Enable Rest backend with default settings" export:"true"`
 
-	Log       *types.TraefikLog
-	AccessLog *types.AccessLog `description:"Access log settings" export:"true"`
-	Tracing   *Tracing         `description:"OpenTracing configuration" export:"true"`
+	Log       *types.TraefikLog `description:"Traefik log settings" export:"true"`
+	AccessLog *types.AccessLog  `description:"Access log settings" export:"true"`
+	Tracing   *Tracing          `description:"OpenTracing configuration" export:"true"`
 
 	HostResolver *types.HostResolverConfig `description:"Enable CNAME Flattening" export:"true"`
 


### PR DESCRIPTION
### What does this PR do?

This PR allow user to configure his traefik log with CLI.

### Motivation

Run command `traefik --log.loglevel=debug`
Actual result:
```console
....
2019/03/15 13:40:49 Error parsing command: unknown flag: --log.loglevel
```

Traefik should start with debug log level.
