### PR TITLE
Handle cross-provider middleware in kubernetes CRD

### DIFF
--- a/docs/content/middlewares/overview.md
+++ b/docs/content/middlewares/overview.md
@@ -123,7 +123,6 @@ In this case, since the definition of the middleware is not in kubernetes,
 specifying a "kubernetes namespace" when refering to the resource does not make any sense,
 and therefore this specification would be ignored even if present.
 
-
 !!! abstract "Referencing a Middleware from Another Provider"
 
     Declaring the add-foo-prefix in the file provider.

--- a/docs/content/middlewares/overview.md
+++ b/docs/content/middlewares/overview.md
@@ -79,32 +79,6 @@ labels:
   - "traefik.http.router.router1.Middlewares=foo-add-prefix@rancher"
 ```
 
-```yaml tab="Kubernetes"
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: tlsoptions.traefik.containo.us
-
-spec:
-  group: traefik.containo.us
-  version: v1alpha1
-  names:
-    kind: TLSOption
-    plural: tlsoptions
-    singular: tlsoption
-  scope: Namespaced
-
----
-apiVersion: traefik.containo.us/v1alpha1
-kind: TLSOption
-metadata:
-  name: mytlsoption
-  namespace: default
-
-spec:
-  minversion: VersionTLS12
-```
-
 ```toml tab="File"
 # As Toml Configuration File
 [providers]
@@ -133,12 +107,22 @@ spec:
 When you declare a middleware, it lives in its provider namespace.
 For example, if you declare a middleware using a Docker label, under the hoods, it will reside in the docker provider namespace.
 
-If you use multiple providers and wish to reference a middleware declared in another provider,
-then you'll have to prefix the middleware name with the provider name.
+If you use multiple providers and wish to reference a middleware declared in another provider
+(aka referencing a cross-provider middleware),
+then you'll have to append to the middleware name, the `@` separator, followed by the provider name.
 
 ```text
 <resource-name>@<provider-name>
 ```
+
+!!! important "Kubernetes Namespace"
+
+	As Kubernetes also has its own notion of namespace, one should not confuse the "provider namespace"
+with the "kubernetes namespace" of a resource when in the context of a cross-provider usage.
+In this case, since the definition of the middleware is not in kubernetes,
+specifying a "kubernetes namespace" when refering to the resource does not make any sense,
+and therefore this specification would be ignored even if present.
+
 
 !!! abstract "Referencing a Middleware from Another Provider"
 
@@ -146,22 +130,44 @@ then you'll have to prefix the middleware name with the provider name.
 
     ```toml
     [providers]
-       [providers.file]
+      [providers.file]
 
     [http.middlewares]
-     [http.middlewares.add-foo-prefix.AddPrefix]
+      [http.middlewares.add-foo-prefix.AddPrefix]
         prefix = "/foo"
     ```
 
-    Using the add-foo-prefix middleware from docker.
+    Using the add-foo-prefix middleware from other providers:
 
-    ```yaml
+    ```yaml tab="Docker"
     your-container: #
-        image: your-docker-image
+      image: your-docker-image
 
-        labels:
-          # Attach add-foo-prefix@file middleware (declared in file)
-          - "traefik.http.routers.my-container.middlewares=add-foo-prefix@file"
+      labels:
+        # Attach add-foo-prefix@file middleware (declared in file)
+        - "traefik.http.routers.my-container.middlewares=add-foo-prefix@file"
+    ```
+
+    ```yaml tab="Kubernetes"
+    apiVersion: traefik.containo.us/v1alpha1
+    kind: IngressRoute
+    metadata:
+      name: ingressroutestripprefix
+
+    spec:
+      entryPoints:
+        - web
+      routes:
+        - match: Host(`bar.com`)
+          kind: Rule
+        services:
+          - name: whoami
+            port: 80
+        middlewares:
+          - name: add-foo-prefix@file
+          # namespace: bar
+          # A namespace specification such as above is ignored
+          # when the cross-provider syntax is used.
     ```
 
 ## Available Middlewares

--- a/docs/content/middlewares/overview.md
+++ b/docs/content/middlewares/overview.md
@@ -120,7 +120,7 @@ then you'll have to append to the middleware name, the `@` separator, followed b
 	As Kubernetes also has its own notion of namespace, one should not confuse the "provider namespace"
 with the "kubernetes namespace" of a resource when in the context of a cross-provider usage.
 In this case, since the definition of the middleware is not in kubernetes,
-specifying a "kubernetes namespace" when refering to the resource does not make any sense,
+specifying a "kubernetes namespace" when referring to the resource does not make any sense,
 and therefore this specification would be ignored even if present.
 
 !!! abstract "Referencing a Middleware from Another Provider"

--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -235,7 +235,7 @@ spec:
 	As Kubernetes also has its own notion of namespace, one should not confuse the kubernetes namespace of a resource
 (in the reference to the middleware) with the [provider namespace](../middlewares/overview.md#provider-namespace),
 when the definition of the middleware is from another provider.
-In this context, specifying a namespace when refering to the resource does not make any sense, and will be ignored.
+In this context, specifying a namespace when referring to the resource does not make any sense, and will be ignored.
 
 More information about available middlewares in the dedicated [middlewares section](../middlewares/overview.md).
 

--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -203,6 +203,7 @@ apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
   name: stripprefix
+  namespace: foo
 
 spec:
   stripPrefix:
@@ -226,13 +227,21 @@ spec:
       port: 80
     middlewares:
     - name: stripprefix
+      namespace: foo
 ```
+
+!!! important "Cross-provider namespace"
+
+	As Kubernetes also has its own notion of namespace, one should not confuse the kubernetes namespace of a resource
+(in the reference to the middleware) with the [provider namespace](../middlewares/overview.md#provider-namespace),
+when the definition of the middleware is from another provider.
+In this context, specifying a namespace when refering to the resource does not make any sense, and will be ignored.
 
 More information about available middlewares in the dedicated [middlewares section](../middlewares/overview.md).
 
-### Traefik TLS Option Definition
+### TLS Option
 
-Additionally, to allow for the use of tls options in an IngressRoute, we defined the CRD below for the TLSOption kind.
+Additionally, to allow for the use of TLS options in an IngressRoute, we defined the CRD below for the TLSOption kind.
 More information about TLS Options is available in the dedicated [TLS Configuration Options](../../https/tls/#tls-options).
 
 ```yaml
@@ -272,8 +281,14 @@ spec:
       namespace: default
 ```
 
-!!! note "TLS Option reference and namespace"
+!!! important "References and namespaces"
+
     If the optional `namespace` attribute is not set, the configuration will be applied with the namespace of the IngressRoute.
+
+	Additionally, when the definition of the TLS option is from another provider,
+the cross-provider syntax (`middlewarename@provider`) should be used to refer to the TLS option,
+just as in the [middleware case](../middlewares/overview.md#provider-namespace).
+Specifying a namespace attribute in this case would not make any sense, and will be ignored.
 
 ### TLS
 

--- a/integration/testdata/rawdata-crd.json
+++ b/integration/testdata/rawdata-crd.json
@@ -1,24 +1,24 @@
 {
 	"routers": {
-		"default/test-crd-6b204d94623b3df4370c@kubernetescrd": {
+		"default/test.crd-6b204d94623b3df4370c@kubernetescrd": {
 			"entryPoints": [
 				"web"
 			],
-			"service": "default/test-crd-6b204d94623b3df4370c",
+			"service": "default/test.crd-6b204d94623b3df4370c",
 			"rule": "Host(`foo.com`) \u0026\u0026 PathPrefix(`/bar`)",
 			"priority": 12,
 			"tls": {
 				"options": "default/mytlsoption"
 			}
 		},
-		"default/test2-crd-23c7f4c450289ee29016@kubernetescrd": {
+		"default/test2.crd-23c7f4c450289ee29016@kubernetescrd": {
 			"entryPoints": [
 				"web"
 			],
 			"middlewares": [
 				"default/stripprefix"
 			],
-			"service": "default/test2-crd-23c7f4c450289ee29016",
+			"service": "default/test2.crd-23c7f4c450289ee29016",
 			"rule": "Host(`foo.com`) \u0026\u0026 PathPrefix(`/tobestripped`)"
 		}
 	},
@@ -30,58 +30,58 @@
 				]
 			},
 			"usedBy": [
-				"default/test2-crd-23c7f4c450289ee29016@kubernetescrd"
+				"default/test2.crd-23c7f4c450289ee29016@kubernetescrd"
 			]
 		}
 	},
 	"services": {
-		"default/test-crd-6b204d94623b3df4370c@kubernetescrd": {
+		"default/test.crd-6b204d94623b3df4370c@kubernetescrd": {
 			"loadbalancer": {
 				"servers": [
 					{
-						"url": "http://10.42.0.2:80"
+						"url": "http://10.42.0.3:80"
 					},
 					{
-						"url": "http://10.42.0.6:80"
+						"url": "http://10.42.0.5:80"
 					}
 				],
 				"passHostHeader": true
 			},
 			"usedBy": [
-				"default/test-crd-6b204d94623b3df4370c@kubernetescrd"
+				"default/test.crd-6b204d94623b3df4370c@kubernetescrd"
 			],
 			"serverStatus": {
-				"http://10.42.0.2:80": "UP",
-				"http://10.42.0.6:80": "UP"
+				"http://10.42.0.3:80": "UP",
+				"http://10.42.0.5:80": "UP"
 			}
 		},
-		"default/test2-crd-23c7f4c450289ee29016@kubernetescrd": {
+		"default/test2.crd-23c7f4c450289ee29016@kubernetescrd": {
 			"loadbalancer": {
 				"servers": [
 					{
-						"url": "http://10.42.0.2:80"
+						"url": "http://10.42.0.3:80"
 					},
 					{
-						"url": "http://10.42.0.6:80"
+						"url": "http://10.42.0.5:80"
 					}
 				],
 				"passHostHeader": true
 			},
 			"usedBy": [
-				"default/test2-crd-23c7f4c450289ee29016@kubernetescrd"
+				"default/test2.crd-23c7f4c450289ee29016@kubernetescrd"
 			],
 			"serverStatus": {
-				"http://10.42.0.2:80": "UP",
-				"http://10.42.0.6:80": "UP"
+				"http://10.42.0.3:80": "UP",
+				"http://10.42.0.5:80": "UP"
 			}
 		}
 	},
 	"tcpRouters": {
-		"default/test3-crd-673acf455cb2dab0b43a@kubernetescrd": {
+		"default/test3.crd-673acf455cb2dab0b43a@kubernetescrd": {
 			"entryPoints": [
 				"footcp"
 			],
-			"service": "default/test3-crd-673acf455cb2dab0b43a",
+			"service": "default/test3.crd-673acf455cb2dab0b43a",
 			"rule": "HostSNI(`*`)",
 			"tls": {
 				"passthrough": false,
@@ -90,19 +90,19 @@
 		}
 	},
 	"tcpServices": {
-		"default/test3-crd-673acf455cb2dab0b43a@kubernetescrd": {
+		"default/test3.crd-673acf455cb2dab0b43a@kubernetescrd": {
 			"loadbalancer": {
 				"servers": [
 					{
-						"address": "10.42.0.3:8080"
+						"address": "10.42.0.4:8080"
 					},
 					{
-						"address": "10.42.0.4:8080"
+						"address": "10.42.0.6:8080"
 					}
 				]
 			},
 			"usedBy": [
-				"default/test3-crd-673acf455cb2dab0b43a@kubernetescrd"
+				"default/test3.crd-673acf455cb2dab0b43a@kubernetescrd"
 			]
 		}
 	}

--- a/pkg/provider/kubernetes/crd/fixtures/with_middleware_crossprovider.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_middleware_crossprovider.yml
@@ -42,6 +42,6 @@ spec:
         - name: stripprefix
         - name: addprefix
           namespace: foo
-        - name: file@basicauth
-        - name: file@redirect
+        - name: basicauth@file
+        - name: redirect@file
           namespace: foo

--- a/pkg/provider/kubernetes/crd/fixtures/with_middleware_crossprovider.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_middleware_crossprovider.yml
@@ -1,0 +1,47 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: stripprefix
+  namespace: default
+
+spec:
+  stripPrefix:
+    prefixes:
+      - /tobestripped
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: addprefix
+  namespace: foo
+
+spec:
+  addPrefix:
+    prefix: /tobeadded
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: test2.crd
+  namespace: default
+
+spec:
+  entryPoints:
+    - web
+
+  routes:
+    - match: Host(`foo.com`) && PathPrefix(`/tobestripped`)
+      priority: 12
+      kind: Rule
+      services:
+        - name: whoami
+          port: 80
+      middlewares:
+        - name: stripprefix
+        - name: addprefix
+          namespace: foo
+        - name: file@basicauth
+        - name: file@redirect
+          namespace: foo

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -434,13 +434,19 @@ func (p *Provider) loadIngressRouteConfiguration(ctx context.Context, client Cli
 				tlsConf := &config.RouterTLSConfig{}
 				if ingressRoute.Spec.TLS.Options != nil && len(ingressRoute.Spec.TLS.Options.Name) > 0 {
 					tlsOptionsName := ingressRoute.Spec.TLS.Options.Name
-					// Is a Kubernetes CRD reference, (i.e. not a cross-provider default)
+					// Is a Kubernetes CRD reference, (i.e. not a cross-provider reference)
+					ns := ingressRoute.Spec.TLS.Options.Namespace
 					if !strings.Contains(tlsOptionsName, "@") {
-						ns := ingressRoute.Spec.TLS.Options.Namespace
 						if len(ns) == 0 {
 							ns = ingressRoute.Namespace
 						}
 						tlsOptionsName = makeID(ns, tlsOptionsName)
+					} else {
+						if len(ns) > 0 {
+							logger.
+								WithField("TLSoptions", ingressRoute.Spec.TLS.Options.Name).
+								Warnf("namespace %q is ignored in cross-provider context", ns)
+						}
 					}
 
 					tlsConf.Options = tlsOptionsName
@@ -532,12 +538,18 @@ func (p *Provider) loadIngressRouteTCPConfiguration(ctx context.Context, client 
 				if ingressRouteTCP.Spec.TLS.Options != nil && len(ingressRouteTCP.Spec.TLS.Options.Name) > 0 {
 					tlsOptionsName := ingressRouteTCP.Spec.TLS.Options.Name
 					// Is a Kubernetes CRD reference (i.e. not a cross-provider reference)
+					ns := ingressRouteTCP.Spec.TLS.Options.Namespace
 					if !strings.Contains(tlsOptionsName, "@") {
-						ns := ingressRouteTCP.Spec.TLS.Options.Namespace
 						if len(ns) == 0 {
 							ns = ingressRouteTCP.Namespace
 						}
 						tlsOptionsName = makeID(ns, tlsOptionsName)
+					} else {
+						if len(ns) > 0 {
+							logger.
+								WithField("TLSoptions", ingressRouteTCP.Spec.TLS.Options.Name).
+								Warnf("namespace %q is ignored in cross-provider context", ns)
+						}
 					}
 
 					conf.Routers[serviceName].TLS.Options = tlsOptionsName

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -400,7 +400,7 @@ func (p *Provider) loadIngressRouteConfiguration(ctx context.Context, client Cli
 				if strings.Contains(mi.Name, "@") {
 					if len(mi.Namespace) > 0 {
 						logger.
-							WithField("middlewareName", mi.Name).
+							WithField(log.MiddlewareName, mi.Name).
 							Warnf("namespace %q is ignored in cross-provider context", mi.Namespace)
 					}
 					mds = append(mds, mi.Name)

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -441,12 +441,10 @@ func (p *Provider) loadIngressRouteConfiguration(ctx context.Context, client Cli
 							ns = ingressRoute.Namespace
 						}
 						tlsOptionsName = makeID(ns, tlsOptionsName)
-					} else {
-						if len(ns) > 0 {
-							logger.
-								WithField("TLSoptions", ingressRoute.Spec.TLS.Options.Name).
-								Warnf("namespace %q is ignored in cross-provider context", ns)
-						}
+					} else if len(ns) > 0 {
+						logger.
+							WithField("TLSoptions", ingressRoute.Spec.TLS.Options.Name).
+							Warnf("namespace %q is ignored in cross-provider context", ns)
 					}
 
 					tlsConf.Options = tlsOptionsName
@@ -544,12 +542,10 @@ func (p *Provider) loadIngressRouteTCPConfiguration(ctx context.Context, client 
 							ns = ingressRouteTCP.Namespace
 						}
 						tlsOptionsName = makeID(ns, tlsOptionsName)
-					} else {
-						if len(ns) > 0 {
-							logger.
-								WithField("TLSoptions", ingressRouteTCP.Spec.TLS.Options.Name).
-								Warnf("namespace %q is ignored in cross-provider context", ns)
-						}
+					} else if len(ns) > 0 {
+						logger.
+							WithField("TLSoptions", ingressRouteTCP.Spec.TLS.Options.Name).
+							Warnf("namespace %q is ignored in cross-provider context", ns)
 					}
 
 					conf.Routers[serviceName].TLS.Options = tlsOptionsName

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -728,7 +728,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 							Service:     "default/test2.crd-23c7f4c450289ee29016",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/tobestripped`)",
 							Priority:    12,
-							Middlewares: []string{"default/stripprefix", "foo/addprefix", "file@basicauth", "file@redirect"},
+							Middlewares: []string{"default/stripprefix", "foo/addprefix", "basicauth@file", "redirect@file"},
 						},
 					},
 					Middlewares: map[string]*config.Middleware{

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -44,14 +44,14 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 				},
 				TCP: &config.TCPConfiguration{
 					Routers: map[string]*config.TCPRouter{
-						"default/test-crd-fdd3e9338e47a45efefc": {
+						"default/test.crd-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test-crd-fdd3e9338e47a45efefc",
+							Service:     "default/test.crd-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 						},
 					},
 					Services: map[string]*config.TCPService{
-						"default/test-crd-fdd3e9338e47a45efefc": {
+						"default/test.crd-fdd3e9338e47a45efefc": {
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
 									{
@@ -75,19 +75,19 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 			expected: &config.Configuration{
 				TCP: &config.TCPConfiguration{
 					Routers: map[string]*config.TCPRouter{
-						"default/test-crd-fdd3e9338e47a45efefc": {
+						"default/test.crd-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test-crd-fdd3e9338e47a45efefc",
+							Service:     "default/test.crd-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 						},
-						"default/test-crd-f44ce589164e656d231c": {
+						"default/test.crd-f44ce589164e656d231c": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test-crd-f44ce589164e656d231c",
+							Service:     "default/test.crd-f44ce589164e656d231c",
 							Rule:        "HostSNI(`bar.com`)",
 						},
 					},
 					Services: map[string]*config.TCPService{
-						"default/test-crd-fdd3e9338e47a45efefc": {
+						"default/test.crd-fdd3e9338e47a45efefc": {
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
 									{
@@ -101,7 +101,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 								},
 							},
 						},
-						"default/test-crd-f44ce589164e656d231c": {
+						"default/test.crd-f44ce589164e656d231c": {
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
 									{
@@ -130,14 +130,14 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 			expected: &config.Configuration{
 				TCP: &config.TCPConfiguration{
 					Routers: map[string]*config.TCPRouter{
-						"default/test-crd-fdd3e9338e47a45efefc": {
+						"default/test.crd-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test-crd-fdd3e9338e47a45efefc",
+							Service:     "default/test.crd-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 						},
 					},
 					Services: map[string]*config.TCPService{
-						"default/test-crd-fdd3e9338e47a45efefc": {
+						"default/test.crd-fdd3e9338e47a45efefc": {
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
 									{
@@ -227,15 +227,15 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 				},
 				TCP: &config.TCPConfiguration{
 					Routers: map[string]*config.TCPRouter{
-						"default/test-crd-fdd3e9338e47a45efefc": {
+						"default/test.crd-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test-crd-fdd3e9338e47a45efefc",
+							Service:     "default/test.crd-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 							TLS:         &config.RouterTCPTLSConfig{},
 						},
 					},
 					Services: map[string]*config.TCPService{
-						"default/test-crd-fdd3e9338e47a45efefc": {
+						"default/test.crd-fdd3e9338e47a45efefc": {
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
 									{
@@ -264,9 +264,9 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 			expected: &config.Configuration{
 				TCP: &config.TCPConfiguration{
 					Routers: map[string]*config.TCPRouter{
-						"default/test-crd-fdd3e9338e47a45efefc": {
+						"default/test.crd-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test-crd-fdd3e9338e47a45efefc",
+							Service:     "default/test.crd-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 							TLS: &config.RouterTCPTLSConfig{
 								Passthrough: true,
@@ -274,7 +274,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 						},
 					},
 					Services: map[string]*config.TCPService{
-						"default/test-crd-fdd3e9338e47a45efefc": {
+						"default/test.crd-fdd3e9338e47a45efefc": {
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
 									{
@@ -320,9 +320,9 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 				},
 				TCP: &config.TCPConfiguration{
 					Routers: map[string]*config.TCPRouter{
-						"default/test-crd-fdd3e9338e47a45efefc": {
+						"default/test.crd-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test-crd-fdd3e9338e47a45efefc",
+							Service:     "default/test.crd-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 							TLS: &config.RouterTCPTLSConfig{
 								Options: "default/foo",
@@ -330,7 +330,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 						},
 					},
 					Services: map[string]*config.TCPService{
-						"default/test-crd-fdd3e9338e47a45efefc": {
+						"default/test.crd-fdd3e9338e47a45efefc": {
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
 									{
@@ -376,9 +376,9 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 				},
 				TCP: &config.TCPConfiguration{
 					Routers: map[string]*config.TCPRouter{
-						"default/test-crd-fdd3e9338e47a45efefc": {
+						"default/test.crd-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test-crd-fdd3e9338e47a45efefc",
+							Service:     "default/test.crd-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 							TLS: &config.RouterTCPTLSConfig{
 								Options: "myns/foo",
@@ -386,7 +386,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 						},
 					},
 					Services: map[string]*config.TCPService{
-						"default/test-crd-fdd3e9338e47a45efefc": {
+						"default/test.crd-fdd3e9338e47a45efefc": {
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
 									{
@@ -431,9 +431,9 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 				},
 				TCP: &config.TCPConfiguration{
 					Routers: map[string]*config.TCPRouter{
-						"default/test-crd-fdd3e9338e47a45efefc": {
+						"default/test.crd-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test-crd-fdd3e9338e47a45efefc",
+							Service:     "default/test.crd-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 							TLS: &config.RouterTCPTLSConfig{
 								Options: "default/foo",
@@ -441,7 +441,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 						},
 					},
 					Services: map[string]*config.TCPService{
-						"default/test-crd-fdd3e9338e47a45efefc": {
+						"default/test.crd-fdd3e9338e47a45efefc": {
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
 									{
@@ -475,9 +475,9 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 				},
 				TCP: &config.TCPConfiguration{
 					Routers: map[string]*config.TCPRouter{
-						"default/test-crd-fdd3e9338e47a45efefc": {
+						"default/test.crd-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test-crd-fdd3e9338e47a45efefc",
+							Service:     "default/test.crd-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 							TLS: &config.RouterTCPTLSConfig{
 								Options: "default/unknown",
@@ -485,7 +485,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 						},
 					},
 					Services: map[string]*config.TCPService{
-						"default/test-crd-fdd3e9338e47a45efefc": {
+						"default/test.crd-fdd3e9338e47a45efefc": {
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
 									{
@@ -519,9 +519,9 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 				},
 				TCP: &config.TCPConfiguration{
 					Routers: map[string]*config.TCPRouter{
-						"default/test-crd-fdd3e9338e47a45efefc": {
+						"default/test.crd-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test-crd-fdd3e9338e47a45efefc",
+							Service:     "default/test.crd-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 							TLS: &config.RouterTCPTLSConfig{
 								Options: "unknown/foo",
@@ -529,7 +529,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 						},
 					},
 					Services: map[string]*config.TCPService{
-						"default/test-crd-fdd3e9338e47a45efefc": {
+						"default/test.crd-fdd3e9338e47a45efefc": {
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
 									{
@@ -558,15 +558,15 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 			expected: &config.Configuration{
 				TCP: &config.TCPConfiguration{
 					Routers: map[string]*config.TCPRouter{
-						"default/test-crd-fdd3e9338e47a45efefc": {
+						"default/test.crd-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test-crd-fdd3e9338e47a45efefc",
+							Service:     "default/test.crd-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 							TLS:         &config.RouterTCPTLSConfig{},
 						},
 					},
 					Services: map[string]*config.TCPService{
-						"default/test-crd-fdd3e9338e47a45efefc": {
+						"default/test.crd-fdd3e9338e47a45efefc": {
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
 									{
@@ -639,16 +639,16 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &config.HTTPConfiguration{
 					Routers: map[string]*config.Router{
-						"default/test-crd-6b204d94623b3df4370c": {
+						"default/test.crd-6b204d94623b3df4370c": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test-crd-6b204d94623b3df4370c",
+							Service:     "default/test.crd-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 						},
 					},
 					Middlewares: map[string]*config.Middleware{},
 					Services: map[string]*config.Service{
-						"default/test-crd-6b204d94623b3df4370c": {
+						"default/test.crd-6b204d94623b3df4370c": {
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
 									{
@@ -675,9 +675,9 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &config.HTTPConfiguration{
 					Routers: map[string]*config.Router{
-						"default/test2-crd-23c7f4c450289ee29016": {
+						"default/test2.crd-23c7f4c450289ee29016": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test2-crd-23c7f4c450289ee29016",
+							Service:     "default/test2.crd-23c7f4c450289ee29016",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/tobestripped`)",
 							Priority:    12,
 							Middlewares: []string{"default/stripprefix", "foo/addprefix"},
@@ -696,7 +696,55 @@ func TestLoadIngressRoutes(t *testing.T) {
 						},
 					},
 					Services: map[string]*config.Service{
-						"default/test2-crd-23c7f4c450289ee29016": {
+						"default/test2.crd-23c7f4c450289ee29016": {
+							LoadBalancer: &config.LoadBalancerService{
+								Servers: []config.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: true,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:  "Simple Ingress Route with middleware crossprovider",
+			paths: []string{"services.yml", "with_middleware_crossprovider.yml"},
+			expected: &config.Configuration{
+				TCP: &config.TCPConfiguration{
+					Routers:  map[string]*config.TCPRouter{},
+					Services: map[string]*config.TCPService{},
+				},
+				HTTP: &config.HTTPConfiguration{
+					Routers: map[string]*config.Router{
+						"default/test2.crd-23c7f4c450289ee29016": {
+							EntryPoints: []string{"web"},
+							Service:     "default/test2.crd-23c7f4c450289ee29016",
+							Rule:        "Host(`foo.com`) && PathPrefix(`/tobestripped`)",
+							Priority:    12,
+							Middlewares: []string{"default/stripprefix", "foo/addprefix", "file@basicauth", "file@redirect"},
+						},
+					},
+					Middlewares: map[string]*config.Middleware{
+						"default/stripprefix": {
+							StripPrefix: &config.StripPrefix{
+								Prefixes: []string{"/tobestripped"},
+							},
+						},
+						"foo/addprefix": {
+							AddPrefix: &config.AddPrefix{
+								Prefix: "/tobeadded",
+							},
+						},
+					},
+					Services: map[string]*config.Service{
+						"default/test2.crd-23c7f4c450289ee29016": {
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
 									{
@@ -723,22 +771,22 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &config.HTTPConfiguration{
 					Routers: map[string]*config.Router{
-						"default/test-crd-6b204d94623b3df4370c": {
+						"default/test.crd-6b204d94623b3df4370c": {
 							EntryPoints: []string{"web"},
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
-							Service:     "default/test-crd-6b204d94623b3df4370c",
+							Service:     "default/test.crd-6b204d94623b3df4370c",
 							Priority:    14,
 						},
-						"default/test-crd-77c62dfe9517144aeeaa": {
+						"default/test.crd-77c62dfe9517144aeeaa": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test-crd-77c62dfe9517144aeeaa",
+							Service:     "default/test.crd-77c62dfe9517144aeeaa",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/foo`)",
 							Priority:    12,
 						},
 					},
 					Middlewares: map[string]*config.Middleware{},
 					Services: map[string]*config.Service{
-						"default/test-crd-6b204d94623b3df4370c": {
+						"default/test.crd-6b204d94623b3df4370c": {
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
 									{
@@ -751,7 +799,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 								PassHostHeader: true,
 							},
 						},
-						"default/test-crd-77c62dfe9517144aeeaa": {
+						"default/test.crd-77c62dfe9517144aeeaa": {
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
 									{
@@ -778,16 +826,16 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &config.HTTPConfiguration{
 					Routers: map[string]*config.Router{
-						"default/test-crd-77c62dfe9517144aeeaa": {
+						"default/test.crd-77c62dfe9517144aeeaa": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test-crd-77c62dfe9517144aeeaa",
+							Service:     "default/test.crd-77c62dfe9517144aeeaa",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/foo`)",
 							Priority:    12,
 						},
 					},
 					Middlewares: map[string]*config.Middleware{},
 					Services: map[string]*config.Service{
-						"default/test-crd-77c62dfe9517144aeeaa": {
+						"default/test.crd-77c62dfe9517144aeeaa": {
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
 									{
@@ -889,9 +937,9 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &config.HTTPConfiguration{
 					Routers: map[string]*config.Router{
-						"default/test-crd-6b204d94623b3df4370c": {
+						"default/test.crd-6b204d94623b3df4370c": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test-crd-6b204d94623b3df4370c",
+							Service:     "default/test.crd-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 							TLS:         &config.RouterTLSConfig{},
@@ -899,7 +947,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 					},
 					Middlewares: map[string]*config.Middleware{},
 					Services: map[string]*config.Service{
-						"default/test-crd-6b204d94623b3df4370c": {
+						"default/test.crd-6b204d94623b3df4370c": {
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
 									{
@@ -943,9 +991,9 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &config.HTTPConfiguration{
 					Routers: map[string]*config.Router{
-						"default/test-crd-6b204d94623b3df4370c": {
+						"default/test.crd-6b204d94623b3df4370c": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test-crd-6b204d94623b3df4370c",
+							Service:     "default/test.crd-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 							TLS: &config.RouterTLSConfig{
@@ -955,7 +1003,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 					},
 					Middlewares: map[string]*config.Middleware{},
 					Services: map[string]*config.Service{
-						"default/test-crd-6b204d94623b3df4370c": {
+						"default/test.crd-6b204d94623b3df4370c": {
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
 									{
@@ -999,9 +1047,9 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &config.HTTPConfiguration{
 					Routers: map[string]*config.Router{
-						"default/test-crd-6b204d94623b3df4370c": {
+						"default/test.crd-6b204d94623b3df4370c": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test-crd-6b204d94623b3df4370c",
+							Service:     "default/test.crd-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 							TLS: &config.RouterTLSConfig{
@@ -1011,7 +1059,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 					},
 					Middlewares: map[string]*config.Middleware{},
 					Services: map[string]*config.Service{
-						"default/test-crd-6b204d94623b3df4370c": {
+						"default/test.crd-6b204d94623b3df4370c": {
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
 									{
@@ -1054,9 +1102,9 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &config.HTTPConfiguration{
 					Routers: map[string]*config.Router{
-						"default/test-crd-6b204d94623b3df4370c": {
+						"default/test.crd-6b204d94623b3df4370c": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test-crd-6b204d94623b3df4370c",
+							Service:     "default/test.crd-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 							TLS: &config.RouterTLSConfig{
@@ -1066,7 +1114,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 					},
 					Middlewares: map[string]*config.Middleware{},
 					Services: map[string]*config.Service{
-						"default/test-crd-6b204d94623b3df4370c": {
+						"default/test.crd-6b204d94623b3df4370c": {
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
 									{
@@ -1098,9 +1146,9 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &config.HTTPConfiguration{
 					Routers: map[string]*config.Router{
-						"default/test-crd-6b204d94623b3df4370c": {
+						"default/test.crd-6b204d94623b3df4370c": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test-crd-6b204d94623b3df4370c",
+							Service:     "default/test.crd-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 							TLS: &config.RouterTLSConfig{
@@ -1110,7 +1158,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 					},
 					Middlewares: map[string]*config.Middleware{},
 					Services: map[string]*config.Service{
-						"default/test-crd-6b204d94623b3df4370c": {
+						"default/test.crd-6b204d94623b3df4370c": {
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
 									{
@@ -1142,9 +1190,9 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &config.HTTPConfiguration{
 					Routers: map[string]*config.Router{
-						"default/test-crd-6b204d94623b3df4370c": {
+						"default/test.crd-6b204d94623b3df4370c": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test-crd-6b204d94623b3df4370c",
+							Service:     "default/test.crd-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 							TLS: &config.RouterTLSConfig{
@@ -1154,7 +1202,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 					},
 					Middlewares: map[string]*config.Middleware{},
 					Services: map[string]*config.Service{
-						"default/test-crd-6b204d94623b3df4370c": {
+						"default/test.crd-6b204d94623b3df4370c": {
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
 									{
@@ -1181,9 +1229,9 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &config.HTTPConfiguration{
 					Routers: map[string]*config.Router{
-						"default/test-crd-6b204d94623b3df4370c": {
+						"default/test.crd-6b204d94623b3df4370c": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test-crd-6b204d94623b3df4370c",
+							Service:     "default/test.crd-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 							TLS:         &config.RouterTLSConfig{},
@@ -1191,7 +1239,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 					},
 					Middlewares: map[string]*config.Middleware{},
 					Services: map[string]*config.Service{
-						"default/test-crd-6b204d94623b3df4370c": {
+						"default/test.crd-6b204d94623b3df4370c": {
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
 									{
@@ -1218,16 +1266,16 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &config.HTTPConfiguration{
 					Routers: map[string]*config.Router{
-						"default/test-crd-6b204d94623b3df4370c": {
+						"default/test.crd-6b204d94623b3df4370c": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test-crd-6b204d94623b3df4370c",
+							Service:     "default/test.crd-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 						},
 					},
 					Middlewares: map[string]*config.Middleware{},
 					Services: map[string]*config.Service{
-						"default/test-crd-6b204d94623b3df4370c": {
+						"default/test.crd-6b204d94623b3df4370c": {
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
 									{


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

This PR handles the case where a middleware is defined in a provider other than the kubernetes CRD one (e.g. file provider), and is used from a Kubernetes CRD.
In this case, the usual cross-provider syntax (middlewarename@provider) should be used, and whatever namespace attribute specified in the middleware reference is ignored.

Some documentation for TLS Option was also added/fixed as it is a similar situation and behaviour.

### Motivation

Having a consistent cross-provider story everywhere.

Fixes #4855

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Co-authored-by: Julien Salleyron <julien.salleyron@gmail.com>
