### PR TITLE
Wrr loadbalancer honors old weight on recovered servers

### DIFF
--- a/healthcheck/healthcheck.go
+++ b/healthcheck/healthcheck.go
@@ -153,16 +153,14 @@ func (hc *HealthCheck) checkBackend(backend *BackendConfig) {
 	for _, url := range enabledURLs {
 		serverUpMetricValue := float64(1)
 		if err := checkHealth(url, backend); err != nil {
-			var weight int
-			var gotWeight bool
+			weight := 1
 			rr, ok := backend.LB.(*roundrobin.RoundRobin)
 			if ok {
+				var gotWeight bool
 				weight, gotWeight = rr.ServerWeight(url)
 				if !gotWeight {
 					weight = 1
 				}
-			} else {
-				weight = 1
 			}
 			log.Warnf("Health check failed: Remove from server list. Backend: %q URL: %q Weight: %d Reason: %s", backend.name, url.String(), weight, err)
 			backend.LB.RemoveServer(url)

--- a/healthcheck/healthcheck_test.go
+++ b/healthcheck/healthcheck_test.go
@@ -112,7 +112,7 @@ func TestSetBackendsConfiguration(t *testing.T) {
 			if test.startHealthy {
 				lb.servers = append(lb.servers, serverURL)
 			} else {
-				backend.disabledURLs = append(backend.disabledURLs, serverURL)
+				backend.disabledURLs = append(backend.disabledURLs, backendURL{serverURL, 1})
 			}
 
 			collectingMetrics := testhelpers.NewCollectingHealthCheckMetrics()


### PR DESCRIPTION
### What does this PR do?

Patches the `checkBackend` method in `healthcheck/healthcheck.go` to preserve the weight of servers that fail a health check, and then restores the weight when a server recovers.


### Motivation

Fixes #2986

I was testing out health checks on my system and discovered that if a server with a very high weight fails and then recovers, it is treated as having a weight of 1 until the server's weight value is modified in any way.


### More

I am not sure if additional tests are required for this change, let me know if they are.

### Additional Notes

I was unable to get the Web UI to function when building from source, even before I made any modifications to Traefik's code, but everything else was working as intended.

Also, I made this change in the v1.7 branch because my current use case requires Consul KV as a provider which isn't in v2 yet. The code in this PR should be able to be fairly easily translated into master branch, however I was told on the Discourse forums that the load balancer for v2 is being rewritten so I'm not sure if it would be necessary.