### PR TITLE
Allow matching with FQDN hosts with trailing periods

### DIFF
--- a/docs/content/contributing/submitting-pull-requests.md
+++ b/docs/content/contributing/submitting-pull-requests.md
@@ -42,4 +42,4 @@ Help the readers focus on what matters, and help them understand the structure o
 
 !!! tip "10 Tips for Better Pull Requests"
 
-    We enjoyed this article, maybe you will too! [10 tips for better pull requests](http://blog.ploeh.dk/2015/01/15/10-tips-for-better-pull-requests/).
+    We enjoyed this article, maybe you will too! [10 tips for better pull requests](https://blog.ploeh.dk/2015/01/15/10-tips-for-better-pull-requests/).

--- a/integration/fixtures/file/simple-hosts.toml
+++ b/integration/fixtures/file/simple-hosts.toml
@@ -1,0 +1,41 @@
+[global]
+checkNewVersion = false
+sendAnonymousUsage = false
+
+[log]
+logLevel = "DEBUG"
+
+[entrypoints]
+  [entrypoints.web]
+    address = ":8000"
+
+[providers]
+   [providers.file]
+
+[http.routers]
+  [http.routers.router1]
+    rule = "Host(`test.localhost`)"
+    service = "service1"
+
+  [http.routers.router2]
+    rule = "Host(`test.foo.localhost.`)"
+    service = "service2"
+
+[http.services]
+  [http.services.service1.loadbalancer]
+    [[http.services.service1.loadbalancer.servers]]
+      url = "http://172.17.0.2:80"
+      weight = 10
+    [[http.services.service1.loadbalancer.servers]]
+      url = "http://172.17.0.3:80"
+      weight = 1
+
+  [http.services.service2]
+    [http.services.service2.loadbalancer]
+      method = "drr"
+      [[http.services.service2.loadbalancer.servers]]
+        url = "http://172.17.0.4:80"
+        weight = 1
+      [[http.services.service2.loadbalancer.servers]]
+        url = "http://172.17.0.5:80"
+        weight = 2

--- a/integration/fixtures/file/simple-hosts.toml
+++ b/integration/fixtures/file/simple-hosts.toml
@@ -19,23 +19,10 @@ logLevel = "DEBUG"
 
   [http.routers.router2]
     rule = "Host(`test.foo.localhost.`)"
-    service = "service2"
+    service = "service1"
 
 [http.services]
   [http.services.service1.loadbalancer]
     [[http.services.service1.loadbalancer.servers]]
-      url = "http://172.17.0.2:80"
-      weight = 10
-    [[http.services.service1.loadbalancer.servers]]
-      url = "http://172.17.0.3:80"
-      weight = 1
-
-  [http.services.service2]
-    [http.services.service2.loadbalancer]
-      method = "drr"
-      [[http.services.service2.loadbalancer.servers]]
-        url = "http://172.17.0.4:80"
-        weight = 1
-      [[http.services.service2.loadbalancer.servers]]
-        url = "http://172.17.0.5:80"
-        weight = 2
+        URL = "{{.Server}}"
+        weight = 10

--- a/integration/fixtures/file/simple-hosts.toml
+++ b/integration/fixtures/file/simple-hosts.toml
@@ -3,10 +3,10 @@ checkNewVersion = false
 sendAnonymousUsage = false
 
 [log]
-logLevel = "DEBUG"
+level = "DEBUG"
 
-[entrypoints]
-  [entrypoints.web]
+[entryPoints]
+  [entryPoints.web]
     address = ":8000"
 
 [providers]

--- a/integration/simple_test.go
+++ b/integration/simple_test.go
@@ -489,9 +489,6 @@ func (s *FileSuite) TestSimpleConfigurationHostRequestTrailingPeriod(c *check.C)
 	c.Assert(err, checker.IsNil)
 	defer cmd.Process.Kill()
 
-	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8000", nil)
-	c.Assert(err, checker.IsNil)
-
 	testCases := []struct {
 		desc        string
 		requestHost string

--- a/integration/simple_test.go
+++ b/integration/simple_test.go
@@ -482,7 +482,7 @@ func (s *SimpleSuite) TestMultiprovider(c *check.C) {
 
 }
 
-func (s *FileSuite) TestSimpleConfigurationHostRequestTrailingPeriod(c *check.C) {
+func (s *SimpleSuite) TestSimpleConfigurationHostRequestTrailingPeriod(c *check.C) {
 	s.createComposeProject(c, "base")
 	s.composeProject.Start(c)
 

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -119,6 +119,22 @@ func host(route *mux.Route, hosts ...string) error {
 			if reqHost == host {
 				return true
 			}
+
+			// Check for match on trailing period on host
+			if last := len(host) - 1; last >= 0 && host[last] == '.' {
+				h := host[:last]
+				if reqHost == h {
+					return true
+				}
+			}
+
+			// Check for match on trailing period on request
+			if last := len(reqHost) - 1; last >= 0 && reqHost[last] == '.' {
+				h := reqHost[:last]
+				if h == host {
+					return true
+				}
+			}
 		}
 		return false
 	})

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -51,6 +51,27 @@ func Test_addRoute(t *testing.T) {
 			},
 		},
 		{
+			desc: "Host with trailing period in rule",
+			rule: "Host(`localhost.`)",
+			expected: map[string]int{
+				"http://localhost/foo": http.StatusOK,
+			},
+		},
+		{
+			desc: "Host with trailing period in domain",
+			rule: "Host(`localhost`)",
+			expected: map[string]int{
+				"http://localhost./foo": http.StatusOK,
+			},
+		},
+		{
+			desc: "Host with trailing period in domain and rule",
+			rule: "Host(`localhost.`)",
+			expected: map[string]int{
+				"http://localhost./foo": http.StatusOK,
+			},
+		},
+		{
 			desc: "wrong Host",
 			rule: "Host(`nope`)",
 			expected: map[string]int{


### PR DESCRIPTION
### What does this PR do?

Allows host and request matching with FQDNs with trailing periods.

### Motivation

Fixes #4622 


### More

- [x] Added/updated tests
- [x] Added/updated documentation - None needed, RFC behavior

### Additional Notes

Interestingly enough, trailing periods in request hosts are apparently more common that I thought! Its most common use is to reduce the number of DNS lookups due to relative domain names.
