### PR TITLE
Don't allow non flag arguments by default.

### DIFF
--- a/pkg/cli/commands_test.go
+++ b/pkg/cli/commands_test.go
@@ -87,6 +87,23 @@ func Test_execute(t *testing.T) {
 			expected: expected{result: "root"},
 		},
 		{
+			desc: "root command, with argument, command not found",
+			args: []string{"", "echo"},
+			command: func() *Command {
+				return &Command{
+					Name:          "root",
+					Description:   "This is a test",
+					Configuration: nil,
+					Run: func(_ []string) error {
+						called = "root"
+						return nil
+					},
+				}
+
+			},
+			expected: expected{error: true},
+		},
+		{
 			desc: "one sub command",
 			args: []string{"", "sub1"},
 			command: func() *Command {
@@ -113,6 +130,34 @@ func Test_execute(t *testing.T) {
 				return rootCmd
 			},
 			expected: expected{result: "sub1"},
+		},
+		{
+			desc: "one sub command, with argument, command not found",
+			args: []string{"", "sub1", "echo"},
+			command: func() *Command {
+				rootCmd := &Command{
+					Name:          "test",
+					Description:   "This is a test",
+					Configuration: nil,
+					Run: func(_ []string) error {
+						called += "root"
+						return nil
+					},
+				}
+
+				_ = rootCmd.AddCommand(&Command{
+					Name:          "sub1",
+					Description:   "sub1",
+					Configuration: nil,
+					Run: func(_ []string) error {
+						called += "sub1"
+						return nil
+					},
+				})
+
+				return rootCmd
+			},
+			expected: expected{error: true},
 		},
 		{
 			desc: "two sub commands",
@@ -376,6 +421,7 @@ func Test_execute(t *testing.T) {
 					Name:          "sub1",
 					Description:   "sub1",
 					Configuration: nil,
+					AllowArg:      true,
 					Run: func(args []string) error {
 						called += "sub1-" + strings.Join(args, "-")
 						return nil
@@ -394,6 +440,7 @@ func Test_execute(t *testing.T) {
 					Name:          "root",
 					Description:   "This is a test",
 					Configuration: nil,
+					AllowArg:      true,
 					Run: func(args []string) error {
 						called += "root-" + strings.Join(args, "-")
 						return nil


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

Don't allow non flag arguments by default.

### Motivation

Be able to pass [`override-cmd` test](https://github.com/docker-library/official-images/tree/3f87965eeb524bd3d47d0b5f37381c71fe20f71f/test/tests/override-cmd)

To validate the test, the following command must return an error:
```
traefik echo 'Hello world-1194-26292'
```


Related to https://github.com/docker-library/official-images/pull/6102#issuecomment-502883063
Related to https://github.com/containous/traefik-library-image/blob/master/alpine/entrypoint.sh

### More

- [x] Added/updated tests
- [ ] ~Added/updated documentation~
