### PR TITLE
Don't add TCP proxy when error occurs during creation.

### DIFF
--- a/pkg/server/router/router.go
+++ b/pkg/server/router/router.go
@@ -75,15 +75,6 @@ func (m *Manager) BuildHandlers(rootCtx context.Context, entryPoints []string, t
 	return entryPointHandlers
 }
 
-func contains(entryPoints []string, entryPointName string) bool {
-	for _, name := range entryPoints {
-		if name == entryPointName {
-			return true
-		}
-	}
-	return false
-}
-
 func (m *Manager) filteredRouters(ctx context.Context, entryPoints []string, tls bool) map[string]map[string]*config.Router {
 	entryPointsRouters := make(map[string]map[string]*config.Router)
 
@@ -121,10 +112,8 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 	}
 
 	for routerName, routerConfig := range configs {
-		ctxRouter := log.With(ctx, log.Str(log.RouterName, routerName))
+		ctxRouter := log.With(internal.AddProviderInContext(ctx, routerName), log.Str(log.RouterName, routerName))
 		logger := log.FromContext(ctxRouter)
-
-		ctxRouter = internal.AddProviderInContext(ctxRouter, routerName)
 
 		handler, err := m.buildRouterHandler(ctxRouter, routerName)
 		if err != nil {
@@ -196,4 +185,13 @@ func (m *Manager) buildHTTPHandler(ctx context.Context, router *config.Router, r
 	}
 
 	return alice.New().Extend(*mHandler).Append(tHandler).Then(sHandler)
+}
+
+func contains(entryPoints []string, entryPointName string) bool {
+	for _, name := range entryPoints {
+		if name == entryPointName {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/server/router/tcp/router.go
+++ b/pkg/server/router/tcp/router.go
@@ -62,14 +62,12 @@ func (m *Manager) BuildHandlers(rootCtx context.Context, entryPoints []string) m
 
 func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string]*config.TCPRouter, handlerHTTP http.Handler, handlerHTTPS http.Handler) (*tcp.Router, error) {
 	router := &tcp.Router{}
-
 	router.HTTPHandler(handlerHTTP)
 	router.HTTPSHandler(handlerHTTPS, m.tlsConfig)
-	for routerName, routerConfig := range configs {
-		ctxRouter := log.With(ctx, log.Str(log.RouterName, routerName))
-		logger := log.FromContext(ctxRouter)
 
-		ctxRouter = internal.AddProviderInContext(ctxRouter, routerName)
+	for routerName, routerConfig := range configs {
+		ctxRouter := log.With(internal.AddProviderInContext(ctx, routerName), log.Str(log.RouterName, routerName))
+		logger := log.FromContext(ctxRouter)
 
 		handler, err := m.serviceManager.BuildTCP(ctxRouter, routerConfig.Service)
 		if err != nil {
@@ -79,18 +77,18 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 
 		domains, err := rules.ParseHostSNI(routerConfig.Rule)
 		if err != nil {
-			log.WithoutContext().Debugf("Unknown rule %s", routerConfig.Rule)
+			logger.Debugf("Unknown rule %s", routerConfig.Rule)
 			continue
 		}
+
 		for _, domain := range domains {
-			log.WithoutContext().Debugf("Add route %s on TCP", domain)
+			logger.Debugf("Add route %s on TCP", domain)
 			switch {
 			case routerConfig.TLS != nil:
 				if routerConfig.TLS.Passthrough {
 					router.AddRoute(domain, handler)
 				} else {
 					router.AddRouteTLS(domain, handler, m.tlsConfig)
-
 				}
 			case domain == "*":
 				router.AddCatchAllNoTLS(handler)
@@ -103,15 +101,6 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 	return router, nil
 }
 
-func contains(entryPoints []string, entryPointName string) bool {
-	for _, name := range entryPoints {
-		if name == entryPointName {
-			return true
-		}
-	}
-	return false
-}
-
 func (m *Manager) filteredRouters(ctx context.Context, entryPoints []string) map[string]map[string]*config.TCPRouter {
 	entryPointsRouters := make(map[string]map[string]*config.TCPRouter)
 
@@ -120,6 +109,7 @@ func (m *Manager) filteredRouters(ctx context.Context, entryPoints []string) map
 		if len(eps) == 0 {
 			eps = entryPoints
 		}
+
 		for _, entryPointName := range eps {
 			if !contains(entryPoints, entryPointName) {
 				log.FromContext(log.With(ctx, log.Str(log.EntryPointName, entryPointName))).
@@ -136,4 +126,13 @@ func (m *Manager) filteredRouters(ctx context.Context, entryPoints []string) map
 	}
 
 	return entryPointsRouters
+}
+
+func contains(entryPoints []string, entryPointName string) bool {
+	for _, name := range entryPoints {
+		if name == entryPointName {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/server/service/tcp/service.go
+++ b/pkg/server/service/tcp/service.go
@@ -25,18 +25,17 @@ func NewManager(configs map[string]*config.TCPService) *Manager {
 
 // BuildTCP Creates a tcp.Handler for a service configuration.
 func (m *Manager) BuildTCP(rootCtx context.Context, serviceName string) (tcp.Handler, error) {
-	ctx := log.With(rootCtx, log.Str(log.ServiceName, serviceName))
+	serviceQualifiedName := internal.GetQualifiedName(rootCtx, serviceName)
+	ctx := internal.AddProviderInContext(rootCtx, serviceQualifiedName)
+	ctx = log.With(ctx, log.Str(log.ServiceName, serviceName))
 
-	serviceName = internal.GetQualifiedName(ctx, serviceName)
-	ctx = internal.AddProviderInContext(ctx, serviceName)
-
-	conf, ok := m.configs[serviceName]
+	conf, ok := m.configs[serviceQualifiedName]
 	if !ok {
-		return nil, fmt.Errorf("the service %q does not exits", serviceName)
+		return nil, fmt.Errorf("the service %q does not exits", serviceQualifiedName)
 	}
 
 	if conf.LoadBalancer == nil {
-		return nil, fmt.Errorf("the service %q doesn't have any TCP load balancer", serviceName)
+		return nil, fmt.Errorf("the service %q doesn't have any TCP load balancer", serviceQualifiedName)
 	}
 
 	logger := log.FromContext(ctx)
@@ -46,13 +45,13 @@ func (m *Manager) BuildTCP(rootCtx context.Context, serviceName string) (tcp.Han
 
 	for _, server := range conf.LoadBalancer.Servers {
 		if _, err := parseIP(server.Address); err != nil {
-			logger.Errorf("Invalid IP address for a %q server %q: %v", serviceName, server.Address, err)
+			logger.Errorf("Invalid IP address for a %q server %q: %v", serviceQualifiedName, server.Address, err)
 			continue
 		}
 
 		handler, err := tcp.NewProxy(server.Address)
 		if err != nil {
-			logger.Errorf("In service %q server %q: %v", serviceName, server.Address, err)
+			logger.Errorf("In service %q server %q: %v", serviceQualifiedName, server.Address, err)
 			continue
 		}
 

--- a/pkg/server/service/tcp/service.go
+++ b/pkg/server/service/tcp/service.go
@@ -30,26 +30,36 @@ func (m *Manager) BuildTCP(rootCtx context.Context, serviceName string) (tcp.Han
 	serviceName = internal.GetQualifiedName(ctx, serviceName)
 	ctx = internal.AddProviderInContext(ctx, serviceName)
 
-	if conf, ok := m.configs[serviceName]; ok {
-		// FIXME Check if the service is declared multiple times with different types
-		if conf.LoadBalancer != nil {
-			loadBalancer := tcp.NewRRLoadBalancer()
+	conf, ok := m.configs[serviceName]
+	if !ok {
+		return nil, fmt.Errorf("the service %q does not exits", serviceName)
+	}
 
-			var handler tcp.Handler
-			for _, server := range conf.LoadBalancer.Servers {
-				_, err := parseIP(server.Address)
-				if err == nil {
-					handler, _ = tcp.NewProxy(server.Address)
-					loadBalancer.AddServer(handler)
-				} else {
-					log.FromContext(ctx).Errorf("Invalid IP address for a %s server %s: %v", serviceName, server.Address, err)
-				}
-			}
-			return loadBalancer, nil
-		}
+	if conf.LoadBalancer == nil {
 		return nil, fmt.Errorf("the service %q doesn't have any TCP load balancer", serviceName)
 	}
-	return nil, fmt.Errorf("the service %q does not exits", serviceName)
+
+	logger := log.FromContext(ctx)
+
+	// FIXME Check if the service is declared multiple times with different types
+	loadBalancer := tcp.NewRRLoadBalancer()
+
+	for _, server := range conf.LoadBalancer.Servers {
+		if _, err := parseIP(server.Address); err != nil {
+			logger.Errorf("Invalid IP address for a %q server %q: %v", serviceName, server.Address, err)
+			continue
+		}
+
+		handler, err := tcp.NewProxy(server.Address)
+		if err != nil {
+			logger.Errorf("In service %q server %q: %v", serviceName, server.Address, err)
+			continue
+		}
+
+		loadBalancer.AddServer(handler)
+	}
+
+	return loadBalancer, nil
 }
 
 func parseIP(s string) (string, error) {

--- a/pkg/server/service/tcp/service_test.go
+++ b/pkg/server/service/tcp/service_test.go
@@ -1,0 +1,82 @@
+package tcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/containous/traefik/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManager_BuildTCP(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		serviceName   string
+		configs       map[string]*config.TCPService
+		expectedError string
+	}{
+		{
+			desc:          "without configuration",
+			serviceName:   "test",
+			configs:       nil,
+			expectedError: `the service "test" does not exits`,
+		},
+		{
+			desc:        "missing lb configuration",
+			serviceName: "test",
+			configs: map[string]*config.TCPService{
+				"test": {},
+			},
+			expectedError: `the service "test" doesn't have any TCP load balancer`,
+		},
+		{
+			desc:        "no such host",
+			serviceName: "test",
+			configs: map[string]*config.TCPService{
+				"test": {
+					LoadBalancer: &config.TCPLoadBalancerService{
+						Servers: []config.TCPServer{
+							{Address: "test:31"},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:        "invalid IP address",
+			serviceName: "test",
+			configs: map[string]*config.TCPService{
+				"test": {
+					LoadBalancer: &config.TCPLoadBalancerService{
+						Servers: []config.TCPServer{
+							{Address: "foobar"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			manager := NewManager(test.configs)
+
+			handler, err := manager.BuildTCP(context.Background(), test.serviceName)
+
+			if test.expectedError != "" {
+				if err == nil {
+					require.Error(t, err)
+				} else {
+					require.EqualError(t, err, test.expectedError)
+					require.Nil(t, handler)
+				}
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, handler)
+			}
+		})
+	}
+}

--- a/pkg/tcp/proxy.go
+++ b/pkg/tcp/proxy.go
@@ -18,15 +18,15 @@ func NewProxy(address string) (*Proxy, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Proxy{
-		target: tcpAddr,
-	}, nil
+
+	return &Proxy{target: tcpAddr}, nil
 }
 
 // ServeTCP forwards the connection to a service
 func (p *Proxy) ServeTCP(conn net.Conn) {
 	log.Debugf("Handling connection from %s", conn.RemoteAddr())
 	defer conn.Close()
+
 	connBackend, err := net.DialTCP("tcp", nil, p.target)
 	if err != nil {
 		log.Errorf("Error while connection to backend: %v", err)

--- a/pkg/tcp/rr_load_balancer.go
+++ b/pkg/tcp/rr_load_balancer.go
@@ -21,6 +21,11 @@ func NewRRLoadBalancer() *RRLoadBalancer {
 
 // ServeTCP forwards the connection to the right service
 func (r *RRLoadBalancer) ServeTCP(conn net.Conn) {
+	if len(r.servers) == 0 {
+		log.WithoutContext().Error("no available server")
+		return
+	}
+
 	r.next().ServeTCP(conn)
 }
 
@@ -38,6 +43,7 @@ func (r *RRLoadBalancer) next() Handler {
 		r.current = 0
 		log.Debugf("Load balancer: going back to the first available server")
 	}
+
 	handler := r.servers[r.current]
 	r.current++
 	return handler


### PR DESCRIPTION
### What does this PR do?

Don't add TCP proxy when error occurs during creation.

### Motivation

Fixes #4856
```
Stack: goroutine 6489 [running]:
runtime/debug.Stack(0xc0000cc240, 0x1fd8c52, 0x17)
	/usr/local/go/src/runtime/debug/stack.go:24 +0x9d
github.com/containous/traefik/pkg/safe.defaultRecoverGoroutine(0x1c9ab60, 0x3a09680)
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:148 +0x9e
github.com/containous/traefik/pkg/safe.GoWithRecover.func1.1(0x207e5c0)
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:139 +0x57
panic(0x1c9ab60, 0x3a09680)
	/usr/local/go/src/runtime/panic.go:522 +0x1b5
github.com/containous/traefik/pkg/tcp.(*Proxy).ServeTCP(0x0, 0x23a9440, 0xc0004d6750)
	/go/src/github.com/containous/traefik/pkg/tcp/proxy.go:30 +0x115
github.com/containous/traefik/pkg/tcp.(*RRLoadBalancer).ServeTCP(0xc000089800, 0x23a9440, 0xc0004d6750)
	/go/src/github.com/containous/traefik/pkg/tcp/rr_load_balancer.go:24 +0x53
github.com/containous/traefik/pkg/tcp.(*Router).ServeTCP(0xc0008e5440, 0x23a93e0, 0xc000628080)
	/go/src/github.com/containous/traefik/pkg/tcp/router.go:35 +0x2c0
github.com/containous/traefik/pkg/tcp.(*HandlerSwitcher).ServeTCP(0xc0003ab320, 0x23a93e0, 0xc000628080)
	/go/src/github.com/containous/traefik/pkg/tcp/switcher.go:19 +0x6c
github.com/containous/traefik/pkg/server.(*TCPEntryPoint).startTCP.func1()
	/go/src/github.com/containous/traefik/pkg/server/server_entrypoint_tcp.go:108 +0xb4
github.com/containous/traefik/pkg/safe.GoWithRecover.func1(0x207e5c0, 0xc000628060)
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:142 +0x4d
created by github.com/containous/traefik/pkg/safe.GoWithRecover
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:136 +0x49
```

### More

- [x] Added/updated tests
- [ ] ~Added/updated documentation~
