### PR TITLE
fix: TLS configuration from directory.

### DIFF
--- a/pkg/provider/file/file.go
+++ b/pkg/provider/file/file.go
@@ -295,9 +295,31 @@ func (p *Provider) loadFileConfigFromDirectory(ctx context.Context, directory st
 				configTLSMaps[conf] = struct{}{}
 			}
 		}
+
+		for name, conf := range c.TLS.Options {
+			if _, exists := configuration.TLS.Options[name]; exists {
+				logger.Warnf("TLS options %v already configured, skipping", name)
+			} else {
+				if configuration.TLS.Options == nil {
+					configuration.TLS.Options = map[string]tls.Options{}
+				}
+				configuration.TLS.Options[name] = conf
+			}
+		}
+
+		for name, conf := range c.TLS.Stores {
+			if _, exists := configuration.TLS.Stores[name]; exists {
+				logger.Warnf("TLS store %v already configured, skipping", name)
+			} else {
+				if configuration.TLS.Stores == nil {
+					configuration.TLS.Stores = map[string]tls.Store{}
+				}
+				configuration.TLS.Stores[name] = conf
+			}
+		}
 	}
 
-	if len(configTLSMaps) > 0 {
+	if len(configTLSMaps) > 0 && configuration.TLS == nil {
 		configuration.TLS = &dynamic.TLSConfiguration{}
 	}
 

--- a/pkg/provider/file/file_test.go
+++ b/pkg/provider/file/file_test.go
@@ -17,12 +17,13 @@ import (
 )
 
 type ProvideTestCase struct {
-	desc               string
-	directoryPaths     []string
-	filePath           string
-	expectedNumRouter  int
-	expectedNumService int
-	expectedNumTLSConf int
+	desc                  string
+	directoryPaths        []string
+	filePath              string
+	expectedNumRouter     int
+	expectedNumService    int
+	expectedNumTLSConf    int
+	expectedNumTLSOptions int
 }
 
 func TestTLSContent(t *testing.T) {
@@ -94,6 +95,7 @@ func TestProvideWithoutWatch(t *testing.T) {
 				assert.Len(t, conf.Configuration.HTTP.Routers, test.expectedNumRouter)
 				require.NotNil(t, conf.Configuration.TLS)
 				assert.Len(t, conf.Configuration.TLS.Certificates, test.expectedNumTLSConf)
+				assert.Len(t, conf.Configuration.TLS.Options, test.expectedNumTLSOptions)
 			case <-timeout:
 				t.Errorf("timeout while waiting for config")
 			}
@@ -192,9 +194,10 @@ func getTestCases() []ProvideTestCase {
 				"./fixtures/toml/dir01_file02.toml",
 				"./fixtures/toml/dir01_file03.toml",
 			},
-			expectedNumRouter:  2,
-			expectedNumService: 3,
-			expectedNumTLSConf: 4,
+			expectedNumRouter:     2,
+			expectedNumService:    3,
+			expectedNumTLSConf:    4,
+			expectedNumTLSOptions: 1,
 		},
 		{
 			desc: "simple directory yaml",
@@ -203,9 +206,10 @@ func getTestCases() []ProvideTestCase {
 				"./fixtures/yaml/dir01_file02.yml",
 				"./fixtures/yaml/dir01_file03.yml",
 			},
-			expectedNumRouter:  2,
-			expectedNumService: 3,
-			expectedNumTLSConf: 4,
+			expectedNumRouter:     2,
+			expectedNumService:    3,
+			expectedNumTLSConf:    4,
+			expectedNumTLSOptions: 1,
 		},
 		{
 			desc: "template in directory",

--- a/pkg/provider/file/fixtures/toml/dir01_file03.toml
+++ b/pkg/provider/file/fixtures/toml/dir01_file03.toml
@@ -15,3 +15,7 @@
 [[tls.certificates]]
   certFile = "integration/fixtures/https/snitest4.com.cert"
   keyFile = "integration/fixtures/https/snitest4.com.key"
+
+[tls.options]
+  [tls.options.mintls13]
+    minVersion = "VersionTLS13"

--- a/pkg/provider/file/fixtures/yaml/dir01_file03.yml
+++ b/pkg/provider/file/fixtures/yaml/dir01_file03.yml
@@ -8,3 +8,7 @@ tls:
     keyFile: integration/fixtures/https/snitest3.com.key
   - certFile: integration/fixtures/https/snitest4.com.cert
     keyFile: integration/fixtures/https/snitest4.com.key
+
+  options:
+    mintls13:
+      minVersion: VersionTLS13


### PR DESCRIPTION
### What does this PR do?

fix: TLS configuration from directory.

### Motivation

Related to:
- https://community.containo.us/t/traefik-v2-alpha8-tls-configuration-options-default-cert-not-applied/921
- #5114

### More

- [x] Added/updated tests
- [ ] ~Added/updated documentation~
