### PR TITLE
Fix response modifier initial building

### DIFF
--- a/pkg/server/router/router.go
+++ b/pkg/server/router/router.go
@@ -178,7 +178,11 @@ func (m *Manager) buildRouterHandler(ctx context.Context, routerName string) (ht
 }
 
 func (m *Manager) buildHTTPHandler(ctx context.Context, router *config.Router, routerName string) (http.Handler, error) {
-	rm := m.modifierBuilder.Build(ctx, router.Middlewares)
+	qualifiedNames := make([]string, len(router.Middlewares))
+	for i, name := range router.Middlewares {
+		qualifiedNames[i] = internal.GetQualifiedName(ctx, name)
+	}
+	rm := m.modifierBuilder.Build(ctx, qualifiedNames)
 
 	sHandler, err := m.serviceManager.BuildHTTP(ctx, router.Service, rm)
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

This PR fixes the middleware names passed as argument to the response modifier middleware Builder. The Builder Build method is expecting qualified names (prefixed with the provider type), so that it can check their existence in the configs map. Before this change, the Build method was receiving non-prefixed names, so the middleware names were never found in the configs map.

### Motivation

While investigating #4708 we found out that custom response headers supposedly added with the response modifier middleware never seemed to actually show up in the responses.

### More

- [ ] Added/updated tests
- [ ] ~~Added/updated documentation~~

### Additional Notes

Co-authored-by: Ludovic Fernandez <ldez@users.noreply.github.com>
