### PR TITLE
add PassHostHeader option to forward auth

### DIFF
--- a/autogen/gentemplates/gen.go
+++ b/autogen/gentemplates/gen.go
@@ -756,6 +756,7 @@ var _templatesDockerTmpl = []byte(`{{$backendServers := .Servers}}
       [frontends."frontend-{{ $frontendName }}".auth.forward]
         address = "{{ $auth.Forward.Address }}"
         trustForwardHeader = {{ $auth.Forward.TrustForwardHeader }}
+        passHostHeader = {{ $auth.Forward.PassHostHeader }}
         {{if $auth.Forward.AuthResponseHeaders }}
         authResponseHeaders = [{{range $auth.Forward.AuthResponseHeaders }}
           "{{.}}",
@@ -1390,6 +1391,7 @@ var _templatesKubernetesTmpl = []byte(`[backends]
             "{{.}}",
             {{end}}]
           trustForwardHeader = {{ $frontend.Auth.Forward.TrustForwardHeader }}
+          passHostHeader = {{ $frontend.Auth.Forward.PassHostHeader }}
           {{if $frontend.Auth.Forward.TLS }}
           [frontends."{{ $frontendName }}".auth.forward.tls]
             cert = """{{ $frontend.Auth.Forward.TLS.Cert }}"""

--- a/configuration/entrypoints.go
+++ b/configuration/entrypoints.go
@@ -146,6 +146,7 @@ func makeEntryPointAuth(result map[string]string) *types.Auth {
 			Address:             address,
 			TLS:                 clientTLS,
 			TrustForwardHeader:  toBool(result, "auth_forward_trustforwardheader"),
+			PassHostHeader:      toBool(result, "auth_forward_passhostheader"),
 			AuthResponseHeaders: authResponseHeaders,
 		}
 	}

--- a/configuration/entrypoints_test.go
+++ b/configuration/entrypoints_test.go
@@ -40,6 +40,7 @@ func Test_parseEntryPointsConfiguration(t *testing.T) {
 				"Auth.Forward.Address:https://authserver.com/auth " +
 				"Auth.Forward.AuthResponseHeaders:X-Auth,X-Test,X-Secret " +
 				"Auth.Forward.TrustForwardHeader:true " +
+				"Auth.Forward.PassHostHeader:true " +
 				"Auth.Forward.TLS.CA:path/to/local.crt " +
 				"Auth.Forward.TLS.CAOptional:true " +
 				"Auth.Forward.TLS.Cert:path/to/foo.cert " +
@@ -62,6 +63,7 @@ func Test_parseEntryPointsConfiguration(t *testing.T) {
 				"auth_forward_tls_insecureskipverify": "true",
 				"auth_forward_tls_key":                "path/to/foo.key",
 				"auth_forward_trustforwardheader":     "true",
+				"auth_forward_passhostheader":         "true",
 				"auth_headerfield":                    "X-WebAuth-User",
 				"ca":                                  "car",
 				"ca_optional":                         "true",

--- a/middlewares/auth/forward.go
+++ b/middlewares/auth/forward.go
@@ -48,7 +48,7 @@ func Forward(config *types.Forward, w http.ResponseWriter, r *http.Request, next
 		return
 	}
 
-	writeHeader(r, forwardReq, config.TrustForwardHeader)
+	writeHeader(r, forwardReq, config.TrustForwardHeader, config.PassHostHeader)
 
 	tracing.InjectRequestHeaders(forwardReq)
 
@@ -107,7 +107,7 @@ func Forward(config *types.Forward, w http.ResponseWriter, r *http.Request, next
 	next(w, r)
 }
 
-func writeHeader(req *http.Request, forwardReq *http.Request, trustForwardHeader bool) {
+func writeHeader(req *http.Request, forwardReq *http.Request, trustForwardHeader, passHostHeader bool) {
 	utils.CopyHeaders(forwardReq.Header, req.Header)
 	utils.RemoveHeaders(forwardReq.Header, forward.HopHeaders...)
 
@@ -154,5 +154,9 @@ func writeHeader(req *http.Request, forwardReq *http.Request, trustForwardHeader
 		forwardReq.Header.Set(xForwardedURI, req.URL.RequestURI())
 	} else {
 		forwardReq.Header.Del(xForwardedURI)
+	}
+
+	if passHostHeader {
+		forwardReq.Host = req.Host
 	}
 }

--- a/middlewares/auth/forward_test.go
+++ b/middlewares/auth/forward_test.go
@@ -238,6 +238,7 @@ func Test_writeHeader(t *testing.T) {
 		name                      string
 		headers                   map[string]string
 		trustForwardHeader        bool
+		passHostHeader            bool
 		emptyHost                 bool
 		expectedHeaders           map[string]string
 		checkForUnexpectedHeaders bool
@@ -378,7 +379,7 @@ func Test_writeHeader(t *testing.T) {
 
 			forwardReq := testhelpers.MustNewRequest(http.MethodGet, "http://foo.bar/path?q=1", nil)
 
-			writeHeader(req, forwardReq, test.trustForwardHeader)
+			writeHeader(req, forwardReq, test.trustForwardHeader, test.passHostHeader)
 
 			actualHeaders := forwardReq.Header
 			expectedHeaders := test.expectedHeaders

--- a/provider/kubernetes/annotations.go
+++ b/provider/kubernetes/annotations.go
@@ -18,6 +18,7 @@ const (
 	annotationKubernetesAuthForwardTrustHeaders         = "ingress.kubernetes.io/auth-trust-headers"
 	annotationKubernetesAuthForwardTLSSecret            = "ingress.kubernetes.io/auth-tls-secret"
 	annotationKubernetesAuthForwardTLSInsecure          = "ingress.kubernetes.io/auth-tls-insecure"
+	annotationKubernetesAuthForwardPassHostHeader       = "ingress.kubernetes.io/auth-pass-host-header"
 	annotationKubernetesRewriteTarget                   = "ingress.kubernetes.io/rewrite-target"
 	annotationKubernetesWhiteListSourceRange            = "ingress.kubernetes.io/whitelist-source-range"
 	annotationKubernetesWhiteListUseXForwardedFor       = "ingress.kubernetes.io/whitelist-x-forwarded-for"

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -933,6 +933,7 @@ func getForwardAuthConfig(i *extensionsv1beta1.Ingress, k8sClient Client) (*type
 		Address:             authURL,
 		TrustForwardHeader:  getBoolValue(i.Annotations, annotationKubernetesAuthForwardTrustHeaders, false),
 		AuthResponseHeaders: getSliceStringValue(i.Annotations, annotationKubernetesAuthForwardResponseHeaders),
+		PassHostHeader:      getBoolValue(i.Annotations, annotationKubernetesAuthForwardPassHostHeader, false),
 	}
 
 	authSecretName := getStringValue(i.Annotations, annotationKubernetesAuthForwardTLSSecret, "")

--- a/provider/label/names.go
+++ b/provider/label/names.go
@@ -55,6 +55,7 @@ const (
 	SuffixFrontendAuthForwardTLSInsecureSkipVerify              = SuffixFrontendAuthForwardTLS + ".insecureSkipVerify"
 	SuffixFrontendAuthForwardTLSKey                             = SuffixFrontendAuthForwardTLS + ".key"
 	SuffixFrontendAuthForwardTrustForwardHeader                 = SuffixFrontendAuthForward + ".trustForwardHeader"
+	SuffixFrontendAuthForwardPassHostHeader                     = SuffixFrontendAuthForward + ".passHostHeader"
 	SuffixFrontendAuthHeaderField                               = SuffixFrontendAuth + ".headerField"
 	SuffixFrontendEntryPoints                                   = "frontend.entryPoints"
 	SuffixFrontendHeaders                                       = "frontend.headers."
@@ -167,6 +168,7 @@ const (
 	TraefikFrontendAuthForwardTLSInsecureSkipVerify             = Prefix + SuffixFrontendAuthForwardTLSInsecureSkipVerify
 	TraefikFrontendAuthForwardTLSKey                            = Prefix + SuffixFrontendAuthForwardTLSKey
 	TraefikFrontendAuthForwardTrustForwardHeader                = Prefix + SuffixFrontendAuthForwardTrustForwardHeader
+	TraefikFrontendAuthForwardPassHostHeader                    = Prefix + SuffixFrontendAuthForwardPassHostHeader
 	TraefikFrontendAuthHeaderField                              = Prefix + SuffixFrontendAuthHeaderField
 	TraefikFrontendEntryPoints                                  = Prefix + SuffixFrontendEntryPoints
 	TraefikFrontendPassHostHeader                               = Prefix + SuffixFrontendPassHostHeader

--- a/provider/label/partial.go
+++ b/provider/label/partial.go
@@ -163,6 +163,7 @@ func getAuthForward(labels map[string]string) *types.Forward {
 		Address:             GetStringValue(labels, TraefikFrontendAuthForwardAddress, ""),
 		AuthResponseHeaders: GetSliceStringValue(labels, TraefikFrontendAuthForwardAuthResponseHeaders),
 		TrustForwardHeader:  GetBoolValue(labels, TraefikFrontendAuthForwardTrustForwardHeader, false),
+		PassHostHeader:      GetBoolValue(labels, TraefikFrontendAuthForwardPassHostHeader, false),
 	}
 
 	// TLS configuration

--- a/provider/label/partial_test.go
+++ b/provider/label/partial_test.go
@@ -776,12 +776,14 @@ func TestGetAuth(t *testing.T) {
 				TraefikFrontendAuthForwardTLSInsecureSkipVerify: "true",
 				TraefikFrontendAuthForwardTLSKey:                "myKey",
 				TraefikFrontendAuthForwardTLSCert:               "myCert",
+				TraefikFrontendAuthForwardPassHostHeader:        "true",
 			},
 			expected: &types.Auth{
 				HeaderField: "myHeaderField",
 				Forward: &types.Forward{
 					TrustForwardHeader: true,
 					Address:            "myAddress",
+					PassHostHeader:     true,
 					TLS: &types.ClientTLS{
 						InsecureSkipVerify: true,
 						CA:                 "ca.crt",

--- a/templates/docker.tmpl
+++ b/templates/docker.tmpl
@@ -125,6 +125,7 @@
       [frontends."frontend-{{ $frontendName }}".auth.forward]
         address = "{{ $auth.Forward.Address }}"
         trustForwardHeader = {{ $auth.Forward.TrustForwardHeader }}
+        passHostHeader = {{ $auth.Forward.PassHostHeader }}
         {{if $auth.Forward.AuthResponseHeaders }}
         authResponseHeaders = [{{range $auth.Forward.AuthResponseHeaders }}
           "{{.}}",

--- a/templates/kubernetes.tmpl
+++ b/templates/kubernetes.tmpl
@@ -84,6 +84,7 @@
             "{{.}}",
             {{end}}]
           trustForwardHeader = {{ $frontend.Auth.Forward.TrustForwardHeader }}
+          passHostHeader = {{ $frontend.Auth.Forward.PassHostHeader }}
           {{if $frontend.Auth.Forward.TLS }}
           [frontends."{{ $frontendName }}".auth.forward.tls]
             cert = """{{ $frontend.Auth.Forward.TLS.Cert }}"""

--- a/types/types.go
+++ b/types/types.go
@@ -426,6 +426,7 @@ type Forward struct {
 	TLS                 *ClientTLS `description:"Enable TLS support" json:"tls,omitempty" export:"true"`
 	TrustForwardHeader  bool       `description:"Trust X-Forwarded-* headers" json:"trustForwardHeader,omitempty" export:"true"`
 	AuthResponseHeaders []string   `description:"Headers to be forwarded from auth response" json:"authResponseHeaders,omitempty"`
+	PassHostHeader      bool       `description:"Use incoming Host header in requests to authentication server" json:"passHostHeader,omitempty" export:"true"`
 }
 
 // CanonicalDomain returns a lower case domain with trim space


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

Add a PassHostHeader option to forward auth, so that requests to the auth server use the incoming `Host` header, as opposed to inferring the `Host` header from the auth server's address.

This PR is against the 1.7 branch, but I would port it to 2.0 if accepted.

### Motivation

This should enable a few new use-cases for auth servers interacting with incoming requests from multiple separate frontends (e.g.: easier redirecting unauthed reqs to the right domain; doing different auth flows for different vhosts; etc).

My original use-case in #4951 turned out to not quite work as expected, but I still believe this might open up a few use-cases.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

The PR currently only supports docker and k8s providers, because these are the systems I could test on. If it's accepted on principle, I can work on adding support to the other providers.