### PR TITLE
Fix regression on plumbing scripts for developer usages

### DIFF
--- a/script/binary
+++ b/script/binary
@@ -26,7 +26,8 @@ if [ -z "$DATE" ]; then
 fi
 
 # Build binaries
-eval CGO_ENABLED=0 GOGC=off go build "${FLAGS[@]}" -ldflags "-s -w \
+# shellcheck disable=SC2086
+CGO_ENABLED=0 GOGC=off go build ${FLAGS[*]} -ldflags "-s -w \
     -X github.com/containous/traefik/pkg/version.Version=$VERSION \
     -X github.com/containous/traefik/pkg/version.Codename=$CODENAME \
     -X github.com/containous/traefik/pkg/version.BuildDate=$DATE" \

--- a/script/binary
+++ b/script/binary
@@ -26,7 +26,7 @@ if [ -z "$DATE" ]; then
 fi
 
 # Build binaries
-CGO_ENABLED=0 GOGC=off go build "${FLAGS[@]}" -ldflags "-s -w \
+eval CGO_ENABLED=0 GOGC=off go build "${FLAGS[@]}" -ldflags "-s -w \
     -X github.com/containous/traefik/pkg/version.Version=$VERSION \
     -X github.com/containous/traefik/pkg/version.Codename=$CODENAME \
     -X github.com/containous/traefik/pkg/version.BuildDate=$DATE" \

--- a/script/test-integration
+++ b/script/test-integration
@@ -17,10 +17,12 @@ docker version
 
 if [ -n "$TEST_CONTAINER" ]; then
     echo "Testing from container…"
-    eval CGO_ENABLED=0 go test -integration -container "${TESTFLAGS[@]}"
+    # shellcheck disable=SC2086
+    CGO_ENABLED=0 go test -integration -container ${TESTFLAGS[*]}
 fi
 
 if [ -n "$TEST_HOST" ]; then
     echo "Testing from host…"
-    eval CGO_ENABLED=0 go test -integration -host "${TESTFLAGS[@]}"
+    # shellcheck disable=SC2086
+    CGO_ENABLED=0 go test -integration -host ${TESTFLAGS[*]}
 fi

--- a/script/test-integration
+++ b/script/test-integration
@@ -17,10 +17,10 @@ docker version
 
 if [ -n "$TEST_CONTAINER" ]; then
     echo "Testing from container…"
-    CGO_ENABLED=0 go test -integration -container "${TESTFLAGS[@]}"
+    eval CGO_ENABLED=0 go test -integration -container "${TESTFLAGS[@]}"
 fi
 
 if [ -n "$TEST_HOST" ]; then
     echo "Testing from host…"
-    CGO_ENABLED=0 go test -integration -host "${TESTFLAGS[@]}"
+    eval CGO_ENABLED=0 go test -integration -host "${TESTFLAGS[@]}"
 fi

--- a/script/test-unit
+++ b/script/test-unit
@@ -21,7 +21,7 @@ fi
 
 set +e
 
-go test "${TESTFLAGS[@]}" ./pkg/...
+eval go test "${TESTFLAGS[@]}" ./pkg/...
 
 CODE=$?
 if [ ${CODE} != 0 ]; then

--- a/script/test-unit
+++ b/script/test-unit
@@ -21,7 +21,8 @@ fi
 
 set +e
 
-eval go test "${TESTFLAGS[@]}" ./pkg/...
+# shellcheck disable=SC2086
+go test ${TESTFLAGS[*]} ./pkg/...
 
 CODE=$?
 if [ ${CODE} != 0 ]; then


### PR DESCRIPTION
### What does this PR do?

This PR fixes a regression introduces by #4859 , where calling some of the plumbing shell with multiple flags has an unwanted behavior: flags are passed to the `go` command a a single string, instead of a collection.

### Motivation

We want developers and maintainers to work locally with multiple flags to have a good experience: CI is not the only use case for such scripts.

### More

- ~[ ] Added/updated tests~
- ~[ ] Added/updated documentation~

### Additional Notes

- How to test it: run the following use cases on your local machine:

```shell
$ make binary
$ make test
$ PRE_TARGET="" CI=1 TESTFLAGS="-tlog -check.f K8sSuite" make test-integration
```

- More on the "how": https://github.com/koalaman/shellcheck/wiki/SC2086
