### PR TITLE
Specify that Rancher provider is for 1.x only

### DIFF
--- a/docs/content/providers/rancher.md
+++ b/docs/content/providers/rancher.md
@@ -8,7 +8,9 @@ A Story of Labels, Services & Containers
 Attach labels to your services and let Traefik do the rest!
 
 !!! important
-    This provider is specific to Rancher 1.x. Rancher 2.x requires Kubernetes and does not have a metadata endpoint of its own for Traefik to query. As such, Rancher 2.x users should utilize the [Kubernetes provider](./kubernetes-crd.md) directly.
+    This provider is specific to Rancher 1.x.
+    Rancher 2.x requires Kubernetes and does not have a metadata endpoint of its own for Traefik to query.
+    As such, Rancher 2.x users should utilize the [Kubernetes provider](./kubernetes-crd.md) directly.
 
 ## Configuration Examples
 

--- a/docs/content/providers/rancher.md
+++ b/docs/content/providers/rancher.md
@@ -1,4 +1,4 @@
-# Traefik & Rancher 1.x
+# Traefik & Rancher
 
 A Story of Labels, Services & Containers
 {: .subtitle }

--- a/docs/content/providers/rancher.md
+++ b/docs/content/providers/rancher.md
@@ -7,7 +7,7 @@ A Story of Labels, Services & Containers
 
 Attach labels to your services and let Traefik do the rest!
 
-Note: This provider is specific to Rancher 1.x. Rancher 2.x requires Kubernetes and does not have a metadata endpoint of its own for Traefik to query. As such, Rancher 2.x users should utilize the [Kubernetes provider](../kubernetes-crd/index.md) directly.
+Note: This provider is specific to Rancher 1.x. Rancher 2.x requires Kubernetes and does not have a metadata endpoint of its own for Traefik to query. As such, Rancher 2.x users should utilize the [Kubernetes provider](./kubernetes-crd.md) directly.
 
 ## Configuration Examples
 

--- a/docs/content/providers/rancher.md
+++ b/docs/content/providers/rancher.md
@@ -1,11 +1,13 @@
-# Traefik & Rancher
+# Traefik & Rancher 1.x
 
-A Story of Labels, Services & Container
+A Story of Labels, Services & Containers
 {: .subtitle }
 
 ![Rancher](../assets/img/providers/rancher.png)
 
 Attach labels to your services and let Traefik do the rest!
+
+Note: This provider is specific to Rancher 1.x. Rancher 2.x requires Kubernetes and does not have a metadata endpoint of its own for Traefik to query. As such, Rancher 2.x users should utilize the [Kubernetes provider](../kubernetes-crd/index.md) directly.
 
 ## Configuration Examples
 

--- a/docs/content/providers/rancher.md
+++ b/docs/content/providers/rancher.md
@@ -7,7 +7,8 @@ A Story of Labels, Services & Containers
 
 Attach labels to your services and let Traefik do the rest!
 
-Note: This provider is specific to Rancher 1.x. Rancher 2.x requires Kubernetes and does not have a metadata endpoint of its own for Traefik to query. As such, Rancher 2.x users should utilize the [Kubernetes provider](./kubernetes-crd.md) directly.
+!!! important
+    This provider is specific to Rancher 1.x. Rancher 2.x requires Kubernetes and does not have a metadata endpoint of its own for Traefik to query. As such, Rancher 2.x users should utilize the [Kubernetes provider](./kubernetes-crd.md) directly.
 
 ## Configuration Examples
 


### PR DESCRIPTION
### What does this PR do?

Updates the Rancher documentation to specify it is specific to Rancher 1.x.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

<!-- What inspired you to submit this pull request? -->
Rancher 2.x is basically a super-duper reverse proxy and control plane for Kubernetes. 

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
