### PR TITLE
Display an error when help is called on a non existing command.

### DIFF
--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -86,6 +86,11 @@ func execute(cmd *Command, args []string, root bool) error {
 }
 
 func run(cmd *Command, args []string) error {
+	if len(args) > 0 && !isFlag(args[0]) && !cmd.AllowArg {
+		_ = PrintHelp(os.Stdout, cmd)
+		return fmt.Errorf("command not found: %s", args[0])
+	}
+
 	if isHelp(args) {
 		return PrintHelp(os.Stdout, cmd)
 	}
@@ -93,11 +98,6 @@ func run(cmd *Command, args []string) error {
 	if cmd.Run == nil {
 		_ = PrintHelp(os.Stdout, cmd)
 		return fmt.Errorf("command %s is not runnable", cmd.Name)
-	}
-
-	if len(args) > 0 && !isFlag(args[0]) && !cmd.AllowArg {
-		_ = PrintHelp(os.Stdout, cmd)
-		return fmt.Errorf("command not found: %v", args)
 	}
 
 	if cmd.Configuration == nil {

--- a/pkg/cli/commands_test.go
+++ b/pkg/cli/commands_test.go
@@ -104,6 +104,22 @@ func Test_execute(t *testing.T) {
 			expected: expected{error: true},
 		},
 		{
+			desc: "root command, call help, with argument, command not found",
+			args: []string{"", "echo", "--help"},
+			command: func() *Command {
+				return &Command{
+					Name:          "root",
+					Description:   "This is a test",
+					Configuration: nil,
+					Run: func(_ []string) error {
+						called = "root"
+						return nil
+					},
+				}
+			},
+			expected: expected{error: true},
+		},
+		{
 			desc: "one sub command",
 			args: []string{"", "sub1"},
 			command: func() *Command {


### PR DESCRIPTION
### What does this PR do?

Display an error when help is called on a non existing command.

### Motivation

Be able to pass [`override-cmd` test](https://github.com/docker-library/official-images/tree/3f87965eeb524bd3d47d0b5f37381c71fe20f71f/test/tests/override-cmd)

To validate the test, the following commands must return an error:
```bash
./traefik echo Hello world-$RANDOM-$RANDOM
./traefik traefik echo Hello world-$RANDOM-$RANDOM
./traefik echo --help
./traefik traefik echo --help
```

Related to #4970

Related to https://github.com/docker-library/official-images/pull/6106#issuecomment-503314187
Related to https://github.com/containous/traefik-library-image/blob/master/alpine/entrypoint.sh

### More

- [x] Added/updated tests
- [ ] ~Added/updated documentation~
