### PR TITLE
Add addHeadersToResponse option in forward auth middleware

### DIFF
--- a/pkg/config/middlewares.go
+++ b/pkg/config/middlewares.go
@@ -113,10 +113,11 @@ type ErrorPage struct {
 
 // ForwardAuth holds the http forward authentication configuration.
 type ForwardAuth struct {
-	Address             string     `description:"Authentication server address" json:"address,omitempty"`
-	TLS                 *ClientTLS `description:"Enable TLS support" json:"tls,omitempty" export:"true"`
-	TrustForwardHeader  bool       `description:"Trust X-Forwarded-* headers" json:"trustForwardHeader,omitempty" export:"true"`
-	AuthResponseHeaders []string   `description:"Headers to be forwarded from auth response" json:"authResponseHeaders,omitempty"`
+	Address              string     `description:"Authentication server address" json:"address,omitempty"`
+	TLS                  *ClientTLS `description:"Enable TLS support" json:"tls,omitempty" export:"true"`
+	TrustForwardHeader   bool       `description:"Trust X-Forwarded-* headers" json:"trustForwardHeader,omitempty" export:"true"`
+	AuthResponseHeaders  []string   `description:"Headers to be forwarded from auth response" json:"authResponseHeaders,omitempty"`
+	AddHeadersToResponse []string   `description:"Headers to be added to response from auth response" json:"addHeadersToResponse,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/config/static/entrypoints_test.go
+++ b/pkg/config/static/entrypoints_test.go
@@ -34,6 +34,7 @@ func Test_parseEntryPointsConfiguration(t *testing.T) {
 				"Auth.HeaderField:X-WebAuth-User " +
 				"Auth.Forward.Address:https://authserver.com/auth " +
 				"Auth.Forward.AuthResponseHeaders:X-Auth,X-Test,X-Secret " +
+				"Auth.Forward.AddHeadersToResponse:X-Auth,X-Test " +
 				"Auth.Forward.TrustForwardHeader:true " +
 				"Auth.Forward.TLS.CA:path/to/local.crt " +
 				"Auth.Forward.TLS.CAOptional:true " +
@@ -54,6 +55,7 @@ func Test_parseEntryPointsConfiguration(t *testing.T) {
 				"auth_digest_removeheader":            "true",
 				"auth_forward_address":                "https://authserver.com/auth",
 				"auth_forward_authresponseheaders":    "X-Auth,X-Test,X-Secret",
+				"auth_forward_addheaderstoresponse":   "X-Auth,X-Test",
 				"auth_forward_tls_ca":                 "path/to/local.crt",
 				"auth_forward_tls_caoptional":         "true",
 				"auth_forward_tls_cert":               "path/to/foo.cert",

--- a/pkg/middlewares/auth/forward_test.go
+++ b/pkg/middlewares/auth/forward_test.go
@@ -64,7 +64,7 @@ func TestForwardAuthSuccess(t *testing.T) {
 	auth := config.ForwardAuth{
 		Address:              server.URL,
 		AuthResponseHeaders:  []string{"X-Auth-User"},
-		AddHeadersToResponse: []string{"X-Auth-Token","X-Auth-User"},
+		AddHeadersToResponse: []string{"X-Auth-Token", "X-Auth-User"},
 	}
 	middleware, err := NewForward(context.Background(), next, auth, "authTest")
 	require.NoError(t, err)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

Adds a config option in forward auth middleware to allow adding headers from auth server to request's response.

### Motivation

Traefik allows copying response headers from auth server to upstream request in forward authentication. This makes it difficult to perform tasks such as updating authentication headers in response.

<!-- What inspired you to submit this pull request? -->
#### Inspiration
_I was fooling around and all unit tests passed_, and also #3660 

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
