### PR TITLE
Adding content-header to api endpoints

### DIFF
--- a/pkg/api/handler.go
+++ b/pkg/api/handler.go
@@ -156,6 +156,7 @@ func (h Handler) getRouters(rw http.ResponseWriter, request *http.Request) {
 		return
 	}
 
+	rw.Header().Set("Content-Type", "application/json")
 	rw.Header().Set(nextPageHeader, strconv.Itoa(pageInfo.nextPage))
 
 	err = json.NewEncoder(rw).Encode(results[pageInfo.startIndex:pageInfo.endIndex])
@@ -179,6 +180,8 @@ func (h Handler) getRouter(rw http.ResponseWriter, request *http.Request) {
 		Name:       routerID,
 		Provider:   getProviderName(routerID),
 	}
+
+	rw.Header().Set("Content-Type", "application/json")
 
 	err := json.NewEncoder(rw).Encode(result)
 	if err != nil {
@@ -209,6 +212,7 @@ func (h Handler) getServices(rw http.ResponseWriter, request *http.Request) {
 		return
 	}
 
+	rw.Header().Set("Content-Type", "application/json")
 	rw.Header().Set(nextPageHeader, strconv.Itoa(pageInfo.nextPage))
 
 	err = json.NewEncoder(rw).Encode(results[pageInfo.startIndex:pageInfo.endIndex])
@@ -233,6 +237,8 @@ func (h Handler) getService(rw http.ResponseWriter, request *http.Request) {
 		Provider:     getProviderName(serviceID),
 		ServerStatus: service.GetAllStatus(),
 	}
+
+	rw.Header().Add("Content-Type", "application/json")
 
 	err := json.NewEncoder(rw).Encode(result)
 	if err != nil {
@@ -262,6 +268,7 @@ func (h Handler) getMiddlewares(rw http.ResponseWriter, request *http.Request) {
 		return
 	}
 
+	rw.Header().Set("Content-Type", "application/json")
 	rw.Header().Set(nextPageHeader, strconv.Itoa(pageInfo.nextPage))
 
 	err = json.NewEncoder(rw).Encode(results[pageInfo.startIndex:pageInfo.endIndex])
@@ -285,6 +292,8 @@ func (h Handler) getMiddleware(rw http.ResponseWriter, request *http.Request) {
 		Name:           middlewareID,
 		Provider:       getProviderName(middlewareID),
 	}
+
+	rw.Header().Set("Content-Type", "application/json")
 
 	err := json.NewEncoder(rw).Encode(result)
 	if err != nil {
@@ -314,6 +323,7 @@ func (h Handler) getTCPRouters(rw http.ResponseWriter, request *http.Request) {
 		return
 	}
 
+	rw.Header().Set("Content-Type", "application/json")
 	rw.Header().Set(nextPageHeader, strconv.Itoa(pageInfo.nextPage))
 
 	err = json.NewEncoder(rw).Encode(results[pageInfo.startIndex:pageInfo.endIndex])
@@ -337,6 +347,8 @@ func (h Handler) getTCPRouter(rw http.ResponseWriter, request *http.Request) {
 		Name:          routerID,
 		Provider:      getProviderName(routerID),
 	}
+
+	rw.Header().Set("Content-Type", "application/json")
 
 	err := json.NewEncoder(rw).Encode(result)
 	if err != nil {
@@ -366,6 +378,7 @@ func (h Handler) getTCPServices(rw http.ResponseWriter, request *http.Request) {
 		return
 	}
 
+	rw.Header().Set("Content-Type", "application/json")
 	rw.Header().Set(nextPageHeader, strconv.Itoa(pageInfo.nextPage))
 
 	err = json.NewEncoder(rw).Encode(results[pageInfo.startIndex:pageInfo.endIndex])
@@ -390,6 +403,8 @@ func (h Handler) getTCPService(rw http.ResponseWriter, request *http.Request) {
 		Provider:       getProviderName(serviceID),
 	}
 
+	rw.Header().Set("Content-Type", "application/json")
+
 	err := json.NewEncoder(rw).Encode(result)
 	if err != nil {
 		log.FromContext(request.Context()).Error(err)
@@ -413,6 +428,8 @@ func (h Handler) getRuntimeConfiguration(rw http.ResponseWriter, request *http.R
 		TCPRouters:  h.runtimeConfiguration.TCPRouters,
 		TCPServices: h.runtimeConfiguration.TCPServices,
 	}
+
+	rw.Header().Set("Content-Type", "application/json")
 
 	err := json.NewEncoder(rw).Encode(result)
 	if err != nil {

--- a/pkg/api/handler_test.go
+++ b/pkg/api/handler_test.go
@@ -898,6 +898,7 @@ func TestHandlerHTTP_API(t *testing.T) {
 func TestHandler_Configuration(t *testing.T) {
 	type expected struct {
 		statusCode int
+		headers    map[string]string
 		json       string
 	}
 
@@ -997,6 +998,7 @@ func TestHandler_Configuration(t *testing.T) {
 			},
 			expected: expected{
 				statusCode: http.StatusOK,
+				headers:    map[string]string{"Content-Type": "application/json"},
 				json:       "testdata/getrawdata.json",
 			},
 		},
@@ -1022,6 +1024,11 @@ func TestHandler_Configuration(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, test.expected.statusCode, resp.StatusCode)
+
+			for key, _ := range test.expected.headers {
+				assert.Contains(t, resp.Header, key)
+				assert.Equal(t, test.expected.headers[key], resp.Header.Get(key))
+			}
 
 			contents, err := ioutil.ReadAll(resp.Body)
 			require.NoError(t, err)

--- a/pkg/api/handler_test.go
+++ b/pkg/api/handler_test.go
@@ -326,6 +326,8 @@ func TestHandlerTCP_API(t *testing.T) {
 				return
 			}
 
+			assert.Equal(t, resp.Header.Get("Content-Type"), "application/json")
+
 			contents, err := ioutil.ReadAll(resp.Body)
 			require.NoError(t, err)
 
@@ -869,6 +871,7 @@ func TestHandlerHTTP_API(t *testing.T) {
 				return
 			}
 
+			assert.Equal(t, resp.Header.Get("Content-Type"), "application/json")
 			contents, err := ioutil.ReadAll(resp.Body)
 			require.NoError(t, err)
 
@@ -898,7 +901,6 @@ func TestHandlerHTTP_API(t *testing.T) {
 func TestHandler_Configuration(t *testing.T) {
 	type expected struct {
 		statusCode int
-		headers    map[string]string
 		json       string
 	}
 
@@ -998,7 +1000,6 @@ func TestHandler_Configuration(t *testing.T) {
 			},
 			expected: expected{
 				statusCode: http.StatusOK,
-				headers:    map[string]string{"Content-Type": "application/json"},
 				json:       "testdata/getrawdata.json",
 			},
 		},
@@ -1024,11 +1025,7 @@ func TestHandler_Configuration(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, test.expected.statusCode, resp.StatusCode)
-
-			for key, _ := range test.expected.headers {
-				assert.Contains(t, resp.Header, key)
-				assert.Equal(t, test.expected.headers[key], resp.Header.Get(key))
-			}
+			assert.Equal(t, resp.Header.Get("Content-Type"), "application/json")
 
 			contents, err := ioutil.ReadAll(resp.Body)
 			require.NoError(t, err)


### PR DESCRIPTION
### What does this PR do?

This PR (re-?)adds `Content-Type` to the Traefik `/api` endpoints. 

I'm unsure if I'm meeting the testing standards but I modified as little as I thought was necessary. Completely happy to receive feedback as I'm not primarily a Golang developer. 

### Motivation

I noticed in the recent `alpha7` that the raw JSON being returned was not being formatted nicely in Firefox anymore. This was working in the past, but I didn't notice any changes to this file which would've added this in the history. I may be unaware of the appropriate Headers being added in some other http middleware. 

Example response headers from `alpha7` `/api/rawdata`

```
HTTP/1.1 200 OK
X-Next-Page: 1
Date: Tue, 25 Jun 2019 13:30:58 GMT
Content-Length: 1338
Content-Type: text/plain; charset=utf-8
```

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes


