### PR TITLE
Update example for letsencrypt

### DIFF
--- a/docs/content/user-guides/crd-acme/03-deployments.yml
+++ b/docs/content/user-guides/crd-acme/03-deployments.yml
@@ -33,7 +33,6 @@ spec:
             - --entrypoints.web.Address=:8000
             - --entrypoints.websecure.Address=:4443
             - --providers.kubernetescrd
-            - --providers.kubernetescrd.trace
             - --acme
             - --acme.acmelogging
             - --acme.tlschallenge


### PR DESCRIPTION
I tried to run the example, but the container would not stay up (on RPI3, same image as above). `kubectl logs` was reporting:

```
command traefik error: failed to decode configuration from flags: field not found, node: trace
```

So I have decided to remove the line and the container started. I have no idea of the possible implication  of this removal.