### PR TITLE
Manage status for TCP element in the endpoint overview.

### DIFF
--- a/pkg/api/handler_overview.go
+++ b/pkg/api/handler_overview.go
@@ -115,30 +115,38 @@ func getHTTPMiddlewareSection(middlewares map[string]*runtime.MiddlewareInfo) *s
 
 func getTCPRouterSection(routers map[string]*runtime.TCPRouterInfo) *section {
 	var countErrors int
+	var countWarnings int
 	for _, rt := range routers {
-		if rt.Err != "" {
+		switch rt.Status {
+		case runtime.StatusDisabled:
 			countErrors++
+		case runtime.StatusWarning:
+			countWarnings++
 		}
 	}
 
 	return &section{
 		Total:    len(routers),
-		Warnings: 0, // TODO
+		Warnings: countWarnings,
 		Errors:   countErrors,
 	}
 }
 
 func getTCPServiceSection(services map[string]*runtime.TCPServiceInfo) *section {
 	var countErrors int
+	var countWarnings int
 	for _, svc := range services {
-		if svc.Err != nil {
+		switch svc.Status {
+		case runtime.StatusDisabled:
 			countErrors++
+		case runtime.StatusWarning:
+			countWarnings++
 		}
 	}
 
 	return &section{
 		Total:    len(services),
-		Warnings: 0, // TODO
+		Warnings: countWarnings,
 		Errors:   countErrors,
 	}
 }

--- a/pkg/api/handler_overview_test.go
+++ b/pkg/api/handler_overview_test.go
@@ -142,6 +142,31 @@ func TestHandler_Overview(t *testing.T) {
 								},
 							},
 						},
+						Status: runtime.StatusEnabled,
+					},
+					"tcpbar-service@myprovider": {
+						TCPService: &dynamic.TCPService{
+							LoadBalancer: &dynamic.TCPLoadBalancerService{
+								Servers: []dynamic.TCPServer{
+									{
+										Address: "127.0.0.2",
+									},
+								},
+							},
+						},
+						Status: runtime.StatusWarning,
+					},
+					"tcpfii-service@myprovider": {
+						TCPService: &dynamic.TCPService{
+							LoadBalancer: &dynamic.TCPLoadBalancerService{
+								Servers: []dynamic.TCPServer{
+									{
+										Address: "127.0.0.2",
+									},
+								},
+							},
+						},
+						Status: runtime.StatusDisabled,
 					},
 				},
 				TCPRouters: map[string]*runtime.TCPRouterInfo{
@@ -151,6 +176,7 @@ func TestHandler_Overview(t *testing.T) {
 							Service:     "tcpfoo-service@myprovider",
 							Rule:        "HostSNI(`foo.bar`)",
 						},
+						Status: runtime.StatusEnabled,
 					},
 					"tcptest@myprovider": {
 						TCPRouter: &dynamic.TCPRouter{
@@ -158,6 +184,15 @@ func TestHandler_Overview(t *testing.T) {
 							Service:     "tcpfoo-service@myprovider",
 							Rule:        "HostSNI(`foo.bar.other`)",
 						},
+						Status: runtime.StatusWarning,
+					},
+					"tcpfoo@myprovider": {
+						TCPRouter: &dynamic.TCPRouter{
+							EntryPoints: []string{"web"},
+							Service:     "tcpfoo-service@myprovider",
+							Rule:        "HostSNI(`foo.bar.other`)",
+						},
+						Status: runtime.StatusDisabled,
 					},
 				},
 			},

--- a/pkg/api/handler_tcp_test.go
+++ b/pkg/api/handler_tcp_test.go
@@ -52,6 +52,7 @@ func TestHandler_TCP(t *testing.T) {
 								Passthrough: false,
 							},
 						},
+						Status: runtime.StatusEnabled,
 					},
 					"bar@myprovider": {
 						TCPRouter: &dynamic.TCPRouter{
@@ -59,6 +60,15 @@ func TestHandler_TCP(t *testing.T) {
 							Service:     "foo-service@myprovider",
 							Rule:        "Host(`foo.bar`)",
 						},
+						Status: runtime.StatusWarning,
+					},
+					"foo@myprovider": {
+						TCPRouter: &dynamic.TCPRouter{
+							EntryPoints: []string{"web"},
+							Service:     "foo-service@myprovider",
+							Rule:        "Host(`foo.bar`)",
+						},
+						Status: runtime.StatusDisabled,
 					},
 				},
 			},
@@ -173,6 +183,7 @@ func TestHandler_TCP(t *testing.T) {
 							},
 						},
 						UsedBy: []string{"foo@myprovider", "test@myprovider"},
+						Status: runtime.StatusEnabled,
 					},
 					"baz@myprovider": {
 						TCPService: &dynamic.TCPService{
@@ -185,6 +196,20 @@ func TestHandler_TCP(t *testing.T) {
 							},
 						},
 						UsedBy: []string{"foo@myprovider"},
+						Status: runtime.StatusWarning,
+					},
+					"foz@myprovider": {
+						TCPService: &dynamic.TCPService{
+							LoadBalancer: &dynamic.TCPLoadBalancerService{
+								Servers: []dynamic.TCPServer{
+									{
+										Address: "127.0.0.2:2345",
+									},
+								},
+							},
+						},
+						UsedBy: []string{"foo@myprovider"},
+						Status: runtime.StatusDisabled,
 					},
 				},
 			},

--- a/pkg/api/testdata/overview-dynamic.json
+++ b/pkg/api/testdata/overview-dynamic.json
@@ -23,14 +23,14 @@
 	},
 	"tcp": {
 		"routers": {
-			"errors": 0,
-			"total": 2,
-			"warnings": 0
+			"errors": 1,
+			"total": 3,
+			"warnings": 1
 		},
 		"services": {
-			"errors": 0,
-			"total": 1,
-			"warnings": 0
+			"errors": 1,
+			"total": 3,
+			"warnings": 1
 		}
 	}
 }

--- a/pkg/api/testdata/tcprouters.json
+++ b/pkg/api/testdata/tcprouters.json
@@ -6,7 +6,18 @@
 		"name": "bar@myprovider",
 		"provider": "myprovider",
 		"rule": "Host(`foo.bar`)",
-		"service": "foo-service@myprovider"
+		"service": "foo-service@myprovider",
+		"status": "warning"
+	},
+	{
+		"entryPoints": [
+			"web"
+		],
+		"name": "foo@myprovider",
+		"provider": "myprovider",
+		"rule": "Host(`foo.bar`)",
+		"service": "foo-service@myprovider",
+		"status": "disabled"
 	},
 	{
 		"entryPoints": [
@@ -16,6 +27,7 @@
 		"provider": "myprovider",
 		"rule": "Host(`foo.bar.other`)",
 		"service": "foo-service@myprovider",
+		"status": "enabled",
 		"tls": {
 			"passthrough": false
 		}

--- a/pkg/api/testdata/tcpservices.json
+++ b/pkg/api/testdata/tcpservices.json
@@ -9,6 +9,7 @@
 		},
 		"name": "bar@myprovider",
 		"provider": "myprovider",
+		"status": "enabled",
 		"usedBy": [
 			"foo@myprovider",
 			"test@myprovider"
@@ -24,6 +25,22 @@
 		},
 		"name": "baz@myprovider",
 		"provider": "myprovider",
+		"status": "warning",
+		"usedBy": [
+			"foo@myprovider"
+		]
+	},
+	{
+		"loadBalancer": {
+			"servers": [
+				{
+					"address": "127.0.0.2:2345"
+				}
+			]
+		},
+		"name": "foz@myprovider",
+		"provider": "myprovider",
+		"status": "disabled",
 		"usedBy": [
 			"foo@myprovider"
 		]


### PR DESCRIPTION
### What does this PR do?

Manages status for TCP element in the endpoint overview.

### Motivation

Be able to get the status for TCP routers and services in the endpoint overview. 

### More

- [x] Added/updated tests
- [ ] ~Added/updated documentation~
