### PR TITLE
Fix panic in tls manager

### DIFF
--- a/pkg/tls/tlsmanager.go
+++ b/pkg/tls/tlsmanager.go
@@ -39,11 +39,12 @@ func (m *Manager) UpdateConfigs(stores map[string]Store, configs map[string]TLS,
 
 	m.stores = make(map[string]*CertificateStore)
 	for storeName, storeConfig := range m.storesConfig {
-		var err error
-		m.stores[storeName], err = buildCertificateStore(storeConfig)
+		store, err := buildCertificateStore(storeConfig)
 		if err != nil {
-			log.Errorf("Error while creating certificate store %s", storeName)
+			log.Errorf("Error while creating certificate store %s: %v", storeName, err)
+			continue
 		}
+		m.stores[storeName] = store
 	}
 
 	storesCertificates := make(map[string]map[string]*tls.Certificate)
@@ -137,14 +138,14 @@ func buildCertificateStore(tlsStore Store) (*CertificateStore, error) {
 	if tlsStore.DefaultCertificate != nil {
 		cert, err := buildDefaultCertificate(tlsStore.DefaultCertificate)
 		if err != nil {
-			return nil, err
+			return certificateStore, err
 		}
 		certificateStore.DefaultCertificate = cert
 	} else {
 		log.Debug("No default certificate, generate one")
 		cert, err := generate.DefaultCertificate()
 		if err != nil {
-			return nil, err
+			return certificateStore, err
 		}
 		certificateStore.DefaultCertificate = cert
 	}

--- a/pkg/tls/tlsmanager_test.go
+++ b/pkg/tls/tlsmanager_test.go
@@ -62,3 +62,30 @@ func TestTLSInStore(t *testing.T) {
 		t.Fatal("got error: default store must have TLS certificates.")
 	}
 }
+
+func TestTLSInvalidStore(t *testing.T) {
+	dynamicConfigs :=
+		[]*Configuration{
+			{
+				Certificate: &Certificate{
+					CertFile: localhostCert,
+					KeyFile:  localhostKey,
+				},
+			},
+		}
+
+	tlsManager := NewManager()
+	tlsManager.UpdateConfigs(map[string]Store{
+		"default": {
+			DefaultCertificate: &Certificate{
+				CertFile: "/wrong",
+				KeyFile:  "/wrong",
+			},
+		},
+	}, nil, dynamicConfigs)
+
+	certs := tlsManager.GetStore("default").DynamicCerts.Get().(map[string]*tls.Certificate)
+	if len(certs) == 0 {
+		t.Fatal("got error: default store must have TLS certificates.")
+	}
+}


### PR DESCRIPTION
### What does this PR do?
Fix a panic in TLS Manager

### Motivation

Avoid panic


### More

- [x] Added/updated tests

### Additional Notes
```
reverse-proxy_1  | time="2019-06-21T12:37:25Z" level=error msg="Error while creating certificate store default"
reverse-proxy_1  | time="2019-06-21T12:37:25Z" level=error msg="Error while creating certificate store default"
reverse-proxy_1  | 2019/06/21 12:37:29 server.go:3012: http: panic serving 8.16.32.64:35996: runtime error: invalid memory address or nil pointer dereference
reverse-proxy_1  | goroutine 52 [running]:
reverse-proxy_1  | net/http.(*conn).serve.func1(0xc0003a1d60)
reverse-proxy_1  |      /usr/local/go/src/net/http/server.go:1769 +0x139
reverse-proxy_1  | panic(0x1d57040, 0x3bad010)
reverse-proxy_1  |      /usr/local/go/src/runtime/panic.go:522 +0x1b5
reverse-proxy_1  | github.com/containous/traefik/pkg/tls.(*Manager).Get.func1(0xc0005ce4d0, 0x40c628, 0xb0, 0x1f925e0)
reverse-proxy_1  |      /go/src/github.com/containous/traefik/pkg/tls/tlsmanager.go:102 +0x9f
reverse-proxy_1  | crypto/tls.(*Config).getCertificate(0xc0008b2600, 0xc0005ce4d0, 0xc0005ce4d0, 0x11, 0x246c680)
reverse-proxy_1  |      /usr/local/go/src/crypto/tls/common.go:879 +0x341
reverse-proxy_1  | crypto/tls.(*serverHandshakeStateTLS13).pickCertificate(0xc000901bf8, 0x0, 0x0)
reverse-proxy_1  |      /usr/local/go/src/crypto/tls/handshake_server_tls13.go:366 +0x77
reverse-proxy_1  | crypto/tls.(*serverHandshakeStateTLS13).handshake(0xc000901bf8, 0xc00013b600, 0x0)
reverse-proxy_1  |      /usr/local/go/src/crypto/tls/handshake_server_tls13.go:52 +0x79
```