### PR TITLE
Fix typo in the CRD documentation

### DIFF
--- a/docs/content/middlewares/overview.md
+++ b/docs/content/middlewares/overview.md
@@ -50,7 +50,7 @@ spec:
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
-  name: ingressroute.crd
+  name: ingressroute
 spec:
 # more fields...
   routes:

--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -151,7 +151,7 @@ That `IngressRoute` kind can then be used to define an `IngressRoute` object, su
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
-  name: ingressroutefoo.crd
+  name: ingressroutefoo
 
 spec:
   entryPoints:

--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -197,7 +197,7 @@ spec:
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
-  name: ingressroutebar.crd
+  name: ingressroutebar
 
 spec:
   entryPoints:
@@ -232,7 +232,7 @@ data:
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
-  name: ingressroutetls.crd
+  name: ingressroutetls
 
 spec:
   entryPoints:

--- a/docs/content/reference/dynamic-configuration/kubernetes-crd.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd.yml
@@ -30,7 +30,7 @@ spec:
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
-  name: ingressroute.crd
+  name: ingressroute
 spec:
   entryPoints:
     - web


### PR DESCRIPTION
I used traefik 2.0, I found When the name contains point，The domain name Can't match. 

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

After the test，Traefik fails to match when the name contains point.

### **when the name contains point.**
```console
$ kubectl get ingressroutes.traefik.containo.us whoami.crd -o yaml
apiVersion: traefik.containo.us/v1alpha1
kind: IngressRoute
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"traefik.containo.us/v1alpha1","kind":"IngressRoute","metadata":{"annotations":{},"name":"whoami.crd","namespace":"kube-system"},"spec":{"entryPoints":["web"],"routes":[{"kind":"Rule","match":"Host(`www.whoami.com`)","priority":12,"services":[{"name":"whoami","port":80}]}]}}
  creationTimestamp: 2019-05-23T05:16:52Z
  generation: 1
  name: whoami.crd
  namespace: kube-system
  resourceVersion: "79805677"
  selfLink: /apis/traefik.containo.us/v1alpha1/namespaces/kube-system/ingressroutes/whoami.crd
  uid: f95540e2-7d19-11e9-b1d0-005056bd0b19
spec:
  entryPoints:
  - web
  routes:
  - kind: Rule
    match: Host(`www.whoami.com`)
    priority: 12
    services:
    - name: whoami
      port: 80
```
**Access to the domain name**
```console
$  curl www.whoami.com
404 page not found
```

**log**
```
172.30.50.215 - - [23/May/2019:05:18:36 +0000] "GET / HTTP/1.1" 404 19 "-" "curl/7.54.0" 167 - - 0ms
172.30.50.215 - - [23/May/2019:05:18:37 +0000] "GET / HTTP/1.1" 404 19 "-" "curl/7.54.0" 168 - - 0ms
```

### **when the name not contains point.**
```console
$ kubectl get ingressroutes.traefik.containo.us whoami.crd 
NAME         AGE
whoami.crd   18m
$ kubectl delete ingressroutes.traefik.containo.us whoami.crd 
ingressroute.traefik.containo.us "whoami.crd" deleted

$ kubectl apply -f whoami.yaml 
ingressroute.traefik.containo.us/whoami created
$ kubectl get ingressroutes.traefik.containo.us --all-namespaces 
NAMESPACE     NAME         AGE
kube-system   whoami       6s
monitoring    promethues   37m
$ kubectl get ingressroutes.traefik.containo.us whoami -o yaml
apiVersion: traefik.containo.us/v1alpha1
kind: IngressRoute
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"traefik.containo.us/v1alpha1","kind":"IngressRoute","metadata":{"annotations":{},"name":"whoami","namespace":"kube-system"},"spec":{"entryPoints":["web"],"routes":[{"kind":"Rule","match":"Host(`www.whoami.com`)","priority":12,"services":[{"name":"whoami","port":80}]}]}}
  creationTimestamp: 2019-05-23T05:36:09Z
  generation: 1
  name: whoami
  namespace: kube-system
  resourceVersion: "79810408"
  selfLink: /apis/traefik.containo.us/v1alpha1/namespaces/kube-system/ingressroutes/whoami
  uid: ab2a763e-7d1c-11e9-acde-005056bd5fee
spec:
  entryPoints:
  - web
  routes:
  - kind: Rule
    match: Host(`www.whoami.com`)
    priority: 12
    services:
    - name: whoami
      port: 80
```
**Access to the domain name**
```console
$  curl www.whoami.com
Hostname: whoami-79f9d7f7d4-qsjqs
IP: 127.0.0.1
IP: 10.244.237.200
GET / HTTP/1.1
Host: www.whoami.com
User-Agent: curl/7.29.0
Accept: */*
Accept-Encoding: gzip
X-Forwarded-For: 10.21.8.24
X-Forwarded-Host: www.whoami.com
X-Forwarded-Port: 80
X-Forwarded-Proto: http
X-Forwarded-Server: traefik-bccd997c6-grtst
X-Real-Ip: 10.21.8.24
```
**log**
```
10.21.8.24 - - [23/May/2019:05:36:59 +0000] "GET / HTTP/1.1" 200 346 "-" "curl/7.29.0" 174 "kubernetescrd.kube-system/whoami-965c93918f12ebd6eb36" "http://10.244.237.200:80" 1ms
10.21.8.24 - - [23/May/2019:05:43:40 +0000] "GET / HTTP/1.1" 200 345 "-" "curl/7.29.0" 175 "kubernetescrd.kube-system/whoami-965c93918f12ebd6eb36" "http://10.244.58.174:80" 1ms
```

### Motivation

update documentation.

### More

- [x] Added/updated documentation
