### PR TITLE
Update docker api version

### DIFF
--- a/provider/docker/docker.go
+++ b/provider/docker/docker.go
@@ -28,7 +28,9 @@ import (
 )
 
 const (
-	// SwarmAPIVersion is a constant holding the version of the Provider API traefik will use
+	// DockerAPIVersion is a constant holding the version of the Provider API traefik will use
+	DockerAPIVersion = "1.24"
+	// SwarmAPIVersion is a constant holding the version of the Provider API traefik will use.
 	SwarmAPIVersion = "1.24"
 )
 
@@ -110,11 +112,10 @@ func (p *Provider) createClient() (client.APIClient, error) {
 		"User-Agent": "Traefik " + version.Version,
 	}
 
-	var apiVersion string
+	apiVersion := DockerAPIVersion
+
 	if p.SwarmMode {
 		apiVersion = SwarmAPIVersion
-	} else {
-		apiVersion = DockerAPIVersion
 	}
 
 	return client.NewClient(p.Endpoint, apiVersion, httpClient, httpHeaders)

--- a/provider/docker/docker_unix.go
+++ b/provider/docker/docker_unix.go
@@ -1,8 +1,0 @@
-// +build !windows
-
-package docker
-
-const (
-	// DockerAPIVersion is a constant holding the version of the Provider API traefik will use
-	DockerAPIVersion = "1.21"
-)

--- a/provider/docker/docker_windows.go
+++ b/provider/docker/docker_windows.go
@@ -1,6 +1,0 @@
-package docker
-
-const (
-	// DockerAPIVersion is a constant holding the version of the Provider API traefik will use
-	DockerAPIVersion string = "1.24"
-)


### PR DESCRIPTION
### What does this PR do?

Updates the docker API version to 1.24

### Motivation

Fixes #4905 


### Additional Notes

From https://docs.docker.com/develop/sdk/#api-version-matrix

```
Docker does not recommend running versions prior to 1.12,
 which means you are encouraged to use an API version of 1.24 or higher.
```