### PR TITLE
feat: service weights for ingressroute

### DIFF
--- a/docs/content/reference/dynamic-configuration/kubernetes-crd.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd.yml
@@ -45,6 +45,8 @@ spec:
       services:
         - name: s1
           port: 80
+          # specify how much will be routed to this service
+          weight: 90
           healthCheck:
             path: /health
             host: baz.com
@@ -55,6 +57,7 @@ spec:
           strategy: RoundRobin
         - name: s2
           port: 433
+          weight: 10
           healthCheck:
             path: /health
             host: baz.com

--- a/pkg/provider/kubernetes/crd/fixtures/with_two_services_weighted.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_two_services_weighted.yml
@@ -1,0 +1,21 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: test.crd
+  namespace: default
+
+spec:
+  entryPoints:
+    - web
+
+  routes:
+  - match: Host(`foo.com`) && PathPrefix(`/foo`)
+    kind: Rule
+    priority: 12
+    services:
+    - name: whoami
+      port: 80
+      weight: 30
+    - name: whoami2
+      port: 8080
+      weight: 70

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -160,6 +160,11 @@ func loadServers(client Client, namespace string, svc v1alpha1.Service) ([]confi
 		return nil, fmt.Errorf("load balancing strategy %v is not supported", strategy)
 	}
 
+	weight := svc.Weight
+	if weight == 0 {
+		weight = 1
+	}
+
 	service, exists, err := client.GetService(namespace, svc.Name)
 	if err != nil {
 		return nil, err
@@ -188,7 +193,7 @@ func loadServers(client Client, namespace string, svc v1alpha1.Service) ([]confi
 	if service.Spec.Type == corev1.ServiceTypeExternalName {
 		servers = append(servers, config.Server{
 			URL:    fmt.Sprintf("http://%s:%d", service.Spec.ExternalName, portSpec.Port),
-			Weight: 1,
+			Weight: weight,
 		})
 	} else {
 		endpoints, endpointsExists, endpointsErr := client.GetEndpoints(namespace, svc.Name)
@@ -225,7 +230,7 @@ func loadServers(client Client, namespace string, svc v1alpha1.Service) ([]confi
 			for _, addr := range subset.Addresses {
 				servers = append(servers, config.Server{
 					URL:    fmt.Sprintf("%s://%s:%d", protocol, addr.IP, port),
-					Weight: 1,
+					Weight: weight,
 				})
 			}
 		}

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -217,6 +217,50 @@ func TestLoadIngressRoutes(t *testing.T) {
 			},
 		},
 		{
+			desc:  "One ingress Route with different services and weights",
+			paths: []string{"services.yml", "with_two_services_weighted.yml"},
+			expected: &config.Configuration{
+				TCP: &config.TCPConfiguration{},
+				HTTP: &config.HTTPConfiguration{
+					Routers: map[string]*config.Router{
+						"default/test.crd-77c62dfe9517144aeeaa": {
+							EntryPoints: []string{"web"},
+							Service:     "default/test.crd-77c62dfe9517144aeeaa",
+							Rule:        "Host(`foo.com`) && PathPrefix(`/foo`)",
+							Priority:    12,
+						},
+					},
+					Middlewares: map[string]*config.Middleware{},
+					Services: map[string]*config.Service{
+						"default/test.crd-77c62dfe9517144aeeaa": {
+							LoadBalancer: &config.LoadBalancerService{
+								Servers: []config.Server{
+									{
+										URL:    "http://10.10.0.1:80",
+										Weight: 30,
+									},
+									{
+										URL:    "http://10.10.0.2:80",
+										Weight: 30,
+									},
+									{
+										URL:    "http://10.10.0.3:8080",
+										Weight: 70,
+									},
+									{
+										URL:    "http://10.10.0.4:8080",
+										Weight: 70,
+									},
+								},
+								Method:         "wrr",
+								PassHostHeader: true,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			desc:         "Ingress class",
 			paths:        []string{"services.yml", "simple.yml"},
 			ingressClass: "tchouk",

--- a/pkg/provider/kubernetes/crd/traefik/v1alpha1/ingressroute.go
+++ b/pkg/provider/kubernetes/crd/traefik/v1alpha1/ingressroute.go
@@ -31,9 +31,9 @@ type TLS struct {
 
 // Service defines an upstream to proxy traffic.
 type Service struct {
-	Name string `json:"name"`
-	Port int32  `json:"port"`
-	// TODO Weight      int          `json:"weight,omitempty"`
+	Name        string       `json:"name"`
+	Port        int32        `json:"port"`
+	Weight      int          `json:"weight,omitempty"`
 	HealthCheck *HealthCheck `json:"healthCheck,omitempty"`
 	Strategy    string       `json:"strategy,omitempty"`
 }


### PR DESCRIPTION
### What does this PR do?

Services defined in an IngressRoute CRD do not support the `weight` attribute. This PR adds that functionality.

### Motivation
I was trying to figure out how to do a canary deployment w/ weighted services - i.e. having `whoami-stable` and `whoami-canary` with a 9:1 traffic ratio.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

I just added a example to the dynamic configuration doc. Do you think that the spec of IngressRoute and Middleware CRDs is kinda final? I'd like to add it to the docs.


I used this IR for testing:
```yaml
apiVersion: traefik.containo.us/v1alpha1
kind: IngressRoute
metadata:
  name: whoami
spec:
  entryPoints:
    - web
  routes:
  - match: HostRegexp(`{host:whoami.*}`)
    kind: Rule
    services:
    - name: whoami-stable
      weight: 1
      port: 80
    - name: whoami-canary
      weight: 99
      port: 80

```

I did some trivial analysis by sending n requests to traefik and looking which upstream is used. Here are the results:

| ratio | num reqs | result | actual ratio |
| --- | --- | --- | --- |
| 1:99 | 17k | 1 : 16999 | 0.006% |
| 2:98 | 1k | 6 : 994 | 0.6% |
| 3:97 | 1k | 3 : 997 | 0.3% |
| 5:95 | 1k | 63 : 964 | 6.5% |
| 10:90  | 1k | 87 : 913 | 9.5% |
| 30:70  | 1k | 285 : 715 | 39.9% |

I just did a single run. I think that ratios below 5% are not stable. I'll do further analysis and add it to the docs once i find the time.
