### PR TITLE
Use dynamodbav tags to override json tags.

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -408,14 +408,14 @@ type Users []string
 
 // Basic HTTP basic authentication
 type Basic struct {
-	Users        `json:"-" mapstructure:","`
+	Users        `json:"-" mapstructure:"," dynamodbav:"users,omitempty"`
 	UsersFile    string `json:"usersFile,omitempty"`
 	RemoveHeader bool   `json:"removeHeader,omitempty"`
 }
 
 // Digest HTTP authentication
 type Digest struct {
-	Users        `json:"-" mapstructure:","`
+	Users        `json:"-" mapstructure:"," dynamodbav:"users,omitempty"`
 	UsersFile    string `json:"usersFile,omitempty"`
 	RemoveHeader bool   `json:"removeHeader,omitempty"`
 }
@@ -511,7 +511,7 @@ type ClientTLS struct {
 	CA                 string `description:"TLS CA" json:"ca,omitempty"`
 	CAOptional         bool   `description:"TLS CA.Optional" json:"caOptional,omitempty"`
 	Cert               string `description:"TLS cert" json:"cert,omitempty"`
-	Key                string `description:"TLS key" json:"-"`
+	Key                string `description:"TLS key" json:"-" dynamodbav:"key,omitempty"`
 	InsecureSkipVerify bool   `description:"TLS insecure skip verify" json:"insecureSkipVerify,omitempty"`
 }
 


### PR DESCRIPTION

### What does this PR do?

Uses `dynamodbav tags` to override json tags.

https://github.com/aws/aws-sdk-go/blob/edc3c2b3cf8402559c7242b17f7793cd799938d7/service/dynamodb/dynamodbattribute/encode.go#L185-L197
```
// A MarshalOptions is a collection of options shared between marshaling
// and unmarshaling
type MarshalOptions struct {
	// States that the encoding/json struct tags should be supported.
	// if a `dynamodbav` struct tag is also provided the encoding/json
	// tag will be ignored.
	//
	// Enabled by default.
	SupportJSONTags bool
}
```

Related to #4918

### Motivation

Fixes #4998

### More

- [ ] ~Added/updated tests~
- [ ] ~Added/updated documentation~
