### PR TITLE
Add scheme to IngressRoute.

### DIFF
--- a/docs/content/reference/dynamic-configuration/kubernetes-crd.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd.yml
@@ -97,6 +97,12 @@ spec:
       middlewares:
         - name: stripprefix
         - name: addprefix
+    - match: PathPrefix(`/misc`)
+      services:
+        - name: s3
+          port: 8443
+          # scheme allow to override the scheme for the service. (ex: https or h2c)
+          scheme: https
   # use an empty tls object for TLS with Let's Encrypt
   tls:
     secretName: supersecret

--- a/integration/fixtures/k8s/03-ingressroute.yml
+++ b/integration/fixtures/k8s/03-ingressroute.yml
@@ -1,7 +1,7 @@
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/integration/fixtures/k8s/04-ingressroute.yml
+++ b/integration/fixtures/k8s/04-ingressroute.yml
@@ -13,7 +13,7 @@ spec:
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
-  name: test2.crd
+  name: test2.route
   namespace: default
 
 spec:

--- a/integration/testdata/rawdata-crd.json
+++ b/integration/testdata/rawdata-crd.json
@@ -1,24 +1,24 @@
 {
 	"routers": {
-		"default/test.crd-6b204d94623b3df4370c@kubernetescrd": {
+		"default/test.route-6b204d94623b3df4370c@kubernetescrd": {
 			"entryPoints": [
 				"web"
 			],
-			"service": "default/test.crd-6b204d94623b3df4370c",
+			"service": "default/test.route-6b204d94623b3df4370c",
 			"rule": "Host(`foo.com`) \u0026\u0026 PathPrefix(`/bar`)",
 			"priority": 12,
 			"tls": {
 				"options": "default/mytlsoption"
 			}
 		},
-		"default/test2.crd-23c7f4c450289ee29016@kubernetescrd": {
+		"default/test2.route-23c7f4c450289ee29016@kubernetescrd": {
 			"entryPoints": [
 				"web"
 			],
 			"middlewares": [
 				"default/stripprefix"
 			],
-			"service": "default/test2.crd-23c7f4c450289ee29016",
+			"service": "default/test2.route-23c7f4c450289ee29016",
 			"rule": "Host(`foo.com`) \u0026\u0026 PathPrefix(`/tobestripped`)"
 		}
 	},
@@ -30,12 +30,12 @@
 				]
 			},
 			"usedBy": [
-				"default/test2.crd-23c7f4c450289ee29016@kubernetescrd"
+				"default/test2.route-23c7f4c450289ee29016@kubernetescrd"
 			]
 		}
 	},
 	"services": {
-		"default/test.crd-6b204d94623b3df4370c@kubernetescrd": {
+		"default/test.route-6b204d94623b3df4370c@kubernetescrd": {
 			"loadBalancer": {
 				"servers": [
 					{
@@ -48,14 +48,14 @@
 				"passHostHeader": true
 			},
 			"usedBy": [
-				"default/test.crd-6b204d94623b3df4370c@kubernetescrd"
+				"default/test.route-6b204d94623b3df4370c@kubernetescrd"
 			],
 			"serverStatus": {
 				"http://10.42.0.3:80": "UP",
 				"http://10.42.0.5:80": "UP"
 			}
 		},
-		"default/test2.crd-23c7f4c450289ee29016@kubernetescrd": {
+		"default/test2.route-23c7f4c450289ee29016@kubernetescrd": {
 			"loadBalancer": {
 				"servers": [
 					{
@@ -68,7 +68,7 @@
 				"passHostHeader": true
 			},
 			"usedBy": [
-				"default/test2.crd-23c7f4c450289ee29016@kubernetescrd"
+				"default/test2.route-23c7f4c450289ee29016@kubernetescrd"
 			],
 			"serverStatus": {
 				"http://10.42.0.3:80": "UP",

--- a/pkg/provider/kubernetes/crd/fixtures/services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/services.yml
@@ -86,3 +86,34 @@ subsets:
     ports:
       - name: web-secure
         port: 443
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoami3
+  namespace: default
+
+spec:
+  ports:
+    - name: web-secure2
+      port: 8443
+      scheme: https
+  selector:
+    app: containous
+    task: whoami3
+
+---
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: whoami3
+  namespace: default
+
+subsets:
+  - addresses:
+      - ip: 10.10.0.7
+      - ip: 10.10.0.8
+    ports:
+      - name: web-secure2
+        port: 8443

--- a/pkg/provider/kubernetes/crd/fixtures/simple.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/simple.yml
@@ -1,7 +1,7 @@
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/simple.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/simple.yml
@@ -1,7 +1,7 @@
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRouteTCP
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/with_bad_host_rule.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/with_bad_host_rule.yml
@@ -1,7 +1,7 @@
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRouteTCP
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/with_bad_tls_options.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/with_bad_tls_options.yml
@@ -52,7 +52,7 @@ data:
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRouteTCP
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/with_no_rule_value.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/with_no_rule_value.yml
@@ -1,7 +1,7 @@
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRouteTCP
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/with_tls.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/with_tls.yml
@@ -12,7 +12,7 @@ data:
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRouteTCP
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/with_tls_acme.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/with_tls_acme.yml
@@ -1,7 +1,7 @@
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRouteTCP
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/with_tls_options.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/with_tls_options.yml
@@ -51,7 +51,7 @@ data:
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRouteTCP
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/with_tls_options_and_specific_namespace.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/with_tls_options_and_specific_namespace.yml
@@ -51,7 +51,7 @@ data:
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRouteTCP
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/with_tls_passthrough.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/with_tls_passthrough.yml
@@ -12,7 +12,7 @@ data:
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRouteTCP
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/with_two_rules.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/with_two_rules.yml
@@ -1,7 +1,7 @@
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRouteTCP
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/with_two_services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/with_two_services.yml
@@ -1,7 +1,7 @@
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRouteTCP
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/with_unknown_tls_options.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/with_unknown_tls_options.yml
@@ -12,7 +12,7 @@ spec:
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRouteTCP
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/with_unknown_tls_options_namespace.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/with_unknown_tls_options_namespace.yml
@@ -12,7 +12,7 @@ spec:
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRouteTCP
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/with_bad_host_rule.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_bad_host_rule.yml
@@ -1,7 +1,7 @@
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/with_bad_tls_options.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_bad_tls_options.yml
@@ -41,7 +41,7 @@ spec:
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/with_https_default.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_https_default.yml
@@ -1,7 +1,7 @@
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/with_https_scheme.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_https_scheme.yml
@@ -1,0 +1,18 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: test.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+  - match: Host(`foo.com`) && PathPrefix(`/bar`)
+    kind: Rule
+    priority: 12
+    services:
+    - name: whoami3
+      port: 8443
+      scheme: https

--- a/pkg/provider/kubernetes/crd/fixtures/with_middleware.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_middleware.yml
@@ -24,7 +24,7 @@ spec:
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
-  name: test2.crd
+  name: test2.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/with_middleware_crossprovider.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_middleware_crossprovider.yml
@@ -24,7 +24,7 @@ spec:
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
-  name: test2.crd
+  name: test2.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/with_no_rule_value.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_no_rule_value.yml
@@ -1,7 +1,7 @@
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/with_tls.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_tls.yml
@@ -12,7 +12,7 @@ data:
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/with_tls_acme.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_tls_acme.yml
@@ -1,7 +1,7 @@
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/with_tls_options.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_tls_options.yml
@@ -40,7 +40,7 @@ spec:
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/with_tls_options_and_specific_namespace.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_tls_options_and_specific_namespace.yml
@@ -40,7 +40,7 @@ spec:
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/with_two_rules.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_two_rules.yml
@@ -1,7 +1,7 @@
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/with_two_services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_two_services.yml
@@ -1,7 +1,7 @@
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/with_unknown_tls_options.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_unknown_tls_options.yml
@@ -11,7 +11,7 @@ spec:
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/with_unknown_tls_options_namespace.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_unknown_tls_options_namespace.yml
@@ -11,7 +11,7 @@ spec:
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/fixtures/with_wrong_rule_kind.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_wrong_rule_kind.yml
@@ -1,7 +1,7 @@
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
-  name: test.crd
+  name: test.route
   namespace: default
 
 spec:

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -278,10 +278,15 @@ func loadServers(client Client, namespace string, svc v1alpha1.Service) ([]confi
 			}
 
 			protocol := "http"
-			if svc.Scheme != "" {
+			switch svc.Scheme {
+			case "http", "https", "h2c":
 				protocol = svc.Scheme
-			} else if port == 443 || strings.HasPrefix(portSpec.Name, "https") {
-				protocol = "https"
+			case "":
+				if port == 443 || strings.HasPrefix(portSpec.Name, "https") {
+					protocol = "https"
+				}
+			default:
+				return nil, fmt.Errorf("invalid scheme %q specified", svc.Scheme)
 			}
 
 			for _, addr := range subset.Addresses {

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -278,7 +278,9 @@ func loadServers(client Client, namespace string, svc v1alpha1.Service) ([]confi
 			}
 
 			protocol := "http"
-			if port == 443 || strings.HasPrefix(portSpec.Name, "https") {
+			if svc.Scheme != "" {
+				protocol = svc.Scheme
+			} else if port == 443 || strings.HasPrefix(portSpec.Name, "https") {
 				protocol = "https"
 			}
 

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -1338,6 +1338,43 @@ func TestLoadIngressRoutes(t *testing.T) {
 			},
 		},
 		{
+			desc:  "Simple Ingress Route, explicit https scheme",
+			paths: []string{"services.yml", "with_https_scheme.yml"},
+			expected: &config.Configuration{
+				TLS: &config.TLSConfiguration{},
+				TCP: &config.TCPConfiguration{
+					Routers:  map[string]*config.TCPRouter{},
+					Services: map[string]*config.TCPService{},
+				},
+				HTTP: &config.HTTPConfiguration{
+					Routers: map[string]*config.Router{
+						"default/test.route-6b204d94623b3df4370c": {
+							EntryPoints: []string{"foo"},
+							Service:     "default/test.route-6b204d94623b3df4370c",
+							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
+							Priority:    12,
+						},
+					},
+					Middlewares: map[string]*config.Middleware{},
+					Services: map[string]*config.Service{
+						"default/test.route-6b204d94623b3df4370c": {
+							LoadBalancer: &config.LoadBalancerService{
+								Servers: []config.Server{
+									{
+										URL: "https://10.10.0.7:8443",
+									},
+									{
+										URL: "https://10.10.0.8:8443",
+									},
+								},
+								PassHostHeader: true,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			desc: "port selected by name (TODO)",
 		},
 	}

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -45,14 +45,14 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 				},
 				TCP: &config.TCPConfiguration{
 					Routers: map[string]*config.TCPRouter{
-						"default/test.crd-fdd3e9338e47a45efefc": {
+						"default/test.route-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.crd-fdd3e9338e47a45efefc",
+							Service:     "default/test.route-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 						},
 					},
 					Services: map[string]*config.TCPService{
-						"default/test.crd-fdd3e9338e47a45efefc": {
+						"default/test.route-fdd3e9338e47a45efefc": {
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
 									{
@@ -77,19 +77,19 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 			expected: &config.Configuration{
 				TCP: &config.TCPConfiguration{
 					Routers: map[string]*config.TCPRouter{
-						"default/test.crd-fdd3e9338e47a45efefc": {
+						"default/test.route-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.crd-fdd3e9338e47a45efefc",
+							Service:     "default/test.route-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 						},
-						"default/test.crd-f44ce589164e656d231c": {
+						"default/test.route-f44ce589164e656d231c": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.crd-f44ce589164e656d231c",
+							Service:     "default/test.route-f44ce589164e656d231c",
 							Rule:        "HostSNI(`bar.com`)",
 						},
 					},
 					Services: map[string]*config.TCPService{
-						"default/test.crd-fdd3e9338e47a45efefc": {
+						"default/test.route-fdd3e9338e47a45efefc": {
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
 									{
@@ -103,7 +103,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 								},
 							},
 						},
-						"default/test.crd-f44ce589164e656d231c": {
+						"default/test.route-f44ce589164e656d231c": {
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
 									{
@@ -133,14 +133,14 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 			expected: &config.Configuration{
 				TCP: &config.TCPConfiguration{
 					Routers: map[string]*config.TCPRouter{
-						"default/test.crd-fdd3e9338e47a45efefc": {
+						"default/test.route-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.crd-fdd3e9338e47a45efefc",
+							Service:     "default/test.route-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 						},
 					},
 					Services: map[string]*config.TCPService{
-						"default/test.crd-fdd3e9338e47a45efefc": {
+						"default/test.route-fdd3e9338e47a45efefc": {
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
 									{
@@ -236,15 +236,15 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 				},
 				TCP: &config.TCPConfiguration{
 					Routers: map[string]*config.TCPRouter{
-						"default/test.crd-fdd3e9338e47a45efefc": {
+						"default/test.route-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.crd-fdd3e9338e47a45efefc",
+							Service:     "default/test.route-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 							TLS:         &config.RouterTCPTLSConfig{},
 						},
 					},
 					Services: map[string]*config.TCPService{
-						"default/test.crd-fdd3e9338e47a45efefc": {
+						"default/test.route-fdd3e9338e47a45efefc": {
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
 									{
@@ -273,9 +273,9 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 			expected: &config.Configuration{
 				TCP: &config.TCPConfiguration{
 					Routers: map[string]*config.TCPRouter{
-						"default/test.crd-fdd3e9338e47a45efefc": {
+						"default/test.route-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.crd-fdd3e9338e47a45efefc",
+							Service:     "default/test.route-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 							TLS: &config.RouterTCPTLSConfig{
 								Passthrough: true,
@@ -283,7 +283,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 						},
 					},
 					Services: map[string]*config.TCPService{
-						"default/test.crd-fdd3e9338e47a45efefc": {
+						"default/test.route-fdd3e9338e47a45efefc": {
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
 									{
@@ -332,9 +332,9 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 				},
 				TCP: &config.TCPConfiguration{
 					Routers: map[string]*config.TCPRouter{
-						"default/test.crd-fdd3e9338e47a45efefc": {
+						"default/test.route-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.crd-fdd3e9338e47a45efefc",
+							Service:     "default/test.route-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 							TLS: &config.RouterTCPTLSConfig{
 								Options: "default/foo",
@@ -342,7 +342,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 						},
 					},
 					Services: map[string]*config.TCPService{
-						"default/test.crd-fdd3e9338e47a45efefc": {
+						"default/test.route-fdd3e9338e47a45efefc": {
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
 									{
@@ -390,9 +390,9 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 				},
 				TCP: &config.TCPConfiguration{
 					Routers: map[string]*config.TCPRouter{
-						"default/test.crd-fdd3e9338e47a45efefc": {
+						"default/test.route-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.crd-fdd3e9338e47a45efefc",
+							Service:     "default/test.route-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 							TLS: &config.RouterTCPTLSConfig{
 								Options: "myns/foo",
@@ -400,7 +400,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 						},
 					},
 					Services: map[string]*config.TCPService{
-						"default/test.crd-fdd3e9338e47a45efefc": {
+						"default/test.route-fdd3e9338e47a45efefc": {
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
 									{
@@ -447,9 +447,9 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 				},
 				TCP: &config.TCPConfiguration{
 					Routers: map[string]*config.TCPRouter{
-						"default/test.crd-fdd3e9338e47a45efefc": {
+						"default/test.route-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.crd-fdd3e9338e47a45efefc",
+							Service:     "default/test.route-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 							TLS: &config.RouterTCPTLSConfig{
 								Options: "default/foo",
@@ -457,7 +457,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 						},
 					},
 					Services: map[string]*config.TCPService{
-						"default/test.crd-fdd3e9338e47a45efefc": {
+						"default/test.route-fdd3e9338e47a45efefc": {
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
 									{
@@ -493,9 +493,9 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 				},
 				TCP: &config.TCPConfiguration{
 					Routers: map[string]*config.TCPRouter{
-						"default/test.crd-fdd3e9338e47a45efefc": {
+						"default/test.route-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.crd-fdd3e9338e47a45efefc",
+							Service:     "default/test.route-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 							TLS: &config.RouterTCPTLSConfig{
 								Options: "default/unknown",
@@ -503,7 +503,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 						},
 					},
 					Services: map[string]*config.TCPService{
-						"default/test.crd-fdd3e9338e47a45efefc": {
+						"default/test.route-fdd3e9338e47a45efefc": {
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
 									{
@@ -539,9 +539,9 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 				},
 				TCP: &config.TCPConfiguration{
 					Routers: map[string]*config.TCPRouter{
-						"default/test.crd-fdd3e9338e47a45efefc": {
+						"default/test.route-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.crd-fdd3e9338e47a45efefc",
+							Service:     "default/test.route-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 							TLS: &config.RouterTCPTLSConfig{
 								Options: "unknown/foo",
@@ -549,7 +549,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 						},
 					},
 					Services: map[string]*config.TCPService{
-						"default/test.crd-fdd3e9338e47a45efefc": {
+						"default/test.route-fdd3e9338e47a45efefc": {
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
 									{
@@ -578,15 +578,15 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 			expected: &config.Configuration{
 				TCP: &config.TCPConfiguration{
 					Routers: map[string]*config.TCPRouter{
-						"default/test.crd-fdd3e9338e47a45efefc": {
+						"default/test.route-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.crd-fdd3e9338e47a45efefc",
+							Service:     "default/test.route-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 							TLS:         &config.RouterTCPTLSConfig{},
 						},
 					},
 					Services: map[string]*config.TCPService{
-						"default/test.crd-fdd3e9338e47a45efefc": {
+						"default/test.route-fdd3e9338e47a45efefc": {
 							LoadBalancer: &config.TCPLoadBalancerService{
 								Servers: []config.TCPServer{
 									{
@@ -661,16 +661,16 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &config.HTTPConfiguration{
 					Routers: map[string]*config.Router{
-						"default/test.crd-6b204d94623b3df4370c": {
+						"default/test.route-6b204d94623b3df4370c": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.crd-6b204d94623b3df4370c",
+							Service:     "default/test.route-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 						},
 					},
 					Middlewares: map[string]*config.Middleware{},
 					Services: map[string]*config.Service{
-						"default/test.crd-6b204d94623b3df4370c": {
+						"default/test.route-6b204d94623b3df4370c": {
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
 									{
@@ -698,9 +698,9 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &config.HTTPConfiguration{
 					Routers: map[string]*config.Router{
-						"default/test2.crd-23c7f4c450289ee29016": {
+						"default/test2.route-23c7f4c450289ee29016": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test2.crd-23c7f4c450289ee29016",
+							Service:     "default/test2.route-23c7f4c450289ee29016",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/tobestripped`)",
 							Priority:    12,
 							Middlewares: []string{"default/stripprefix", "foo/addprefix"},
@@ -719,7 +719,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 						},
 					},
 					Services: map[string]*config.Service{
-						"default/test2.crd-23c7f4c450289ee29016": {
+						"default/test2.route-23c7f4c450289ee29016": {
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
 									{
@@ -748,9 +748,9 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &config.HTTPConfiguration{
 					Routers: map[string]*config.Router{
-						"default/test2.crd-23c7f4c450289ee29016": {
+						"default/test2.route-23c7f4c450289ee29016": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test2.crd-23c7f4c450289ee29016",
+							Service:     "default/test2.route-23c7f4c450289ee29016",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/tobestripped`)",
 							Priority:    12,
 							Middlewares: []string{"default/stripprefix", "foo/addprefix", "basicauth@file", "redirect@file"},
@@ -769,7 +769,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 						},
 					},
 					Services: map[string]*config.Service{
-						"default/test2.crd-23c7f4c450289ee29016": {
+						"default/test2.route-23c7f4c450289ee29016": {
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
 									{
@@ -796,22 +796,22 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &config.HTTPConfiguration{
 					Routers: map[string]*config.Router{
-						"default/test.crd-6b204d94623b3df4370c": {
+						"default/test.route-6b204d94623b3df4370c": {
 							EntryPoints: []string{"web"},
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
-							Service:     "default/test.crd-6b204d94623b3df4370c",
+							Service:     "default/test.route-6b204d94623b3df4370c",
 							Priority:    14,
 						},
-						"default/test.crd-77c62dfe9517144aeeaa": {
+						"default/test.route-77c62dfe9517144aeeaa": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test.crd-77c62dfe9517144aeeaa",
+							Service:     "default/test.route-77c62dfe9517144aeeaa",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/foo`)",
 							Priority:    12,
 						},
 					},
 					Middlewares: map[string]*config.Middleware{},
 					Services: map[string]*config.Service{
-						"default/test.crd-6b204d94623b3df4370c": {
+						"default/test.route-6b204d94623b3df4370c": {
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
 									{
@@ -824,7 +824,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 								PassHostHeader: true,
 							},
 						},
-						"default/test.crd-77c62dfe9517144aeeaa": {
+						"default/test.route-77c62dfe9517144aeeaa": {
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
 									{
@@ -853,16 +853,16 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &config.HTTPConfiguration{
 					Routers: map[string]*config.Router{
-						"default/test.crd-77c62dfe9517144aeeaa": {
+						"default/test.route-77c62dfe9517144aeeaa": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test.crd-77c62dfe9517144aeeaa",
+							Service:     "default/test.route-77c62dfe9517144aeeaa",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/foo`)",
 							Priority:    12,
 						},
 					},
 					Middlewares: map[string]*config.Middleware{},
 					Services: map[string]*config.Service{
-						"default/test.crd-77c62dfe9517144aeeaa": {
+						"default/test.route-77c62dfe9517144aeeaa": {
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
 									{
@@ -970,9 +970,9 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &config.HTTPConfiguration{
 					Routers: map[string]*config.Router{
-						"default/test.crd-6b204d94623b3df4370c": {
+						"default/test.route-6b204d94623b3df4370c": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test.crd-6b204d94623b3df4370c",
+							Service:     "default/test.route-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 							TLS:         &config.RouterTLSConfig{},
@@ -980,7 +980,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 					},
 					Middlewares: map[string]*config.Middleware{},
 					Services: map[string]*config.Service{
-						"default/test.crd-6b204d94623b3df4370c": {
+						"default/test.route-6b204d94623b3df4370c": {
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
 									{
@@ -1026,9 +1026,9 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &config.HTTPConfiguration{
 					Routers: map[string]*config.Router{
-						"default/test.crd-6b204d94623b3df4370c": {
+						"default/test.route-6b204d94623b3df4370c": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test.crd-6b204d94623b3df4370c",
+							Service:     "default/test.route-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 							TLS: &config.RouterTLSConfig{
@@ -1038,7 +1038,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 					},
 					Middlewares: map[string]*config.Middleware{},
 					Services: map[string]*config.Service{
-						"default/test.crd-6b204d94623b3df4370c": {
+						"default/test.route-6b204d94623b3df4370c": {
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
 									{
@@ -1084,9 +1084,9 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &config.HTTPConfiguration{
 					Routers: map[string]*config.Router{
-						"default/test.crd-6b204d94623b3df4370c": {
+						"default/test.route-6b204d94623b3df4370c": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test.crd-6b204d94623b3df4370c",
+							Service:     "default/test.route-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 							TLS: &config.RouterTLSConfig{
@@ -1096,7 +1096,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 					},
 					Middlewares: map[string]*config.Middleware{},
 					Services: map[string]*config.Service{
-						"default/test.crd-6b204d94623b3df4370c": {
+						"default/test.route-6b204d94623b3df4370c": {
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
 									{
@@ -1141,9 +1141,9 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &config.HTTPConfiguration{
 					Routers: map[string]*config.Router{
-						"default/test.crd-6b204d94623b3df4370c": {
+						"default/test.route-6b204d94623b3df4370c": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test.crd-6b204d94623b3df4370c",
+							Service:     "default/test.route-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 							TLS: &config.RouterTLSConfig{
@@ -1153,7 +1153,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 					},
 					Middlewares: map[string]*config.Middleware{},
 					Services: map[string]*config.Service{
-						"default/test.crd-6b204d94623b3df4370c": {
+						"default/test.route-6b204d94623b3df4370c": {
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
 									{
@@ -1187,9 +1187,9 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &config.HTTPConfiguration{
 					Routers: map[string]*config.Router{
-						"default/test.crd-6b204d94623b3df4370c": {
+						"default/test.route-6b204d94623b3df4370c": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test.crd-6b204d94623b3df4370c",
+							Service:     "default/test.route-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 							TLS: &config.RouterTLSConfig{
@@ -1199,7 +1199,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 					},
 					Middlewares: map[string]*config.Middleware{},
 					Services: map[string]*config.Service{
-						"default/test.crd-6b204d94623b3df4370c": {
+						"default/test.route-6b204d94623b3df4370c": {
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
 									{
@@ -1233,9 +1233,9 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &config.HTTPConfiguration{
 					Routers: map[string]*config.Router{
-						"default/test.crd-6b204d94623b3df4370c": {
+						"default/test.route-6b204d94623b3df4370c": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test.crd-6b204d94623b3df4370c",
+							Service:     "default/test.route-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 							TLS: &config.RouterTLSConfig{
@@ -1245,7 +1245,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 					},
 					Middlewares: map[string]*config.Middleware{},
 					Services: map[string]*config.Service{
-						"default/test.crd-6b204d94623b3df4370c": {
+						"default/test.route-6b204d94623b3df4370c": {
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
 									{
@@ -1273,9 +1273,9 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &config.HTTPConfiguration{
 					Routers: map[string]*config.Router{
-						"default/test.crd-6b204d94623b3df4370c": {
+						"default/test.route-6b204d94623b3df4370c": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test.crd-6b204d94623b3df4370c",
+							Service:     "default/test.route-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 							TLS:         &config.RouterTLSConfig{},
@@ -1283,7 +1283,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 					},
 					Middlewares: map[string]*config.Middleware{},
 					Services: map[string]*config.Service{
-						"default/test.crd-6b204d94623b3df4370c": {
+						"default/test.route-6b204d94623b3df4370c": {
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
 									{
@@ -1311,16 +1311,16 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &config.HTTPConfiguration{
 					Routers: map[string]*config.Router{
-						"default/test.crd-6b204d94623b3df4370c": {
+						"default/test.route-6b204d94623b3df4370c": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.crd-6b204d94623b3df4370c",
+							Service:     "default/test.route-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 						},
 					},
 					Middlewares: map[string]*config.Middleware{},
 					Services: map[string]*config.Service{
-						"default/test.crd-6b204d94623b3df4370c": {
+						"default/test.route-6b204d94623b3df4370c": {
 							LoadBalancer: &config.LoadBalancerService{
 								Servers: []config.Server{
 									{

--- a/pkg/provider/kubernetes/crd/traefik/v1alpha1/ingressroute.go
+++ b/pkg/provider/kubernetes/crd/traefik/v1alpha1/ingressroute.go
@@ -45,6 +45,7 @@ type TLSOptionRef struct {
 type Service struct {
 	Name        string       `json:"name"`
 	Port        int32        `json:"port"`
+	Scheme      string       `json:"scheme,omitempty"`
 	HealthCheck *HealthCheck `json:"healthCheck,omitempty"`
 	Strategy    string       `json:"strategy,omitempty"`
 }


### PR DESCRIPTION
### What does this PR do?

Allows to override the scheme for a service inside an IngressRoute.

Closes  #5044

### Motivation

Be able to specify schemes as `https` or `h2c`.


### More

- [x] Added/updated tests
- [x] Added/updated documentation
