### PR TITLE
Fix two minor nits in Traefik 2.0 docs

### DIFF
--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -199,7 +199,7 @@ The Service automatically gets a server per instance of the container, and the r
 
 ### Routers
 
-To update the configuration of the Router automatically attached to the container, add labels starting with `traefik.routers.{name-of-your-choice}.` and followed by the option you want to change. For example, to change the rule, you could add the label `traefik.http.routers.my-container.rule=Host(my-domain)`.
+To update the configuration of the Router automatically attached to the container, add labels starting with `traefik.http.routers.{name-of-your-choice}.` and followed by the option you want to change. For example, to change the rule, you could add the label `traefik.http.routers.my-container.rule=Host(my-domain)`.
 
 Every [Router](../routing/routers/index.md) parameter can be updated this way.
 

--- a/docs/content/reference/providers/docker.md
+++ b/docs/content/reference/providers/docker.md
@@ -53,10 +53,10 @@ watch = true
 #
 exposedByDefault = true
 
-# Use the IP address from the binded port instead of the inner network one.
+# Use the IP address from the bound port instead of the inner network one.
 #
-# In case no IP address is attached to the binded port (or in case 
-# there is no bind), the inner network one will be used as a fallback.     
+# In case no IP address is attached to the bound port (or in case
+# there is no bind), the inner network one will be used as a fallback.
 #
 # Optional
 # Default: false


### PR DESCRIPTION
### What does this PR do?

It fixes two small issues found in the Traefik 2.0 documentation.

### Motivation

I just upgraded to Traefik 2.0 and was confused how to configure routing rules. I think this is because the provided label in the documentation is incorrect in one location.