### PR TITLE
dumpcerts.sh compatibility

### DIFF
--- a/contrib/scripts/dumpcerts.sh
+++ b/contrib/scripts/dumpcerts.sh
@@ -152,7 +152,7 @@ trap 'umask ${oldumask}' EXIT
 # key if it does not parse out correctly. The other mechanisms were left as
 # comments so that the user can choose the mechanism most appropriate to them.
 echo -e "-----BEGIN RSA PRIVATE KEY-----\n${priv}\n-----END RSA PRIVATE KEY-----" \
-   | openssl rsa -inform pem -out "${pdir}/letsencrypt.key"
+   | fold -w 64 | openssl rsa -inform pem -out "${pdir}/letsencrypt.key"
 
 # Process the certificates for each of the domains in acme.json
 domains=$(jq -r '.Certificates[].Domain.Main' ${acmefile}) || bad_acme


### PR DESCRIPTION
The dumpcerts.sh script uses OpenSSL to verify that the private key is valid.

In doing so, the key is piped to the command openssl, without limiting the line lengths.
This appears not to work for all implementations of SSL.
Within a Docker image based on alpine:3.8 the key line length need to be less than 80 charaters.

See issue:   #4777