### PR TITLE
TLSOptions: handle conflict: same host name, different TLS options

### DIFF
--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -332,13 +332,9 @@ It refers to a [TLS Options](../../https/tls.md#tls-options) and will be applied
 
 !!! note "Server Name Association"
 
-    Even though one might get the impression that a TLS options reference is mapped to a router, or a router rule,
-one should realize that it is actually mapped only to the host name found in the `Host` part of the rule.
-Of course, there could also be several `Host` parts in a rule,
-in which case the TLS options reference would be mapped to as many host names.
+    Even though one might get the impression that a TLS options reference is mapped to a router, or a router rule, one should realize that it is actually mapped only to the host name found in the `Host` part of the rule. Of course, there could also be several `Host` parts in a rule, in which case the TLS options reference would be mapped to as many host names.
 
-    Another thing to keep in mind is: the TLS option is picked from the mapping mentioned above
-and based on the server name provided during the TLS handshake, and it all happens before routing actually occurs.
+    Another thing to keep in mind is: the TLS option is picked from the mapping mentioned above and based on the server name provided during the TLS handshake, and it all happens before routing actually occurs.
 
 ??? example "Configuring the TLS options"
 
@@ -381,26 +377,37 @@ and based on the server name provided during the TLS handshake, and it all happe
 
 !!! important "Conflicting TLS Options"
 
-	Since a TLS options reference is mapped to a host name,
-if a configuration introduces a situation where the same host name (from a `Host` rule) gets matched with two TLS options references, a conflict occurs, such as in the example below:
+    Since a TLS options reference is mapped to a host name, if a configuration introduces a situation where the same host name (from a `Host` rule) gets matched with two TLS options references, a conflict occurs, such as in the example below:
 
-
-    ```toml
+    ```toml tab="TOML"
     [http.routers]
       [http.routers.routerfoo]
         rule = "Host(`snitest.com`) && Path(`/foo`)"
         [http.routers.routerfoo.tls]
-            options="foo"
+          options="foo"
 
     [http.routers]
       [http.routers.routerbar]
         rule = "Host(`snitest.com`) && Path(`/bar`)"
         [http.routers.routerbar.tls]
-           options="bar"
+          options="bar"
     ```
 
-	If that happens, both mappings are discarded,
-and the host name (`snitest.com` in this case) for these routers gets matched with the default TLS options instead.
+    ```yaml tab="YAML"
+    http:
+      routers:
+        routerfoo:
+          rule: "Host(`snitest.com`) && Path(`/foo`)"
+          tls:
+            options: foo
+
+        routerbar:
+          rule: "Host(`snitest.com`) && Path(`/bar`)"
+          tls:
+            options: bar
+    ```
+
+    If that happens, both mappings are discarded, and the host name (`snitest.com` in this case) for these routers gets associated with the default TLS options instead.
 
 ## Configuring TCP Routers
 

--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -327,8 +327,18 @@ Traefik will terminate the SSL connections (meaning that it will send decrypted 
 
 #### `Options`
 
-The `Options` field enables fine-grained control of the TLS parameters.  
+The `Options` field enables fine-grained control of the TLS parameters.
 It refers to a [TLS Options](../../https/tls.md#tls-options) and will be applied only if a `Host` rule is defined.
+
+!!! note "Server Name Association"
+
+    Even though one might get the impression that a TLS options reference is mapped to a router, or a router rule,
+one should realize that it is actually mapped only to the host name found in the `Host` part of the rule.
+Of course, there could also be several `Host` parts in a rule,
+in which case the TLS options reference would be mapped to as many host names.
+
+    Another thing to keep in mind is: the TLS option is picked from the mapping mentioned above
+and based on the server name provided during the TLS handshake, and it all happens before routing actually occurs.
 
 ??? example "Configuring the TLS options"
 
@@ -368,6 +378,29 @@ It refers to a [TLS Options](../../https/tls.md#tls-options) and will be applied
           - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
           - TLS_RSA_WITH_AES_256_GCM_SHA384
     ```
+
+!!! important "Conflicting TLS Options"
+
+	Since a TLS options reference is mapped to a host name,
+if a configuration introduces a situation where the same host name (from a `Host` rule) gets matched with two TLS options references, a conflict occurs, such as in the example below:
+
+
+    ```toml
+    [http.routers]
+      [http.routers.routerfoo]
+        rule = "Host(`snitest.com`) && Path(`/foo`)"
+        [http.routers.routerfoo.tls]
+            options="foo"
+
+    [http.routers]
+      [http.routers.routerbar]
+        rule = "Host(`snitest.com`) && Path(`/bar`)"
+        [http.routers.routerbar.tls]
+           options="bar"
+    ```
+
+	If that happens, both mappings are discarded,
+and the host name (`snitest.com` in this case) for these routers gets matched with the default TLS options instead.
 
 ## Configuring TCP Routers
 

--- a/docs/content/user-guides/crd-acme/01-crd.yml
+++ b/docs/content/user-guides/crd-acme/01-crd.yml
@@ -43,6 +43,21 @@ spec:
   scope: Namespaced
 
 ---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tlsoptions.traefik.containo.us
+
+spec:
+  group: traefik.containo.us
+  version: v1alpha1
+  names:
+    kind: TLSOption
+    plural: tlsoptions
+    singular: tlsoption
+  scope: Namespaced
+
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -93,6 +108,14 @@ rules:
       - traefik.containo.us
     resources:
       - ingressroutetcps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.containo.us
+    resources:
+      - tlsoptions
     verbs:
       - get
       - list

--- a/integration/fixtures/https/https_tls_options.toml
+++ b/integration/fixtures/https/https_tls_options.toml
@@ -35,6 +35,18 @@
     [http.routers.router3.tls]
       options = "unknown"
 
+  [http.routers.router4]
+    Service = "service1"
+    Rule = "Host(`snitest.net`)"
+    [http.routers.router4.tls]
+      options = "foo"
+
+  [http.routers.router5]
+    Service = "service1"
+    Rule = "Host(`snitest.net`)"
+    [http.routers.router5.tls]
+      options = "baz"
+
 [http.services]
   [http.services.service1]
     [http.services.service1.loadBalancer]
@@ -59,5 +71,11 @@
   [tls.options.foo]
     minversion = "VersionTLS11"
 
+  [tls.options.baz]
+    minversion = "VersionTLS11"
+
   [tls.options.bar]
+    minversion = "VersionTLS12"
+
+  [tls.options.default]
     minversion = "VersionTLS12"

--- a/integration/fixtures/https/https_tls_options.toml
+++ b/integration/fixtures/https/https_tls_options.toml
@@ -36,14 +36,14 @@
       options = "unknown"
 
   [http.routers.router4]
-    Service = "service1"
-    Rule = "Host(`snitest.net`)"
+    service = "service1"
+    rule = "Host(`snitest.net`)"
     [http.routers.router4.tls]
       options = "foo"
 
   [http.routers.router5]
-    Service = "service1"
-    Rule = "Host(`snitest.net`)"
+    service = "service1"
+    rule = "Host(`snitest.net`)"
     [http.routers.router5.tls]
       options = "baz"
 

--- a/pkg/tcp/router.go
+++ b/pkg/tcp/router.go
@@ -90,7 +90,6 @@ func (r *Router) AddRouteHTTPTLS(sniHost string, config *tls.Config) {
 	if r.hostHTTPTLSConfig == nil {
 		r.hostHTTPTLSConfig = map[string]*tls.Config{}
 	}
-	log.Debugf("adding route %s with minversion %d", sniHost, config.MinVersion)
 	r.hostHTTPTLSConfig[sniHost] = config
 }
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

This PR handles the conflict that occurs when several routers have the same Host in their rule, but have different TLS options associated to that Host.
To address that problem, this PR:
1) Documents the conflict.
2) Warns the user about the situation with log messages.
3) Fallbacks to the default TLS option when such a conflict is detected.

In addition, we took the opportunity to fix some related documentation (about TLS options) in the acme CRD user-guide.

### Motivation

To fix the conflict, which could potentially even have security implications (e.g. when a router would end up using some less strict TLS options than the ones specified by the user).

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Fixes #5046 

Co-authored-by: Julien Salleyron <julien.salleyron@gmail.com>
