### PR TITLE
Improve log message about redundant TLS certificate

### DIFF
--- a/tls/certificate.go
+++ b/tls/certificate.go
@@ -102,7 +102,7 @@ func (c *Certificates) CreateTLSConfig(entryPointName string) (*tls.Config, erro
 		config.Certificates = append(config.Certificates, *cert)
 	} else {
 		for _, certificate := range *c {
-			err := certificate.AppendCertificates(domainsCertificates, entryPointName)
+			err := certificate.AppendCertificate(domainsCertificates, entryPointName)
 			if err != nil {
 				log.Errorf("Unable to add a certificate to the entryPoint %q : %v", entryPointName, err)
 				continue
@@ -133,8 +133,8 @@ func (c *Certificates) isEmpty() bool {
 	return key == len(*c)
 }
 
-// AppendCertificates appends a Certificate to a certificates map sorted by entrypoints
-func (c *Certificate) AppendCertificates(certs map[string]map[string]*tls.Certificate, ep string) error {
+// AppendCertificate appends a Certificate to a certificates map keyed by entrypoint.
+func (c *Certificate) AppendCertificate(certs map[string]map[string]*tls.Certificate, ep string) error {
 
 	certContent, err := c.CertFile.Read()
 	if err != nil {
@@ -187,9 +187,9 @@ func (c *Certificate) AppendCertificates(certs map[string]map[string]*tls.Certif
 		}
 	}
 	if certExists {
-		log.Warnf("Into EntryPoint %s, try to add certificate for domains which already have this certificate (%s). The new certificate will not be append to the EntryPoint.", ep, certKey)
+		log.Warnf("Skipping addition of certificate for domain(s) %q, to EntryPoint %s, as it already exists for this Entrypoint.", certKey, ep)
 	} else {
-		log.Debugf("Add certificate for domains %s", certKey)
+		log.Debugf("Adding certificate for domain(s) %s", certKey)
 		certs[ep][certKey] = &tlsCert
 	}
 

--- a/tls/tls.go
+++ b/tls/tls.go
@@ -94,7 +94,7 @@ func SortTLSPerEntryPoints(configurations []*Configuration, epConfiguration map[
 			conf.EntryPoints = append(conf.EntryPoints, defaultEntryPoints...)
 		}
 		for _, ep := range conf.EntryPoints {
-			if err := conf.Certificate.AppendCertificates(epConfiguration, ep); err != nil {
+			if err := conf.Certificate.AppendCertificate(epConfiguration, ep); err != nil {
 				log.Errorf("Unable to append certificate %s to entrypoint %s: %v", conf.Certificate.getTruncatedCertificateName(), ep, err)
 			}
 		}


### PR DESCRIPTION
### What does this PR do?

It improves a log message about when a TLS certificate already exists for a given entrypoint.
Also fixed a func name which had an incorrect plural while I was at it.

### Motivation

Fixes #4650
