### PR TITLE
Keep consistent order

### DIFF
--- a/docs/configuration/commons.md
+++ b/docs/configuration/commons.md
@@ -249,8 +249,8 @@ Multiple sets of rates can be added to each frontend, but the time periods must 
 ```
 
 In the above example, frontend1 is configured to limit requests by the client's ip address.  
-An average of 5 requests every 3 seconds is allowed and an average of 100 requests every 10 seconds.  
-These can "burst" up to 10 and 200 in each period respectively. 
+An average of 100 requests every 10 seconds is allowed and an average of 5 requests every 3 seconds.  
+These can "burst" up to 200 and 10 in each period respectively. 
 
 Valid values for `extractorfunc` are:
   * `client.ip`


### PR DESCRIPTION
### What does this PR do?

In TOML first is 100 req/10s and second is 5req/3s, so it will be better to keep it this way in the text also

### More

- [x] Added/updated documentation
