### PR TITLE
Use the latest stable version of traefik in the docs

### DIFF
--- a/docs/user-guide/cluster-docker-consul.md
+++ b/docs/user-guide/cluster-docker-consul.md
@@ -91,7 +91,7 @@ To watch docker events, add `--docker.watch`.
 version: "3"
 services:
   traefik:
-    image: traefik:1.5
+    image: traefik:<stable version from https://hub.docker.com/_/traefik>
     command:
       - "--api"
       - "--entrypoints=Name:http Address::80 Redirect.EntryPoint:https"
@@ -156,7 +156,7 @@ The initializer in a docker-compose file will be:
 
 ```yaml
   traefik_init:
-    image: traefik:1.5
+    image: traefik:<stable version from https://hub.docker.com/_/traefik>
     command:
       - "storeconfig"
       - "--api"
@@ -177,7 +177,7 @@ And now, the Traefik part will only have the Consul configuration.
 
 ```yaml
   traefik:
-    image: traefik:1.5
+    image: traefik:<stable version from https://hub.docker.com/_/traefik>
     depends_on:
       - traefik_init
       - consul
@@ -200,7 +200,7 @@ The new configuration will be stored in Consul, and you need to restart the Trae
 version: "3.4"
 services:
   traefik_init:
-    image: traefik:1.5
+    image: traefik:<stable version from https://hub.docker.com/_/traefik>
     command:
       - "storeconfig"
       - "--api"
@@ -229,7 +229,7 @@ services:
     depends_on:
       - consul
   traefik:
-    image: traefik:1.5
+    image: traefik:<stable version from https://hub.docker.com/_/traefik>
     depends_on:
       - traefik_init
       - consul

--- a/docs/user-guide/docker-and-lets-encrypt.md
+++ b/docs/user-guide/docker-and-lets-encrypt.md
@@ -50,7 +50,7 @@ version: '2'
 
 services:
   traefik:
-    image: traefik:1.5.4
+    image: traefik:latest
     restart: always
     ports:
       - 80:80

--- a/docs/user-guide/docker-and-lets-encrypt.md
+++ b/docs/user-guide/docker-and-lets-encrypt.md
@@ -50,7 +50,7 @@ version: '2'
 
 services:
   traefik:
-    image: traefik:latest
+    image: traefik:<stable version from https://hub.docker.com/_/traefik>
     restart: always
     ports:
       - 80:80

--- a/docs/user-guide/kv-config.md
+++ b/docs/user-guide/kv-config.md
@@ -139,7 +139,7 @@ Here is the [docker-compose file](https://docs.docker.com/compose/compose-file/)
 
 ```yaml
 traefik:
-  image: traefik
+  image: traefik:<stable version from https://hub.docker.com/_/traefik>
   command: --consul --consul.endpoint=127.0.0.1:8500
   ports:
     - "80:80"

--- a/docs/user-guide/swarm-mode.md
+++ b/docs/user-guide/swarm-mode.md
@@ -85,7 +85,7 @@ docker-machine ssh manager "docker service create \
 	--publish 80:80 --publish 8080:8080 \
 	--mount	type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \
 	--network traefik-net \
-	traefik \
+	traefik:<stable version from https://hub.docker.com/_/traefik> \
 	--docker \
 	--docker.swarmMode \
 	--docker.domain=traefik \

--- a/docs/user-guide/swarm.md
+++ b/docs/user-guide/swarm.md
@@ -81,7 +81,7 @@ docker $(docker-machine config mhs-demo0) run \
     -p 80:80 -p 8080:8080 \
     --net=my-net \
     -v /var/lib/boot2docker/:/ssl \
-    traefik \
+    traefik:<stable version from https://hub.docker.com/_/traefik> \
     -l DEBUG \
     -c /dev/null \
     --docker \


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This pr updates version of the traefik docker container in the example docker-compose file in the user guide for using traefik with docker and LE.

### Motivation

<!-- What inspired you to submit this pull request? -->
 I've had some issues caused by me using an outdated version of traefik (see #4926) which was mostly caused by just copying the docker compose file. From [docker hub](https://hub.docker.com/_/traefik) it looks like `latest` ist the latest stable image, so I propose to just use that in the examples.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation
