### PR TITLE
Add Jaeger collector endpoint

### DIFF
--- a/docs/content/observability/tracing/jaeger.md
+++ b/docs/content/observability/tracing/jaeger.md
@@ -146,7 +146,8 @@ This must be in lower-case to avoid mismatches when decoding incoming headers.
 --tracing.jaeger.traceContextHeaderName="uber-trace-id"
 ```
 
-#### `collectorEndpoint`
+### `collector`
+#### `endpoint`
 
 _Optional, Default=""_
 
@@ -154,13 +155,13 @@ Collector Endpoint instructs reporter to send spans to jaeger-collector at this 
 
 ```toml tab="File"
 [tracing]
-  [tracing.jaeger]
-    collectorEndpoint = "http://127.0.0.1:14268/api/traces?format=jaeger.thrift"
+  [tracing.jaeger.collector]
+    endpoint = "http://127.0.0.1:14268/api/traces?format=jaeger.thrift"
 ```
 
 ```bash tab="CLI"
 --tracing
---tracing.jaeger.collectorEndpoint="http://127.0.0.1:14268/api/traces?format=jaeger.thrift"
+--tracing.jaeger.collector.endpoint="http://127.0.0.1:14268/api/traces?format=jaeger.thrift"
 ```
 
 #### `user`
@@ -171,13 +172,13 @@ User instructs reporter to include a user for basic http authentication when sen
 
 ```toml tab="File"
 [tracing]
-  [tracing.jaeger]
+  [tracing.jaeger.collector]
     user = "my-user"
 ```
 
 ```bash tab="CLI"
 --tracing
---tracing.jaeger.user="my-user"
+--tracing.jaeger.collector.user="my-user"
 ```
 
 #### `password`
@@ -188,11 +189,11 @@ Password instructs reporter to include a password for basic http authentication 
 
 ```toml tab="File"
 [tracing]
-  [tracing.jaeger]
+  [tracing.jaeger.collector]
     password = "my-password"
 ```
 
 ```bash tab="CLI"
 --tracing
---tracing.jaeger.password="my-password"
+--tracing.jaeger.collector.password="my-password"
 ```

--- a/docs/content/observability/tracing/jaeger.md
+++ b/docs/content/observability/tracing/jaeger.md
@@ -13,7 +13,8 @@ To enable the Jaeger:
 ```
 
 !!! warning
-    Traefik is only able to send data over the compact thrift protocol to the [Jaeger agent](https://www.jaegertracing.io/docs/deployment/#agent).
+    Traefik is only able to send data over the compact thrift protocol to the [Jaeger agent](https://www.jaegertracing.io/docs/deployment/#agent)
+    or a [Jaeger collector](https://www.jaegertracing.io/docs/deployment/#collectors).
 
 #### `samplingServerURL`
 
@@ -143,4 +144,55 @@ This must be in lower-case to avoid mismatches when decoding incoming headers.
 ```bash tab="CLI"
 --tracing
 --tracing.jaeger.traceContextHeaderName="uber-trace-id"
+```
+
+#### `collectorEndpoint`
+
+_Optional, Default=""_
+
+Collector Endpoint instructs reporter to send spans to jaeger-collector at this URL.
+
+```toml tab="File"
+[tracing]
+  [tracing.jaeger]
+    collectorEndpoint = "http://127.0.0.1:14268/"
+```
+
+```bash tab="CLI"
+--tracing
+--tracing.jaeger.collectorEndpoint="http://127.0.0.1:14268/"
+```
+
+#### `user`
+
+_Optional, Default=""_
+
+User instructs reporter to include a user for basic http authentication when sending spans to jaeger-collector.
+
+```toml tab="File"
+[tracing]
+  [tracing.jaeger]
+    user = "my-user"
+```
+
+```bash tab="CLI"
+--tracing
+--tracing.jaeger.user="my-user"
+```
+
+#### `password`
+
+_Optional, Default=""_
+
+Password instructs reporter to include a password for basic http authentication when sending spans to jaeger-collector.
+
+```toml tab="File"
+[tracing]
+  [tracing.jaeger]
+    password = "my-password"
+```
+
+```bash tab="CLI"
+--tracing
+--tracing.jaeger.password="my-password"
 ```

--- a/docs/content/observability/tracing/jaeger.md
+++ b/docs/content/observability/tracing/jaeger.md
@@ -13,7 +13,7 @@ To enable the Jaeger:
 ```
 
 !!! warning
-    Traefik is only able to send data over the compact thrift protocol to the [Jaeger agent](https://www.jaegertracing.io/docs/deployment/#agent)
+    Traefik is able to send data over the compact thrift protocol to the [Jaeger agent](https://www.jaegertracing.io/docs/deployment/#agent)
     or a [Jaeger collector](https://www.jaegertracing.io/docs/deployment/#collectors).
 
 #### `samplingServerURL`
@@ -155,12 +155,12 @@ Collector Endpoint instructs reporter to send spans to jaeger-collector at this 
 ```toml tab="File"
 [tracing]
   [tracing.jaeger]
-    collectorEndpoint = "http://127.0.0.1:14268/"
+    collectorEndpoint = "http://127.0.0.1:14268/api/traces?format=jaeger.thrift"
 ```
 
 ```bash tab="CLI"
 --tracing
---tracing.jaeger.collectorEndpoint="http://127.0.0.1:14268/"
+--tracing.jaeger.collectorEndpoint="http://127.0.0.1:14268/api/traces?format=jaeger.thrift"
 ```
 
 #### `user`

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -540,8 +540,14 @@ Set instana-agent's log level. ('error','warn','info','debug') (Default: ```info
 `--tracing.jaeger`:  
 Settings for Jaeger. (Default: ```false```)
 
-`--tracing.jaeger.collectorendpoint`:  
+`--tracing.jaeger.collector.endpoint`:  
 Instructs reporter to send spans to jaeger-collector at this URL.
+
+`--tracing.jaeger.collector.password`:  
+Password for basic http authentication when sending spans to jaeger-collector.
+
+`--tracing.jaeger.collector.user`:  
+User for basic http authentication when sending spans to jaeger-collector.
 
 `--tracing.jaeger.gen128bit`:  
 Generate 128 bit span IDs. (Default: ```false```)
@@ -549,11 +555,8 @@ Generate 128 bit span IDs. (Default: ```false```)
 `--tracing.jaeger.localagenthostport`:  
 Set jaeger-agent's host:port that the reporter will used. (Default: ```127.0.0.1:6831```)
 
-`--tracing.jaeger.password`:  
-Password for basic http authentication when sending spans to jaeger-collector.
-
 `--tracing.jaeger.propagation`:  
-Which propgation format to use (jaeger/b3). (Default: ```jaeger```)
+Which propagation format to use (jaeger/b3). (Default: ```jaeger```)
 
 `--tracing.jaeger.samplingparam`:  
 Set the sampling parameter. (Default: ```1.000000```)
@@ -566,9 +569,6 @@ Set the sampling type. (Default: ```const```)
 
 `--tracing.jaeger.tracecontextheadername`:  
 Set the header to use for the trace-id. (Default: ```uber-trace-id```)
-
-`--tracing.jaeger.user`:  
-User for basic http authentication when sending spans to jaeger-collector.
 
 `--tracing.servicename`:  
 Set the name for this service. (Default: ```traefik```)

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -540,11 +540,17 @@ Set instana-agent's log level. ('error','warn','info','debug') (Default: ```info
 `--tracing.jaeger`:  
 Settings for Jaeger. (Default: ```false```)
 
+`--tracing.jaeger.collectorendpoint`:  
+Instructs reporter to send spans to jaeger-collector at this URL.
+
 `--tracing.jaeger.gen128bit`:  
 Generate 128 bit span IDs. (Default: ```false```)
 
 `--tracing.jaeger.localagenthostport`:  
 Set jaeger-agent's host:port that the reporter will used. (Default: ```127.0.0.1:6831```)
+
+`--tracing.jaeger.password`:  
+Password for basic http authentication when sending spans to jaeger-collector.
 
 `--tracing.jaeger.propagation`:  
 Which propgation format to use (jaeger/b3). (Default: ```jaeger```)
@@ -560,6 +566,9 @@ Set the sampling type. (Default: ```const```)
 
 `--tracing.jaeger.tracecontextheadername`:  
 Set the header to use for the trace-id. (Default: ```uber-trace-id```)
+
+`--tracing.jaeger.user`:  
+User for basic http authentication when sending spans to jaeger-collector.
 
 `--tracing.servicename`:  
 Set the name for this service. (Default: ```traefik```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -540,8 +540,14 @@ Set instana-agent's log level. ('error','warn','info','debug') (Default: ```info
 `TRAEFIK_TRACING_JAEGER`:  
 Settings for Jaeger. (Default: ```false```)
 
-`TRAEFIK_TRACING_JAEGER_COLLECTORENDPOINT`:  
+`TRAEFIK_TRACING_JAEGER_COLLECTOR_ENDPOINT`:  
 Instructs reporter to send spans to jaeger-collector at this URL.
+
+`TRAEFIK_TRACING_JAEGER_COLLECTOR_PASSWORD`:  
+Password for basic http authentication when sending spans to jaeger-collector.
+
+`TRAEFIK_TRACING_JAEGER_COLLECTOR_USER`:  
+User for basic http authentication when sending spans to jaeger-collector.
 
 `TRAEFIK_TRACING_JAEGER_GEN128BIT`:  
 Generate 128 bit span IDs. (Default: ```false```)
@@ -549,11 +555,8 @@ Generate 128 bit span IDs. (Default: ```false```)
 `TRAEFIK_TRACING_JAEGER_LOCALAGENTHOSTPORT`:  
 Set jaeger-agent's host:port that the reporter will used. (Default: ```127.0.0.1:6831```)
 
-`TRAEFIK_TRACING_JAEGER_PASSWORD`:  
-Password for basic http authentication when sending spans to jaeger-collector.
-
 `TRAEFIK_TRACING_JAEGER_PROPAGATION`:  
-Which propgation format to use (jaeger/b3). (Default: ```jaeger```)
+Which propagation format to use (jaeger/b3). (Default: ```jaeger```)
 
 `TRAEFIK_TRACING_JAEGER_SAMPLINGPARAM`:  
 Set the sampling parameter. (Default: ```1.000000```)
@@ -566,9 +569,6 @@ Set the sampling type. (Default: ```const```)
 
 `TRAEFIK_TRACING_JAEGER_TRACECONTEXTHEADERNAME`:  
 Set the header to use for the trace-id. (Default: ```uber-trace-id```)
-
-`TRAEFIK_TRACING_JAEGER_USER`:  
-User for basic http authentication when sending spans to jaeger-collector.
 
 `TRAEFIK_TRACING_SERVICENAME`:  
 Set the name for this service. (Default: ```traefik```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -540,11 +540,17 @@ Set instana-agent's log level. ('error','warn','info','debug') (Default: ```info
 `TRAEFIK_TRACING_JAEGER`:  
 Settings for Jaeger. (Default: ```false```)
 
+`TRAEFIK_TRACING_JAEGER_COLLECTORENDPOINT`:  
+Instructs reporter to send spans to jaeger-collector at this URL.
+
 `TRAEFIK_TRACING_JAEGER_GEN128BIT`:  
 Generate 128 bit span IDs. (Default: ```false```)
 
 `TRAEFIK_TRACING_JAEGER_LOCALAGENTHOSTPORT`:  
 Set jaeger-agent's host:port that the reporter will used. (Default: ```127.0.0.1:6831```)
+
+`TRAEFIK_TRACING_JAEGER_PASSWORD`:  
+Password for basic http authentication when sending spans to jaeger-collector.
 
 `TRAEFIK_TRACING_JAEGER_PROPAGATION`:  
 Which propgation format to use (jaeger/b3). (Default: ```jaeger```)
@@ -560,6 +566,9 @@ Set the sampling type. (Default: ```const```)
 
 `TRAEFIK_TRACING_JAEGER_TRACECONTEXTHEADERNAME`:  
 Set the header to use for the trace-id. (Default: ```uber-trace-id```)
+
+`TRAEFIK_TRACING_JAEGER_USER`:  
+User for basic http authentication when sending spans to jaeger-collector.
 
 `TRAEFIK_TRACING_SERVICENAME`:  
 Set the name for this service. (Default: ```traefik```)

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -174,6 +174,9 @@
     gen128Bit = true
     propagation = "foobar"
     traceContextHeaderName = "foobar"
+    collectorEndpoint = "foobar"
+    user = "foobar"
+    password = "foobar"
   [tracing.zipkin]
     httpEndpoint = "foobar"
     sameSpan = true

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -174,9 +174,10 @@
     gen128Bit = true
     propagation = "foobar"
     traceContextHeaderName = "foobar"
-    collectorEndpoint = "foobar"
-    user = "foobar"
-    password = "foobar"
+    [tracing.jaeger.collector]
+      endpoint = "foobar"
+      user = "foobar"
+      password = "foobar"
   [tracing.zipkin]
     httpEndpoint = "foobar"
     sameSpan = true

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -185,9 +185,10 @@ tracing:
     gen128Bit: true
     propagation: foobar
     traceContextHeaderName: foobar
-    collectorEndpoint: foobar
-    user: foobar
-    password: foobar
+    collector:
+      endpoint: foobar
+      user: foobar
+      password: foobar
   zipkin:
     httpEndpoint: foobar
     sameSpan: true

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -185,6 +185,9 @@ tracing:
     gen128Bit: true
     propagation: foobar
     traceContextHeaderName: foobar
+    collectorEndpoint: foobar
+    user: foobar
+    password: foobar
   zipkin:
     httpEndpoint: foobar
     sameSpan: true

--- a/integration/fixtures/tracing/simple-jaeger-collector.toml
+++ b/integration/fixtures/tracing/simple-jaeger-collector.toml
@@ -19,8 +19,8 @@
     samplingServerURL = "http://{{.IP}}:5778/sampling"
     collectorEndpoint = "http://{{.IP}}:14268/api/traces?format=jaeger.thrift"
 
-[providers]
-  [providers.file]
+[providers.file]
+  filename = "{{ .SelfFilename }}"
 
 ## dynamic configuration ##
 

--- a/integration/fixtures/tracing/simple-jaeger-collector.toml
+++ b/integration/fixtures/tracing/simple-jaeger-collector.toml
@@ -1,0 +1,75 @@
+[global]
+  checkNewVersion = false
+  sendAnonymousUsage = false
+
+[log]
+  level = "DEBUG"
+
+[api]
+
+[entryPoints]
+  [entryPoints.web]
+    address = ":8000"
+
+[tracing]
+  servicename = "tracing"
+  [tracing.jaeger]
+    samplingType = "const"
+    samplingParam = 1.0
+    samplingServerURL = "http://{{.IP}}:5778/sampling"
+    collectorEndpoint = "http://{{.IP}}:14268/api/traces?format=jaeger.thrift"
+
+[providers]
+  [providers.file]
+
+## dynamic configuration ##
+
+[http.routers]
+  [http.routers.router1]
+    Service = "service1"
+    Middlewares = ["retry", "ratelimit"]
+    Rule = "Path(`/ratelimit`)"
+  [http.routers.router2]
+    Service = "service2"
+    Middlewares = ["retry"]
+    Rule = "Path(`/retry`)"
+  [http.routers.router3]
+    Service = "service3"
+    Middlewares = ["retry", "basic-auth"]
+    Rule = "Path(`/auth`)"
+
+[http.middlewares]
+  [http.middlewares.retry.retry]
+    attempts = 3
+  [http.middlewares.basic-auth.basicAuth]
+    users = ["test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/", "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"]
+  [http.middlewares.ratelimit.rateLimit]
+    extractorfunc = "client.ip"
+      [http.middlewares.ratelimit.rateLimit.rateSet.rateset1]
+        period = "60s"
+        average = 4
+        burst = 5
+      [http.middlewares.ratelimit.rateLimit.rateSet.rateset2]
+        period = "3s"
+        average = 1
+        burst = 2
+
+
+[http.services]
+  [http.services.service1]
+    [http.services.service1.loadBalancer]
+      passHostHeader = true
+      [[http.services.service1.loadBalancer.servers]]
+        url = "http://{{.WhoAmiIP}}:{{.WhoAmiPort}}"
+
+  [http.services.service2]
+    passHostHeader = true
+    [http.services.service2.loadBalancer]
+      [[http.services.service2.loadBalancer.servers]]
+        url = "http://{{.WhoAmiIP}}:{{.WhoAmiPort}}"
+
+  [http.services.service3]
+    passHostHeader = true
+    [http.services.service3.loadBalancer]
+      [[http.services.service3.loadBalancer.servers]]
+        url = "http://{{.WhoAmiIP}}:{{.WhoAmiPort}}"

--- a/integration/fixtures/tracing/simple-jaeger-collector.toml
+++ b/integration/fixtures/tracing/simple-jaeger-collector.toml
@@ -17,7 +17,8 @@
     samplingType = "const"
     samplingParam = 1.0
     samplingServerURL = "http://{{.IP}}:5778/sampling"
-    collectorEndpoint = "http://{{.IP}}:14268/api/traces?format=jaeger.thrift"
+    [tracing.jaeger.collector]
+      endpoint = "http://{{.IP}}:14268/api/traces?format=jaeger.thrift"
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/tracing_test.go
+++ b/integration/tracing_test.go
@@ -258,3 +258,30 @@ func (s *TracingSuite) TestJaegerAuth(c *check.C) {
 	err = try.GetRequest("http://"+s.IP+":16686/api/traces?service=tracing", 20*time.Second, try.BodyContains("EntryPoint web", "basic-auth@file"))
 	c.Assert(err, checker.IsNil)
 }
+
+func (s *TracingSuite) TestJaegerAuthCollector(c *check.C) {
+	s.startJaeger(c)
+	defer s.composeProject.Stop(c, "jaeger")
+	file := s.adaptFile(c, "fixtures/tracing/simple-jaeger-collector.toml", TracingTemplate{
+		WhoAmiIP:   s.WhoAmiIP,
+		WhoAmiPort: s.WhoAmiPort,
+		IP:         s.IP,
+	})
+	defer os.Remove(file)
+
+	cmd, display := s.traefikCmd(withConfigFile(file))
+	defer display(c)
+	err := cmd.Start()
+	c.Assert(err, checker.IsNil)
+	defer cmd.Process.Kill()
+
+	// wait for traefik
+	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", time.Second, try.BodyContains("basic-auth"))
+	c.Assert(err, checker.IsNil)
+
+	err = try.GetRequest("http://127.0.0.1:8000/auth", 500*time.Millisecond, try.StatusCodeIs(http.StatusUnauthorized))
+	c.Assert(err, checker.IsNil)
+
+	err = try.GetRequest("http://"+s.IP+":16686/api/traces?service=tracing", 20*time.Second, try.BodyContains("EntryPoint web", "basic-auth@file"))
+	c.Assert(err, checker.IsNil)
+}

--- a/pkg/tracing/jaeger/jaeger.go
+++ b/pkg/tracing/jaeger/jaeger.go
@@ -25,6 +25,9 @@ type Config struct {
 	Gen128Bit              bool    `description:"Generate 128 bit span IDs." json:"gen128Bit,omitempty" toml:"gen128Bit,omitempty" yaml:"gen128Bit,omitempty" export:"true"`
 	Propagation            string  `description:"Which propgation format to use (jaeger/b3)." json:"propagation,omitempty" toml:"propagation,omitempty" yaml:"propagation,omitempty" export:"true"`
 	TraceContextHeaderName string  `description:"Set the header to use for the trace-id." json:"traceContextHeaderName,omitempty" toml:"traceContextHeaderName,omitempty" yaml:"traceContextHeaderName,omitempty" export:"true"`
+	CollectorEndpoint      string  `description:"Instructs reporter to send spans to jaeger-collector at this URL." json:"collectorEndpoint,omitempty" toml:"collectorEndpoint,omitempty" yaml:"collectorEndpoint,omitempty"`
+	User                   string  `description:"User for basic http authentication when sending spans to jaeger-collector." json:"user,omitempty" toml:"user,omitempty" yaml:"user,omitempty"`
+	Password               string  `description:"Password for basic http authentication when sending spans to jaeger-collector." json:"password,omitempty" toml:"password,omitempty" yaml:"password,omitempty"`
 }
 
 // SetDefaults sets the default values.
@@ -36,6 +39,9 @@ func (c *Config) SetDefaults() {
 	c.Propagation = "jaeger"
 	c.Gen128Bit = false
 	c.TraceContextHeaderName = jaegercli.TraceContextHeaderName
+	c.CollectorEndpoint = ""
+	c.User = ""
+	c.Password = ""
 }
 
 // Setup sets up the tracer
@@ -49,6 +55,9 @@ func (c *Config) Setup(componentName string) (opentracing.Tracer, io.Closer, err
 		Reporter: &jaegercfg.ReporterConfig{
 			LogSpans:           true,
 			LocalAgentHostPort: c.LocalAgentHostPort,
+			CollectorEndpoint:  c.CollectorEndpoint,
+			User:               c.User,
+			Password:           c.Password,
 		},
 		Headers: &jaeger.HeadersConfig{
 			TraceContextHeaderName: c.TraceContextHeaderName,

--- a/pkg/tracing/jaeger/jaeger.go
+++ b/pkg/tracing/jaeger/jaeger.go
@@ -13,21 +13,19 @@ import (
 	jaegermet "github.com/uber/jaeger-lib/metrics"
 )
 
-// Name sets the name of this tracer
+// Name sets the name of this tracer.
 const Name = "jaeger"
 
-// Config provides configuration settings for a jaeger tracer
+// Config provides configuration settings for a jaeger tracer.
 type Config struct {
-	SamplingServerURL      string  `description:"Set the sampling server url." json:"samplingServerURL,omitempty" toml:"samplingServerURL,omitempty" yaml:"samplingServerURL,omitempty"`
-	SamplingType           string  `description:"Set the sampling type." json:"samplingType,omitempty" toml:"samplingType,omitempty" yaml:"samplingType,omitempty" export:"true"`
-	SamplingParam          float64 `description:"Set the sampling parameter." json:"samplingParam,omitempty" toml:"samplingParam,omitempty" yaml:"samplingParam,omitempty" export:"true"`
-	LocalAgentHostPort     string  `description:"Set jaeger-agent's host:port that the reporter will used." json:"localAgentHostPort,omitempty" toml:"localAgentHostPort,omitempty" yaml:"localAgentHostPort,omitempty"`
-	Gen128Bit              bool    `description:"Generate 128 bit span IDs." json:"gen128Bit,omitempty" toml:"gen128Bit,omitempty" yaml:"gen128Bit,omitempty" export:"true"`
-	Propagation            string  `description:"Which propgation format to use (jaeger/b3)." json:"propagation,omitempty" toml:"propagation,omitempty" yaml:"propagation,omitempty" export:"true"`
-	TraceContextHeaderName string  `description:"Set the header to use for the trace-id." json:"traceContextHeaderName,omitempty" toml:"traceContextHeaderName,omitempty" yaml:"traceContextHeaderName,omitempty" export:"true"`
-	CollectorEndpoint      string  `description:"Instructs reporter to send spans to jaeger-collector at this URL." json:"collectorEndpoint,omitempty" toml:"collectorEndpoint,omitempty" yaml:"collectorEndpoint,omitempty"`
-	User                   string  `description:"User for basic http authentication when sending spans to jaeger-collector." json:"user,omitempty" toml:"user,omitempty" yaml:"user,omitempty"`
-	Password               string  `description:"Password for basic http authentication when sending spans to jaeger-collector." json:"password,omitempty" toml:"password,omitempty" yaml:"password,omitempty"`
+	SamplingServerURL      string     `description:"Set the sampling server url." json:"samplingServerURL,omitempty" toml:"samplingServerURL,omitempty" yaml:"samplingServerURL,omitempty"`
+	SamplingType           string     `description:"Set the sampling type." json:"samplingType,omitempty" toml:"samplingType,omitempty" yaml:"samplingType,omitempty" export:"true"`
+	SamplingParam          float64    `description:"Set the sampling parameter." json:"samplingParam,omitempty" toml:"samplingParam,omitempty" yaml:"samplingParam,omitempty" export:"true"`
+	LocalAgentHostPort     string     `description:"Set jaeger-agent's host:port that the reporter will used." json:"localAgentHostPort,omitempty" toml:"localAgentHostPort,omitempty" yaml:"localAgentHostPort,omitempty"`
+	Gen128Bit              bool       `description:"Generate 128 bit span IDs." json:"gen128Bit,omitempty" toml:"gen128Bit,omitempty" yaml:"gen128Bit,omitempty" export:"true"`
+	Propagation            string     `description:"Which propagation format to use (jaeger/b3)." json:"propagation,omitempty" toml:"propagation,omitempty" yaml:"propagation,omitempty" export:"true"`
+	TraceContextHeaderName string     `description:"Set the header to use for the trace-id." json:"traceContextHeaderName,omitempty" toml:"traceContextHeaderName,omitempty" yaml:"traceContextHeaderName,omitempty" export:"true"`
+	Collector              *Collector `description:"Define the collector information" json:"collector,omitempty" toml:"collector,omitempty" yaml:"collector,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values.
@@ -39,26 +37,42 @@ func (c *Config) SetDefaults() {
 	c.Propagation = "jaeger"
 	c.Gen128Bit = false
 	c.TraceContextHeaderName = jaegercli.TraceContextHeaderName
-	c.CollectorEndpoint = ""
+}
+
+// Collector provides configuration settings for jaeger collector.
+type Collector struct {
+	Endpoint string `description:"Instructs reporter to send spans to jaeger-collector at this URL." json:"endpoint,omitempty" toml:"endpoint,omitempty" yaml:"endpoint,omitempty" export:"true"`
+	User     string `description:"User for basic http authentication when sending spans to jaeger-collector." json:"user,omitempty" toml:"user,omitempty" yaml:"user,omitempty"`
+	Password string `description:"Password for basic http authentication when sending spans to jaeger-collector." json:"password,omitempty" toml:"password,omitempty" yaml:"password,omitempty"`
+}
+
+// SetDefaults sets the default values.
+func (c *Collector) SetDefaults() {
+	c.Endpoint = ""
 	c.User = ""
 	c.Password = ""
 }
 
 // Setup sets up the tracer
 func (c *Config) Setup(componentName string) (opentracing.Tracer, io.Closer, error) {
+	reporter := &jaegercfg.ReporterConfig{
+		LogSpans:           true,
+		LocalAgentHostPort: c.LocalAgentHostPort,
+	}
+
+	if c.Collector != nil {
+		reporter.CollectorEndpoint = c.Collector.Endpoint
+		reporter.User = c.Collector.User
+		reporter.Password = c.Collector.Password
+	}
+
 	jcfg := jaegercfg.Configuration{
 		Sampler: &jaegercfg.SamplerConfig{
 			SamplingServerURL: c.SamplingServerURL,
 			Type:              c.SamplingType,
 			Param:             c.SamplingParam,
 		},
-		Reporter: &jaegercfg.ReporterConfig{
-			LogSpans:           true,
-			LocalAgentHostPort: c.LocalAgentHostPort,
-			CollectorEndpoint:  c.CollectorEndpoint,
-			User:               c.User,
-			Password:           c.Password,
-		},
+		Reporter: reporter,
 		Headers: &jaeger.HeadersConfig{
 			TraceContextHeaderName: c.TraceContextHeaderName,
 		},


### PR DESCRIPTION
### What does this PR do?

Adds the Jaeger collector endpoint and basic auth reporter configuration settings.


### Motivation

Allows trace submission to Jaeger collectors via http, removing agent requirement.


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
