### PR TITLE
HttpOnly and Secure flags on the affinity cookie

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1612,7 +1612,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:86f14aadf288fe3ad8ac060bcb2b5083cec3829dd883803486ec834d031060c9"
+  digest = "1:d7ace03de79a9cec30e7a55cc16160602760470c5fe031b780dc2d84234d7f5a"
   name = "github.com/vulcand/oxy"
   packages = [
     "buffer",
@@ -1625,7 +1625,7 @@
     "utils",
   ]
   pruneopts = "NUT"
-  revision = "0d102f45103cf49a95b5c6e810e092973cbcb68c"
+  revision = "3d629cff40b7040e0519628e7774ed11a95d9aff"
 
 [[projects]]
   digest = "1:ca6bac407fedc14fbeeba861dd33a821ba3a1624c10126ec6003b0a28d4139c5"

--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -103,12 +103,18 @@ On subsequent requests, the client is forwarded to the same server.
     
     The default cookie name is an abbreviation of a sha1 (ex: `_1d52e`).
 
+!!! note "Secure & HTTPOnly flags"
+
+    By default, the affinity cookie is created without those flags. One however can change that through configuration. 
+
 ??? example "Adding Stickiness"
 
     ```toml
     [http.services]
       [http.services.my-service]
         [http.services.my-service.LoadBalancer.stickiness]
+          secureCookie = true
+          httpOnlyCookie = true
     ```
 
 ??? example "Adding Stickiness with a Custom Cookie Name"
@@ -118,6 +124,8 @@ On subsequent requests, the client is forwarded to the same server.
       [http.services.my-service]
         [http.services.my-service.LoadBalancer.stickiness]
            cookieName = "my_stickiness_cookie_name"
+           secureCookie = true
+           httpOnlyCookie = true
     ```
 
 #### Health Check

--- a/pkg/config/dyn_config.go
+++ b/pkg/config/dyn_config.go
@@ -97,7 +97,9 @@ type ResponseForwarding struct {
 
 // Stickiness holds the stickiness configuration.
 type Stickiness struct {
-	CookieName string `json:"cookieName,omitempty" toml:",omitempty"`
+	CookieName     string `json:"cookieName,omitempty" toml:",omitempty"`
+	SecureCookie   bool   `json:"secureCookie,omitempty" toml:",omitempty"`
+	HTTPOnlyCookie bool   `json:"httpOnlyCookie,omitempty" toml:",omitempty"`
 }
 
 // Server holds the server configuration.

--- a/pkg/provider/label/parser_test.go
+++ b/pkg/provider/label/parser_test.go
@@ -143,6 +143,7 @@ func TestDecodeConfiguration(t *testing.T) {
 		"traefik.http.services.Service0.loadbalancer.server.scheme":                    "foobar",
 		"traefik.http.services.Service0.loadbalancer.server.port":                      "8080",
 		"traefik.http.services.Service0.loadbalancer.stickiness.cookiename":            "foobar",
+		"traefik.http.services.Service0.loadbalancer.stickiness.securecookie":          "true",
 		"traefik.http.services.Service1.loadbalancer.healthcheck.headers.name0":        "foobar",
 		"traefik.http.services.Service1.loadbalancer.healthcheck.headers.name1":        "foobar",
 		"traefik.http.services.Service1.loadbalancer.healthcheck.hostname":             "foobar",
@@ -505,7 +506,9 @@ func TestDecodeConfiguration(t *testing.T) {
 				"Service0": {
 					LoadBalancer: &config.LoadBalancerService{
 						Stickiness: &config.Stickiness{
-							CookieName: "foobar",
+							CookieName:     "foobar",
+							SecureCookie:   true,
+							HTTPOnlyCookie: false,
 						},
 						Servers: []config.Server{
 							{
@@ -897,7 +900,8 @@ func TestEncodeConfiguration(t *testing.T) {
 				"Service0": {
 					LoadBalancer: &config.LoadBalancerService{
 						Stickiness: &config.Stickiness{
-							CookieName: "foobar",
+							CookieName:     "foobar",
+							HTTPOnlyCookie: true,
 						},
 						Servers: []config.Server{
 							{
@@ -1086,6 +1090,7 @@ func TestEncodeConfiguration(t *testing.T) {
 		"traefik.HTTP.Services.Service0.LoadBalancer.server.Port":                      "8080",
 		"traefik.HTTP.Services.Service0.LoadBalancer.server.Scheme":                    "foobar",
 		"traefik.HTTP.Services.Service0.LoadBalancer.Stickiness.CookieName":            "foobar",
+		"traefik.HTTP.Services.Service0.LoadBalancer.Stickiness.HTTPOnlyCookie":        "true",
 		"traefik.HTTP.Services.Service1.LoadBalancer.HealthCheck.Headers.name0":        "foobar",
 		"traefik.HTTP.Services.Service1.LoadBalancer.HealthCheck.Headers.name1":        "foobar",
 		"traefik.HTTP.Services.Service1.LoadBalancer.HealthCheck.Hostname":             "foobar",

--- a/pkg/provider/label/parser_test.go
+++ b/pkg/provider/label/parser_test.go
@@ -1091,6 +1091,7 @@ func TestEncodeConfiguration(t *testing.T) {
 		"traefik.HTTP.Services.Service0.LoadBalancer.server.Scheme":                    "foobar",
 		"traefik.HTTP.Services.Service0.LoadBalancer.Stickiness.CookieName":            "foobar",
 		"traefik.HTTP.Services.Service0.LoadBalancer.Stickiness.HTTPOnlyCookie":        "true",
+		"traefik.HTTP.Services.Service0.LoadBalancer.Stickiness.SecureCookie":          "false",
 		"traefik.HTTP.Services.Service1.LoadBalancer.HealthCheck.Headers.name0":        "foobar",
 		"traefik.HTTP.Services.Service1.LoadBalancer.HealthCheck.Headers.name1":        "foobar",
 		"traefik.HTTP.Services.Service1.LoadBalancer.HealthCheck.Hostname":             "foobar",

--- a/pkg/server/service/service.go
+++ b/pkg/server/service/service.go
@@ -192,7 +192,8 @@ func (m *Manager) getLoadBalancer(ctx context.Context, serviceName string, servi
 	var cookieName string
 	if stickiness := service.Stickiness; stickiness != nil {
 		cookieName = cookie.GetName(stickiness.CookieName, serviceName)
-		options = append(options, roundrobin.EnableStickySession(roundrobin.NewStickySession(cookieName)))
+		opts := roundrobin.CookieOptions{HTTPOnly: stickiness.HTTPOnlyCookie, Secure: stickiness.SecureCookie}
+		options = append(options, roundrobin.EnableStickySession(roundrobin.NewStickySessionWithOptions(cookieName, opts)))
 		logger.Debugf("Sticky session cookie name: %v", cookieName)
 	}
 

--- a/pkg/server/service/service_test.go
+++ b/pkg/server/service/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/containous/traefik/pkg/config"
@@ -103,8 +104,10 @@ func TestGetLoadBalancerServiceHandler(t *testing.T) {
 	defer serverPassHostFalse.Close()
 
 	type ExpectedResult struct {
-		StatusCode int
-		XFrom      string
+		StatusCode     int
+		XFrom          string
+		SecureCookie   bool
+		HTTPOnlyCookie bool
 	}
 
 	testCases := []struct {
@@ -193,6 +196,28 @@ func TestGetLoadBalancerServiceHandler(t *testing.T) {
 			},
 		},
 		{
+			desc:        "Sticky Cookie's options set correctly",
+			serviceName: "test",
+			service: &config.LoadBalancerService{
+				Stickiness: &config.Stickiness{HTTPOnlyCookie: true, SecureCookie: true},
+				Servers: []config.Server{
+					{
+						URL:    server1.URL,
+						Weight: 1,
+					},
+				},
+				Method: "wrr",
+			},
+			expected: []ExpectedResult{
+				{
+					StatusCode:     http.StatusOK,
+					XFrom:          "first",
+					SecureCookie:   true,
+					HTTPOnlyCookie: true,
+				},
+			},
+		},
+		{
 			desc:        "PassHost passes the host instead of the IP",
 			serviceName: "test",
 			service: &config.LoadBalancerService{
@@ -249,8 +274,11 @@ func TestGetLoadBalancerServiceHandler(t *testing.T) {
 				assert.Equal(t, expected.StatusCode, recorder.Code)
 				assert.Equal(t, expected.XFrom, recorder.Header().Get("X-From"))
 
-				if len(recorder.Header().Get("Set-Cookie")) > 0 {
-					req.Header.Set("Cookie", recorder.Header().Get("Set-Cookie"))
+				cookieHeader := recorder.Header().Get("Set-Cookie")
+				if len(cookieHeader) > 0 {
+					req.Header.Set("Cookie", cookieHeader)
+					assert.Equal(t, expected.SecureCookie, strings.Contains(cookieHeader, "Secure"))
+					assert.Equal(t, expected.HTTPOnlyCookie, strings.Contains(cookieHeader, "HttpOnly"))
 				}
 			}
 		})

--- a/pkg/server/service/service_test.go
+++ b/pkg/server/service/service_test.go
@@ -202,11 +202,9 @@ func TestGetLoadBalancerServiceHandler(t *testing.T) {
 				Stickiness: &config.Stickiness{HTTPOnlyCookie: true, SecureCookie: true},
 				Servers: []config.Server{
 					{
-						URL:    server1.URL,
-						Weight: 1,
+						URL: server1.URL,
 					},
 				},
-				Method: "wrr",
 			},
 			expected: []ExpectedResult{
 				{


### PR DESCRIPTION
### What does this PR do?

Introduce 2 new boolean entries to the configuration for marking the affinity cookies HttpOnly and Secure. They are "false" by default for backward compatibility. Additionally, it uses the configured values to create the affinity cookie as such.

### Motivation

Security
Fixes #4738 and #2653 

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

The PR in Oxy (the vendor using which affinity cookie is implemented) has been reviewed and merged.