### PR TITLE
Change the provider separator from . to @

### DIFF
--- a/docs/content/middlewares/overview.md
+++ b/docs/content/middlewares/overview.md
@@ -121,8 +121,8 @@ If you use multiple `providers` and wish to reference a middleware declared in a
         image: your-docker-image
 
         labels:
-          # Attach file.add-foo-prefix middleware (declared in file)
-          - "traefik.http.routers.my-container.middlewares=file.add-foo-prefix"
+          # Attach file@add-foo-prefix middleware (declared in file)
+          - "traefik.http.routers.my-container.middlewares=file@add-foo-prefix"
     ```
 
 ## Available Middlewares

--- a/integration/access_log_test.go
+++ b/integration/access_log_test.go
@@ -581,7 +581,7 @@ func CheckAccessLogFormat(c *check.C, line string, i int) {
 	c.Assert(results, checker.HasLen, 14)
 	c.Assert(results[accesslog.OriginStatus], checker.Matches, `^(-|\d{3})$`)
 	c.Assert(results[accesslog.RequestCount], checker.Equals, fmt.Sprintf("%d", i+1))
-	c.Assert(results[accesslog.RouterName], checker.HasPrefix, "\"docker.rt-")
+	c.Assert(results[accesslog.RouterName], checker.HasPrefix, "\"docker@rt-")
 	c.Assert(results[accesslog.ServiceURL], checker.HasPrefix, "\"http://")
 	c.Assert(results[accesslog.Duration], checker.Matches, `^\d+ms$`)
 }
@@ -596,7 +596,7 @@ func checkAccessLogExactValues(c *check.C, line string, i int, v accessLogValue)
 	}
 	c.Assert(results[accesslog.OriginStatus], checker.Equals, v.code)
 	c.Assert(results[accesslog.RequestCount], checker.Equals, fmt.Sprintf("%d", i+1))
-	c.Assert(results[accesslog.RouterName], checker.Matches, `^"?(docker\.)?`+v.routerName+`.*$`)
+	c.Assert(results[accesslog.RouterName], checker.Matches, `^"?(docker@)?`+v.routerName+`.*$`)
 	c.Assert(results[accesslog.ServiceURL], checker.Matches, `^"?`+v.serviceURL+`.*$`)
 	c.Assert(results[accesslog.Duration], checker.Matches, `^\d+ms$`)
 }

--- a/integration/docker_compose_test.go
+++ b/integration/docker_compose_test.go
@@ -77,7 +77,7 @@ func (s *DockerComposeSuite) TestComposeScale(c *check.C) {
 	services := rtconf.Services
 	c.Assert(services, checker.HasLen, 1)
 	for k, v := range services {
-		c.Assert(k, checker.Equals, "docker."+composeService+"_integrationtest"+composeProject)
+		c.Assert(k, checker.Equals, "docker@"+composeService+"_integrationtest"+composeProject)
 		c.Assert(v.LoadBalancer.Servers, checker.HasLen, serviceCount)
 		// We could break here, but we don't just to keep us honest.
 	}

--- a/integration/fixtures/simple_auth.toml
+++ b/integration/fixtures/simple_auth.toml
@@ -13,7 +13,7 @@ level = "DEBUG"
   address = ":8001"
 
 [api]
-   middlewares = ["file.authentication"]
+   middlewares = ["file@authentication"]
 
 [ping]
 

--- a/integration/simple_test.go
+++ b/integration/simple_test.go
@@ -444,8 +444,8 @@ func (s *SimpleSuite) TestMultiprovider(c *check.C) {
 		Routers: map[string]*config.Router{
 			"router1": {
 				EntryPoints: []string{"web"},
-				Middlewares: []string{"file.customheader"},
-				Service:     "file.service",
+				Middlewares: []string{"file@customheader"},
+				Service:     "file@service",
 				Rule:        "PathPrefix(`/`)",
 			},
 		},

--- a/integration/testdata/rawdata-crd.json
+++ b/integration/testdata/rawdata-crd.json
@@ -1,6 +1,6 @@
 {
 	"routers": {
-		"kubernetescrd.default/test-crd-6b204d94623b3df4370c": {
+		"kubernetescrd@default/test-crd-6b204d94623b3df4370c": {
 			"entryPoints": [
 				"web"
 			],
@@ -8,7 +8,7 @@
 			"rule": "Host(`foo.com`) \u0026\u0026 PathPrefix(`/bar`)",
 			"priority": 12
 		},
-		"kubernetescrd.default/test2-crd-23c7f4c450289ee29016": {
+		"kubernetescrd@default/test2-crd-23c7f4c450289ee29016": {
 			"entryPoints": [
 				"web"
 			],
@@ -20,19 +20,19 @@
 		}
 	},
 	"middlewares": {
-		"kubernetescrd.default/stripprefix": {
+		"kubernetescrd@default/stripprefix": {
 			"stripPrefix": {
 				"prefixes": [
 					"/tobestripped"
 				]
 			},
 			"usedBy": [
-				"kubernetescrd.default/test2-crd-23c7f4c450289ee29016"
+				"kubernetescrd@default/test2-crd-23c7f4c450289ee29016"
 			]
 		}
 	},
 	"services": {
-		"kubernetescrd.default/test-crd-6b204d94623b3df4370c": {
+		"kubernetescrd@default/test-crd-6b204d94623b3df4370c": {
 			"loadbalancer": {
 				"servers": [
 					{
@@ -45,14 +45,14 @@
 				"passHostHeader": true
 			},
 			"usedBy": [
-				"kubernetescrd.default/test-crd-6b204d94623b3df4370c"
+				"kubernetescrd@default/test-crd-6b204d94623b3df4370c"
 			],
 			"serverStatus": {
 				"http://10.42.0.4:80": "UP",
 				"http://10.42.0.5:80": "UP"
 			}
 		},
-		"kubernetescrd.default/test2-crd-23c7f4c450289ee29016": {
+		"kubernetescrd@default/test2-crd-23c7f4c450289ee29016": {
 			"loadbalancer": {
 				"servers": [
 					{
@@ -65,7 +65,7 @@
 				"passHostHeader": true
 			},
 			"usedBy": [
-				"kubernetescrd.default/test2-crd-23c7f4c450289ee29016"
+				"kubernetescrd@default/test2-crd-23c7f4c450289ee29016"
 			],
 			"serverStatus": {
 				"http://10.42.0.4:80": "UP",
@@ -74,7 +74,7 @@
 		}
 	},
 	"tcpRouters": {
-		"kubernetescrd.default/test3-crd-673acf455cb2dab0b43a": {
+		"kubernetescrd@default/test3-crd-673acf455cb2dab0b43a": {
 			"entryPoints": [
 				"footcp"
 			],
@@ -83,7 +83,7 @@
 		}
 	},
 	"tcpServices": {
-		"kubernetescrd.default/test3-crd-673acf455cb2dab0b43a": {
+		"kubernetescrd@default/test3-crd-673acf455cb2dab0b43a": {
 			"loadbalancer": {
 				"servers": [
 					{
@@ -95,7 +95,7 @@
 				]
 			},
 			"usedBy": [
-				"kubernetescrd.default/test3-crd-673acf455cb2dab0b43a"
+				"kubernetescrd@default/test3-crd-673acf455cb2dab0b43a"
 			]
 		}
 	}

--- a/integration/testdata/rawdata-ingress.json
+++ b/integration/testdata/rawdata-ingress.json
@@ -1,13 +1,13 @@
 {
 	"routers": {
-		"kubernetes.whoami-test/whoami": {
+		"kubernetes@whoami-test/whoami": {
 			"entryPoints": null,
 			"service": "default/whoami/http",
 			"rule": "Host(`whoami.test`) \u0026\u0026 PathPrefix(`/whoami`)"
 		}
 	},
 	"services": {
-		"kubernetes.default/whoami/http": {
+		"kubernetes@default/whoami/http": {
 			"loadbalancer": {
 				"servers": [
 					{
@@ -20,7 +20,7 @@
 				"passHostHeader": true
 			},
 			"usedBy": [
-				"kubernetes.whoami-test/whoami"
+				"kubernetes@whoami-test/whoami"
 			],
 			"serverStatus": {
 				"http://10.42.0.2:80": "UP",

--- a/integration/tracing_test.go
+++ b/integration/tracing_test.go
@@ -89,7 +89,7 @@ func (s *TracingSuite) TestZipkinRateLimit(c *check.C) {
 	err = try.GetRequest("http://127.0.0.1:8000/ratelimit", 500*time.Millisecond, try.StatusCodeIs(http.StatusTooManyRequests))
 	c.Assert(err, checker.IsNil)
 
-	err = try.GetRequest("http://"+s.ZipkinIP+":9411/api/v2/spans?serviceName=tracing", 20*time.Second, try.BodyContains("forward service1/file.router1", "file.ratelimit"))
+	err = try.GetRequest("http://"+s.ZipkinIP+":9411/api/v2/spans?serviceName=tracing", 20*time.Second, try.BodyContains("forward service1/file@router1", "file@ratelimit"))
 	c.Assert(err, checker.IsNil)
 
 }
@@ -117,7 +117,7 @@ func (s *TracingSuite) TestZipkinRetry(c *check.C) {
 	err = try.GetRequest("http://127.0.0.1:8000/retry", 500*time.Millisecond, try.StatusCodeIs(http.StatusBadGateway))
 	c.Assert(err, checker.IsNil)
 
-	err = try.GetRequest("http://"+s.ZipkinIP+":9411/api/v2/spans?serviceName=tracing", 20*time.Second, try.BodyContains("forward service2/file.router2", "file.retry"))
+	err = try.GetRequest("http://"+s.ZipkinIP+":9411/api/v2/spans?serviceName=tracing", 20*time.Second, try.BodyContains("forward service2/file@router2", "file@retry"))
 	c.Assert(err, checker.IsNil)
 }
 
@@ -144,6 +144,6 @@ func (s *TracingSuite) TestZipkinAuth(c *check.C) {
 	err = try.GetRequest("http://127.0.0.1:8000/auth", 500*time.Millisecond, try.StatusCodeIs(http.StatusUnauthorized))
 	c.Assert(err, checker.IsNil)
 
-	err = try.GetRequest("http://"+s.ZipkinIP+":9411/api/v2/spans?serviceName=tracing", 20*time.Second, try.BodyContains("entrypoint web", "file.basic-auth"))
+	err = try.GetRequest("http://"+s.ZipkinIP+":9411/api/v2/spans?serviceName=tracing", 20*time.Second, try.BodyContains("entrypoint web", "file@basic-auth"))
 	c.Assert(err, checker.IsNil)
 }

--- a/pkg/api/handler_test.go
+++ b/pkg/api/handler_test.go
@@ -912,7 +912,7 @@ func TestHandler_Configuration(t *testing.T) {
 			path: "/api/rawdata",
 			conf: config.RuntimeConfiguration{
 				Services: map[string]*config.ServiceInfo{
-					"myprovider.foo-service": {
+					"myprovider@foo-service": {
 						Service: &config.Service{
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
@@ -925,21 +925,21 @@ func TestHandler_Configuration(t *testing.T) {
 					},
 				},
 				Middlewares: map[string]*config.MiddlewareInfo{
-					"myprovider.auth": {
+					"myprovider@auth": {
 						Middleware: &config.Middleware{
 							BasicAuth: &config.BasicAuth{
 								Users: []string{"admin:admin"},
 							},
 						},
 					},
-					"myprovider.addPrefixTest": {
+					"myprovider@addPrefixTest": {
 						Middleware: &config.Middleware{
 							AddPrefix: &config.AddPrefix{
 								Prefix: "/titi",
 							},
 						},
 					},
-					"anotherprovider.addPrefixTest": {
+					"anotherprovider@addPrefixTest": {
 						Middleware: &config.Middleware{
 							AddPrefix: &config.AddPrefix{
 								Prefix: "/toto",
@@ -948,25 +948,25 @@ func TestHandler_Configuration(t *testing.T) {
 					},
 				},
 				Routers: map[string]*config.RouterInfo{
-					"myprovider.bar": {
+					"myprovider@bar": {
 						Router: &config.Router{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`foo.bar`)",
-							Middlewares: []string{"auth", "anotherprovider.addPrefixTest"},
+							Middlewares: []string{"auth", "anotherprovider@addPrefixTest"},
 						},
 					},
-					"myprovider.test": {
+					"myprovider@test": {
 						Router: &config.Router{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`foo.bar.other`)",
 							Middlewares: []string{"addPrefixTest", "auth"},
 						},
 					},
 				},
 				TCPServices: map[string]*config.TCPServiceInfo{
-					"myprovider.tcpfoo-service": {
+					"myprovider@tcpfoo-service": {
 						TCPService: &config.TCPService{
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
@@ -979,17 +979,17 @@ func TestHandler_Configuration(t *testing.T) {
 					},
 				},
 				TCPRouters: map[string]*config.TCPRouterInfo{
-					"myprovider.tcpbar": {
+					"myprovider@tcpbar": {
 						TCPRouter: &config.TCPRouter{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.tcpfoo-service",
+							Service:     "myprovider@tcpfoo-service",
 							Rule:        "HostSNI(`foo.bar`)",
 						},
 					},
-					"myprovider.tcptest": {
+					"myprovider@tcptest": {
 						TCPRouter: &config.TCPRouter{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.tcpfoo-service",
+							Service:     "myprovider@tcpfoo-service",
 							Rule:        "HostSNI(`foo.bar.other`)",
 						},
 					},

--- a/pkg/api/handler_test.go
+++ b/pkg/api/handler_test.go
@@ -47,20 +47,20 @@ func TestHandlerTCP_API(t *testing.T) {
 			path: "/api/tcp/routers",
 			conf: config.RuntimeConfiguration{
 				TCPRouters: map[string]*config.TCPRouterInfo{
-					"myprovider.test": {
+					"myprovider@test": {
 						TCPRouter: &config.TCPRouter{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`foo.bar.other`)",
 							TLS: &config.RouterTCPTLSConfig{
 								Passthrough: false,
 							},
 						},
 					},
-					"myprovider.bar": {
+					"myprovider@bar": {
 						TCPRouter: &config.TCPRouter{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`foo.bar`)",
 						},
 					},
@@ -77,24 +77,24 @@ func TestHandlerTCP_API(t *testing.T) {
 			path: "/api/tcp/routers?page=2&per_page=1",
 			conf: config.RuntimeConfiguration{
 				TCPRouters: map[string]*config.TCPRouterInfo{
-					"myprovider.bar": {
+					"myprovider@bar": {
 						TCPRouter: &config.TCPRouter{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`foo.bar`)",
 						},
 					},
-					"myprovider.baz": {
+					"myprovider@baz": {
 						TCPRouter: &config.TCPRouter{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`toto.bar`)",
 						},
 					},
-					"myprovider.test": {
+					"myprovider@test": {
 						TCPRouter: &config.TCPRouter{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`foo.bar.other`)",
 						},
 					},
@@ -108,13 +108,13 @@ func TestHandlerTCP_API(t *testing.T) {
 		},
 		{
 			desc: "one TCP router by id",
-			path: "/api/tcp/routers/myprovider.bar",
+			path: "/api/tcp/routers/myprovider@bar",
 			conf: config.RuntimeConfiguration{
 				TCPRouters: map[string]*config.TCPRouterInfo{
-					"myprovider.bar": {
+					"myprovider@bar": {
 						TCPRouter: &config.TCPRouter{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`foo.bar`)",
 						},
 					},
@@ -127,13 +127,13 @@ func TestHandlerTCP_API(t *testing.T) {
 		},
 		{
 			desc: "one TCP router by id, that does not exist",
-			path: "/api/tcp/routers/myprovider.foo",
+			path: "/api/tcp/routers/myprovider@foo",
 			conf: config.RuntimeConfiguration{
 				TCPRouters: map[string]*config.TCPRouterInfo{
-					"myprovider.bar": {
+					"myprovider@bar": {
 						TCPRouter: &config.TCPRouter{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`foo.bar`)",
 						},
 					},
@@ -145,7 +145,7 @@ func TestHandlerTCP_API(t *testing.T) {
 		},
 		{
 			desc: "one TCP router by id, but no config",
-			path: "/api/tcp/routers/myprovider.bar",
+			path: "/api/tcp/routers/myprovider@bar",
 			conf: config.RuntimeConfiguration{},
 			expected: expected{
 				statusCode: http.StatusNotFound,
@@ -166,7 +166,7 @@ func TestHandlerTCP_API(t *testing.T) {
 			path: "/api/tcp/services",
 			conf: config.RuntimeConfiguration{
 				TCPServices: map[string]*config.TCPServiceInfo{
-					"myprovider.bar": {
+					"myprovider@bar": {
 						TCPService: &config.TCPService{
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
@@ -176,9 +176,9 @@ func TestHandlerTCP_API(t *testing.T) {
 								},
 							},
 						},
-						UsedBy: []string{"myprovider.foo", "myprovider.test"},
+						UsedBy: []string{"myprovider@foo", "myprovider@test"},
 					},
-					"myprovider.baz": {
+					"myprovider@baz": {
 						TCPService: &config.TCPService{
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
@@ -188,7 +188,7 @@ func TestHandlerTCP_API(t *testing.T) {
 								},
 							},
 						},
-						UsedBy: []string{"myprovider.foo"},
+						UsedBy: []string{"myprovider@foo"},
 					},
 				},
 			},
@@ -203,7 +203,7 @@ func TestHandlerTCP_API(t *testing.T) {
 			path: "/api/tcp/services?page=2&per_page=1",
 			conf: config.RuntimeConfiguration{
 				TCPServices: map[string]*config.TCPServiceInfo{
-					"myprovider.bar": {
+					"myprovider@bar": {
 						TCPService: &config.TCPService{
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
@@ -213,9 +213,9 @@ func TestHandlerTCP_API(t *testing.T) {
 								},
 							},
 						},
-						UsedBy: []string{"myprovider.foo", "myprovider.test"},
+						UsedBy: []string{"myprovider@foo", "myprovider@test"},
 					},
-					"myprovider.baz": {
+					"myprovider@baz": {
 						TCPService: &config.TCPService{
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
@@ -225,9 +225,9 @@ func TestHandlerTCP_API(t *testing.T) {
 								},
 							},
 						},
-						UsedBy: []string{"myprovider.foo"},
+						UsedBy: []string{"myprovider@foo"},
 					},
-					"myprovider.test": {
+					"myprovider@test": {
 						TCPService: &config.TCPService{
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
@@ -248,10 +248,10 @@ func TestHandlerTCP_API(t *testing.T) {
 		},
 		{
 			desc: "one tcp service by id",
-			path: "/api/tcp/services/myprovider.bar",
+			path: "/api/tcp/services/myprovider@bar",
 			conf: config.RuntimeConfiguration{
 				TCPServices: map[string]*config.TCPServiceInfo{
-					"myprovider.bar": {
+					"myprovider@bar": {
 						TCPService: &config.TCPService{
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
@@ -261,7 +261,7 @@ func TestHandlerTCP_API(t *testing.T) {
 								},
 							},
 						},
-						UsedBy: []string{"myprovider.foo", "myprovider.test"},
+						UsedBy: []string{"myprovider@foo", "myprovider@test"},
 					},
 				},
 			},
@@ -272,10 +272,10 @@ func TestHandlerTCP_API(t *testing.T) {
 		},
 		{
 			desc: "one tcp service by id, that does not exist",
-			path: "/api/tcp/services/myprovider.nono",
+			path: "/api/tcp/services/myprovider@nono",
 			conf: config.RuntimeConfiguration{
 				TCPServices: map[string]*config.TCPServiceInfo{
-					"myprovider.bar": {
+					"myprovider@bar": {
 						TCPService: &config.TCPService{
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
@@ -285,7 +285,7 @@ func TestHandlerTCP_API(t *testing.T) {
 								},
 							},
 						},
-						UsedBy: []string{"myprovider.foo", "myprovider.test"},
+						UsedBy: []string{"myprovider@foo", "myprovider@test"},
 					},
 				},
 			},
@@ -295,7 +295,7 @@ func TestHandlerTCP_API(t *testing.T) {
 		},
 		{
 			desc: "one tcp service by id, but no config",
-			path: "/api/tcp/services/myprovider.foo",
+			path: "/api/tcp/services/myprovider@foo",
 			conf: config.RuntimeConfiguration{},
 			expected: expected{
 				statusCode: http.StatusNotFound,
@@ -379,20 +379,20 @@ func TestHandlerHTTP_API(t *testing.T) {
 			path: "/api/http/routers",
 			conf: config.RuntimeConfiguration{
 				Routers: map[string]*config.RouterInfo{
-					"myprovider.test": {
+					"myprovider@test": {
 						Router: &config.Router{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`foo.bar.other`)",
 							Middlewares: []string{"addPrefixTest", "auth"},
 						},
 					},
-					"myprovider.bar": {
+					"myprovider@bar": {
 						Router: &config.Router{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`foo.bar`)",
-							Middlewares: []string{"auth", "anotherprovider.addPrefixTest"},
+							Middlewares: []string{"auth", "anotherprovider@addPrefixTest"},
 						},
 					},
 				},
@@ -408,25 +408,25 @@ func TestHandlerHTTP_API(t *testing.T) {
 			path: "/api/http/routers?page=2&per_page=1",
 			conf: config.RuntimeConfiguration{
 				Routers: map[string]*config.RouterInfo{
-					"myprovider.bar": {
+					"myprovider@bar": {
 						Router: &config.Router{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`foo.bar`)",
-							Middlewares: []string{"auth", "anotherprovider.addPrefixTest"},
+							Middlewares: []string{"auth", "anotherprovider@addPrefixTest"},
 						},
 					},
-					"myprovider.baz": {
+					"myprovider@baz": {
 						Router: &config.Router{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`toto.bar`)",
 						},
 					},
-					"myprovider.test": {
+					"myprovider@test": {
 						Router: &config.Router{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`foo.bar.other`)",
 							Middlewares: []string{"addPrefixTest", "auth"},
 						},
@@ -473,15 +473,15 @@ func TestHandlerHTTP_API(t *testing.T) {
 		},
 		{
 			desc: "one router by id",
-			path: "/api/http/routers/myprovider.bar",
+			path: "/api/http/routers/myprovider@bar",
 			conf: config.RuntimeConfiguration{
 				Routers: map[string]*config.RouterInfo{
-					"myprovider.bar": {
+					"myprovider@bar": {
 						Router: &config.Router{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`foo.bar`)",
-							Middlewares: []string{"auth", "anotherprovider.addPrefixTest"},
+							Middlewares: []string{"auth", "anotherprovider@addPrefixTest"},
 						},
 					},
 				},
@@ -493,15 +493,15 @@ func TestHandlerHTTP_API(t *testing.T) {
 		},
 		{
 			desc: "one router by id, that does not exist",
-			path: "/api/http/routers/myprovider.foo",
+			path: "/api/http/routers/myprovider@foo",
 			conf: config.RuntimeConfiguration{
 				Routers: map[string]*config.RouterInfo{
-					"myprovider.bar": {
+					"myprovider@bar": {
 						Router: &config.Router{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`foo.bar`)",
-							Middlewares: []string{"auth", "anotherprovider.addPrefixTest"},
+							Middlewares: []string{"auth", "anotherprovider@addPrefixTest"},
 						},
 					},
 				},
@@ -512,7 +512,7 @@ func TestHandlerHTTP_API(t *testing.T) {
 		},
 		{
 			desc: "one router by id, but no config",
-			path: "/api/http/routers/myprovider.foo",
+			path: "/api/http/routers/myprovider@foo",
 			conf: config.RuntimeConfiguration{},
 			expected: expected{
 				statusCode: http.StatusNotFound,
@@ -533,7 +533,7 @@ func TestHandlerHTTP_API(t *testing.T) {
 			path: "/api/http/services",
 			conf: config.RuntimeConfiguration{
 				Services: map[string]*config.ServiceInfo{
-					"myprovider.bar": func() *config.ServiceInfo {
+					"myprovider@bar": func() *config.ServiceInfo {
 						si := &config.ServiceInfo{
 							Service: &config.Service{
 								LoadBalancer: &config.LoadBalancerService{
@@ -544,12 +544,12 @@ func TestHandlerHTTP_API(t *testing.T) {
 									},
 								},
 							},
-							UsedBy: []string{"myprovider.foo", "myprovider.test"},
+							UsedBy: []string{"myprovider@foo", "myprovider@test"},
 						}
 						si.UpdateStatus("http://127.0.0.1", "UP")
 						return si
 					}(),
-					"myprovider.baz": func() *config.ServiceInfo {
+					"myprovider@baz": func() *config.ServiceInfo {
 						si := &config.ServiceInfo{
 							Service: &config.Service{
 								LoadBalancer: &config.LoadBalancerService{
@@ -560,7 +560,7 @@ func TestHandlerHTTP_API(t *testing.T) {
 									},
 								},
 							},
-							UsedBy: []string{"myprovider.foo"},
+							UsedBy: []string{"myprovider@foo"},
 						}
 						si.UpdateStatus("http://127.0.0.2", "UP")
 						return si
@@ -578,7 +578,7 @@ func TestHandlerHTTP_API(t *testing.T) {
 			path: "/api/http/services?page=2&per_page=1",
 			conf: config.RuntimeConfiguration{
 				Services: map[string]*config.ServiceInfo{
-					"myprovider.bar": func() *config.ServiceInfo {
+					"myprovider@bar": func() *config.ServiceInfo {
 						si := &config.ServiceInfo{
 							Service: &config.Service{
 								LoadBalancer: &config.LoadBalancerService{
@@ -589,12 +589,12 @@ func TestHandlerHTTP_API(t *testing.T) {
 									},
 								},
 							},
-							UsedBy: []string{"myprovider.foo", "myprovider.test"},
+							UsedBy: []string{"myprovider@foo", "myprovider@test"},
 						}
 						si.UpdateStatus("http://127.0.0.1", "UP")
 						return si
 					}(),
-					"myprovider.baz": func() *config.ServiceInfo {
+					"myprovider@baz": func() *config.ServiceInfo {
 						si := &config.ServiceInfo{
 							Service: &config.Service{
 								LoadBalancer: &config.LoadBalancerService{
@@ -605,12 +605,12 @@ func TestHandlerHTTP_API(t *testing.T) {
 									},
 								},
 							},
-							UsedBy: []string{"myprovider.foo"},
+							UsedBy: []string{"myprovider@foo"},
 						}
 						si.UpdateStatus("http://127.0.0.2", "UP")
 						return si
 					}(),
-					"myprovider.test": func() *config.ServiceInfo {
+					"myprovider@test": func() *config.ServiceInfo {
 						si := &config.ServiceInfo{
 							Service: &config.Service{
 								LoadBalancer: &config.LoadBalancerService{
@@ -621,7 +621,7 @@ func TestHandlerHTTP_API(t *testing.T) {
 									},
 								},
 							},
-							UsedBy: []string{"myprovider.foo", "myprovider.test"},
+							UsedBy: []string{"myprovider@foo", "myprovider@test"},
 						}
 						si.UpdateStatus("http://127.0.0.4", "UP")
 						return si
@@ -636,10 +636,10 @@ func TestHandlerHTTP_API(t *testing.T) {
 		},
 		{
 			desc: "one service by id",
-			path: "/api/http/services/myprovider.bar",
+			path: "/api/http/services/myprovider@bar",
 			conf: config.RuntimeConfiguration{
 				Services: map[string]*config.ServiceInfo{
-					"myprovider.bar": func() *config.ServiceInfo {
+					"myprovider@bar": func() *config.ServiceInfo {
 						si := &config.ServiceInfo{
 							Service: &config.Service{
 								LoadBalancer: &config.LoadBalancerService{
@@ -650,7 +650,7 @@ func TestHandlerHTTP_API(t *testing.T) {
 									},
 								},
 							},
-							UsedBy: []string{"myprovider.foo", "myprovider.test"},
+							UsedBy: []string{"myprovider@foo", "myprovider@test"},
 						}
 						si.UpdateStatus("http://127.0.0.1", "UP")
 						return si
@@ -664,10 +664,10 @@ func TestHandlerHTTP_API(t *testing.T) {
 		},
 		{
 			desc: "one service by id, that does not exist",
-			path: "/api/http/services/myprovider.nono",
+			path: "/api/http/services/myprovider@nono",
 			conf: config.RuntimeConfiguration{
 				Services: map[string]*config.ServiceInfo{
-					"myprovider.bar": func() *config.ServiceInfo {
+					"myprovider@bar": func() *config.ServiceInfo {
 						si := &config.ServiceInfo{
 							Service: &config.Service{
 								LoadBalancer: &config.LoadBalancerService{
@@ -678,7 +678,7 @@ func TestHandlerHTTP_API(t *testing.T) {
 									},
 								},
 							},
-							UsedBy: []string{"myprovider.foo", "myprovider.test"},
+							UsedBy: []string{"myprovider@foo", "myprovider@test"},
 						}
 						si.UpdateStatus("http://127.0.0.1", "UP")
 						return si
@@ -691,7 +691,7 @@ func TestHandlerHTTP_API(t *testing.T) {
 		},
 		{
 			desc: "one service by id, but no config",
-			path: "/api/http/services/myprovider.foo",
+			path: "/api/http/services/myprovider@foo",
 			conf: config.RuntimeConfiguration{},
 			expected: expected{
 				statusCode: http.StatusNotFound,
@@ -712,29 +712,29 @@ func TestHandlerHTTP_API(t *testing.T) {
 			path: "/api/http/middlewares",
 			conf: config.RuntimeConfiguration{
 				Middlewares: map[string]*config.MiddlewareInfo{
-					"myprovider.auth": {
+					"myprovider@auth": {
 						Middleware: &config.Middleware{
 							BasicAuth: &config.BasicAuth{
 								Users: []string{"admin:admin"},
 							},
 						},
-						UsedBy: []string{"myprovider.bar", "myprovider.test"},
+						UsedBy: []string{"myprovider@bar", "myprovider@test"},
 					},
-					"myprovider.addPrefixTest": {
+					"myprovider@addPrefixTest": {
 						Middleware: &config.Middleware{
 							AddPrefix: &config.AddPrefix{
 								Prefix: "/titi",
 							},
 						},
-						UsedBy: []string{"myprovider.test"},
+						UsedBy: []string{"myprovider@test"},
 					},
-					"anotherprovider.addPrefixTest": {
+					"anotherprovider@addPrefixTest": {
 						Middleware: &config.Middleware{
 							AddPrefix: &config.AddPrefix{
 								Prefix: "/toto",
 							},
 						},
-						UsedBy: []string{"myprovider.bar"},
+						UsedBy: []string{"myprovider@bar"},
 					},
 				},
 			},
@@ -749,29 +749,29 @@ func TestHandlerHTTP_API(t *testing.T) {
 			path: "/api/http/middlewares?page=2&per_page=1",
 			conf: config.RuntimeConfiguration{
 				Middlewares: map[string]*config.MiddlewareInfo{
-					"myprovider.auth": {
+					"myprovider@auth": {
 						Middleware: &config.Middleware{
 							BasicAuth: &config.BasicAuth{
 								Users: []string{"admin:admin"},
 							},
 						},
-						UsedBy: []string{"myprovider.bar", "myprovider.test"},
+						UsedBy: []string{"myprovider@bar", "myprovider@test"},
 					},
-					"myprovider.addPrefixTest": {
+					"myprovider@addPrefixTest": {
 						Middleware: &config.Middleware{
 							AddPrefix: &config.AddPrefix{
 								Prefix: "/titi",
 							},
 						},
-						UsedBy: []string{"myprovider.test"},
+						UsedBy: []string{"myprovider@test"},
 					},
-					"anotherprovider.addPrefixTest": {
+					"anotherprovider@addPrefixTest": {
 						Middleware: &config.Middleware{
 							AddPrefix: &config.AddPrefix{
 								Prefix: "/toto",
 							},
 						},
-						UsedBy: []string{"myprovider.bar"},
+						UsedBy: []string{"myprovider@bar"},
 					},
 				},
 			},
@@ -783,32 +783,32 @@ func TestHandlerHTTP_API(t *testing.T) {
 		},
 		{
 			desc: "one middleware by id",
-			path: "/api/http/middlewares/myprovider.auth",
+			path: "/api/http/middlewares/myprovider@auth",
 			conf: config.RuntimeConfiguration{
 				Middlewares: map[string]*config.MiddlewareInfo{
-					"myprovider.auth": {
+					"myprovider@auth": {
 						Middleware: &config.Middleware{
 							BasicAuth: &config.BasicAuth{
 								Users: []string{"admin:admin"},
 							},
 						},
-						UsedBy: []string{"myprovider.bar", "myprovider.test"},
+						UsedBy: []string{"myprovider@bar", "myprovider@test"},
 					},
-					"myprovider.addPrefixTest": {
+					"myprovider@addPrefixTest": {
 						Middleware: &config.Middleware{
 							AddPrefix: &config.AddPrefix{
 								Prefix: "/titi",
 							},
 						},
-						UsedBy: []string{"myprovider.test"},
+						UsedBy: []string{"myprovider@test"},
 					},
-					"anotherprovider.addPrefixTest": {
+					"anotherprovider@addPrefixTest": {
 						Middleware: &config.Middleware{
 							AddPrefix: &config.AddPrefix{
 								Prefix: "/toto",
 							},
 						},
-						UsedBy: []string{"myprovider.bar"},
+						UsedBy: []string{"myprovider@bar"},
 					},
 				},
 			},
@@ -819,16 +819,16 @@ func TestHandlerHTTP_API(t *testing.T) {
 		},
 		{
 			desc: "one middleware by id, that does not exist",
-			path: "/api/http/middlewares/myprovider.foo",
+			path: "/api/http/middlewares/myprovider@foo",
 			conf: config.RuntimeConfiguration{
 				Middlewares: map[string]*config.MiddlewareInfo{
-					"myprovider.auth": {
+					"myprovider@auth": {
 						Middleware: &config.Middleware{
 							BasicAuth: &config.BasicAuth{
 								Users: []string{"admin:admin"},
 							},
 						},
-						UsedBy: []string{"myprovider.bar", "myprovider.test"},
+						UsedBy: []string{"myprovider@bar", "myprovider@test"},
 					},
 				},
 			},
@@ -838,7 +838,7 @@ func TestHandlerHTTP_API(t *testing.T) {
 		},
 		{
 			desc: "one middleware by id, but no config",
-			path: "/api/http/middlewares/myprovider.foo",
+			path: "/api/http/middlewares/myprovider@foo",
 			conf: config.RuntimeConfiguration{},
 			expected: expected{
 				statusCode: http.StatusNotFound,
@@ -1054,10 +1054,10 @@ func TestHandler_Configuration(t *testing.T) {
 func generateHTTPRouters(nbRouters int) map[string]*config.RouterInfo {
 	routers := make(map[string]*config.RouterInfo, nbRouters)
 	for i := 0; i < nbRouters; i++ {
-		routers[fmt.Sprintf("myprovider.bar%2d", i)] = &config.RouterInfo{
+		routers[fmt.Sprintf("myprovider@bar%2d", i)] = &config.RouterInfo{
 			Router: &config.Router{
 				EntryPoints: []string{"web"},
-				Service:     "myprovider.foo-service",
+				Service:     "myprovider@foo-service",
 				Rule:        "Host(`foo.bar" + strconv.Itoa(i) + "`)",
 			},
 		}

--- a/pkg/api/testdata/getrawdata.json
+++ b/pkg/api/testdata/getrawdata.json
@@ -1,17 +1,17 @@
 {
 	"routers": {
-		"myprovider.bar": {
+		"myprovider@bar": {
 			"entryPoints": [
 				"web"
 			],
 			"middlewares": [
 				"auth",
-				"anotherprovider.addPrefixTest"
+				"anotherprovider@addPrefixTest"
 			],
-			"service": "myprovider.foo-service",
+			"service": "myprovider@foo-service",
 			"rule": "Host(`foo.bar`)"
 		},
-		"myprovider.test": {
+		"myprovider@test": {
 			"entryPoints": [
 				"web"
 			],
@@ -19,41 +19,41 @@
 				"addPrefixTest",
 				"auth"
 			],
-			"service": "myprovider.foo-service",
+			"service": "myprovider@foo-service",
 			"rule": "Host(`foo.bar.other`)"
 		}
 	},
 	"middlewares": {
-		"anotherprovider.addPrefixTest": {
+		"anotherprovider@addPrefixTest": {
 			"addPrefix": {
 				"prefix": "/toto"
 			},
 			"usedBy": [
-				"myprovider.bar"
+				"myprovider@bar"
 			]
 		},
-		"myprovider.addPrefixTest": {
+		"myprovider@addPrefixTest": {
 			"addPrefix": {
 				"prefix": "/titi"
 			},
 			"usedBy": [
-				"myprovider.test"
+				"myprovider@test"
 			]
 		},
-		"myprovider.auth": {
+		"myprovider@auth": {
 			"basicAuth": {
 				"users": [
 					"admin:admin"
 				]
 			},
 			"usedBy": [
-				"myprovider.bar",
-				"myprovider.test"
+				"myprovider@bar",
+				"myprovider@test"
 			]
 		}
 	},
 	"services": {
-		"myprovider.foo-service": {
+		"myprovider@foo-service": {
 			"loadbalancer": {
 				"servers": [
 					{
@@ -63,29 +63,29 @@
 				"passHostHeader": false
 			},
 			"usedBy": [
-				"myprovider.bar",
-				"myprovider.test"
+				"myprovider@bar",
+				"myprovider@test"
 			]
 		}
 	},
 	"tcpRouters": {
-		"myprovider.tcpbar": {
+		"myprovider@tcpbar": {
 			"entryPoints": [
 				"web"
 			],
-			"service": "myprovider.tcpfoo-service",
+			"service": "myprovider@tcpfoo-service",
 			"rule": "HostSNI(`foo.bar`)"
 		},
-		"myprovider.tcptest": {
+		"myprovider@tcptest": {
 			"entryPoints": [
 				"web"
 			],
-			"service": "myprovider.tcpfoo-service",
+			"service": "myprovider@tcpfoo-service",
 			"rule": "HostSNI(`foo.bar.other`)"
 		}
 	},
 	"tcpServices": {
-		"myprovider.tcpfoo-service": {
+		"myprovider@tcpfoo-service": {
 			"loadbalancer": {
 				"servers": [
 					{
@@ -94,8 +94,8 @@
 				]
 			},
 			"usedBy": [
-				"myprovider.tcpbar",
-				"myprovider.tcptest"
+				"myprovider@tcpbar",
+				"myprovider@tcptest"
 			]
 		}
 	}

--- a/pkg/api/testdata/middleware-auth.json
+++ b/pkg/api/testdata/middleware-auth.json
@@ -4,10 +4,10 @@
 			"admin:admin"
 		]
 	},
-	"name": "myprovider.auth",
-	"provider": "myprovider",
+	"name": "myprovider@auth",
+	"provider": "myprovider@auth",
 	"usedBy": [
-		"myprovider.bar",
-		"myprovider.test"
+		"myprovider@bar",
+		"myprovider@test"
 	]
 }

--- a/pkg/api/testdata/middlewares-page2.json
+++ b/pkg/api/testdata/middlewares-page2.json
@@ -3,10 +3,10 @@
 		"addPrefix": {
 			"prefix": "/titi"
 		},
-		"name": "myprovider.addPrefixTest",
-		"provider": "myprovider",
+		"name": "myprovider@addPrefixTest",
+		"provider": "myprovider@addPrefixTest",
 		"usedBy": [
-			"myprovider.test"
+			"myprovider@test"
 		]
 	}
 ]

--- a/pkg/api/testdata/middlewares.json
+++ b/pkg/api/testdata/middlewares.json
@@ -3,20 +3,20 @@
 		"addPrefix": {
 			"prefix": "/toto"
 		},
-		"name": "anotherprovider.addPrefixTest",
-		"provider": "anotherprovider",
+		"name": "anotherprovider@addPrefixTest",
+		"provider": "anotherprovider@addPrefixTest",
 		"usedBy": [
-			"myprovider.bar"
+			"myprovider@bar"
 		]
 	},
 	{
 		"addPrefix": {
 			"prefix": "/titi"
 		},
-		"name": "myprovider.addPrefixTest",
-		"provider": "myprovider",
+		"name": "myprovider@addPrefixTest",
+		"provider": "myprovider@addPrefixTest",
 		"usedBy": [
-			"myprovider.test"
+			"myprovider@test"
 		]
 	},
 	{
@@ -25,11 +25,11 @@
 				"admin:admin"
 			]
 		},
-		"name": "myprovider.auth",
-		"provider": "myprovider",
+		"name": "myprovider@auth",
+		"provider": "myprovider@auth",
 		"usedBy": [
-			"myprovider.bar",
-			"myprovider.test"
+			"myprovider@bar",
+			"myprovider@test"
 		]
 	}
 ]

--- a/pkg/api/testdata/router-bar.json
+++ b/pkg/api/testdata/router-bar.json
@@ -4,10 +4,10 @@
 	],
 	"middlewares": [
 		"auth",
-		"anotherprovider.addPrefixTest"
+		"anotherprovider@addPrefixTest"
 	],
-	"name": "myprovider.bar",
-	"provider": "myprovider",
+	"name": "myprovider@bar",
+	"provider": "myprovider@bar",
 	"rule": "Host(`foo.bar`)",
-	"service": "myprovider.foo-service"
+	"service": "myprovider@foo-service"
 }

--- a/pkg/api/testdata/routers-many-lastpage.json
+++ b/pkg/api/testdata/routers-many-lastpage.json
@@ -3,45 +3,45 @@
 		"entryPoints": [
 			"web"
 		],
-		"name": "myprovider.bar14",
-		"provider": "myprovider",
+		"name": "myprovider@bar14",
+		"provider": "myprovider@bar14",
 		"rule": "Host(`foo.bar14`)",
-		"service": "myprovider.foo-service"
+		"service": "myprovider@foo-service"
 	},
 	{
 		"entryPoints": [
 			"web"
 		],
-		"name": "myprovider.bar15",
-		"provider": "myprovider",
+		"name": "myprovider@bar15",
+		"provider": "myprovider@bar15",
 		"rule": "Host(`foo.bar15`)",
-		"service": "myprovider.foo-service"
+		"service": "myprovider@foo-service"
 	},
 	{
 		"entryPoints": [
 			"web"
 		],
-		"name": "myprovider.bar16",
-		"provider": "myprovider",
+		"name": "myprovider@bar16",
+		"provider": "myprovider@bar16",
 		"rule": "Host(`foo.bar16`)",
-		"service": "myprovider.foo-service"
+		"service": "myprovider@foo-service"
 	},
 	{
 		"entryPoints": [
 			"web"
 		],
-		"name": "myprovider.bar17",
-		"provider": "myprovider",
+		"name": "myprovider@bar17",
+		"provider": "myprovider@bar17",
 		"rule": "Host(`foo.bar17`)",
-		"service": "myprovider.foo-service"
+		"service": "myprovider@foo-service"
 	},
 	{
 		"entryPoints": [
 			"web"
 		],
-		"name": "myprovider.bar18",
-		"provider": "myprovider",
+		"name": "myprovider@bar18",
+		"provider": "myprovider@bar18",
 		"rule": "Host(`foo.bar18`)",
-		"service": "myprovider.foo-service"
+		"service": "myprovider@foo-service"
 	}
 ]

--- a/pkg/api/testdata/routers-page2.json
+++ b/pkg/api/testdata/routers-page2.json
@@ -3,9 +3,9 @@
 		"entryPoints": [
 			"web"
 		],
-		"name": "myprovider.baz",
-		"provider": "myprovider",
+		"name": "myprovider@baz",
+		"provider": "myprovider@baz",
 		"rule": "Host(`toto.bar`)",
-		"service": "myprovider.foo-service"
+		"service": "myprovider@foo-service"
 	}
 ]

--- a/pkg/api/testdata/routers.json
+++ b/pkg/api/testdata/routers.json
@@ -5,12 +5,12 @@
 		],
 		"middlewares": [
 			"auth",
-			"anotherprovider.addPrefixTest"
+			"anotherprovider@addPrefixTest"
 		],
-		"name": "myprovider.bar",
-		"provider": "myprovider",
+		"name": "myprovider@bar",
+		"provider": "myprovider@bar",
 		"rule": "Host(`foo.bar`)",
-		"service": "myprovider.foo-service"
+		"service": "myprovider@foo-service"
 	},
 	{
 		"entryPoints": [
@@ -20,9 +20,9 @@
 			"addPrefixTest",
 			"auth"
 		],
-		"name": "myprovider.test",
-		"provider": "myprovider",
+		"name": "myprovider@test",
+		"provider": "myprovider@test",
 		"rule": "Host(`foo.bar.other`)",
-		"service": "myprovider.foo-service"
+		"service": "myprovider@foo-service"
 	}
 ]

--- a/pkg/api/testdata/service-bar.json
+++ b/pkg/api/testdata/service-bar.json
@@ -7,13 +7,13 @@
 			}
 		]
 	},
-	"name": "myprovider.bar",
-	"provider": "myprovider",
+	"name": "myprovider@bar",
+	"provider": "myprovider@bar",
 	"serverStatus": {
 		"http://127.0.0.1": "UP"
 	},
 	"usedBy": [
-		"myprovider.foo",
-		"myprovider.test"
+		"myprovider@foo",
+		"myprovider@test"
 	]
 }

--- a/pkg/api/testdata/services-page2.json
+++ b/pkg/api/testdata/services-page2.json
@@ -8,13 +8,13 @@
 				}
 			]
 		},
-		"name": "myprovider.baz",
-		"provider": "myprovider",
+		"name": "myprovider@baz",
+		"provider": "myprovider@baz",
 		"serverStatus": {
 			"http://127.0.0.2": "UP"
 		},
 		"usedBy": [
-			"myprovider.foo"
+			"myprovider@foo"
 		]
 	}
 ]

--- a/pkg/api/testdata/services.json
+++ b/pkg/api/testdata/services.json
@@ -8,14 +8,14 @@
 				}
 			]
 		},
-		"name": "myprovider.bar",
-		"provider": "myprovider",
+		"name": "myprovider@bar",
+		"provider": "myprovider@bar",
 		"serverStatus": {
 			"http://127.0.0.1": "UP"
 		},
 		"usedBy": [
-			"myprovider.foo",
-			"myprovider.test"
+			"myprovider@foo",
+			"myprovider@test"
 		]
 	},
 	{
@@ -27,13 +27,13 @@
 				}
 			]
 		},
-		"name": "myprovider.baz",
-		"provider": "myprovider",
+		"name": "myprovider@baz",
+		"provider": "myprovider@baz",
 		"serverStatus": {
 			"http://127.0.0.2": "UP"
 		},
 		"usedBy": [
-			"myprovider.foo"
+			"myprovider@foo"
 		]
 	}
 ]

--- a/pkg/api/testdata/tcprouter-bar.json
+++ b/pkg/api/testdata/tcprouter-bar.json
@@ -2,8 +2,8 @@
 	"entryPoints": [
 		"web"
 	],
-	"name": "myprovider.bar",
-	"provider": "myprovider",
+	"name": "myprovider@bar",
+	"provider": "myprovider@bar",
 	"rule": "Host(`foo.bar`)",
-	"service": "myprovider.foo-service"
+	"service": "myprovider@foo-service"
 }

--- a/pkg/api/testdata/tcprouters-page2.json
+++ b/pkg/api/testdata/tcprouters-page2.json
@@ -3,9 +3,9 @@
 		"entryPoints": [
 			"web"
 		],
-		"name": "myprovider.baz",
-		"provider": "myprovider",
+		"name": "myprovider@baz",
+		"provider": "myprovider@baz",
 		"rule": "Host(`toto.bar`)",
-		"service": "myprovider.foo-service"
+		"service": "myprovider@foo-service"
 	}
 ]

--- a/pkg/api/testdata/tcprouters.json
+++ b/pkg/api/testdata/tcprouters.json
@@ -3,19 +3,19 @@
 		"entryPoints": [
 			"web"
 		],
-		"name": "myprovider.bar",
-		"provider": "myprovider",
+		"name": "myprovider@bar",
+		"provider": "myprovider@bar",
 		"rule": "Host(`foo.bar`)",
-		"service": "myprovider.foo-service"
+		"service": "myprovider@foo-service"
 	},
 	{
 		"entryPoints": [
 			"web"
 		],
-		"name": "myprovider.test",
-		"provider": "myprovider",
+		"name": "myprovider@test",
+		"provider": "myprovider@test",
 		"rule": "Host(`foo.bar.other`)",
-		"service": "myprovider.foo-service",
+		"service": "myprovider@foo-service",
 		"tls": {
 			"passthrough": false
 		}

--- a/pkg/api/testdata/tcpservice-bar.json
+++ b/pkg/api/testdata/tcpservice-bar.json
@@ -6,10 +6,10 @@
 			}
 		]
 	},
-	"name": "myprovider.bar",
-	"provider": "myprovider",
+	"name": "myprovider@bar",
+	"provider": "myprovider@bar",
 	"usedBy": [
-		"myprovider.foo",
-		"myprovider.test"
+		"myprovider@foo",
+		"myprovider@test"
 	]
 }

--- a/pkg/api/testdata/tcpservices-page2.json
+++ b/pkg/api/testdata/tcpservices-page2.json
@@ -7,10 +7,10 @@
 				}
 			]
 		},
-		"name": "myprovider.baz",
-		"provider": "myprovider",
+		"name": "myprovider@baz",
+		"provider": "myprovider@baz",
 		"usedBy": [
-			"myprovider.foo"
+			"myprovider@foo"
 		]
 	}
 ]

--- a/pkg/api/testdata/tcpservices.json
+++ b/pkg/api/testdata/tcpservices.json
@@ -7,11 +7,11 @@
 				}
 			]
 		},
-		"name": "myprovider.bar",
-		"provider": "myprovider",
+		"name": "myprovider@bar",
+		"provider": "myprovider@bar",
 		"usedBy": [
-			"myprovider.foo",
-			"myprovider.test"
+			"myprovider@foo",
+			"myprovider@test"
 		]
 	},
 	{
@@ -22,10 +22,10 @@
 				}
 			]
 		},
-		"name": "myprovider.baz",
-		"provider": "myprovider",
+		"name": "myprovider@baz",
+		"provider": "myprovider@baz",
 		"usedBy": [
-			"myprovider.foo"
+			"myprovider@foo"
 		]
 	}
 ]

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -263,7 +263,7 @@ type TCPServiceInfo struct {
 }
 
 func getProviderName(elementName string) string {
-	parts := strings.Split(elementName, ".")
+	parts := strings.Split(elementName, "@")
 	if len(parts) > 1 {
 		return parts[0]
 	}
@@ -271,9 +271,9 @@ func getProviderName(elementName string) string {
 }
 
 func getQualifiedName(provider, elementName string) string {
-	parts := strings.Split(elementName, ".")
+	parts := strings.Split(elementName, "@")
 	if len(parts) == 1 {
-		return provider + "." + elementName
+		return provider + "@" + elementName
 	}
 	return elementName
 }

--- a/pkg/config/runtime_test.go
+++ b/pkg/config/runtime_test.go
@@ -25,23 +25,23 @@ func TestPopulateUsedby(t *testing.T) {
 			desc: "One service used by two routers",
 			conf: &config.RuntimeConfiguration{
 				Routers: map[string]*config.RouterInfo{
-					"myprovider.foo": {
+					"myprovider@foo": {
 						Router: &config.Router{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`bar.foo`)",
 						},
 					},
-					"myprovider.bar": {
+					"myprovider@bar": {
 						Router: &config.Router{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`foo.bar`)",
 						},
 					},
 				},
 				Services: map[string]*config.ServiceInfo{
-					"myprovider.foo-service": {
+					"myprovider@foo-service": {
 						Service: &config.Service{
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
@@ -59,12 +59,12 @@ func TestPopulateUsedby(t *testing.T) {
 			},
 			expected: config.RuntimeConfiguration{
 				Routers: map[string]*config.RouterInfo{
-					"myprovider.foo": {},
-					"myprovider.bar": {},
+					"myprovider@foo": {},
+					"myprovider@bar": {},
 				},
 				Services: map[string]*config.ServiceInfo{
-					"myprovider.foo-service": {
-						UsedBy: []string{"myprovider.bar", "myprovider.foo"},
+					"myprovider@foo-service": {
+						UsedBy: []string{"myprovider@bar", "myprovider@foo"},
 					},
 				},
 			},
@@ -73,7 +73,7 @@ func TestPopulateUsedby(t *testing.T) {
 			desc: "One service used by two routers, but one router with wrong rule",
 			conf: &config.RuntimeConfiguration{
 				Services: map[string]*config.ServiceInfo{
-					"myprovider.foo-service": {
+					"myprovider@foo-service": {
 						Service: &config.Service{
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
@@ -84,17 +84,17 @@ func TestPopulateUsedby(t *testing.T) {
 					},
 				},
 				Routers: map[string]*config.RouterInfo{
-					"myprovider.foo": {
+					"myprovider@foo": {
 						Router: &config.Router{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "WrongRule(`bar.foo`)",
 						},
 					},
-					"myprovider.bar": {
+					"myprovider@bar": {
 						Router: &config.Router{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`foo.bar`)",
 						},
 					},
@@ -102,12 +102,12 @@ func TestPopulateUsedby(t *testing.T) {
 			},
 			expected: config.RuntimeConfiguration{
 				Routers: map[string]*config.RouterInfo{
-					"myprovider.foo": {},
-					"myprovider.bar": {},
+					"myprovider@foo": {},
+					"myprovider@bar": {},
 				},
 				Services: map[string]*config.ServiceInfo{
-					"myprovider.foo-service": {
-						UsedBy: []string{"myprovider.bar", "myprovider.foo"},
+					"myprovider@foo-service": {
+						UsedBy: []string{"myprovider@bar", "myprovider@foo"},
 					},
 				},
 			},
@@ -116,17 +116,17 @@ func TestPopulateUsedby(t *testing.T) {
 			desc: "Broken Service used by one Router",
 			conf: &config.RuntimeConfiguration{
 				Services: map[string]*config.ServiceInfo{
-					"myprovider.foo-service": {
+					"myprovider@foo-service": {
 						Service: &config.Service{
 							LoadBalancer: nil,
 						},
 					},
 				},
 				Routers: map[string]*config.RouterInfo{
-					"myprovider.bar": {
+					"myprovider@bar": {
 						Router: &config.Router{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`foo.bar`)",
 						},
 					},
@@ -134,11 +134,11 @@ func TestPopulateUsedby(t *testing.T) {
 			},
 			expected: config.RuntimeConfiguration{
 				Routers: map[string]*config.RouterInfo{
-					"myprovider.bar": {},
+					"myprovider@bar": {},
 				},
 				Services: map[string]*config.ServiceInfo{
-					"myprovider.foo-service": {
-						UsedBy: []string{"myprovider.bar"},
+					"myprovider@foo-service": {
+						UsedBy: []string{"myprovider@bar"},
 					},
 				},
 			},
@@ -147,7 +147,7 @@ func TestPopulateUsedby(t *testing.T) {
 			desc: "2 different Services each used by a disctinct router.",
 			conf: &config.RuntimeConfiguration{
 				Services: map[string]*config.ServiceInfo{
-					"myprovider.foo-service": {
+					"myprovider@foo-service": {
 						Service: &config.Service{
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
@@ -165,7 +165,7 @@ func TestPopulateUsedby(t *testing.T) {
 							},
 						},
 					},
-					"myprovider.bar-service": {
+					"myprovider@bar-service": {
 						Service: &config.Service{
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
@@ -185,17 +185,17 @@ func TestPopulateUsedby(t *testing.T) {
 					},
 				},
 				Routers: map[string]*config.RouterInfo{
-					"myprovider.foo": {
+					"myprovider@foo": {
 						Router: &config.Router{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`bar.foo`)",
 						},
 					},
-					"myprovider.bar": {
+					"myprovider@bar": {
 						Router: &config.Router{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.bar-service",
+							Service:     "myprovider@bar-service",
 							Rule:        "Host(`foo.bar`)",
 						},
 					},
@@ -203,15 +203,15 @@ func TestPopulateUsedby(t *testing.T) {
 			},
 			expected: config.RuntimeConfiguration{
 				Routers: map[string]*config.RouterInfo{
-					"myprovider.bar": {},
-					"myprovider.foo": {},
+					"myprovider@bar": {},
+					"myprovider@foo": {},
 				},
 				Services: map[string]*config.ServiceInfo{
-					"myprovider.foo-service": {
-						UsedBy: []string{"myprovider.foo"},
+					"myprovider@foo-service": {
+						UsedBy: []string{"myprovider@foo"},
 					},
-					"myprovider.bar-service": {
-						UsedBy: []string{"myprovider.bar"},
+					"myprovider@bar-service": {
+						UsedBy: []string{"myprovider@bar"},
 					},
 				},
 			},
@@ -220,7 +220,7 @@ func TestPopulateUsedby(t *testing.T) {
 			desc: "2 middlewares both used by 2 Routers",
 			conf: &config.RuntimeConfiguration{
 				Services: map[string]*config.ServiceInfo{
-					"myprovider.foo-service": {
+					"myprovider@foo-service": {
 						Service: &config.Service{
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
@@ -233,14 +233,14 @@ func TestPopulateUsedby(t *testing.T) {
 					},
 				},
 				Middlewares: map[string]*config.MiddlewareInfo{
-					"myprovider.auth": {
+					"myprovider@auth": {
 						Middleware: &config.Middleware{
 							BasicAuth: &config.BasicAuth{
 								Users: []string{"admin:admin"},
 							},
 						},
 					},
-					"myprovider.addPrefixTest": {
+					"myprovider@addPrefixTest": {
 						Middleware: &config.Middleware{
 							AddPrefix: &config.AddPrefix{
 								Prefix: "/toto",
@@ -249,18 +249,18 @@ func TestPopulateUsedby(t *testing.T) {
 					},
 				},
 				Routers: map[string]*config.RouterInfo{
-					"myprovider.bar": {
+					"myprovider@bar": {
 						Router: &config.Router{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`foo.bar`)",
 							Middlewares: []string{"auth", "addPrefixTest"},
 						},
 					},
-					"myprovider.test": {
+					"myprovider@test": {
 						Router: &config.Router{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`foo.bar.other`)",
 							Middlewares: []string{"addPrefixTest", "auth"},
 						},
@@ -269,20 +269,20 @@ func TestPopulateUsedby(t *testing.T) {
 			},
 			expected: config.RuntimeConfiguration{
 				Routers: map[string]*config.RouterInfo{
-					"myprovider.bar":  {},
-					"myprovider.test": {},
+					"myprovider@bar":  {},
+					"myprovider@test": {},
 				},
 				Services: map[string]*config.ServiceInfo{
-					"myprovider.foo-service": {
-						UsedBy: []string{"myprovider.bar", "myprovider.test"},
+					"myprovider@foo-service": {
+						UsedBy: []string{"myprovider@bar", "myprovider@test"},
 					},
 				},
 				Middlewares: map[string]*config.MiddlewareInfo{
-					"myprovider.auth": {
-						UsedBy: []string{"myprovider.bar", "myprovider.test"},
+					"myprovider@auth": {
+						UsedBy: []string{"myprovider@bar", "myprovider@test"},
 					},
-					"myprovider.addPrefixTest": {
-						UsedBy: []string{"myprovider.bar", "myprovider.test"},
+					"myprovider@addPrefixTest": {
+						UsedBy: []string{"myprovider@bar", "myprovider@test"},
 					},
 				},
 			},
@@ -291,7 +291,7 @@ func TestPopulateUsedby(t *testing.T) {
 			desc: "Unknown middleware is not used by the Router",
 			conf: &config.RuntimeConfiguration{
 				Services: map[string]*config.ServiceInfo{
-					"myprovider.foo-service": {
+					"myprovider@foo-service": {
 						Service: &config.Service{
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
@@ -304,7 +304,7 @@ func TestPopulateUsedby(t *testing.T) {
 					},
 				},
 				Middlewares: map[string]*config.MiddlewareInfo{
-					"myprovider.auth": {
+					"myprovider@auth": {
 						Middleware: &config.Middleware{
 							BasicAuth: &config.BasicAuth{
 								Users: []string{"admin:admin"},
@@ -313,10 +313,10 @@ func TestPopulateUsedby(t *testing.T) {
 					},
 				},
 				Routers: map[string]*config.RouterInfo{
-					"myprovider.bar": {
+					"myprovider@bar": {
 						Router: &config.Router{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`foo.bar`)",
 							Middlewares: []string{"unknown"},
 						},
@@ -325,8 +325,8 @@ func TestPopulateUsedby(t *testing.T) {
 			},
 			expected: config.RuntimeConfiguration{
 				Services: map[string]*config.ServiceInfo{
-					"myprovider.foo-service": {
-						UsedBy: []string{"myprovider.bar"},
+					"myprovider@foo-service": {
+						UsedBy: []string{"myprovider@bar"},
 					},
 				},
 			},
@@ -335,7 +335,7 @@ func TestPopulateUsedby(t *testing.T) {
 			desc: "Broken middleware is used by Router",
 			conf: &config.RuntimeConfiguration{
 				Services: map[string]*config.ServiceInfo{
-					"myprovider.foo-service": {
+					"myprovider@foo-service": {
 						Service: &config.Service{
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
@@ -348,7 +348,7 @@ func TestPopulateUsedby(t *testing.T) {
 					},
 				},
 				Middlewares: map[string]*config.MiddlewareInfo{
-					"myprovider.auth": {
+					"myprovider@auth": {
 						Middleware: &config.Middleware{
 							BasicAuth: &config.BasicAuth{
 								Users: []string{"badConf"},
@@ -357,28 +357,28 @@ func TestPopulateUsedby(t *testing.T) {
 					},
 				},
 				Routers: map[string]*config.RouterInfo{
-					"myprovider.bar": {
+					"myprovider@bar": {
 						Router: &config.Router{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`foo.bar`)",
-							Middlewares: []string{"myprovider.auth"},
+							Middlewares: []string{"myprovider@auth"},
 						},
 					},
 				},
 			},
 			expected: config.RuntimeConfiguration{
 				Routers: map[string]*config.RouterInfo{
-					"myprovider.bar": {},
+					"myprovider@bar": {},
 				},
 				Services: map[string]*config.ServiceInfo{
-					"myprovider.foo-service": {
-						UsedBy: []string{"myprovider.bar"},
+					"myprovider@foo-service": {
+						UsedBy: []string{"myprovider@bar"},
 					},
 				},
 				Middlewares: map[string]*config.MiddlewareInfo{
-					"myprovider.auth": {
-						UsedBy: []string{"myprovider.bar"},
+					"myprovider@auth": {
+						UsedBy: []string{"myprovider@bar"},
 					},
 				},
 			},
@@ -387,7 +387,7 @@ func TestPopulateUsedby(t *testing.T) {
 			desc: "2 middlewares from 2 disctinct providers both used by 2 Routers",
 			conf: &config.RuntimeConfiguration{
 				Services: map[string]*config.ServiceInfo{
-					"myprovider.foo-service": {
+					"myprovider@foo-service": {
 						Service: &config.Service{
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
@@ -400,21 +400,21 @@ func TestPopulateUsedby(t *testing.T) {
 					},
 				},
 				Middlewares: map[string]*config.MiddlewareInfo{
-					"myprovider.auth": {
+					"myprovider@auth": {
 						Middleware: &config.Middleware{
 							BasicAuth: &config.BasicAuth{
 								Users: []string{"admin:admin"},
 							},
 						},
 					},
-					"myprovider.addPrefixTest": {
+					"myprovider@addPrefixTest": {
 						Middleware: &config.Middleware{
 							AddPrefix: &config.AddPrefix{
 								Prefix: "/titi",
 							},
 						},
 					},
-					"anotherprovider.addPrefixTest": {
+					"anotherprovider@addPrefixTest": {
 						Middleware: &config.Middleware{
 							AddPrefix: &config.AddPrefix{
 								Prefix: "/toto",
@@ -423,18 +423,18 @@ func TestPopulateUsedby(t *testing.T) {
 					},
 				},
 				Routers: map[string]*config.RouterInfo{
-					"myprovider.bar": {
+					"myprovider@bar": {
 						Router: &config.Router{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`foo.bar`)",
-							Middlewares: []string{"auth", "anotherprovider.addPrefixTest"},
+							Middlewares: []string{"auth", "anotherprovider@addPrefixTest"},
 						},
 					},
-					"myprovider.test": {
+					"myprovider@test": {
 						Router: &config.Router{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`foo.bar.other`)",
 							Middlewares: []string{"addPrefixTest", "auth"},
 						},
@@ -443,23 +443,23 @@ func TestPopulateUsedby(t *testing.T) {
 			},
 			expected: config.RuntimeConfiguration{
 				Routers: map[string]*config.RouterInfo{
-					"myprovider.bar":  {},
-					"myprovider.test": {},
+					"myprovider@bar":  {},
+					"myprovider@test": {},
 				},
 				Services: map[string]*config.ServiceInfo{
-					"myprovider.foo-service": {
-						UsedBy: []string{"myprovider.bar", "myprovider.test"},
+					"myprovider@foo-service": {
+						UsedBy: []string{"myprovider@bar", "myprovider@test"},
 					},
 				},
 				Middlewares: map[string]*config.MiddlewareInfo{
-					"myprovider.auth": {
-						UsedBy: []string{"myprovider.bar", "myprovider.test"},
+					"myprovider@auth": {
+						UsedBy: []string{"myprovider@bar", "myprovider@test"},
 					},
-					"myprovider.addPrefixTest": {
-						UsedBy: []string{"myprovider.test"},
+					"myprovider@addPrefixTest": {
+						UsedBy: []string{"myprovider@test"},
 					},
-					"anotherprovider.addPrefixTest": {
-						UsedBy: []string{"myprovider.bar"},
+					"anotherprovider@addPrefixTest": {
+						UsedBy: []string{"myprovider@bar"},
 					},
 				},
 			},
@@ -470,23 +470,23 @@ func TestPopulateUsedby(t *testing.T) {
 			desc: "TCP, One service used by two routers",
 			conf: &config.RuntimeConfiguration{
 				TCPRouters: map[string]*config.TCPRouterInfo{
-					"myprovider.foo": {
+					"myprovider@foo": {
 						TCPRouter: &config.TCPRouter{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`bar.foo`)",
 						},
 					},
-					"myprovider.bar": {
+					"myprovider@bar": {
 						TCPRouter: &config.TCPRouter{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`foo.bar`)",
 						},
 					},
 				},
 				TCPServices: map[string]*config.TCPServiceInfo{
-					"myprovider.foo-service": {
+					"myprovider@foo-service": {
 						TCPService: &config.TCPService{
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
@@ -506,12 +506,12 @@ func TestPopulateUsedby(t *testing.T) {
 			},
 			expected: config.RuntimeConfiguration{
 				TCPRouters: map[string]*config.TCPRouterInfo{
-					"myprovider.foo": {},
-					"myprovider.bar": {},
+					"myprovider@foo": {},
+					"myprovider@bar": {},
 				},
 				TCPServices: map[string]*config.TCPServiceInfo{
-					"myprovider.foo-service": {
-						UsedBy: []string{"myprovider.bar", "myprovider.foo"},
+					"myprovider@foo-service": {
+						UsedBy: []string{"myprovider@bar", "myprovider@foo"},
 					},
 				},
 			},
@@ -520,7 +520,7 @@ func TestPopulateUsedby(t *testing.T) {
 			desc: "TCP, One service used by two routers, but one router with wrong rule",
 			conf: &config.RuntimeConfiguration{
 				TCPServices: map[string]*config.TCPServiceInfo{
-					"myprovider.foo-service": {
+					"myprovider@foo-service": {
 						TCPService: &config.TCPService{
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
@@ -533,17 +533,17 @@ func TestPopulateUsedby(t *testing.T) {
 					},
 				},
 				TCPRouters: map[string]*config.TCPRouterInfo{
-					"myprovider.foo": {
+					"myprovider@foo": {
 						TCPRouter: &config.TCPRouter{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "WrongRule(`bar.foo`)",
 						},
 					},
-					"myprovider.bar": {
+					"myprovider@bar": {
 						TCPRouter: &config.TCPRouter{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`foo.bar`)",
 						},
 					},
@@ -551,12 +551,12 @@ func TestPopulateUsedby(t *testing.T) {
 			},
 			expected: config.RuntimeConfiguration{
 				TCPRouters: map[string]*config.TCPRouterInfo{
-					"myprovider.foo": {},
-					"myprovider.bar": {},
+					"myprovider@foo": {},
+					"myprovider@bar": {},
 				},
 				TCPServices: map[string]*config.TCPServiceInfo{
-					"myprovider.foo-service": {
-						UsedBy: []string{"myprovider.bar", "myprovider.foo"},
+					"myprovider@foo-service": {
+						UsedBy: []string{"myprovider@bar", "myprovider@foo"},
 					},
 				},
 			},
@@ -565,17 +565,17 @@ func TestPopulateUsedby(t *testing.T) {
 			desc: "TCP, Broken Service used by one Router",
 			conf: &config.RuntimeConfiguration{
 				TCPServices: map[string]*config.TCPServiceInfo{
-					"myprovider.foo-service": {
+					"myprovider@foo-service": {
 						TCPService: &config.TCPService{
 							LoadBalancer: nil,
 						},
 					},
 				},
 				TCPRouters: map[string]*config.TCPRouterInfo{
-					"myprovider.bar": {
+					"myprovider@bar": {
 						TCPRouter: &config.TCPRouter{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`foo.bar`)",
 						},
 					},
@@ -583,11 +583,11 @@ func TestPopulateUsedby(t *testing.T) {
 			},
 			expected: config.RuntimeConfiguration{
 				TCPRouters: map[string]*config.TCPRouterInfo{
-					"myprovider.bar": {},
+					"myprovider@bar": {},
 				},
 				TCPServices: map[string]*config.TCPServiceInfo{
-					"myprovider.foo-service": {
-						UsedBy: []string{"myprovider.bar"},
+					"myprovider@foo-service": {
+						UsedBy: []string{"myprovider@bar"},
 					},
 				},
 			},
@@ -596,7 +596,7 @@ func TestPopulateUsedby(t *testing.T) {
 			desc: "TCP, 2 different Services each used by a disctinct router.",
 			conf: &config.RuntimeConfiguration{
 				TCPServices: map[string]*config.TCPServiceInfo{
-					"myprovider.foo-service": {
+					"myprovider@foo-service": {
 						TCPService: &config.TCPService{
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
@@ -612,7 +612,7 @@ func TestPopulateUsedby(t *testing.T) {
 							},
 						},
 					},
-					"myprovider.bar-service": {
+					"myprovider@bar-service": {
 						TCPService: &config.TCPService{
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
@@ -630,17 +630,17 @@ func TestPopulateUsedby(t *testing.T) {
 					},
 				},
 				TCPRouters: map[string]*config.TCPRouterInfo{
-					"myprovider.foo": {
+					"myprovider@foo": {
 						TCPRouter: &config.TCPRouter{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`bar.foo`)",
 						},
 					},
-					"myprovider.bar": {
+					"myprovider@bar": {
 						TCPRouter: &config.TCPRouter{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.bar-service",
+							Service:     "myprovider@bar-service",
 							Rule:        "Host(`foo.bar`)",
 						},
 					},
@@ -648,15 +648,15 @@ func TestPopulateUsedby(t *testing.T) {
 			},
 			expected: config.RuntimeConfiguration{
 				TCPRouters: map[string]*config.TCPRouterInfo{
-					"myprovider.bar": {},
-					"myprovider.foo": {},
+					"myprovider@bar": {},
+					"myprovider@foo": {},
 				},
 				TCPServices: map[string]*config.TCPServiceInfo{
-					"myprovider.foo-service": {
-						UsedBy: []string{"myprovider.foo"},
+					"myprovider@foo-service": {
+						UsedBy: []string{"myprovider@foo"},
 					},
-					"myprovider.bar-service": {
-						UsedBy: []string{"myprovider.bar"},
+					"myprovider@bar-service": {
+						UsedBy: []string{"myprovider@bar"},
 					},
 				},
 			},
@@ -716,7 +716,7 @@ func TestGetTCPRoutersByEntrypoints(t *testing.T) {
 					Routers: map[string]*config.Router{
 						"foo": {
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`bar.foo`)",
 						},
 					},
@@ -725,7 +725,7 @@ func TestGetTCPRoutersByEntrypoints(t *testing.T) {
 					Routers: map[string]*config.TCPRouter{
 						"foo": {
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "HostSNI(`bar.foo`)",
 						},
 					},
@@ -741,17 +741,17 @@ func TestGetTCPRoutersByEntrypoints(t *testing.T) {
 					Routers: map[string]*config.Router{
 						"foo": {
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`bar.foo`)",
 						},
 						"bar": {
 							EntryPoints: []string{"webs"},
-							Service:     "myprovider.bar-service",
+							Service:     "myprovider@bar-service",
 							Rule:        "Host(`foo.bar`)",
 						},
 						"foobar": {
 							EntryPoints: []string{"web", "webs"},
-							Service:     "myprovider.foobar-service",
+							Service:     "myprovider@foobar-service",
 							Rule:        "Host(`bar.foobar`)",
 						},
 					},
@@ -760,17 +760,17 @@ func TestGetTCPRoutersByEntrypoints(t *testing.T) {
 					Routers: map[string]*config.TCPRouter{
 						"foo": {
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "HostSNI(`bar.foo`)",
 						},
 						"bar": {
 							EntryPoints: []string{"webs"},
-							Service:     "myprovider.bar-service",
+							Service:     "myprovider@bar-service",
 							Rule:        "HostSNI(`foo.bar`)",
 						},
 						"foobar": {
 							EntryPoints: []string{"web", "webs"},
-							Service:     "myprovider.foobar-service",
+							Service:     "myprovider@foobar-service",
 							Rule:        "HostSNI(`bar.foobar`)",
 						},
 					},
@@ -782,14 +782,14 @@ func TestGetTCPRoutersByEntrypoints(t *testing.T) {
 					"foo": {
 						TCPRouter: &config.TCPRouter{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "HostSNI(`bar.foo`)",
 						},
 					},
 					"foobar": {
 						TCPRouter: &config.TCPRouter{
 							EntryPoints: []string{"web", "webs"},
-							Service:     "myprovider.foobar-service",
+							Service:     "myprovider@foobar-service",
 							Rule:        "HostSNI(`bar.foobar`)",
 						},
 					},
@@ -803,17 +803,17 @@ func TestGetTCPRoutersByEntrypoints(t *testing.T) {
 					Routers: map[string]*config.Router{
 						"foo": {
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`bar.foo`)",
 						},
 						"bar": {
 							EntryPoints: []string{"webs"},
-							Service:     "myprovider.bar-service",
+							Service:     "myprovider@bar-service",
 							Rule:        "Host(`foo.bar`)",
 						},
 						"foobar": {
 							EntryPoints: []string{"web", "webs"},
-							Service:     "myprovider.foobar-service",
+							Service:     "myprovider@foobar-service",
 							Rule:        "Host(`bar.foobar`)",
 						},
 					},
@@ -822,17 +822,17 @@ func TestGetTCPRoutersByEntrypoints(t *testing.T) {
 					Routers: map[string]*config.TCPRouter{
 						"foo": {
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "HostSNI(`bar.foo`)",
 						},
 						"bar": {
 							EntryPoints: []string{"webs"},
-							Service:     "myprovider.bar-service",
+							Service:     "myprovider@bar-service",
 							Rule:        "HostSNI(`foo.bar`)",
 						},
 						"foobar": {
 							EntryPoints: []string{"web", "webs"},
-							Service:     "myprovider.foobar-service",
+							Service:     "myprovider@foobar-service",
 							Rule:        "HostSNI(`bar.foobar`)",
 						},
 					},
@@ -844,14 +844,14 @@ func TestGetTCPRoutersByEntrypoints(t *testing.T) {
 					"foo": {
 						TCPRouter: &config.TCPRouter{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "HostSNI(`bar.foo`)",
 						},
 					},
 					"foobar": {
 						TCPRouter: &config.TCPRouter{
 							EntryPoints: []string{"web", "webs"},
-							Service:     "myprovider.foobar-service",
+							Service:     "myprovider@foobar-service",
 							Rule:        "HostSNI(`bar.foobar`)",
 						},
 					},
@@ -861,14 +861,14 @@ func TestGetTCPRoutersByEntrypoints(t *testing.T) {
 						TCPRouter: &config.TCPRouter{
 
 							EntryPoints: []string{"webs"},
-							Service:     "myprovider.bar-service",
+							Service:     "myprovider@bar-service",
 							Rule:        "HostSNI(`foo.bar`)",
 						},
 					},
 					"foobar": {
 						TCPRouter: &config.TCPRouter{
 							EntryPoints: []string{"web", "webs"},
-							Service:     "myprovider.foobar-service",
+							Service:     "myprovider@foobar-service",
 							Rule:        "HostSNI(`bar.foobar`)",
 						},
 					},
@@ -914,7 +914,7 @@ func TestGetRoutersByEntrypoints(t *testing.T) {
 					Routers: map[string]*config.Router{
 						"foo": {
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`bar.foo`)",
 						},
 					},
@@ -923,7 +923,7 @@ func TestGetRoutersByEntrypoints(t *testing.T) {
 					Routers: map[string]*config.TCPRouter{
 						"foo": {
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "HostSNI(`bar.foo`)",
 						},
 					},
@@ -939,17 +939,17 @@ func TestGetRoutersByEntrypoints(t *testing.T) {
 					Routers: map[string]*config.Router{
 						"foo": {
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`bar.foo`)",
 						},
 						"bar": {
 							EntryPoints: []string{"webs"},
-							Service:     "myprovider.bar-service",
+							Service:     "myprovider@bar-service",
 							Rule:        "Host(`foo.bar`)",
 						},
 						"foobar": {
 							EntryPoints: []string{"web", "webs"},
-							Service:     "myprovider.foobar-service",
+							Service:     "myprovider@foobar-service",
 							Rule:        "Host(`bar.foobar`)",
 						},
 					},
@@ -958,17 +958,17 @@ func TestGetRoutersByEntrypoints(t *testing.T) {
 					Routers: map[string]*config.TCPRouter{
 						"foo": {
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "HostSNI(`bar.foo`)",
 						},
 						"bar": {
 							EntryPoints: []string{"webs"},
-							Service:     "myprovider.bar-service",
+							Service:     "myprovider@bar-service",
 							Rule:        "HostSNI(`foo.bar`)",
 						},
 						"foobar": {
 							EntryPoints: []string{"web", "webs"},
-							Service:     "myprovider.foobar-service",
+							Service:     "myprovider@foobar-service",
 							Rule:        "HostSNI(`bar.foobar`)",
 						},
 					},
@@ -980,14 +980,14 @@ func TestGetRoutersByEntrypoints(t *testing.T) {
 					"foo": {
 						Router: &config.Router{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`bar.foo`)",
 						},
 					},
 					"foobar": {
 						Router: &config.Router{
 							EntryPoints: []string{"web", "webs"},
-							Service:     "myprovider.foobar-service",
+							Service:     "myprovider@foobar-service",
 							Rule:        "Host(`bar.foobar`)",
 						},
 					},
@@ -1001,17 +1001,17 @@ func TestGetRoutersByEntrypoints(t *testing.T) {
 					Routers: map[string]*config.Router{
 						"foo": {
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`bar.foo`)",
 						},
 						"bar": {
 							EntryPoints: []string{"webs"},
-							Service:     "myprovider.bar-service",
+							Service:     "myprovider@bar-service",
 							Rule:        "Host(`foo.bar`)",
 						},
 						"foobar": {
 							EntryPoints: []string{"web", "webs"},
-							Service:     "myprovider.foobar-service",
+							Service:     "myprovider@foobar-service",
 							Rule:        "Host(`bar.foobar`)",
 						},
 					},
@@ -1020,17 +1020,17 @@ func TestGetRoutersByEntrypoints(t *testing.T) {
 					Routers: map[string]*config.TCPRouter{
 						"foo": {
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "HostSNI(`bar.foo`)",
 						},
 						"bar": {
 							EntryPoints: []string{"webs"},
-							Service:     "myprovider.bar-service",
+							Service:     "myprovider@bar-service",
 							Rule:        "HostSNI(`foo.bar`)",
 						},
 						"foobar": {
 							EntryPoints: []string{"web", "webs"},
-							Service:     "myprovider.foobar-service",
+							Service:     "myprovider@foobar-service",
 							Rule:        "HostSNI(`bar.foobar`)",
 						},
 					},
@@ -1042,14 +1042,14 @@ func TestGetRoutersByEntrypoints(t *testing.T) {
 					"foo": {
 						Router: &config.Router{
 							EntryPoints: []string{"web"},
-							Service:     "myprovider.foo-service",
+							Service:     "myprovider@foo-service",
 							Rule:        "Host(`bar.foo`)",
 						},
 					},
 					"foobar": {
 						Router: &config.Router{
 							EntryPoints: []string{"web", "webs"},
-							Service:     "myprovider.foobar-service",
+							Service:     "myprovider@foobar-service",
 							Rule:        "Host(`bar.foobar`)",
 						},
 					},
@@ -1059,14 +1059,14 @@ func TestGetRoutersByEntrypoints(t *testing.T) {
 						Router: &config.Router{
 
 							EntryPoints: []string{"webs"},
-							Service:     "myprovider.bar-service",
+							Service:     "myprovider@bar-service",
 							Rule:        "Host(`foo.bar`)",
 						},
 					},
 					"foobar": {
 						Router: &config.Router{
 							EntryPoints: []string{"web", "webs"},
-							Service:     "myprovider.foobar-service",
+							Service:     "myprovider@foobar-service",
 							Rule:        "Host(`bar.foobar`)",
 						},
 					},

--- a/pkg/server/aggregator_test.go
+++ b/pkg/server/aggregator_test.go
@@ -41,13 +41,13 @@ func TestAggregator(t *testing.T) {
 			},
 			expected: &config.HTTPConfiguration{
 				Routers: map[string]*config.Router{
-					"provider-1.router-1": {},
+					"provider-1@router-1": {},
 				},
 				Middlewares: map[string]*config.Middleware{
-					"provider-1.middleware-1": {},
+					"provider-1@middleware-1": {},
 				},
 				Services: map[string]*config.Service{
-					"provider-1.service-1": {},
+					"provider-1@service-1": {},
 				},
 			},
 		},
@@ -83,16 +83,16 @@ func TestAggregator(t *testing.T) {
 			},
 			expected: &config.HTTPConfiguration{
 				Routers: map[string]*config.Router{
-					"provider-1.router-1": {},
-					"provider-2.router-1": {},
+					"provider-1@router-1": {},
+					"provider-2@router-1": {},
 				},
 				Middlewares: map[string]*config.Middleware{
-					"provider-1.middleware-1": {},
-					"provider-2.middleware-1": {},
+					"provider-1@middleware-1": {},
+					"provider-2@middleware-1": {},
 				},
 				Services: map[string]*config.Service{
-					"provider-1.service-1": {},
-					"provider-2.service-1": {},
+					"provider-1@service-1": {},
+					"provider-2@service-1": {},
 				},
 			},
 		},

--- a/pkg/server/internal/provider.go
+++ b/pkg/server/internal/provider.go
@@ -15,7 +15,7 @@ const (
 
 // AddProviderInContext Adds the provider name in the context
 func AddProviderInContext(ctx context.Context, elementName string) context.Context {
-	parts := strings.Split(elementName, ".")
+	parts := strings.Split(elementName, "@")
 	if len(parts) == 1 {
 		log.FromContext(ctx).Debugf("Could not find a provider for %s.", elementName)
 		return ctx
@@ -30,7 +30,7 @@ func AddProviderInContext(ctx context.Context, elementName string) context.Conte
 
 // GetQualifiedName Gets the fully qualified name.
 func GetQualifiedName(ctx context.Context, elementName string) string {
-	parts := strings.Split(elementName, ".")
+	parts := strings.Split(elementName, "@")
 	if len(parts) == 1 {
 		if providerName, ok := ctx.Value(providerKey).(string); ok {
 			return MakeQualifiedName(providerName, parts[0])
@@ -41,5 +41,5 @@ func GetQualifiedName(ctx context.Context, elementName string) string {
 
 // MakeQualifiedName Creates a qualified name for an element
 func MakeQualifiedName(providerName string, elementName string) string {
-	return providerName + "." + elementName
+	return providerName + "@" + elementName
 }

--- a/pkg/server/middleware/middlewares_test.go
+++ b/pkg/server/middleware/middlewares_test.go
@@ -77,7 +77,7 @@ func TestBuilder_BuildChainWithContext(t *testing.T) {
 			desc:       "Should prefix the middlewareName with the provider in the context",
 			buildChain: []string{"middleware-1"},
 			configuration: map[string]*config.Middleware{
-				"provider-1.middleware-1": {
+				"provider-1@middleware-1": {
 					Headers: &config.Headers{
 						CustomRequestHeaders: map[string]string{"provider-1.middleware-1": "value-middleware-1"},
 					},
@@ -88,9 +88,9 @@ func TestBuilder_BuildChainWithContext(t *testing.T) {
 		},
 		{
 			desc:       "Should not prefix a qualified middlewareName with the provider in the context",
-			buildChain: []string{"provider-1.middleware-1"},
+			buildChain: []string{"provider-1@middleware-1"},
 			configuration: map[string]*config.Middleware{
-				"provider-1.middleware-1": {
+				"provider-1@middleware-1": {
 					Headers: &config.Headers{
 						CustomRequestHeaders: map[string]string{"provider-1.middleware-1": "value-middleware-1"},
 					},
@@ -101,14 +101,14 @@ func TestBuilder_BuildChainWithContext(t *testing.T) {
 		},
 		{
 			desc:       "Should be context aware if a chain references another middleware",
-			buildChain: []string{"provider-1.middleware-chain-1"},
+			buildChain: []string{"provider-1@middleware-chain-1"},
 			configuration: map[string]*config.Middleware{
-				"provider-1.middleware-1": {
+				"provider-1@middleware-1": {
 					Headers: &config.Headers{
 						CustomRequestHeaders: map[string]string{"middleware-1": "value-middleware-1"},
 					},
 				},
-				"provider-1.middleware-chain-1": {
+				"provider-1@middleware-chain-1": {
 					Chain: &config.Chain{
 						Middlewares: []string{"middleware-1"},
 					},
@@ -118,31 +118,31 @@ func TestBuilder_BuildChainWithContext(t *testing.T) {
 		},
 		{
 			desc:       "Should handle nested chains with different context",
-			buildChain: []string{"provider-1.middleware-chain-1", "middleware-chain-1"},
+			buildChain: []string{"provider-1@middleware-chain-1", "middleware-chain-1"},
 			configuration: map[string]*config.Middleware{
-				"provider-1.middleware-1": {
+				"provider-1@middleware-1": {
 					Headers: &config.Headers{
 						CustomRequestHeaders: map[string]string{"middleware-1": "value-middleware-1"},
 					},
 				},
-				"provider-1.middleware-2": {
+				"provider-1@middleware-2": {
 					Headers: &config.Headers{
 						CustomRequestHeaders: map[string]string{"middleware-2": "value-middleware-2"},
 					},
 				},
-				"provider-1.middleware-chain-1": {
+				"provider-1@middleware-chain-1": {
 					Chain: &config.Chain{
 						Middlewares: []string{"middleware-1"},
 					},
 				},
-				"provider-1.middleware-chain-2": {
+				"provider-1@middleware-chain-2": {
 					Chain: &config.Chain{
 						Middlewares: []string{"middleware-2"},
 					},
 				},
-				"provider-2.middleware-chain-1": {
+				"provider-2@middleware-chain-1": {
 					Chain: &config.Chain{
-						Middlewares: []string{"provider-1.middleware-2", "provider-1.middleware-chain-2"},
+						Middlewares: []string{"provider-1@middleware-2", "provider-1@middleware-chain-2"},
 					},
 				},
 			},
@@ -176,28 +176,28 @@ func TestBuilder_BuildChainWithContext(t *testing.T) {
 		},
 		{
 			desc:       "Detects recursion in Middleware chain",
-			buildChain: []string{"provider.m1"},
+			buildChain: []string{"provider@m1"},
 			configuration: map[string]*config.Middleware{
-				"provider2.ok": {
+				"provider2@ok": {
 					Retry: &config.Retry{},
 				},
-				"provider.m1": {
+				"provider@m1": {
 					Chain: &config.Chain{
-						Middlewares: []string{"provider2.m2"},
+						Middlewares: []string{"provider2@m2"},
 					},
 				},
-				"provider2.m2": {
+				"provider2@m2": {
 					Chain: &config.Chain{
-						Middlewares: []string{"ok", "provider.m3"},
+						Middlewares: []string{"ok", "provider@m3"},
 					},
 				},
-				"provider.m3": {
+				"provider@m3": {
 					Chain: &config.Chain{
 						Middlewares: []string{"m1"},
 					},
 				},
 			},
-			expectedError: errors.New("could not instantiate middleware provider.m1: recursion detected in provider.m1->provider2.m2->provider.m3->provider.m1"),
+			expectedError: errors.New("could not instantiate middleware provider@m1: recursion detected in provider@m1->provider2@m2->provider@m3->provider@m1"),
 		},
 		{
 			buildChain: []string{"ok", "m0"},
@@ -261,7 +261,7 @@ func TestBuilder_BuildChainWithContext(t *testing.T) {
 
 			ctx := context.Background()
 			if len(test.contextProvider) > 0 {
-				ctx = internal.AddProviderInContext(ctx, test.contextProvider+".foobar")
+				ctx = internal.AddProviderInContext(ctx, test.contextProvider+"@foobar")
 			}
 
 			rtConf := config.NewRuntimeConfig(config.Configuration{

--- a/pkg/server/router/router_test.go
+++ b/pkg/server/router/router_test.go
@@ -204,14 +204,14 @@ func TestRouterManager_Get(t *testing.T) {
 		{
 			desc: "no middleware with provider name",
 			routersConfig: map[string]*config.Router{
-				"provider-1.foo": {
+				"provider-1@foo": {
 					EntryPoints: []string{"web"},
 					Service:     "foo-service",
 					Rule:        "Host(`foo.bar`)",
 				},
 			},
 			serviceConfig: map[string]*config.Service{
-				"provider-1.foo-service": {
+				"provider-1@foo-service": {
 					LoadBalancer: &config.LoadBalancerService{
 						Servers: []config.Server{
 							{
@@ -227,14 +227,14 @@ func TestRouterManager_Get(t *testing.T) {
 		{
 			desc: "no middleware with specified provider name",
 			routersConfig: map[string]*config.Router{
-				"provider-1.foo": {
+				"provider-1@foo": {
 					EntryPoints: []string{"web"},
-					Service:     "provider-2.foo-service",
+					Service:     "provider-2@foo-service",
 					Rule:        "Host(`foo.bar`)",
 				},
 			},
 			serviceConfig: map[string]*config.Service{
-				"provider-2.foo-service": {
+				"provider-2@foo-service": {
 					LoadBalancer: &config.LoadBalancerService{
 						Servers: []config.Server{
 							{
@@ -250,15 +250,15 @@ func TestRouterManager_Get(t *testing.T) {
 		{
 			desc: "middleware: chain with provider name",
 			routersConfig: map[string]*config.Router{
-				"provider-1.foo": {
+				"provider-1@foo": {
 					EntryPoints: []string{"web"},
-					Middlewares: []string{"provider-2.chain-middle", "headers-middle"},
+					Middlewares: []string{"provider-2@chain-middle", "headers-middle"},
 					Service:     "foo-service",
 					Rule:        "Host(`foo.bar`)",
 				},
 			},
 			serviceConfig: map[string]*config.Service{
-				"provider-1.foo-service": {
+				"provider-1@foo-service": {
 					LoadBalancer: &config.LoadBalancerService{
 						Servers: []config.Server{
 							{
@@ -269,15 +269,15 @@ func TestRouterManager_Get(t *testing.T) {
 				},
 			},
 			middlewaresConfig: map[string]*config.Middleware{
-				"provider-2.chain-middle": {
+				"provider-2@chain-middle": {
 					Chain: &config.Chain{Middlewares: []string{"auth-middle"}},
 				},
-				"provider-2.auth-middle": {
+				"provider-2@auth-middle": {
 					BasicAuth: &config.BasicAuth{
 						Users: []string{"toto:titi"},
 					},
 				},
-				"provider-1.headers-middle": {
+				"provider-1@headers-middle": {
 					Headers: &config.Headers{
 						CustomRequestHeaders: map[string]string{"X-Apero": "beer"},
 					},

--- a/pkg/server/service/service_test.go
+++ b/pkg/server/service/service_test.go
@@ -303,9 +303,9 @@ func TestManager_Build(t *testing.T) {
 		},
 		{
 			desc:        "Service name with provider",
-			serviceName: "provider-1.serviceName",
+			serviceName: "provider-1@serviceName",
 			configs: map[string]*config.ServiceInfo{
-				"provider-1.serviceName": {
+				"provider-1@serviceName": {
 					Service: &config.Service{
 						LoadBalancer: &config.LoadBalancerService{},
 					},
@@ -316,7 +316,7 @@ func TestManager_Build(t *testing.T) {
 			desc:        "Service name with provider in context",
 			serviceName: "serviceName",
 			configs: map[string]*config.ServiceInfo{
-				"provider-1.serviceName": {
+				"provider-1@serviceName": {
 					Service: &config.Service{
 						LoadBalancer: &config.LoadBalancerService{},
 					},
@@ -335,7 +335,7 @@ func TestManager_Build(t *testing.T) {
 
 			ctx := context.Background()
 			if len(test.providerName) > 0 {
-				ctx = internal.AddProviderInContext(ctx, test.providerName+".foobar")
+				ctx = internal.AddProviderInContext(ctx, test.providerName+"@foobar")
 			}
 
 			_, err := manager.BuildHTTP(ctx, test.serviceName, nil)

--- a/pkg/server/service/tcp/service_test.go
+++ b/pkg/server/service/tcp/service_test.go
@@ -77,9 +77,9 @@ func TestManager_BuildTCP(t *testing.T) {
 		},
 		{
 			desc:        "Service name with provider",
-			serviceName: "provider-1.serviceName",
+			serviceName: "provider-1@serviceName",
 			configs: map[string]*config.TCPServiceInfo{
-				"provider-1.serviceName": {
+				"provider-1@serviceName": {
 					TCPService: &config.TCPService{
 						LoadBalancer: &config.TCPLoadBalancerService{},
 					},
@@ -90,7 +90,7 @@ func TestManager_BuildTCP(t *testing.T) {
 			desc:        "Service name with provider in context",
 			serviceName: "serviceName",
 			configs: map[string]*config.TCPServiceInfo{
-				"provider-1.serviceName": {
+				"provider-1@serviceName": {
 					TCPService: &config.TCPService{
 						LoadBalancer: &config.TCPLoadBalancerService{},
 					},
@@ -102,7 +102,7 @@ func TestManager_BuildTCP(t *testing.T) {
 			desc:        "Server with correct host:port as address",
 			serviceName: "serviceName",
 			configs: map[string]*config.TCPServiceInfo{
-				"provider-1.serviceName": {
+				"provider-1@serviceName": {
 					TCPService: &config.TCPService{
 						LoadBalancer: &config.TCPLoadBalancerService{
 							Servers: []config.TCPServer{
@@ -120,7 +120,7 @@ func TestManager_BuildTCP(t *testing.T) {
 			desc:        "Server with correct ip:port as address",
 			serviceName: "serviceName",
 			configs: map[string]*config.TCPServiceInfo{
-				"provider-1.serviceName": {
+				"provider-1@serviceName": {
 					TCPService: &config.TCPService{
 						LoadBalancer: &config.TCPLoadBalancerService{
 							Servers: []config.TCPServer{
@@ -138,7 +138,7 @@ func TestManager_BuildTCP(t *testing.T) {
 			desc:        "missing port in address with hostname, server is skipped, error is logged",
 			serviceName: "serviceName",
 			configs: map[string]*config.TCPServiceInfo{
-				"provider-1.serviceName": {
+				"provider-1@serviceName": {
 					TCPService: &config.TCPService{
 						LoadBalancer: &config.TCPLoadBalancerService{
 							Servers: []config.TCPServer{
@@ -156,7 +156,7 @@ func TestManager_BuildTCP(t *testing.T) {
 			desc:        "missing port in address with ip, server is skipped, error is logged",
 			serviceName: "serviceName",
 			configs: map[string]*config.TCPServiceInfo{
-				"provider-1.serviceName": {
+				"provider-1@serviceName": {
 					TCPService: &config.TCPService{
 						LoadBalancer: &config.TCPLoadBalancerService{
 							Servers: []config.TCPServer{
@@ -183,7 +183,7 @@ func TestManager_BuildTCP(t *testing.T) {
 
 			ctx := context.Background()
 			if len(test.providerName) > 0 {
-				ctx = internal.AddProviderInContext(ctx, test.providerName+".foobar")
+				ctx = internal.AddProviderInContext(ctx, test.providerName+"@foobar")
 			}
 
 			handler, err := manager.BuildTCP(ctx, test.serviceName)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

use `@` as the separator between provider name and reference name (instead of `.`)

### Motivation

Have less unambiguous separator.

### More

- [x] Added/updated tests
- [x] Added/updated documentation
