### PR TITLE
fix kubernetes template for backend responseforwarding flushinterval setting

### DIFF
--- a/autogen/gentemplates/gen.go
+++ b/autogen/gentemplates/gen.go
@@ -1316,7 +1316,7 @@ var _templatesKubernetesTmpl = []byte(`[backends]
 
     {{if $backend.ResponseForwarding }}
     [backends."{{ $backendName }}".responseForwarding]
-      flushInterval = "{{ $backend.responseForwarding.FlushInterval }}"
+      flushInterval = "{{ $backend.ResponseForwarding.FlushInterval }}"
     {{end}}
 
     [backends."{{ $backendName }}".loadBalancer]

--- a/templates/kubernetes.tmpl
+++ b/templates/kubernetes.tmpl
@@ -10,7 +10,7 @@
 
     {{if $backend.ResponseForwarding }}
     [backends."{{ $backendName }}".responseForwarding]
-      flushInterval = "{{ $backend.responseForwarding.FlushInterval }}"
+      flushInterval = "{{ $backend.ResponseForwarding.FlushInterval }}"
     {{end}}
 
     [backends."{{ $backendName }}".loadBalancer]


### PR DESCRIPTION

### What does this PR do?

Fix the template error for Kubernetes provider


### Motivation
Setting traefik.ingress.kubernetes.io/responseforwarding-flushinterval annotation on a Kubernetes service resource results in below template error:

"msg":"template: :13:34: executing \"\" at \u003c$backend.responseFor...\u003e: can't evaluate field responseForwarding in type *types.Backend"


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
