### PR TITLE
Fix `make validate` on MacOS outside container

### DIFF
--- a/script/test-integration
+++ b/script/test-integration
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SCRIPT_DIR="$( cd "$( dirname "${0}" )" && pwd -P)"; export SCRIPT_DIR
 export DEST=.
 
 TESTFLAGS="${TESTFLAGS} -test.timeout=20m -check.v"

--- a/script/update-cert.sh
+++ b/script/update-cert.sh
@@ -5,7 +5,8 @@ set -e
 CERT_IMAGE="alpine:edge"
 
 # cd to the current directory so the script can be run from anywhere.
-cd `dirname $0`
+SCRIPT_DIR="$( cd "$( dirname "${0}" )" && pwd -P)"; export SCRIPT_DIR
+cd "${SCRIPT_DIR}"
 
 # Update the cert image.
 docker pull $CERT_IMAGE

--- a/script/update-generated-crd-code.sh
+++ b/script/update-generated-crd-code.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-HACK_DIR=$(dirname "${BASH_SOURCE}")
+HACK_DIR="$( cd "$( dirname "${0}" )" && pwd -P)"; export HACK_DIR
 REPO_ROOT=${HACK_DIR}/..
 
 ${REPO_ROOT}/vendor/k8s.io/code-generator/generate-groups.sh \

--- a/script/validate-vendor
+++ b/script/validate-vendor
@@ -3,7 +3,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-SCRIPT_DIR="$( cd "$( dirname "${0}" )" && pwd )"; export SCRIPT_DIR
+SCRIPT_DIR="$( cd "$( dirname "${0}" )" && pwd -P)"; export SCRIPT_DIR
 vendor_dir="./vendor/"
 
 # We run dep install to and see if we have a diff afterwards

--- a/script/validate-vendor
+++ b/script/validate-vendor
@@ -3,14 +3,14 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"; export SCRIPT_DIR
+SCRIPT_DIR="$( cd "$( dirname "${0}" )" && pwd )"; export SCRIPT_DIR
 vendor_dir="./vendor/"
 
 # We run dep install to and see if we have a diff afterwards
 echo "checking ${vendor_dir} for unintentional changes..."
 
 dep ensure -v
-(${SCRIPT_DIR}/prune-dep.sh)
+("${SCRIPT_DIR}"/prune-dep.sh)
 
 # Let see if the working directory is clean
 diffs="$(git status --porcelain -- ${vendor_dir} 2>/dev/null)"


### PR DESCRIPTION

### What does this PR do?

Fix a shell script which fails on macOS and BSD, 
allowing the command `PRE_TARGET= make validate` to work fine on macOS.

### Motivation

Because some of us have damned souls using macOS :trollface: 

### More

- ~[ ] Added/updated tests~
- ~[ ] Added/updated documentation~

### Additional Notes

This fix is from @mpl :)
