### PR TITLE
Change the loading resource order

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -44,7 +44,7 @@ func main() {
 	// traefik config inits
 	tConfig := cmd.NewTraefikConfiguration()
 
-	loaders := []cli.ResourceLoader{&cli.FileLoader{}, &cli.EnvLoader{}, &cli.FlagLoader{}}
+	loaders := []cli.ResourceLoader{&cli.FileLoader{}, &cli.FlagLoader{}, &cli.EnvLoader{}}
 
 	cmdTraefik := &cli.Command{
 		Name: "traefik",

--- a/docs/content/getting-started/configuration-overview.md
+++ b/docs/content/getting-started/configuration-overview.md
@@ -36,8 +36,8 @@ Traefik gets its _dynamic configuration_ from [providers](../providers/overview.
 There are three different, mutually exclusive, ways to define static configuration options in Traefik:
 
 - In a configuration file
-- As environment variables
 - In the command-line arguments
+- As environment variables
 
 These ways are evaluated in the order listed above.
 

--- a/pkg/cli/loader_env.go
+++ b/pkg/cli/loader_env.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/containous/traefik/pkg/config/env"
 	"github.com/containous/traefik/pkg/log"
@@ -19,7 +20,8 @@ func (e *EnvLoader) Load(_ []string, cmd *Command) (bool, error) {
 	}
 
 	if err := env.Decode(vars, env.DefaultNamePrefix, cmd.Configuration); err != nil {
-		return false, fmt.Errorf("failed to decode configuration from environment variables: %v", err)
+		log.WithoutContext().Debug("environment variables", strings.Join(vars, ", "))
+		return false, fmt.Errorf("failed to decode configuration from environment variables: %v ", err)
 	}
 
 	log.WithoutContext().Println("Configuration loaded from environment variables.")

--- a/pkg/cli/loader_flag.go
+++ b/pkg/cli/loader_flag.go
@@ -12,6 +12,10 @@ type FlagLoader struct{}
 
 // Load loads the command's configuration from flag arguments.
 func (*FlagLoader) Load(args []string, cmd *Command) (bool, error) {
+	if len(args) == 0 {
+		return false, nil
+	}
+
 	if err := flag.Decode(args, cmd.Configuration); err != nil {
 		return false, fmt.Errorf("failed to decode configuration from flags: %v", err)
 	}


### PR DESCRIPTION
### What does this PR do?

Changes the loading resource order:
- before: file > env > flags
- after: file > flags > env

Related to #4985

### Motivation

Kubernetes automatically creates a bunch of variables prefixed with `TRAEFIK_` (probably based on the image name), and since our config loader was checking for the presence of the above prefix, this situation was obviously creating a conflict.

### More

- [ ] ~Added/updated tests~
- [x] Added/updated documentation
