### PR TITLE
doc/crd-acme: specify required kubectl version

### DIFF
--- a/docs/content/user-guides/crd-acme/index.md
+++ b/docs/content/user-guides/crd-acme/index.md
@@ -16,6 +16,10 @@ In the following, the Kubernetes resources defined in YAML configuration files c
 - the first, and usual way, is simply with the `kubectl apply` command.
 - the second, which can be used for this tutorial, is to directly place the files in the directory used by the k3s docker image for such inputs (`/var/lib/rancher/k3s/server/manifests`).
 
+!!! important "Kubectl Version"
+
+    With the `rancher/k3s` version used in this guide (`0.5.0`), the kubectl version needs to be >= `0.11`.
+
 ## k3s Docker-compose Configuration
 
 Our starting point is the docker-compose configuration file, to start the k3s cluster.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

This change specifies the required minimum kubectl version for the Acme with CRD guide.

### Motivation

The guide fails with kubectl version < 0.11

### More

- ~[ ] Added/updated tests~
- [x] Added/updated documentation

### Additional Notes

Fixes #4279 (maybe?)