### PR TITLE
Update documentation to clarify the default format for logs

### DIFF
--- a/docs/configuration/logs.md
+++ b/docs/configuration/logs.md
@@ -13,7 +13,7 @@ logLevel = "INFO"
 
 [accessLog]
   filePath = "/path/to/access.log"
-  format = "json" # Default: "common"
+  format = "json"
 
   [accessLog.filters]
     statusCodes = ["200", "300-302"]
@@ -44,7 +44,7 @@ For more information about the CLI, see the documentation about [Traefik command
 --traefikLog.filePath="/path/to/traefik.log"
 --traefikLog.format="json"
 --accessLog.filePath="/path/to/access.log"
---accessLog.format="json"  # Default: "common"
+--accessLog.format="json"
 --accessLog.filters.statusCodes="200,300-302"
 --accessLog.filters.retryAttempts="true"
 --accessLog.filters.minDuration="10ms"

--- a/docs/configuration/logs.md
+++ b/docs/configuration/logs.md
@@ -9,11 +9,11 @@ logLevel = "INFO"
 
 [traefikLog]
   filePath = "/path/to/traefik.log"
-  format   = "json"
+  format   = "json" # Default: "common"
 
 [accessLog]
   filePath = "/path/to/access.log"
-  format = "json"
+  format = "json" # Default: "common"
 
   [accessLog.filters]
     statusCodes = ["200", "300-302"]
@@ -39,12 +39,12 @@ logLevel = "INFO"
 
 For more information about the CLI, see the documentation about [Traefik command](/basics/#traefik).
 
-```shell
+```bash
 --logLevel="DEBUG"
 --traefikLog.filePath="/path/to/traefik.log"
---traefikLog.format="json"
+--traefikLog.format="json"  # Default: "common"
 --accessLog.filePath="/path/to/access.log"
---accessLog.format="json"
+--accessLog.format="json"  # Default: "common"
 --accessLog.filters.statusCodes="200,300-302"
 --accessLog.filters.retryAttempts="true"
 --accessLog.filters.minDuration="10ms"
@@ -53,7 +53,6 @@ For more information about the CLI, see the documentation about [Traefik command
 --accessLog.fields.headers.defaultMode="keep"
 --accessLog.fields.headers.names="User-Agent=redact Authorization=drop Content-Type=keep"
 ```
-
 
 ## Traefik Logs
 
@@ -66,14 +65,13 @@ To write the logs into a log file specify the `filePath`:
   filePath = "/path/to/traefik.log"
 ```
 
-To write JSON format logs, specify `json` as the format:
+To switch to JSON format instead of [Common Log Format (CLF)](#clf-common-log-format), specify `json` as the format:
 
 ```toml
 [traefikLog]
   filePath = "/path/to/traefik.log"
-  format   = "json"
+  format   = "json" # Default: "common"
 ```
-
 
 Deprecated way (before 1.4):
 
@@ -105,11 +103,10 @@ To customize the log level:
 logLevel = "ERROR"
 ```
 
-
 ## Access Logs
 
 Access logs are written when `[accessLog]` is defined.
-By default it will write to stdout and produce logs in the textual Common Log Format (CLF), extended with additional fields.
+By default it will write to stdout and produce logs in the textual [Common Log Format (CLF)](#clf-common-log-format), extended with additional fields.
 
 To enable access logs using the default settings just add the `[accessLog]` entry:
 
@@ -124,12 +121,12 @@ To write the logs into a log file specify the `filePath`:
 filePath = "/path/to/access.log"
 ```
 
-To write JSON format logs, specify `json` as the format:
+To switch to JSON format instead of [Common Log Format (CLF)](#clf-common-log-format), specify `json` as the format:
 
 ```toml
 [accessLog]
 filePath = "/path/to/access.log"
-format = "json"
+format = "json"  # Default: "common"
 ```
 
 To write the logs in async, specify `bufferingSize` as the format (must be >0):
@@ -152,7 +149,7 @@ To filter logs you can specify a set of filters which are logically "OR-connecte
 ```toml
 [accessLog]
 filePath = "/path/to/access.log"
-format = "json"
+format = "json"  # Default: "common"
 
   [accessLog.filters]
 
@@ -178,12 +175,12 @@ format = "json"
   minDuration = "10ms"
 ```
 
-To customize logs format:
+To customize logs format, you must switch to the JSON format:
 
 ```toml
 [accessLog]
 filePath = "/path/to/access.log"
-format = "json"
+format = "json" # Default: "common"
 
   [accessLog.filters]
 
@@ -226,7 +223,6 @@ format = "json"
       "Content-Type" = "keep"
       # ...
 ```
-
 
 ### List of all available fields
 
@@ -281,9 +277,8 @@ accessLogsFile = "log/access.log"
 By default, Traefik use the CLF (`common`) as access log format.
 
 ```html
-<remote_IP_address> - <client_user_name_if_available> [<timestamp>] "<request_method> <request_path> <request_protocol>" <origin_server_HTTP_status> <origin_server_content_size> "<request_referrer>" "<request_user_agent>" <number_of_requests_received_since_Traefik_started> "<Traefik_frontend_name>" "<Traefik_backend_URL>" <request_duration_in_ms>ms 
+<remote_IP_address> - <client_user_name_if_available> [<timestamp>] "<request_method> <request_path> <request_protocol>" <origin_server_HTTP_status> <origin_server_content_size> "<request_referrer>" "<request_user_agent>" <number_of_requests_received_since_Traefik_started> "<Traefik_frontend_name>" "<Traefik_backend_URL>" <request_duration_in_ms>ms
 ```
-
 
 ## Log Rotation
 

--- a/docs/configuration/logs.md
+++ b/docs/configuration/logs.md
@@ -9,7 +9,7 @@ logLevel = "INFO"
 
 [traefikLog]
   filePath = "/path/to/traefik.log"
-  format   = "json" # Default: "common"
+  format   = "json"
 
 [accessLog]
   filePath = "/path/to/access.log"
@@ -42,7 +42,7 @@ For more information about the CLI, see the documentation about [Traefik command
 ```bash
 --logLevel="DEBUG"
 --traefikLog.filePath="/path/to/traefik.log"
---traefikLog.format="json"  # Default: "common"
+--traefikLog.format="json"
 --accessLog.filePath="/path/to/access.log"
 --accessLog.format="json"  # Default: "common"
 --accessLog.filters.statusCodes="200,300-302"
@@ -65,12 +65,12 @@ To write the logs into a log file specify the `filePath`:
   filePath = "/path/to/traefik.log"
 ```
 
-To switch to JSON format instead of [Common Log Format (CLF)](#clf-common-log-format), specify `json` as the format:
+To switch to JSON format instead of standard format (`common`), specify `json` as the format:
 
 ```toml
 [traefikLog]
   filePath = "/path/to/traefik.log"
-  format   = "json" # Default: "common"
+  format   = "json"
 ```
 
 Deprecated way (before 1.4):


### PR DESCRIPTION
Signed-off-by: dduportal <1522731+dduportal@users.noreply.github.com>

### What does this PR do?

This PR clarifies the documentation page about logs:

- Adding comment to explicit that the default value is `common` and refers to the default CLF format
- Clarifies that customizing the fields requires to switch to the JSON format

### Motivation

This PR follows up #3942 and is inspired by #3870 where the user was not aware about the mandatory format switch, which could have avoided wasting time searching for a non existent configuration.

Closes #4869.

### More

- ~[ ] Added/updated tests~
- [x] Added/updated documentation

### Additional Notes


![sheldon-nitpick](https://www.cheatsheet.com/wp-content/uploads/2016/02/Game-of-Thrones-Jon-Snow-reading.jpg)
