### PR TITLE
Clarify docs with labels in Swarm Mode

### DIFF
--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -45,7 +45,7 @@ Attach labels to your containers and let Traefik do the rest!
     swarmMode = true
     ```
 
-    Attaching labels to containers (in your docker compose file)
+    Attach labels to services (not to containers) while in Swarm mode (in your docker compose file)
 
     ```yaml
     version: "3"
@@ -57,7 +57,7 @@ Attach labels to your containers and let Traefik do the rest!
     ```
 
     !!! important "Labels in Docker Swarm Mode"
-        If you use a compose file with the Swarm mode, labels should be defined in the `deploy` part of your service.
+        While in Swarm Mode, Traefik uses labels found on services, not on individual containers. Therefore, if you use a compose file with Swarm Mode, labels should be defined in the `deploy` part of your service.
         This behavior is only enabled for docker-compose version 3+ ([Compose file reference](https://docs.docker.com/compose/compose-file/#labels-1)).
 
 ## Provider Configuration Options


### PR DESCRIPTION
### What does this PR do?

Small documentation clarification regarding labels when running in Swarm Mode.

### Motivation

Many folks here have gotten confused on where labels go when running in Swarm Mode. They don't realize that Traefik isn't watching the individual container, but only the services running in the Swarm. Hopefully, these adjustments help clarify the how and why.

### More

- [X] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

None.
