### PR TITLE
Allow SANs for wildcards domain.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,7 +158,7 @@ Integration tests must be run from the `integration/` directory and require the 
 
 ## Documentation
 
-The [documentation site](http://docs.traefik.io/) is built with [mkdocs](http://mkdocs.org/)
+The [documentation site](https://docs.traefik.io/) is built with [mkdocs](https://mkdocs.org/)
 
 ### Building Documentation
 

--- a/acme/acme.go
+++ b/acme/acme.go
@@ -751,12 +751,6 @@ func (a *ACME) getValidDomains(domains []string, wildcardAllowed bool) ([]string
 			return nil, fmt.Errorf("unable to generate a wildcard certificate for domain %q : ACME does not allow '*.*' wildcard domain", strings.Join(domains, ","))
 		}
 	}
-	for _, san := range domains[1:] {
-		if strings.HasPrefix(san, "*") {
-			return nil, fmt.Errorf("unable to generate a certificate for domains %q: SANs can not be a wildcard domain", strings.Join(domains, ","))
-
-		}
-	}
 
 	domains = fun.Map(types.CanonicalDomain, domains).([]string)
 	return domains, nil

--- a/acme/acme_test.go
+++ b/acme/acme_test.go
@@ -419,12 +419,12 @@ func TestAcme_getValidDomain(t *testing.T) {
 			expectedDomains: []string{"*.traefik.wtf", "traefik.wtf"},
 		},
 		{
-			desc:            "unexpected SANs",
+			desc:            "wildcard SANs",
 			domains:         []string{"*.traefik.wtf", "*.acme.wtf"},
 			dnsChallenge:    &acmeprovider.DNSChallenge{},
 			wildcardAllowed: true,
-			expectedErr:     "unable to generate a certificate for domains \"*.traefik.wtf,*.acme.wtf\": SANs can not be a wildcard domain",
-			expectedDomains: nil,
+			expectedErr:     "",
+			expectedDomains: []string{"*.traefik.wtf", "*.acme.wtf"},
 		},
 	}
 	for _, test := range testCases {

--- a/docs/theme/partials/footer.html
+++ b/docs/theme/partials/footer.html
@@ -88,9 +88,9 @@
                 </div>
                 {% endif %}
                 powered by
-                <a href="http://www.mkdocs.org" title="MkDocs">MkDocs</a>
+                <a href="https://www.mkdocs.org" title="MkDocs">MkDocs</a>
                 and
-                <a href="http://squidfunk.github.io/mkdocs-material/"
+                <a href="https://squidfunk.github.io/mkdocs-material/"
                    title="Material for MkDocs">
                     Material for MkDocs</a>
             </div>

--- a/provider/acme/provider.go
+++ b/provider/acme/provider.go
@@ -49,7 +49,7 @@ type Configuration struct {
 	DNSChallenge  *DNSChallenge  `description:"Activate DNS-01 Challenge"`
 	HTTPChallenge *HTTPChallenge `description:"Activate HTTP-01 Challenge"`
 	TLSChallenge  *TLSChallenge  `description:"Activate TLS-ALPN-01 Challenge"`
-	Domains       []types.Domain `description:"CN and SANs (alternative domains) to each main domain using format: --acme.domains='main.com,san1.com,san2.com' --acme.domains='*.main.net'. No SANs for wildcards domain. Wildcard domains only accepted with DNSChallenge"`
+	Domains       []types.Domain `description:"CN and SANs (alternative domains) to each main domain using format: --acme.domains='main.com,san1.com,san2.com' --acme.domains='*.main.net'. Wildcard domains only accepted with DNSChallenge"`
 }
 
 // Provider holds configurations of the provider.
@@ -753,12 +753,6 @@ func (p *Provider) getValidDomains(domain types.Domain, wildcardAllowed bool) ([
 
 		if strings.HasPrefix(domain.Main, "*.*") {
 			return nil, fmt.Errorf("unable to generate a wildcard certificate in ACME provider for domain %q : ACME does not allow '*.*' wildcard domain", strings.Join(domains, ","))
-		}
-	}
-
-	for _, san := range domain.SANs {
-		if strings.HasPrefix(san, "*") {
-			return nil, fmt.Errorf("unable to generate a certificate in ACME provider for domains %q: SAN %q can not be a wildcard domain", strings.Join(domains, ","), san)
 		}
 	}
 

--- a/provider/acme/provider_test.go
+++ b/provider/acme/provider_test.go
@@ -266,6 +266,14 @@ func TestGetValidDomain(t *testing.T) {
 			expectedErr:     "",
 			expectedDomains: []string{"*.traefik.wtf", "traefik.wtf"},
 		},
+		{
+			desc:            "wildcard SANs",
+			domains:         types.Domain{Main: "*.traefik.wtf", SANs: []string{"*.acme.wtf"}},
+			dnsChallenge:    &DNSChallenge{},
+			wildcardAllowed: true,
+			expectedErr:     "",
+			expectedDomains: []string{"*.traefik.wtf", "*.acme.wtf"},
+		},
 	}
 
 	for _, test := range testCases {

--- a/provider/acme/provider_test.go
+++ b/provider/acme/provider_test.go
@@ -266,14 +266,6 @@ func TestGetValidDomain(t *testing.T) {
 			expectedErr:     "",
 			expectedDomains: []string{"*.traefik.wtf", "traefik.wtf"},
 		},
-		{
-			desc:            "unexpected SANs",
-			domains:         types.Domain{Main: "*.traefik.wtf", SANs: []string{"*.acme.wtf"}},
-			dnsChallenge:    &DNSChallenge{},
-			wildcardAllowed: true,
-			expectedErr:     "unable to generate a certificate in ACME provider for domains \"*.traefik.wtf,*.acme.wtf\": SAN \"*.acme.wtf\" can not be a wildcard domain",
-			expectedDomains: nil,
-		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Allow issue certificates with multiple wildcard domains.

### Motivation

<!-- What inspired you to submit this pull request? -->
* I need certificate that support multiple wildcard domains (e.g. *.domain.tld and *.tunnel.domain.tld)
* This fixes #4585

### More

- [X] Added/updated tests
- [ ] Added/updated documentation (will do)

### Additional Notes

<!-- Anything else we should know when reviewing? -->
ACME specification actually allows multiple wildcard domains, it only says one wildcard (the * character) per domain, not one wildcard domain per certificate