### PR TITLE
Docs: improve the "reading path" for new contributers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing
 
-See https://docs.traefik.io.
+See <https://docs.traefik.io/v2.0/contributing/thank-you/>.

--- a/docs/content/contributing/thank-you.md
+++ b/docs/content/contributing/thank-you.md
@@ -8,3 +8,20 @@ and wouldn't have become what it is today without the help of our [many contribu
 not accounting for people having helped with issues, tests, comments, articles, ... or just enjoying it and letting others know.
 
 So once again, thank you for your invaluable help on making Traefik such a good product.
+
+!!! question "Where to Go Next?"
+    If you want to:
+
+    - Propose and idea, request a feature a report a bug,
+      read the page [Submitting Issues](./submitting-issues.md).
+    - Discover how to make an efficient contribution,
+      read the page [Submitting Pull Requests](./submitting-pull-requests.md).
+    - Learn how to build and test Traefik,
+      the page [Building and Testing](./building-testing.md) is for you.
+    - Contribute to the documentation,
+      read the related page [Documentation](./documentation.md).
+    - Understand how we we learn about Traefik usage,
+      read the [Data Collection](./data-collection.md) page.
+    - Spread the love about Traefik, please check the [Advocating](./advocating.md) page.
+    - Learn about who are the maintainers and how they work on the project,
+      read the [Maintainers](./maintainers.md) page.

--- a/docs/content/contributing/thank-you.md
+++ b/docs/content/contributing/thank-you.md
@@ -20,7 +20,7 @@ So once again, thank you for your invaluable help on making Traefik such a good 
       the page [Building and Testing](./building-testing.md) is for you.
     - Contribute to the documentation,
       read the related page [Documentation](./documentation.md).
-    - Understand how we we learn about Traefik usage,
+    - Understand how do we learn about Traefik usage,
       read the [Data Collection](./data-collection.md) page.
     - Spread the love about Traefik, please check the [Advocating](./advocating.md) page.
     - Learn about who are the maintainers and how they work on the project,


### PR DESCRIPTION
### What does this PR do?

- The `./CONTRIBUTING.md` file now points to the "v2.0 -> Contributing -> Thank You!" page
- Improve the "v2.0 -> Contributing -> Thank You!" page by adding an admonition serving as "micro-ToC".

### Motivation

Improved reading path for new (or potential) contributors.

### More

- ~[ ] Added/updated tests~
- [x] Added/updated documentation

### Additional Notes

A fun GIF because... why not?

![76473](https://user-images.githubusercontent.com/1522731/58427925-4ce9ee00-80a1-11e9-8991-5ffeddea0cb4.gif)

