### PR TITLE
Clear TLS client headers if TLSMutualAuth is optional

### DIFF
--- a/middlewares/tlsClientHeaders.go
+++ b/middlewares/tlsClientHeaders.go
@@ -271,6 +271,7 @@ func (s *TLSClientHeaders) getXForwardedTLSClientCertInfo(certs []*x509.Certific
 // ModifyRequestHeaders set the wanted headers with the certificates informations
 func (s *TLSClientHeaders) ModifyRequestHeaders(r *http.Request) {
 	if s.PEM {
+		r.Header.Del(xForwardedTLSClientCert)
 		if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
 			r.Header.Set(xForwardedTLSClientCert, getXForwardedTLSClientCert(r.TLS.PeerCertificates))
 		} else {
@@ -279,6 +280,7 @@ func (s *TLSClientHeaders) ModifyRequestHeaders(r *http.Request) {
 	}
 
 	if s.Infos != nil {
+		r.Header.Del(xForwardedTLSClientCertInfos)
 		if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
 			headerContent := s.getXForwardedTLSClientCertInfo(r.TLS.PeerCertificates)
 			r.Header.Set(xForwardedTLSClientCertInfos, url.QueryEscape(headerContent))

--- a/middlewares/tlsClientHeaders.go
+++ b/middlewares/tlsClientHeaders.go
@@ -44,7 +44,7 @@ type DistinguishedNameOptions struct {
 
 // TLSClientHeaders is a middleware that helps setup a few tls info features.
 type TLSClientHeaders struct {
-	Infos *TLSClientCertificateInfos // pass selected informations from the client certificate
+	Infos *TLSClientCertificateInfos // pass selected information from the client certificate
 	PEM   bool                       // pass the sanitized pem to the backend in a specific header
 }
 
@@ -79,23 +79,14 @@ func newTLSClientInfos(infos *types.TLSClientCertificateInfos) *TLSClientCertifi
 }
 
 // NewTLSClientHeaders constructs a new TLSClientHeaders instance from supplied frontend header struct.
-func NewTLSClientHeaders(frontend *types.Frontend) *TLSClientHeaders {
-	if frontend == nil {
+func NewTLSClientHeaders(passTLSClientCert *types.TLSClientHeaders) *TLSClientHeaders {
+	if passTLSClientCert == nil {
 		return nil
 	}
 
-	var addPEM bool
-	var infos *TLSClientCertificateInfos
-
-	if frontend.PassTLSClientCert != nil {
-		conf := frontend.PassTLSClientCert
-		addPEM = conf.PEM
-		infos = newTLSClientInfos(conf.Infos)
-	}
-
 	return &TLSClientHeaders{
-		Infos: infos,
-		PEM:   addPEM,
+		Infos: newTLSClientInfos(passTLSClientCert.Infos),
+		PEM:   passTLSClientCert.PEM,
 	}
 }
 
@@ -221,7 +212,7 @@ func writePart(content *strings.Builder, entry string, prefix string) {
 	}
 }
 
-// getXForwardedTLSClientCertInfo Build a string with the wanted client certificates informations
+// getXForwardedTLSClientCertInfo Build a string with the wanted client certificates information
 // like Subject="DC=%s,C=%s,ST=%s,L=%s,O=%s,CN=%s",NB=%d,NA=%d,SAN=%s;
 func (s *TLSClientHeaders) getXForwardedTLSClientCertInfo(certs []*x509.Certificate) string {
 	var headerValues []string
@@ -268,10 +259,10 @@ func (s *TLSClientHeaders) getXForwardedTLSClientCertInfo(certs []*x509.Certific
 	return strings.Join(headerValues, ";")
 }
 
-// ModifyRequestHeaders set the wanted headers with the certificates informations
+// ModifyRequestHeaders set the wanted headers with the certificates information
 func (s *TLSClientHeaders) ModifyRequestHeaders(r *http.Request) {
+	r.Header.Del(xForwardedTLSClientCert)
 	if s.PEM {
-		r.Header.Del(xForwardedTLSClientCert)
 		if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
 			r.Header.Set(xForwardedTLSClientCert, getXForwardedTLSClientCert(r.TLS.PeerCertificates))
 		} else {
@@ -279,8 +270,8 @@ func (s *TLSClientHeaders) ModifyRequestHeaders(r *http.Request) {
 		}
 	}
 
+	r.Header.Del(xForwardedTLSClientCertInfos)
 	if s.Infos != nil {
-		r.Header.Del(xForwardedTLSClientCertInfos)
 		if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
 			headerContent := s.getXForwardedTLSClientCertInfo(r.TLS.PeerCertificates)
 			r.Header.Set(xForwardedTLSClientCertInfos, url.QueryEscape(headerContent))

--- a/middlewares/tlsClientHeaders_test.go
+++ b/middlewares/tlsClientHeaders_test.go
@@ -404,6 +404,10 @@ func TestTlsClientheadersWithPEM(t *testing.T) {
 		res := httptest.NewRecorder()
 		req := testhelpers.MustNewRequest(http.MethodGet, "http://example.com/foo", nil)
 
+		if test.tlsClientCertHeaders != nil {
+			req.Header.Set(xForwardedTLSClientCert, "Unsanitized HEADER")
+		}
+
 		if test.certContents != nil && len(test.certContents) > 0 {
 			req.TLS = buildTLSWith(test.certContents)
 		}
@@ -631,6 +635,10 @@ func TestTlsClientheadersWithCertInfos(t *testing.T) {
 
 		res := httptest.NewRecorder()
 		req := testhelpers.MustNewRequest(http.MethodGet, "http://example.com/foo", nil)
+
+		if test.tlsClientCertHeaders != nil {
+			req.Header.Set(xForwardedTLSClientCertInfos, "Unsanitized HEADER")
+		}
 
 		if test.certContents != nil && len(test.certContents) > 0 {
 			req.TLS = buildTLSWith(test.certContents)

--- a/server/server_middlewares.go
+++ b/server/server_middlewares.go
@@ -113,7 +113,7 @@ func (s *Server) buildMiddlewares(frontendName string, frontend *types.Frontend,
 	}
 
 	// TLSClientHeaders
-	tlsClientHeadersMiddleware := middlewares.NewTLSClientHeaders(frontend)
+	tlsClientHeadersMiddleware := middlewares.NewTLSClientHeaders(frontend.PassTLSClientCert)
 	if tlsClientHeadersMiddleware != nil {
 		log.Debugf("Adding TLSClientHeaders middleware for frontend %s", frontendName)
 


### PR DESCRIPTION
### What does this PR do?

If no client peer certificates could be found always clear the headers so no request could pass them to backends, e.g. if TLSMutualAuth is optional.

### Motivation

<!-- What inspired you to submit this pull request? -->
Using an optional TLSMutualAuth we've seen that clients could pass the headers into the request and the final request to the backend may look like it has been TLS mutual authenticated.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
