### PR TITLE
Update api.md

### DIFF
--- a/docs/configuration/api.md
+++ b/docs/configuration/api.md
@@ -2,6 +2,10 @@
 
 ## Configuration
 
+Note: If you are using toml remove your command argument --api. If not traefik will log fatal error:  
+`Error preparing server: error opening listener: listen tcp :8080: bind: address already in use"`
+
+
 ```toml
 # API definition
 # Warning: Enabling API will expose Traefik's configuration.


### PR DESCRIPTION
### What does this PR do?
Clearly state that if using the toml to define [api] the CLI argument needs to be removed.


### Motivation
I spent almost three days trying to figure out what was happening to my dashboard.  I continued to get the same error message port 8080 is already in use.
```
traefik_1   | time="2019-06-27T00:10:51Z" level=fatal msg="Error preparing server: error opening listener: listen tcp :8080: bind: address already in use"
traefik-template_traefik_1 exited with code 1
```
I became very close to giving up but understanding how this works is important to me.  It wasn't until digging through comments in the issues section that I came across a post describing the same issue.  The solution was so simple but frustrating. 

### More

- [ ] Added/updated tests
- [X] Added/updated documentation

### Additional Notes
I joined the containous traefik forum to find the solution and everyone just directed me to the documentation where I still did not find the answer.  
<!-- Anything else we should know when reviewing? -->

