### PR TITLE
Allow fsnotify to reload config files on k8s (or symlinks)

### DIFF
--- a/pkg/provider/file/file.go
+++ b/pkg/provider/file/file.go
@@ -111,7 +111,10 @@ func (p *Provider) addWatcher(pool *safe.Pool, directory string, configurationCh
 				return
 			case evt := <-watcher.Events:
 				if evt.Op == fsnotify.Remove {
-					watcher.Remove(evt.Name)
+					err = watcher.Remove(evt.Name)
+					if err != nil {
+						log.WithoutContext().WithField(log.ProviderName, providerName).Errorf("Could not remove watcher: %s", err)
+					}
 					err = watcher.Add(directory)
 					if err != nil {
 						log.WithoutContext().WithField(log.ProviderName, providerName).Errorf("Could not re-add watcher: %s", err)

--- a/pkg/provider/file/file.go
+++ b/pkg/provider/file/file.go
@@ -110,6 +110,14 @@ func (p *Provider) addWatcher(pool *safe.Pool, directory string, configurationCh
 			case <-ctx.Done():
 				return
 			case evt := <-watcher.Events:
+				if evt.Op == fsnotify.Remove {
+					watcher.Remove(evt.Name)
+					err = watcher.Add(directory)
+					if err != nil {
+						log.WithoutContext().WithField(log.ProviderName, providerName).Errorf("Could not re-add watcher: %s", err)
+					}
+				}
+
 				if p.Directory == "" {
 					_, evtFileName := filepath.Split(evt.Name)
 					_, confFileName := filepath.Split(p.Filename)

--- a/pkg/provider/file/file.go
+++ b/pkg/provider/file/file.go
@@ -113,11 +113,13 @@ func (p *Provider) addWatcher(pool *safe.Pool, directory string, configurationCh
 				if evt.Op == fsnotify.Remove {
 					err = watcher.Remove(evt.Name)
 					if err != nil {
-						log.WithoutContext().WithField(log.ProviderName, providerName).Errorf("Could not remove watcher: %s", err)
+						log.WithoutContext().WithField(log.ProviderName, providerName).
+							Errorf("Could not remove watcher for %s: %s", directory, err)
 					}
 					err = watcher.Add(directory)
 					if err != nil {
-						log.WithoutContext().WithField(log.ProviderName, providerName).Errorf("Could not re-add watcher: %s", err)
+						log.WithoutContext().WithField(log.ProviderName, providerName).
+							Errorf("Could not re-add watcher for %s: %s", directory, err)
 					}
 				}
 


### PR DESCRIPTION
### What does this PR do?

Watches for delete events on the watched config file, and re-register the watch on the same file.

This allows configmaps to be updated in k8s, and have traefik follow the new updated code.

See:

https://martensson.io/go-fsnotify-and-kubernetes-configmaps/
http://thrawn01.org/posts/2016/03/22/howto-write-configmap-enabled-golang-microservices/
https://medium.com/@xcoulon/kubernetes-configmap-hot-reload-in-action-with-viper-d413128a1c9a


### Motivation

Fixes the original issue in #1188
