### PR TITLE
Make it possible to have consistent and constant backend names

### DIFF
--- a/provider/docker/config.go
+++ b/provider/docker/config.go
@@ -278,7 +278,7 @@ func getBackendName(container dockerData) string {
 func getSegmentBackendName(container dockerData) string {
 	serviceName := getServiceName(container)
 	if value := label.GetStringValue(container.SegmentLabels, label.TraefikBackend, ""); len(value) > 0 {
-		return provider.Normalize(serviceName + "-" + value)
+		return provider.Normalize(value + "-" + container.SegmentName)
 	}
 
 	return provider.Normalize(serviceName + "-" + container.SegmentName)

--- a/provider/ecs/config.go
+++ b/provider/ecs/config.go
@@ -123,7 +123,7 @@ func getBackendName(i ecsInstance) string {
 
 func getSegmentBackendName(i ecsInstance) string {
 	if value := label.GetStringValue(i.SegmentLabels, label.TraefikBackend, ""); len(value) > 0 {
-		return provider.Normalize(i.Name + "-" + value)
+		return provider.Normalize(value + "-" + i.SegmentName)
 	}
 
 	return provider.Normalize(i.Name + "-" + i.SegmentName)

--- a/provider/rancher/config.go
+++ b/provider/rancher/config.go
@@ -162,7 +162,7 @@ func getSegmentBackendName(service rancherData) string {
 		return provider.Normalize(service.Name + "-" + value)
 	}
 
-	return provider.Normalize(service.Name + "-" + getDefaultBackendName(service) + "-" + service.SegmentName)
+	return provider.Normalize(service.Name + "-" + service.SegmentName)
 }
 
 func getDefaultBackendName(service rancherData) string {

--- a/provider/rancher/config.go
+++ b/provider/rancher/config.go
@@ -159,7 +159,7 @@ func getBackendName(service rancherData) string {
 
 func getSegmentBackendName(service rancherData) string {
 	if value := label.GetStringValue(service.SegmentLabels, label.TraefikBackend, ""); len(value) > 0 {
-		return provider.Normalize(service.Name + "-" + value)
+		return provider.Normalize(value + "-" + service.SegmentName)
 	}
 
 	return provider.Normalize(service.Name + "-" + service.SegmentName)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This PR is a first attempt to implement a possible solution/fix for #4723. This is a Work-in-Progress PR, tests still need to be adapted.


### Motivation

<!-- What inspired you to submit this pull request? -->
See #4723 for more information. Basically the idea is to make it possible to have consistent and constant backend names, especially in case segments are used.

At the moment the backend name for a segment would look like this for Docker and ECS:

`[service-name]-[segment-value-or-fallback-to-segment-name]`

Only the Racher provider currently uses the following layout:

`[service-name]-[segment-value]`
/
`[service-name]-[default-value-or-fallback-to-service-name]-[segment-name]`

This PR aligns the 3 providers and changes the layout to the following:

`[segment-value-or-fallback-to-service-name]-[segment-name]`

Therefore the segment name is always kept at the end of the backend name, and the segment-based value replaces the default value of the service name instead of the segment name.

An alternative solution could be to use a 3-part names for segment-based backends, like the Rancher provider did by default before aligning it within the first commit of this PR, e.g.:

`[service-name]-[default-value-or-fallback-to-service-name]-[segment-name]`

Since it does not make sense to include the service name twice, I would then instead propose the following:

`[default-value-or-fallback-to-service-name]-[segment-value-or-fallback-to-segment-name]`

### More

To be done:
- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Please do not hesitate to ask me any questions about this. I am looking forward to feedback.
<!-- Anything else we should know when reviewing? -->
