### PR TITLE
Use default backend name instead of service name in backend name

### DIFF
--- a/provider/docker/config.go
+++ b/provider/docker/config.go
@@ -278,10 +278,10 @@ func getBackendName(container dockerData) string {
 func getSegmentBackendName(container dockerData) string {
 	serviceName := getServiceName(container)
 	if value := label.GetStringValue(container.SegmentLabels, label.TraefikBackend, ""); len(value) > 0 {
-		return provider.Normalize(serviceName + "-" + value)
+		return provider.Normalize(getDefaultBackendName(container) + "-" + value)
 	}
 
-	return provider.Normalize(serviceName + "-" + container.SegmentName)
+	return provider.Normalize(getDefaultBackendName(container) + "-" + container.SegmentName)
 }
 
 func getDefaultBackendName(container dockerData) string {

--- a/provider/ecs/config.go
+++ b/provider/ecs/config.go
@@ -123,10 +123,10 @@ func getBackendName(i ecsInstance) string {
 
 func getSegmentBackendName(i ecsInstance) string {
 	if value := label.GetStringValue(i.SegmentLabels, label.TraefikBackend, ""); len(value) > 0 {
-		return provider.Normalize(i.Name + "-" + value)
+		return provider.Normalize(getDefaultBackendName(i) + "-" + value)
 	}
 
-	return provider.Normalize(i.Name + "-" + i.SegmentName)
+	return provider.Normalize(getDefaultBackendName(i) + "-" + i.SegmentName)
 }
 
 func getDefaultBackendName(i ecsInstance) string {

--- a/provider/rancher/config.go
+++ b/provider/rancher/config.go
@@ -159,10 +159,10 @@ func getBackendName(service rancherData) string {
 
 func getSegmentBackendName(service rancherData) string {
 	if value := label.GetStringValue(service.SegmentLabels, label.TraefikBackend, ""); len(value) > 0 {
-		return provider.Normalize(service.Name + "-" + value)
+		return provider.Normalize(getDefaultBackendName(service) + "-" + value)
 	}
 
-	return provider.Normalize(service.Name + "-" + getDefaultBackendName(service) + "-" + service.SegmentName)
+	return provider.Normalize(getDefaultBackendName(service) + "-" + service.SegmentName)
 }
 
 func getDefaultBackendName(service rancherData) string {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This PR is an alternative attempt to #4731 in order to implement a possible solution/fix for #4723. This is a Work-in-Progress PR, tests still need to be adapted.


### Motivation

<!-- What inspired you to submit this pull request? -->
Please see original/primary PR #4731 and issue #4723. This PR implements the alternative solutions already explained in the original PR:

> An alternative solution could be to use a 3-part names for segment-based backends, like the Rancher provider did by default before aligning it within the first commit of this PR, e.g.:
> 
> `[service-name]-[default-value-or-fallback-to-service-name]-[segment-name]`
> 
> Since it does not make sense to include the service name twice, I would then instead propose the following:
> 
> `[default-value-or-fallback-to-service-name]-[segment-value-or-fallback-to-segment-name]`

### More

To be done:
- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
Please let me know which PR I should continue to work on.
