### PR TITLE
Update Slack support channel references to Discourse community forum

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@
 [![Docs](https://img.shields.io/badge/docs-current-brightgreen.svg)](/)
 [![Go Report Card](https://goreportcard.com/badge/github.com/containous/traefik)](https://goreportcard.com/report/github.com/containous/traefik)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/containous/traefik/blob/master/LICENSE.md)
-[![Join the chat at https://slack.traefik.io](https://img.shields.io/badge/style-register-green.svg?style=social&label=Slack)](https://slack.traefik.io)
+[![Join the community support forum at https://community.containo.us/](https://img.shields.io/badge/style-register-green.svg?style=social&label=Discourse)](https://community.containo.us/)
 [![Twitter](https://img.shields.io/twitter/follow/traefik.svg?style=social)](https://twitter.com/intent/follow?screen_name=traefik)
 
 


### PR DESCRIPTION
Signed-off-by: dduportal <1522731+dduportal@users.noreply.github.com>

### What does this PR do?

This PR replaces the Slack badge of the documentation's homepage by the Discourse badge

### Motivation

With the Community Support moving to Discourse, we want our users to use the right website.

### More

- ~[ ] Added/updated tests~
- [x] Added/updated documentation

### Additional Notes

![GIF dog with books](https://media.giphy.com/media/3LrK7Q7UhF5MnhZ5ja/giphy.gif)