### PR TITLE
Get Structor version from CI env var.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_deploy:
       if [ "$TRAVIS_TAG" ]; then
         make release-packages;
       fi;
-      curl -sfL https://raw.githubusercontent.com/containous/structor/master/godownloader.sh | bash -s -- -b "${GOPATH}/bin" v1.7.0
+      curl -sfL https://raw.githubusercontent.com/containous/structor/master/godownloader.sh | bash -s -- -b "${GOPATH}/bin" ${STRUCTOR_VERSION}
       structor -o containous -r traefik --dockerfile-url="https://raw.githubusercontent.com/containous/traefik/v1.7/docs.Dockerfile" --menu.js-url="https://raw.githubusercontent.com/containous/structor/master/traefik-menu.js.gotmpl" --rqts-url="https://raw.githubusercontent.com/containous/structor/master/requirements-override.txt" --force-edit-url --exp-branch=master --debug;
     fi
 


### PR DESCRIPTION
### What does this PR do?

Get Structor version from CI env var.

### Motivation

Be able to update Structor without a commit on Traefik.

Fix #4742 

### More

- [ ] ~Added/updated tests~
- [ ] ~Added/updated documentation~
