### PR TITLE
Fix dead maintainers link on the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ You will learn fundamental Traefik features and see some demos with Kubernetes.
 
 ## Maintainers
 
-[Information about process and maintainers](MAINTAINER.md)
+[Information about process and maintainers](docs/content/contributing/maintainers.md)
 
 ## Contributing
 


### PR DESCRIPTION


### What does this PR do?

This CL simply fixes a dead link toward the maintainers pages in the
README.md.


### Motivation

Just found it while reading the documentation :)


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
