### PR TITLE
Update default keytype in acme

### DIFF
--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -55,7 +55,7 @@ type Configuration struct {
 func (a *Configuration) SetDefaults() {
 	a.CAServer = lego.LEDirectoryProduction
 	a.Storage = "acme.json"
-	a.KeyType = "RSA4096"
+	a.KeyType = "EC256"
 }
 
 // Certificate is a struct which contains all data needed from an ACME certificate


### PR DESCRIPTION
According @Kindratte comment ( https://github.com/containous/traefik/issues/2673#issuecomment-472348299 ) ECDSA cryptography is more efficiently optimized in Go than RSA cryptography.

The following dokumnt explain benefits and limitations of the changes: https://csrc.nist.gov/csrc/media/events/workshop-on-elliptic-curve-cryptography-standards/documents/presentations/session2-andrews-rick.pdf 
Mozilla recommends to use ECDSA in "modern" configuration of web server ( https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility ). 
It would be optimal to implement dual-stack support and support both at the same time. My Go skills does not allow it.

Me personally motivates that this change is beneficial when the client and server are Go app.

This PR is resubmit of #4992 after mistake.