### PR TITLE
Use context-aware secure middleware functions

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1564,11 +1564,11 @@
 
 [[projects]]
   branch = "v1"
-  digest = "1:60888cead16f066c948c078258b27f2885dce91cb6aadacf545b62a1ae1d08cb"
+  digest = "1:c543a613e815450e9812f3c2164cd631faed79821850c27f2f176102b2539429"
   name = "github.com/unrolled/secure"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "a1cf62cc2159fff407728f118c41aece76c397fa"
+  revision = "4e32686ccfd4360eba208873a5c397fef3b50cc4"
 
 [[projects]]
   digest = "1:a68c3f55d44d225da4f22ffbed2d8572d267cb19aaa1d60537769034ac66bc01"

--- a/pkg/middlewares/addprefix/add_prefix.go
+++ b/pkg/middlewares/addprefix/add_prefix.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	typeName = "AddPrefix"
+	TypeName = "AddPrefix"
 )
 
 // AddPrefix is a middleware used to add prefix to an URL request.
@@ -24,7 +24,7 @@ type addPrefix struct {
 
 // New creates a new handler.
 func New(ctx context.Context, next http.Handler, config config.AddPrefix, name string) (http.Handler, error) {
-	middlewares.GetLogger(ctx, name, typeName).Debug("Creating middleware")
+	middlewares.GetLogger(ctx, name, TypeName).Debug("Creating middleware")
 	var result *addPrefix
 
 	if len(config.Prefix) > 0 {
@@ -45,7 +45,7 @@ func (ap *addPrefix) GetTracingInformation() (string, ext.SpanKindEnum) {
 }
 
 func (ap *addPrefix) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	logger := middlewares.GetLogger(req.Context(), ap.name, typeName)
+	logger := middlewares.GetLogger(req.Context(), ap.name, TypeName)
 
 	oldURLPath := req.URL.Path
 	req.URL.Path = ap.prefix + req.URL.Path
@@ -57,6 +57,7 @@ func (ap *addPrefix) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		logger.Debugf("URL.RawPath is now %s (was %s).", req.URL.RawPath, oldURLRawPath)
 	}
 	req.RequestURI = req.URL.RequestURI()
+	req = req.WithContext(context.WithValue(req.Context(), TypeName, ap.prefix))
 
 	ap.next.ServeHTTP(rw, req)
 }

--- a/pkg/middlewares/addprefix/add_prefix.go
+++ b/pkg/middlewares/addprefix/add_prefix.go
@@ -11,8 +11,12 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 )
 
+type key string
+
 const (
-	TypeName = "AddPrefix"
+	typeName = "AddPrefix"
+	// AddPrefixKey is the context key for storing the added prefix
+	AddPrefixKey key = "AddPrefix"
 )
 
 // AddPrefix is a middleware used to add prefix to an URL request.
@@ -24,7 +28,7 @@ type addPrefix struct {
 
 // New creates a new handler.
 func New(ctx context.Context, next http.Handler, config config.AddPrefix, name string) (http.Handler, error) {
-	middlewares.GetLogger(ctx, name, TypeName).Debug("Creating middleware")
+	middlewares.GetLogger(ctx, name, typeName).Debug("Creating middleware")
 	var result *addPrefix
 
 	if len(config.Prefix) > 0 {
@@ -45,7 +49,7 @@ func (ap *addPrefix) GetTracingInformation() (string, ext.SpanKindEnum) {
 }
 
 func (ap *addPrefix) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	logger := middlewares.GetLogger(req.Context(), ap.name, TypeName)
+	logger := middlewares.GetLogger(req.Context(), ap.name, typeName)
 
 	oldURLPath := req.URL.Path
 	req.URL.Path = ap.prefix + req.URL.Path
@@ -57,7 +61,7 @@ func (ap *addPrefix) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		logger.Debugf("URL.RawPath is now %s (was %s).", req.URL.RawPath, oldURLRawPath)
 	}
 	req.RequestURI = req.URL.RequestURI()
-	req = req.WithContext(context.WithValue(req.Context(), TypeName, ap.prefix))
+	req = req.WithContext(context.WithValue(req.Context(), AddPrefixKey, ap.prefix))
 
 	ap.next.ServeHTTP(rw, req)
 }

--- a/pkg/middlewares/headers/headers.go
+++ b/pkg/middlewares/headers/headers.go
@@ -73,6 +73,7 @@ func (h *headers) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	h.handler.ServeHTTP(rw, req)
 }
 
+// SecureHeader holds a new secure instance from supplied frontend header struct.
 type SecureHeader struct {
 	next   http.Handler
 	secure *secure.Secure
@@ -109,6 +110,7 @@ func NewSecure(next http.Handler, headers config.Headers) *SecureHeader {
 	}
 }
 
+// HandlerFuncWithNextForRequestOnlyWithContextCheck processes the request with a context aware process. It also does not modify the response.
 func (s *SecureHeader) HandlerFuncWithNextForRequestOnlyWithContextCheck(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	originalURL := r.URL
 	requestURL := r.URL

--- a/pkg/middlewares/headers/headers_test.go
+++ b/pkg/middlewares/headers/headers_test.go
@@ -116,13 +116,13 @@ func TestSSLForceHost(t *testing.T) {
 	testCases := []struct {
 		desc             string
 		host             string
-		secureMiddleware *secureHeader
+		secureMiddleware *SecureHeader
 		expected         int
 	}{
 		{
 			desc: "http should return a 301",
 			host: "http://powpow.example.com",
-			secureMiddleware: newSecure(next, config.Headers{
+			secureMiddleware: NewSecure(next, config.Headers{
 				SSLRedirect:  true,
 				SSLForceHost: true,
 				SSLHost:      "powpow.example.com",
@@ -132,7 +132,7 @@ func TestSSLForceHost(t *testing.T) {
 		{
 			desc: "http sub domain should return a 301",
 			host: "http://www.powpow.example.com",
-			secureMiddleware: newSecure(next, config.Headers{
+			secureMiddleware: NewSecure(next, config.Headers{
 				SSLRedirect:  true,
 				SSLForceHost: true,
 				SSLHost:      "powpow.example.com",
@@ -142,7 +142,7 @@ func TestSSLForceHost(t *testing.T) {
 		{
 			desc: "https should return a 200",
 			host: "https://powpow.example.com",
-			secureMiddleware: newSecure(next, config.Headers{
+			secureMiddleware: NewSecure(next, config.Headers{
 				SSLRedirect:  true,
 				SSLForceHost: true,
 				SSLHost:      "powpow.example.com",
@@ -152,7 +152,7 @@ func TestSSLForceHost(t *testing.T) {
 		{
 			desc: "https sub domain should return a 301",
 			host: "https://www.powpow.example.com",
-			secureMiddleware: newSecure(next, config.Headers{
+			secureMiddleware: NewSecure(next, config.Headers{
 				SSLRedirect:  true,
 				SSLForceHost: true,
 				SSLHost:      "powpow.example.com",
@@ -162,7 +162,7 @@ func TestSSLForceHost(t *testing.T) {
 		{
 			desc: "http without force host and sub domain should return a 301",
 			host: "http://www.powpow.example.com",
-			secureMiddleware: newSecure(next, config.Headers{
+			secureMiddleware: NewSecure(next, config.Headers{
 				SSLRedirect:  true,
 				SSLForceHost: false,
 				SSLHost:      "powpow.example.com",
@@ -172,7 +172,7 @@ func TestSSLForceHost(t *testing.T) {
 		{
 			desc: "https without force host and sub domain should return a 301",
 			host: "https://www.powpow.example.com",
-			secureMiddleware: newSecure(next, config.Headers{
+			secureMiddleware: NewSecure(next, config.Headers{
 				SSLRedirect:  true,
 				SSLForceHost: false,
 				SSLHost:      "powpow.example.com",

--- a/pkg/middlewares/headers/headers_test.go
+++ b/pkg/middlewares/headers/headers_test.go
@@ -560,6 +560,7 @@ func TestSSLRedirectWithModifiedRequest(t *testing.T) {
 			err := headerMiddleware.ModifyResponseHeaders(rw.Result())
 			require.NoError(t, err)
 			returnedLocation, err := rw.Result().Location()
+			require.NoError(t, err)
 			assert.Equal(t, test.expected, returnedLocation.Path)
 		})
 	}

--- a/pkg/middlewares/headers/headers_test.go
+++ b/pkg/middlewares/headers/headers_test.go
@@ -539,7 +539,7 @@ func TestSSLRedirectWithModifiedRequest(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
 
-			headerMiddleware := NewHeader(emptyHandler, config.Headers{
+			headerMiddleware := NewSecure(emptyHandler, config.Headers{
 				SSLRedirect:  true,
 				SSLForceHost: true,
 				SSLHost:      "powpow.example.com",
@@ -557,8 +557,9 @@ func TestSSLRedirectWithModifiedRequest(t *testing.T) {
 			req.RequestURI = req.URL.RequestURI()
 			rw := httptest.NewRecorder()
 			headerMiddleware.ServeHTTP(rw, req)
-			returnedLocation, err := rw.Result().Location()
+			err := headerMiddleware.ModifyResponseHeaders(rw.Result())
 			require.NoError(t, err)
+			returnedLocation, err := rw.Result().Location()
 			assert.Equal(t, test.expected, returnedLocation.Path)
 		})
 	}

--- a/pkg/middlewares/replacepath/replace_path.go
+++ b/pkg/middlewares/replacepath/replace_path.go
@@ -10,10 +10,14 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 )
 
+type key string
+
 const (
 	// ReplacedPathHeader is the default header to set the old path to.
 	ReplacedPathHeader = "X-Replaced-Path"
-	TypeName           = "ReplacePath"
+	typeName           = "ReplacePath"
+	// ReplacePathKey is the context key for storing the unmodified URL request path
+	ReplacePathKey key = "ReplacePath"
 )
 
 // ReplacePath is a middleware used to replace the path of a URL request.
@@ -25,7 +29,7 @@ type replacePath struct {
 
 // New creates a new replace path middleware.
 func New(ctx context.Context, next http.Handler, config config.ReplacePath, name string) (http.Handler, error) {
-	middlewares.GetLogger(ctx, name, TypeName).Debug("Creating middleware")
+	middlewares.GetLogger(ctx, name, typeName).Debug("Creating middleware")
 
 	return &replacePath{
 		next: next,
@@ -39,7 +43,7 @@ func (r *replacePath) GetTracingInformation() (string, ext.SpanKindEnum) {
 }
 
 func (r *replacePath) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	req = req.WithContext(context.WithValue(req.Context(), TypeName, req.URL.Path))
+	req = req.WithContext(context.WithValue(req.Context(), ReplacePathKey, req.URL.Path))
 	req.Header.Add(ReplacedPathHeader, req.URL.Path)
 	req.URL.Path = r.path
 	req.RequestURI = req.URL.RequestURI()

--- a/pkg/middlewares/replacepath/replace_path.go
+++ b/pkg/middlewares/replacepath/replace_path.go
@@ -13,7 +13,7 @@ import (
 const (
 	// ReplacedPathHeader is the default header to set the old path to.
 	ReplacedPathHeader = "X-Replaced-Path"
-	typeName           = "ReplacePath"
+	TypeName           = "ReplacePath"
 )
 
 // ReplacePath is a middleware used to replace the path of a URL request.
@@ -25,7 +25,7 @@ type replacePath struct {
 
 // New creates a new replace path middleware.
 func New(ctx context.Context, next http.Handler, config config.ReplacePath, name string) (http.Handler, error) {
-	middlewares.GetLogger(ctx, name, typeName).Debug("Creating middleware")
+	middlewares.GetLogger(ctx, name, TypeName).Debug("Creating middleware")
 
 	return &replacePath{
 		next: next,
@@ -39,6 +39,7 @@ func (r *replacePath) GetTracingInformation() (string, ext.SpanKindEnum) {
 }
 
 func (r *replacePath) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	req = req.WithContext(context.WithValue(req.Context(), TypeName, req.URL.Path))
 	req.Header.Add(ReplacedPathHeader, req.URL.Path)
 	req.URL.Path = r.path
 	req.RequestURI = req.URL.RequestURI()

--- a/pkg/middlewares/replacepathregex/replace_path_regex.go
+++ b/pkg/middlewares/replacepathregex/replace_path_regex.go
@@ -49,7 +49,7 @@ func (rp *replacePathRegex) GetTracingInformation() (string, ext.SpanKindEnum) {
 
 func (rp *replacePathRegex) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if rp.regexp != nil && len(rp.replacement) > 0 && rp.regexp.MatchString(req.URL.Path) {
-		req = req.WithContext(context.WithValue(req.Context(), replacepath.TypeName, req.URL.Path))
+		req = req.WithContext(context.WithValue(req.Context(), replacepath.ReplacePathKey, req.URL.Path))
 		req.Header.Add(replacepath.ReplacedPathHeader, req.URL.Path)
 		req.URL.Path = rp.regexp.ReplaceAllString(req.URL.Path, rp.replacement)
 		req.RequestURI = req.URL.RequestURI()

--- a/pkg/middlewares/replacepathregex/replace_path_regex.go
+++ b/pkg/middlewares/replacepathregex/replace_path_regex.go
@@ -49,6 +49,7 @@ func (rp *replacePathRegex) GetTracingInformation() (string, ext.SpanKindEnum) {
 
 func (rp *replacePathRegex) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if rp.regexp != nil && len(rp.replacement) > 0 && rp.regexp.MatchString(req.URL.Path) {
+		req = req.WithContext(context.WithValue(req.Context(), replacepath.TypeName, req.URL.Path))
 		req.Header.Add(replacepath.ReplacedPathHeader, req.URL.Path)
 		req.URL.Path = rp.regexp.ReplaceAllString(req.URL.Path, rp.replacement)
 		req.RequestURI = req.URL.RequestURI()

--- a/pkg/middlewares/stripprefix/strip_prefix.go
+++ b/pkg/middlewares/stripprefix/strip_prefix.go
@@ -14,7 +14,7 @@ import (
 const (
 	// ForwardedPrefixHeader is the default header to set prefix.
 	ForwardedPrefixHeader = "X-Forwarded-Prefix"
-	typeName              = "StripPrefix"
+	TypeName              = "StripPrefix"
 )
 
 // stripPrefix is a middleware used to strip prefix from an URL request.
@@ -26,7 +26,7 @@ type stripPrefix struct {
 
 // New creates a new strip prefix middleware.
 func New(ctx context.Context, next http.Handler, config config.StripPrefix, name string) (http.Handler, error) {
-	middlewares.GetLogger(ctx, name, typeName).Debug("Creating middleware")
+	middlewares.GetLogger(ctx, name, TypeName).Debug("Creating middleware")
 	return &stripPrefix{
 		prefixes: config.Prefixes,
 		next:     next,
@@ -41,6 +41,7 @@ func (s *stripPrefix) GetTracingInformation() (string, ext.SpanKindEnum) {
 func (s *stripPrefix) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	for _, prefix := range s.prefixes {
 		if strings.HasPrefix(req.URL.Path, prefix) {
+			req = req.WithContext(context.WithValue(req.Context(), TypeName, req.URL.Path))
 			req.URL.Path = getPrefixStripped(req.URL.Path, prefix)
 			if req.URL.RawPath != "" {
 				req.URL.RawPath = getPrefixStripped(req.URL.RawPath, prefix)

--- a/pkg/middlewares/stripprefix/strip_prefix.go
+++ b/pkg/middlewares/stripprefix/strip_prefix.go
@@ -11,10 +11,14 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 )
 
+type key string
+
 const (
 	// ForwardedPrefixHeader is the default header to set prefix.
 	ForwardedPrefixHeader = "X-Forwarded-Prefix"
-	TypeName              = "StripPrefix"
+	typeName              = "StripPrefix"
+	// StripPrefixKey is the context key for storing the unmodified URL request path
+	StripPrefixKey key = "StripPrefix"
 )
 
 // stripPrefix is a middleware used to strip prefix from an URL request.
@@ -26,7 +30,7 @@ type stripPrefix struct {
 
 // New creates a new strip prefix middleware.
 func New(ctx context.Context, next http.Handler, config config.StripPrefix, name string) (http.Handler, error) {
-	middlewares.GetLogger(ctx, name, TypeName).Debug("Creating middleware")
+	middlewares.GetLogger(ctx, name, typeName).Debug("Creating middleware")
 	return &stripPrefix{
 		prefixes: config.Prefixes,
 		next:     next,
@@ -41,7 +45,7 @@ func (s *stripPrefix) GetTracingInformation() (string, ext.SpanKindEnum) {
 func (s *stripPrefix) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	for _, prefix := range s.prefixes {
 		if strings.HasPrefix(req.URL.Path, prefix) {
-			req = req.WithContext(context.WithValue(req.Context(), TypeName, req.URL.Path))
+			req = req.WithContext(context.WithValue(req.Context(), StripPrefixKey, req.URL.Path))
 			req.URL.Path = getPrefixStripped(req.URL.Path, prefix)
 			if req.URL.RawPath != "" {
 				req.URL.RawPath = getPrefixStripped(req.URL.RawPath, prefix)

--- a/pkg/middlewares/stripprefixregex/strip_prefix_regex.go
+++ b/pkg/middlewares/stripprefixregex/strip_prefix_regex.go
@@ -60,7 +60,7 @@ func (s *stripPrefixRegex) ServeHTTP(rw http.ResponseWriter, req *http.Request) 
 			logger.Error("Error in stripPrefix middleware", err)
 			return
 		}
-
+		req = req.WithContext(context.WithValue(req.Context(), stripprefix.TypeName, req.URL.Path))
 		req.URL.Path = req.URL.Path[len(prefix.Path):]
 		if req.URL.RawPath != "" {
 			req.URL.RawPath = req.URL.RawPath[len(prefix.Path):]

--- a/pkg/middlewares/stripprefixregex/strip_prefix_regex.go
+++ b/pkg/middlewares/stripprefixregex/strip_prefix_regex.go
@@ -60,7 +60,7 @@ func (s *stripPrefixRegex) ServeHTTP(rw http.ResponseWriter, req *http.Request) 
 			logger.Error("Error in stripPrefix middleware", err)
 			return
 		}
-		req = req.WithContext(context.WithValue(req.Context(), stripprefix.TypeName, req.URL.Path))
+		req = req.WithContext(context.WithValue(req.Context(), stripprefix.StripPrefixKey, req.URL.Path))
 		req.URL.Path = req.URL.Path[len(prefix.Path):]
 		if req.URL.RawPath != "" {
 			req.URL.RawPath = req.URL.RawPath[len(prefix.Path):]

--- a/pkg/responsemodifiers/headers.go
+++ b/pkg/responsemodifiers/headers.go
@@ -5,33 +5,9 @@ import (
 
 	"github.com/containous/traefik/pkg/config"
 	"github.com/containous/traefik/pkg/middlewares/headers"
-	"github.com/unrolled/secure"
 )
 
 func buildHeaders(hdrs *config.Headers) func(*http.Response) error {
-	opt := secure.Options{
-		BrowserXssFilter:        hdrs.BrowserXSSFilter,
-		ContentTypeNosniff:      hdrs.ContentTypeNosniff,
-		ForceSTSHeader:          hdrs.ForceSTSHeader,
-		FrameDeny:               hdrs.FrameDeny,
-		IsDevelopment:           hdrs.IsDevelopment,
-		SSLRedirect:             hdrs.SSLRedirect,
-		SSLForceHost:            hdrs.SSLForceHost,
-		SSLTemporaryRedirect:    hdrs.SSLTemporaryRedirect,
-		STSIncludeSubdomains:    hdrs.STSIncludeSubdomains,
-		STSPreload:              hdrs.STSPreload,
-		ContentSecurityPolicy:   hdrs.ContentSecurityPolicy,
-		CustomBrowserXssValue:   hdrs.CustomBrowserXSSValue,
-		CustomFrameOptionsValue: hdrs.CustomFrameOptionsValue,
-		PublicKey:               hdrs.PublicKey,
-		ReferrerPolicy:          hdrs.ReferrerPolicy,
-		SSLHost:                 hdrs.SSLHost,
-		AllowedHosts:            hdrs.AllowedHosts,
-		HostsProxyHeaders:       hdrs.HostsProxyHeaders,
-		SSLProxyHeaders:         hdrs.SSLProxyHeaders,
-		STSSeconds:              hdrs.STSSeconds,
-	}
-
 	return func(resp *http.Response) error {
 		if hdrs.HasCustomHeadersDefined() || hdrs.HasCorsHeadersDefined() {
 			err := headers.NewHeader(nil, *hdrs).ModifyResponseHeaders(resp)
@@ -41,7 +17,7 @@ func buildHeaders(hdrs *config.Headers) func(*http.Response) error {
 		}
 
 		if hdrs.HasSecureHeadersDefined() {
-			err := secure.New(opt).ModifyResponseHeaders(resp)
+			err := headers.NewSecure(nil, *hdrs).ModifyResponseHeaders(resp)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### What does this PR do?

Adds a context-aware function to the secure middleware so that redirections after a path has been modified will correctly redirect


### Motivation

#4085


### More

- [x] Added/updated tests
- [x] Added/updated documentation - None needed, correcting behavior

### Additional Notes

Contexts suck