### PR TITLE
Get Structor version from CI env var.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_deploy:
         make -j${N_MAKE_JOBS} crossbinary-parallel;
         tar cfz dist/traefik-${VERSION}.src.tar.gz --exclude-vcs --exclude dist .;
       fi;
-      curl -sfL https://raw.githubusercontent.com/containous/structor/master/godownloader.sh | bash -s -- -b "${GOPATH}/bin" v1.7.0
+      curl -sfL https://raw.githubusercontent.com/containous/structor/master/godownloader.sh | bash -s -- -b "${GOPATH}/bin" ${STRUCTOR_VERSION}
       structor -o containous -r traefik --dockerfile-url="https://raw.githubusercontent.com/containous/traefik/v1.7/docs.Dockerfile" --menu.js-url="https://raw.githubusercontent.com/containous/structor/master/traefik-menu.js.gotmpl" --rqts-url="https://raw.githubusercontent.com/containous/structor/master/requirements-override.txt" --exp-branch=master --force-edit-url --debug;
     fi
 deploy:


### PR DESCRIPTION
### What does this PR do?

Get Structor version from CI env var.

### Motivation

Be able to update Structor without a commit on Traefik.

Fix #4742 

### More

- [ ] ~Added/updated tests~
- [ ] ~Added/updated documentation~
