### PR TITLE
Add acme certificate import/export scripts

### DIFF
--- a/contrib/letsencrypt_acme/README.md
+++ b/contrib/letsencrypt_acme/README.md
@@ -1,0 +1,44 @@
+## Let's Encrypt Acme Import/Export
+
+The two scripts provided here are designed to import / export basic certificates issued by Let's Encrypt.
+
+Two scenarios are addressed by this:
+
+ - Using a pre-existing Let's Encrypt certificate with Traefik ( such as when migrating during a DNS change to Traefik when previously using Nginx )
+ - Migrating away from Traefik to Nginx
+
+### Import - Migrating to Traefik
+
+#### View usage
+
+    ./import.pl --help
+
+#### Import My Site
+
+    ./import.pl --file acme_part.json --cert mySite.pem --key mySiteKey.pem --chain chain.pem
+
+In this case chain.pem is the intermediate certificate of Let's Encrypt.
+
+The acme_part.json file is generated, and the "Certificates" portion of it should be copied and pasted into your Traefik acme.json file. For safety and simplicity the script is not designed to directly modify your acme.json
+
+### Export - Migrating away from Traefik
+#### View Usage
+
+    ./export.pl --help
+
+#### List sites in acme.json
+
+    ./export --file /path/to/acme.json
+
+#### Export My Site
+
+    ./export --file /path/to/acme.json --certnum 0
+
+This saves out the following 3 files:
+
+ - cert.pem ( the certificate for your site )
+ - privkey.pem ( the private key for your site )
+ - chain.pem ( the intermed cert of Let's encrypt )
+
+These files could then be used to configure a Nginx instance, for example, with the certificate last used in Traefik.
+

--- a/contrib/letsencrypt_acme/export.pl
+++ b/contrib/letsencrypt_acme/export.pl
@@ -1,0 +1,136 @@
+#!/usr/bin/perl -w
+use strict;
+
+use File::Slurp qw/read_file write_file/;
+use JSON::XS;
+use MIME::Base64 qw/decode_base64 encode_base64/;
+use File::Copy qw/mv/;
+use Getopt::Long qw/GetOptions/;
+use Pod::Usage qw/pod2usage/;
+
+my $coder = JSON::XS->new->ascii->pretty;
+
+my $acme     = "acme.json";
+my $chainOut = "chain.pem";
+my $certOut  = "cert.pem";
+my $keyOut   = "privkey.pem";
+my $certNum  = -1;
+my $help = 0;
+GetOptions(
+    "file:s"    => \$acme,
+    "chain:s"   => \$chainOut,
+    "cert:s"    => \$certOut,
+    "key:s"     => \$keyOut,
+    "certnum:i" => \$certNum,
+    "help|?"    => \$help
+    );
+pod2usage(1) if $help;
+if( $acme     =~ m|/$| || -d $acme     ) { $acme     = "$acme/acme.json"; }
+if( $chainOut =~ m|/$| || -d $chainOut ) { $chainOut = "$chainOut/chain.pem"; }
+if( $certOut  =~ m|/$| || -d $certOut  ) { $certOut  = "$certOut/cert.pem"; }
+if( $keyOut   =~ m|/$| || -d $keyOut   ) { $keyOut   = "$keyOut/privkey.pem"; }
+
+if( $certNum == -1 ) {
+    listDomains( $acme );
+}
+else {
+    export( $acme, $chainOut, $certOut, $keyOut, $certNum );
+}
+
+sub listDomains {
+    my $acme = shift;
+    my $raw_json = read_file( $acme );
+    my $json = $coder->decode( $raw_json );
+    my $certs = $json->{Certificates};
+    
+    print "Sites in acme.json:\n";
+    my $n = 0;
+    for my $cert ( @$certs ) {
+        my $domain = $cert->{Domain};
+        my $main = $domain->{Main};
+        print "$n. $main\n";
+        $n++;
+    }
+}
+
+sub export {
+    my ( $acme, $chainFile, $certFile, $keyFile, $certNum ) = @_;
+    if( ! -e $acme ) {
+        die "Acme file \"$acme\" not found";
+    }
+    my $raw_json = read_file( $acme );
+    
+    my $json = $coder->decode( $raw_json );
+    
+    my $certs = $json->{Certificates};
+    
+    #for my $cert ( @$certs ) {
+        my $certN = $certs->[$certNum];
+        my $key = $certN->{Key};
+        my $cert = $certN->{Certificate};
+        $key = decode_base64( to_lines( $key ) );
+        $cert = decode_base64( to_lines( $cert ) );
+        
+        my $n = 1;
+        while( $cert =~ m/(-----BEGIN CERTIFICATE-----\n.+?\n-----END CERTIFICATE-----)/sg ) {
+            write_file("part$n.pem", $1 );
+            my $subject = `openssl x509 -subject -noout -in part$n.pem`;
+            # This matches the intermediate cert of Let's Encrypt production
+            if( $subject =~ m/O = Let's Encrypt/ ) {
+                print "Writing Let's Encrypt intermediate cert to $chainFile\n";
+                mv "part$n.pem", $chainFile;
+            }
+            # This matches the intermediate cert of Let's Encrypt staging
+            elsif( $subject =~ m/Intermediate/ ) {
+                print "Writing intermediate cert to $chainFile\n";
+                mv "part$n.pem", $chainFile;
+            }
+            elsif( $subject =~ m/^(subject=)?CN = ([a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)+)$/ ) {
+                my $domain = $2;
+                print "Writing \"$domain\" cert to $certFile\n";
+                mv "part$n.pem", $certFile;
+            }
+            else {
+                print "Unrecognized CN present: \"$subject\"\n";
+            }
+            $n++;
+        }
+        
+        print "Writing private key to $keyFile\n";
+        write_file( $keyFile, $key );
+        #print `openssl rsa -text -noout -in key.pem`;
+    #}
+}
+
+sub to_lines {
+    $_ = shift;
+    s/(.{64})/$1\n/g;
+    return $_;
+}
+
+__END__
+
+=head1 NAME
+
+LetsEncypt acme.json certificate exporter
+
+=head1 SYNOPSIS
+
+export.pl [options]
+
+  Options:
+    --file    Path to acme.json
+    --chain   Path to save chain.pem as
+    --cert    Path to save cert.pem as
+    --key     Path to save privkey.pem as
+    --certnum Number of domain within acme.json
+
+Example:
+
+  ./export.pl --file /path/to/acme.json
+    List the domains within acme.json
+    
+  ./export.pl --file /path/to/acme.json --certnum 0
+    Save out the pem files for site number 0
+
+=cut

--- a/contrib/letsencrypt_acme/import.pl
+++ b/contrib/letsencrypt_acme/import.pl
@@ -1,0 +1,98 @@
+#!/usr/bin/perl -w
+use strict;
+
+use File::Slurp qw/read_file write_file/;
+use JSON::XS;
+use MIME::Base64 qw/decode_base64 encode_base64/;
+use Getopt::Long qw/GetOptions/;
+use Pod::Usage qw/pod2usage/;
+
+my $coder = JSON::XS->new->ascii->pretty;
+
+my $acme    = "acme_part.json";
+my $chainIn = "chain.pem";
+my $certIn  = "cert.pem";
+my $keyIn   = "privkey.pem";
+my $help = 0;
+GetOptions(
+    "file:s"  => \$acme,
+    "chain:s" => \$chainIn,
+    "cert:s"  => \$certIn,
+    "key:s"   => \$keyIn,
+    "help|?"  => \$help
+    );
+pod2usage(1) if $help;
+if( $acme    =~ m|/$| || -d $acme    ) { $acme    = "$acme/acme.json"; }
+if( $chainIn =~ m|/$| || -d $chainIn ) { $chainIn = "$chainIn/chain.pem"; }
+if( $certIn  =~ m|/$| || -d $certIn  ) { $certIn  = "$certIn/cert.pem"; }
+if( $keyIn   =~ m|/$| || -d $keyIn   ) { $keyIn   = "$keyIn/privkey.pem"; }
+
+import( $acme, $chainIn, $certIn, $keyIn );
+
+sub import {
+    my ( $acme, $chainFile, $certFile, $keyFile ) = @_;
+    if( ! -e $chainFile ) {
+        die "Chain file \"$chainFile\" not found";
+    }
+    if( ! -e $certFile ) {
+        die "Chain file \"$certFile\" not found";
+    }
+    if( ! -e $keyFile ) {
+        die "Chain file \"$keyFile\" not found";
+    }
+
+    my $certRaw  = read_file( $certFile );
+    if( $certRaw !~ m/^-----BEGIN CERTIFICATE-----\n.+-----END CERTIFICATE-----\n?$/s ) {
+        die "Cert \"$certFile\" is not armored properly";
+    }
+    my $chainRaw = read_file( $chainFile );
+    if( $chainRaw !~ m/^-----BEGIN CERTIFICATE-----\n.+-----END CERTIFICATE-----\n?$/s ) {
+        die "Cert \"$chainFile\" is not armored properly";
+    }
+    my $keyRaw   = read_file( $keyFile );
+    
+    my $subject = `openssl x509 -subject -noout -in $certFile`;
+    if( $subject =~ m/^(subject=)?CN = ([a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)+)$/ ) {
+        my $domain = $2;    
+    
+        my $keyEncoded  = encode_base64( $keyRaw );
+        my $certEncoded = encode_base64( "$certRaw\n\n$chainRaw" );
+        $keyEncoded  =~ s/\n//g;
+        $certEncoded =~ s/\n//g;
+        my $json = {
+            Certificates => [
+                {
+                    Domain => {
+                        Main => $domain,
+                        SANs => undef
+                    },
+                    Certificate => $certEncoded,
+                    Key => $keyEncoded
+                }
+            ]
+        };
+        print "Portion of acme.json written to \"$acme\"\n";
+        write_file( $acme, $coder->encode( $json ) );
+    }
+    else {
+        die "Subject of cert \"$certFile\" does not look like a domain: \"$subject\"\n";
+    }
+}
+
+__END__
+
+=head1 NAME
+
+LetsEncypt acme.json certificate importer
+
+=head1 SYNOPSIS
+
+import.pl [options]
+
+  Options:
+    --file   Path to save acme_part.json
+    --chain  Path to chain.pem
+    --cert   Path to cert.pem
+    --key    Path to privkey.pem
+
+=cut


### PR DESCRIPTION
Created perl scripts to import/export basic certificates to/from acme.json

This enables users to more easily migrate to Traefik from other solutions, as well as to extract plain certificate files from acme.json for whatever reason that may be needed.

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

It adds scripts that can be used to import or export Let's Encrypt certs to/from the internal acme.json file of Traefik.


### Motivation

I needed to import a certificate into Traefik to handle DNS migration when moving from Nginx to Traefik. Changing DNS at the same time as changing to a different box cannot be done reliably as DNS may change for clients before it changes for Let's Encrypt, resulting in no certificate being issuable on Traefik with TLS challenge.


### More

- [ ] Added/updated tests
- [ X] Added/updated documentation

### Additional Notes

Removing the previous script to export certs wasn't exactly helpful. I can understand that the shellscript was potentially hard to read and fragile. Hopefully this is cleaner and more reliably and is a more maintainable solution long term.
