### PR TITLE
Throttle Kubernetes config refresh

### DIFF
--- a/docs/configuration/backends/kubernetes.md
+++ b/docs/configuration/backends/kubernetes.md
@@ -73,6 +73,14 @@ See also [Kubernetes user guide](/user-guide/kubernetes).
 #
 # enablePassTLSCert = true
 
+# Throttle how frequently we refresh our configuration from Ingresses when there
+# are frequent changes.
+#
+# Optional
+# Default: 0 (no throttling)
+#
+# throttleDuration = 10s
+
 # Override default configuration template.
 #
 # Optional
@@ -210,7 +218,7 @@ infos:
     serialnumber: true
 ```
 
-If `pem` is set, it will add a `X-Forwarded-Tls-Client-Cert` header that contains the escaped pem as value.  
+If `pem` is set, it will add a `X-Forwarded-Tls-Client-Cert` header that contains the escaped pem as value.
 If at least one flag of the `infos` part is set, it will add a `X-Forwarded-Tls-Client-Cert-Infos` header that contains an escaped string composed of the client certificate data selected by the infos flags.
 This infos part is composed like the following example (not escaped):
 ```Subject="C=FR,ST=SomeState,L=Lyon,O=Cheese,CN=*.cheese.org",NB=1531900816,NA=1563436816,SAN=*.cheese.org,*.cheese.net,cheese.in,test@cheese.org,test@cheese.net,10.0.1.0,10.0.1.2```
@@ -231,7 +239,7 @@ rateset:
 ```
 
 <5> `traefik.ingress.kubernetes.io/rule-type`
-Note: `ReplacePath` is deprecated in this annotation, use the `traefik.ingress.kubernetes.io/request-modifier` annotation instead. Default: `PathPrefix`. 
+Note: `ReplacePath` is deprecated in this annotation, use the `traefik.ingress.kubernetes.io/request-modifier` annotation instead. Default: `PathPrefix`.
 
 <6> `traefik.ingress.kubernetes.io/service-weights`:
 Service weights enable to split traffic across multiple backing services in a fine-grained manner.

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -140,12 +140,13 @@ func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *s
 				}
 			}
 
-			eventsChanBuffered := eventsChan
+			eventsChanToRead := eventsChan
 			throttleDuration := time.Duration(p.ThrottleDuration)
 			if throttleDuration > 0 {
 				// Create a buffered channel to hold the pending event (if we're
 				// delaying processing the event due to throttling)
 				eventsChanBuffered := make(chan interface{}, 1)
+				eventsChanToRead = eventsChanBuffered
 
 				// Run a goroutine that reads events from eventChan and does a
 				// non-blocking write to pendingEvent. This guarantees that writing to
@@ -176,7 +177,7 @@ func (p *Provider) Provide(configurationChan chan<- types.ConfigMessage, pool *s
 				select {
 				case <-stop:
 					return nil
-				case event := <-eventsChanBuffered:
+				case event := <-eventsChanToRead:
 					// Note that event is the *first* event that came in during this
 					// throttling interval -- if we're hitting our throttle, we may have
 					// dropped events. This is fine, because we don't treat different


### PR DESCRIPTION
### What does this PR do?

This is an in-progress change to throttle how frequently we refresh the Kubernetes ingress configuration.

This isn't ready to merge; I wanted to start a discussion about the approach and share my results testing this change in my production environment. 

### Motivation

My team is in the process of moving from the Nginx ingress controller to Traefik. Overall, it's been going well but we saw concerningly high CPU usage from Traefik. We're not handling very much traffic, but each of our 19 Traefik pods was using around 200 millicores, with spikes up to 700-800 millicores. For reference, our nginx pods were using around 40-50 millicores for a heaver traffic load.

Our cluster is roughly 25 nodes, but we're running many more independent services than is typical for a Kubernetes cluster -- we have about 2000 ingresses and 700 services. 

I took a pprof of the traefik process:

![profile-pre](https://user-images.githubusercontent.com/207390/55505389-0045e180-5621-11e9-8582-313f37da518c.png)

I noticed that most of the time was spent loading the configuration from Kubernetes and diffing it with the current configuration. If I understand correctly, Traefik throttles these updates *after* they've been sent from the Kubernetes provider to [server_configuration.go](https://github.com/containous/traefik/blob/v1.7/server/server_configuration.go#L440) -- so when we get a lot of updates from Kubernetes, Traefik spends a lot of time generating and diffing configurations that are then immediately discarded by the throttler.

The PR is a first stab at *also* throttling in the Kubernetes provider. We've deployed this branch to our production environment, with a 10-second throttle, and observed that our CPU usage has declined to roughly 25 millicores (almost a 10x improvement). Here's the pprof after applying this PR:

![profile001](https://user-images.githubusercontent.com/207390/55506993-c2e35300-5624-11e9-97d2-2c815e154a6e.png)

Even throttled that heavily, you can see that we're still spending most of our time refreshing the Kubernetes config, but it's definitely a big improvement. I think there's a lot of additional performance that could be squeezed out of the code that refreshes the config, but starting with this throttling is a good first step.

### Open Questions

- Is this approach generally reasonable?
- How should we configure the throttling? I think the ideal thing would be to use the same throttle configuration as `server_configuration.go`, but I don't think that config value is passed down to the Kubernetes provider
- Are there other low-hanging performance improvements we could make to improve performance in clusters with a large number of ingresses, services, and endpoints? 
- I've been working on top of the `v1.7` branch because I wanted to test this in our production environment -- is this something that can make it into the `v1.7` branch or should I work against the `master` branch?
