### PR TITLE
Add local spell and tests to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,10 @@ generate-crd:
 
 lint:
 	script/validate-lint
+	script/validate-misspell
+
+local-test-unit:
+	go test ./pkg/...
 
 fmt:
 	gofmt -s -l -w $(SRCS)


### PR DESCRIPTION
### What does this PR do?

Add a makefile target for local unit tests, bypassing testing containers, also adds spellcheck to local lint.

### Motivation

Running unit tests and linting in containers in a dev environment is slow and affects performance.
