### PR TITLE
Create BlockPathRegex Middleware

### DIFF
--- a/pkg/config/middlewares.go
+++ b/pkg/config/middlewares.go
@@ -327,6 +327,15 @@ type ReplacePathRegex struct {
 
 // +k8s:deepcopy-gen=true
 
+// BlockPathRegex holds the BlockPathRegex configuration.
+type BlockPathRegex struct {
+	Regex        string `json:"regex,omitempty"`
+	ResponseCode int    `json:"responseCode,omitempty"`
+	Message      string `json:"message,omitempty"`
+}
+
+// +k8s:deepcopy-gen=true
+
 // Retry holds the retry configuration.
 type Retry struct {
 	Attempts int `description:"Number of attempts" export:"true"`

--- a/pkg/middlewares/blockpathregex/block_path_regex.go
+++ b/pkg/middlewares/blockpathregex/block_path_regex.go
@@ -56,7 +56,10 @@ func (b *blockPathRegex) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if b.regexp != nil && b.responseCode != 0 && b.regexp.MatchString(req.URL.Path) {
 		rw.WriteHeader(b.responseCode)
 		if len(b.message) > 0 {
-			rw.Write([]byte(b.message))
+			_, err := rw.Write([]byte(b.message))
+			if err != nil {
+				return
+			}
 		}
 		return
 	}

--- a/pkg/middlewares/blockpathregex/block_path_regex.go
+++ b/pkg/middlewares/blockpathregex/block_path_regex.go
@@ -1,0 +1,64 @@
+package blockpathregex
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/containous/traefik/pkg/config"
+	"github.com/containous/traefik/pkg/middlewares"
+	"github.com/containous/traefik/pkg/tracing"
+	"github.com/opentracing/opentracing-go/ext"
+)
+
+const (
+	typeName = "BlockPathRegex"
+)
+
+// BlockPathRegex is a middleware used to replace the path of a URL request with a regular expression.
+type blockPathRegex struct {
+	next         http.Handler
+	regexp       *regexp.Regexp
+	responseCode int
+	message      string
+	name         string
+}
+
+// New creates a new block path regex middleware.
+func New(ctx context.Context, next http.Handler, config config.BlockPathRegex, name string) (http.Handler, error) {
+	middlewares.GetLogger(ctx, name, typeName).Debug("Creating middleware")
+
+	exp, err := regexp.Compile(strings.TrimSpace(config.Regex))
+	if err != nil {
+		return nil, fmt.Errorf("error compiling regular expression %s: %s", config.Regex, err)
+	}
+
+	if config.ResponseCode < 0 || config.ResponseCode > 599 {
+		return nil, fmt.Errorf("response code is out of bounds (0-599): %d", config.ResponseCode)
+	}
+
+	return &blockPathRegex{
+		regexp:       exp,
+		responseCode: config.ResponseCode,
+		message:      config.Message,
+		next:         next,
+		name:         name,
+	}, nil
+}
+
+func (b *blockPathRegex) GetTracingInformation() (string, ext.SpanKindEnum) {
+	return b.name, tracing.SpanKindNoneEnum
+}
+
+func (b *blockPathRegex) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	if b.regexp != nil && b.responseCode != 0 && b.regexp.MatchString(req.URL.Path) {
+		rw.WriteHeader(b.responseCode)
+		if len(b.message) > 0 {
+			rw.Write([]byte(b.message))
+		}
+		return
+	}
+	b.next.ServeHTTP(rw, req)
+}

--- a/pkg/middlewares/blockpathregex/block_path_regex_test.go
+++ b/pkg/middlewares/blockpathregex/block_path_regex_test.go
@@ -1,0 +1,75 @@
+package blockpathregex
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/containous/traefik/pkg/config"
+	"github.com/containous/traefik/pkg/testhelpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockPathRegex(t *testing.T) {
+	testCases := []struct {
+		desc            string
+		path            string
+		config          config.BlockPathRegex
+		expectedCode    int
+		expectedMessage string
+		expectsError    bool
+	}{
+		{
+			desc: "simple regex",
+			path: "/whoami/and/whoami",
+			config: config.BlockPathRegex{
+				Regex:        `^/whoami/(.*)`,
+				ResponseCode: 588,
+				Message:      "foo",
+			},
+			expectedCode:    588,
+			expectedMessage: "foo",
+		},
+		{
+			desc: "invalid regular expression",
+			path: "/invalid/regexp/test",
+			config: config.BlockPathRegex{
+				Regex:        `^(?err)/invalid/regexp/([^/]+)$`,
+				ResponseCode: 588,
+				Message:      "invalid",
+			},
+			expectsError: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+			handler, err := New(context.Background(), next, test.config, "foo-block-path-regexp")
+			if test.expectsError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+
+				req := testhelpers.MustNewRequest(http.MethodGet, "http://localhost"+test.path, nil)
+				req.RequestURI = test.path
+
+				rw := httptest.NewRecorder()
+				handler.ServeHTTP(rw, req)
+
+				if test.expectedCode != 0 {
+					assert.Equal(t, test.expectedCode, rw.Code, "Unexpected response code: %d.", rw.Code)
+				}
+
+				if len(test.expectedMessage) > 0 {
+					assert.Equal(t, test.expectedMessage, rw.Body.String(), "Unexpected response message: %s.", rw.Body.String())
+				}
+
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Creates a regex middleware that blocks requests, and returns a configured response code and message.

### Motivation

Fixes #4813, #4812 


### More

- [x] Added/updated tests
- [ ] Added/updated documentation
