### PR TITLE
Check for multiport services on Global Backend Ingress

### DIFF
--- a/provider/kubernetes/fixtures/loadGlobalIngressWithMultiplePortNumbers_endpoints.yml
+++ b/provider/kubernetes/fixtures/loadGlobalIngressWithMultiplePortNumbers_endpoints.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: service1
+  namespace: testing
+subsets:
+- addresses:
+  - ip: 10.10.0.1
+  ports:
+  - port: 8080
+    name: http
+  - port: 1111
+    name: foo

--- a/provider/kubernetes/fixtures/loadGlobalIngressWithMultiplePortNumbers_ingresses.yml
+++ b/provider/kubernetes/fixtures/loadGlobalIngressWithMultiplePortNumbers_ingresses.yml
@@ -1,0 +1,8 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  namespace: testing
+spec:
+  backend:
+    serviceName: service1
+    servicePort: 80

--- a/provider/kubernetes/fixtures/loadGlobalIngressWithMultiplePortNumbers_services.yml
+++ b/provider/kubernetes/fixtures/loadGlobalIngressWithMultiplePortNumbers_services.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: service1
+  namespace: testing
+spec:
+  clusterIP: 10.0.0.1
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+  - name: foo
+    port: 1111
+    targetPort: 1111

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -508,6 +508,10 @@ func (p *Provider) addGlobalBackend(cl Client, i *extensionsv1beta1.Ingress, tem
 
 	for _, port := range service.Spec.Ports {
 
+		if !equalPorts(port, i.Spec.Backend.ServicePort) {
+			continue
+		}
+
 		// We have to treat external-name service differently here b/c it doesn't have any endpoints
 		if service.Spec.Type == corev1.ServiceTypeExternalName {
 

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -169,6 +169,33 @@ func TestProvider_loadIngresses(t *testing.T) {
 			),
 		},
 		{
+			desc: "loadGlobalIngressWithMultiplePortNumbers",
+			fixtures: []string{
+				filepath.Join("fixtures", "loadGlobalIngressWithMultiplePortNumbers_ingresses.yml"),
+				filepath.Join("fixtures", "loadGlobalIngressWithMultiplePortNumbers_services.yml"),
+				filepath.Join("fixtures", "loadGlobalIngressWithMultiplePortNumbers_endpoints.yml"),
+			},
+			expected: buildConfiguration(
+				backends(
+					backend("global-default-backend",
+						lbMethod("wrr"),
+						servers(
+							server("http://10.10.0.1:8080", weight(1)),
+						),
+					),
+				),
+				frontends(
+					frontend("global-default-backend",
+						frontendName("global-default-frontend"),
+						passHostHeader(),
+						routes(
+							route("/", "PathPrefix:/"),
+						),
+					),
+				),
+			),
+		},
+		{
 			desc: "loadGlobalIngressWithHttpsPortNames",
 			fixtures: []string{
 				filepath.Join("fixtures", "loadGlobalIngressWithHttpsPortNames_ingresses.yml"),


### PR DESCRIPTION
### What does this PR do?

This PR checks for port matches on multiport services. This check is present in the main ingress processing, but was absent for the global ingress processing.


### Motivation

Fixes #5000 

### More

- [x] Added/updated tests
- [x] Added/updated documentation - None needed, intended behavior(bugfix)

