### PR TITLE
API: remove configuration of Entrypoint and Middlewares

### DIFF
--- a/cmd/healthcheck/healthcheck.go
+++ b/cmd/healthcheck/healthcheck.go
@@ -51,7 +51,7 @@ func Do(staticConfiguration static.Configuration) (*http.Response, error) {
 		return nil, errors.New("please enable `ping` to use health check")
 	}
 
-	pingEntryPoint, ok := staticConfiguration.EntryPoints[staticConfiguration.Ping.EntryPoint]
+	pingEntryPoint, ok := staticConfiguration.EntryPoints["traefik"]
 	if !ok {
 		return nil, errors.New("missing `ping` entrypoint")
 	}

--- a/docs/content/observability/metrics/prometheus.md
+++ b/docs/content/observability/metrics/prometheus.md
@@ -44,54 +44,6 @@ metrics:
 --metrics.prometheus.buckets=0.100000, 0.300000, 1.200000, 5.000000
 ```
 
-#### `entryPoint`
-
-_Optional, Default=traefik_
-
-Entry-point used by prometheus to expose metrics.
-
-```toml tab="File (TOML)"
-[metrics]
-  [metrics.prometheus]
-    entryPoint = traefik
-```
-
-```yaml tab="File (TOML)"
-metrics:
-  prometheus:
-    entryPoint: traefik
-```
-
-```bash tab="CLI"
---metrics
---metrics.prometheus.entryPoint=traefik
-```
-
-#### `middlewares`
-
-_Optional, Default=""_
-
-Middlewares.
-
-```toml tab="File (TOML)"
-[metrics]
-  [metrics.prometheus]
-    middlewares = ["xxx", "yyy"]
-```
-
-```yaml tab="File (TOML)"
-metrics:
-  prometheus:
-    middlewares:
-    - xxx
-    - yyy
-```
-
-```bash tab="CLI"
---metrics
---metrics.prometheus.middlewares="xxx,yyy"
-```
-
 #### `addEntryPointsLabels`
 
 _Optional, Default=true_

--- a/docs/content/operations/api.md
+++ b/docs/content/operations/api.md
@@ -1,5 +1,8 @@
 # API
 
+!!! important
+    In the beta version, you can't configure middlewares (basic authentication or white listing) anymore, but as security is important, this will change before the RC version.
+
 Traefik exposes a number of information through an API handler, such as the configuration of all routers, services, middlewares, etc.
 
 As with all features of Traefik, this handler can be enabled with the [static configuration](../getting-started/configuration-overview.md#the-static-configuration).
@@ -19,7 +22,7 @@ would be to apply the following protection mechanisms:
   keeping it restricted to internal networks
   (as in the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege), applied to networks).
 
-!!! warning
+!!! important
     In the beta version, you can't configure middlewares (basic authentication or white listing) anymore, but as security is important, this will change before the RC version.
 
 ## Configuration

--- a/docs/content/operations/api.md
+++ b/docs/content/operations/api.md
@@ -14,13 +14,13 @@ In production, it should be at least secured by authentication and authorization
 A good sane default (non exhaustive) set of recommendations
 would be to apply the following protection mechanisms:
 
-* At the application level:  
-  securing with middlewares such as [basic authentication](../middlewares/basicauth.md) or [white listing](../middlewares/ipwhitelist.md).
-
 * At the transport level:  
   NOT publicly exposing the API's port,
   keeping it restricted to internal networks
   (as in the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege), applied to networks).
+
+!!! warning
+    In the beta version, you can't configure middlewares (basic authentication or white listing) anymore, but as security is important, this will change before the RC version.
 
 ## Configuration
 
@@ -47,37 +47,6 @@ Enable the dashboard. More about the dashboard features [here](./dashboard.md).
 
 ```bash tab="CLI"
 --api.dashboard
-```
-
-### `entrypoint`
-
-_Optional, Default="traefik"_
-
-The entry point that the API handler will be bound to.
-The default ("traefik") is an internal entry point (which is always defined).
-
-```toml tab="File"
-[api]
-  entrypoint = "web"
-```
-
-```bash tab="CLI"
---api.entrypoint="web"
-```
-
-### `middlewares`
-
-_Optional, Default=empty_
-
-The list of [middlewares](../middlewares/overview.md) applied to the API handler.
-
-```toml tab="File"
-[api]
-  middlewares = ["api-auth", "api-prefix"]
-```
-
-```bash tab="CLI"
---api.middlewares="api-auth,api-prefix"
 ```
 
 ### `debug`
@@ -120,51 +89,3 @@ All the following endpoints must be accessed with a `GET` HTTP request.
 | `/debug/pprof/profile`         | See the [pprof Profile](https://golang.org/pkg/net/http/pprof/#Profile) Go documentation. |
 | `/debug/pprof/symbol`          | See the [pprof Symbol](https://golang.org/pkg/net/http/pprof/#Symbol) Go documentation.   |
 | `/debug/pprof/trace`           | See the [pprof Trace](https://golang.org/pkg/net/http/pprof/#Trace) Go documentation.     |
-
-## Common Configuration Use Cases
-
-### Address / Port
-
-You can define a custom address/port like this:
-
-```toml
-[entryPoints]
-  [entryPoints.web]
-    address = ":80"
-
-  [entryPoints.foo]
-    address = ":8082"
-
-  [entryPoints.bar]
-    address = ":8083"
-
-[ping]
-  entryPoint = "foo"
-
-[api]
-  entryPoint = "bar"
-```
-
-In the above example, you would access a service at /foo, an api endpoint, or the health-check as follows:
-
-* Service: `http://hostname:80/foo`
-* API: `http://hostname:8083/api/http/routers`
-* Ping URL: `http://hostname:8082/ping`
-
-### Authentication
-
-To restrict access to the API handler, one can add authentication with the [basic auth middleware](../middlewares/basicauth.md).
-
-```toml
-[api]
-  middlewares=["api-auth"]
-```
-
-```toml
-[http.middlewares]
-  [http.middlewares.api-auth.basicAuth]
-    users = [
-      "test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/",
-      "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0",
-    ]
-```

--- a/docs/content/operations/ping.md
+++ b/docs/content/operations/ping.md
@@ -11,20 +11,6 @@ Checking the Health of Your Traefik Instances
     [ping]
     ```
 
-??? example "Enabling /ping on a dedicated EntryPoint"
-    
-    ```toml
-    [entryPoints]
-      [entryPoints.web]
-        address = ":80"
-      
-      [entryPoints.ping]
-        address = ":8082"
-    
-    [ping]
-      entryPoint = "ping"
-    ```
-
 | Path    | Method        | Description                                                                                         |
 |---------|---------------|-----------------------------------------------------------------------------------------------------|
 | `/ping` | `GET`, `HEAD` | A simple endpoint to check for Traefik process liveness. Return a code `200` with the content: `OK` |
@@ -32,5 +18,3 @@ Checking the Health of Your Traefik Instances
 ## Configuration Options
 
 The `/ping` health-check URL is enabled with the command-line `--ping` or config file option `[ping]`.
-
-You can customize the `entryPoint` where the `/ping` is active with the `entryPoint` option (default value: `traefik`)

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -45,18 +45,6 @@ Activate dashboard. (Default: ```true```)
 `--api.debug`:  
 Enable additional endpoints for debugging and profiling. (Default: ```false```)
 
-`--api.entrypoint`:  
-The entry point that the API handler will be bound to. (Default: ```traefik```)
-
-`--api.middlewares`:  
-Middleware list.
-
-`--api.statistics`:  
-Enable more detailed statistics. (Default: ```false```)
-
-`--api.statistics.recenterrors`:  
-Number of recent errors logged. (Default: ```10```)
-
 `--certificatesresolvers.<name>`:  
 Certificates resolvers configuration. (Default: ```false```)
 
@@ -219,12 +207,6 @@ Enable metrics on services. (Default: ```true```)
 `--metrics.prometheus.buckets`:  
 Buckets for latency metrics. (Default: ```0.100000, 0.300000, 1.200000, 5.000000```)
 
-`--metrics.prometheus.entrypoint`:  
-EntryPoint. (Default: ```traefik```)
-
-`--metrics.prometheus.middlewares`:  
-Middlewares.
-
 `--metrics.statsd`:  
 StatsD metrics exporter type. (Default: ```false```)
 
@@ -241,13 +223,7 @@ Enable metrics on services. (Default: ```true```)
 StatsD push interval. (Default: ```10```)
 
 `--ping`:  
-Enable ping. (Default: ```false```)
-
-`--ping.entrypoint`:  
-Ping entryPoint. (Default: ```traefik```)
-
-`--ping.middlewares`:  
-Middleware list.
+Enable ping. (Default: ```true```)
 
 `--providers.docker`:  
 Enable Docker backend with default settings. (Default: ```false```)
@@ -457,10 +433,7 @@ Defines the polling interval in seconds. (Default: ```15```)
 Watch provider. (Default: ```true```)
 
 `--providers.rest`:  
-Enable Rest backend with default settings. (Default: ```false```)
-
-`--providers.rest.entrypoint`:  
-EntryPoint. (Default: ```traefik```)
+Enable Rest backend with default settings. (Default: ```true```)
 
 `--serverstransport.forwardingtimeouts.dialtimeout`:  
 The amount of time to wait until a connection to a backend server can be established. If zero, no timeout exists. (Default: ```30```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -45,18 +45,6 @@ Activate dashboard. (Default: ```true```)
 `TRAEFIK_API_DEBUG`:  
 Enable additional endpoints for debugging and profiling. (Default: ```false```)
 
-`TRAEFIK_API_ENTRYPOINT`:  
-The entry point that the API handler will be bound to. (Default: ```traefik```)
-
-`TRAEFIK_API_MIDDLEWARES`:  
-Middleware list.
-
-`TRAEFIK_API_STATISTICS`:  
-Enable more detailed statistics. (Default: ```false```)
-
-`TRAEFIK_API_STATISTICS_RECENTERRORS`:  
-Number of recent errors logged. (Default: ```10```)
-
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>`:  
 Certificates resolvers configuration. (Default: ```false```)
 
@@ -219,12 +207,6 @@ Enable metrics on services. (Default: ```true```)
 `TRAEFIK_METRICS_PROMETHEUS_BUCKETS`:  
 Buckets for latency metrics. (Default: ```0.100000, 0.300000, 1.200000, 5.000000```)
 
-`TRAEFIK_METRICS_PROMETHEUS_ENTRYPOINT`:  
-EntryPoint. (Default: ```traefik```)
-
-`TRAEFIK_METRICS_PROMETHEUS_MIDDLEWARES`:  
-Middlewares.
-
 `TRAEFIK_METRICS_STATSD`:  
 StatsD metrics exporter type. (Default: ```false```)
 
@@ -241,13 +223,7 @@ Enable metrics on services. (Default: ```true```)
 StatsD push interval. (Default: ```10```)
 
 `TRAEFIK_PING`:  
-Enable ping. (Default: ```false```)
-
-`TRAEFIK_PING_ENTRYPOINT`:  
-Ping entryPoint. (Default: ```traefik```)
-
-`TRAEFIK_PING_MIDDLEWARES`:  
-Middleware list.
+Enable ping. (Default: ```true```)
 
 `TRAEFIK_PROVIDERS_DOCKER`:  
 Enable Docker backend with default settings. (Default: ```false```)
@@ -457,10 +433,7 @@ Defines the polling interval in seconds. (Default: ```15```)
 Watch provider. (Default: ```true```)
 
 `TRAEFIK_PROVIDERS_REST`:  
-Enable Rest backend with default settings. (Default: ```false```)
-
-`TRAEFIK_PROVIDERS_REST_ENTRYPOINT`:  
-EntryPoint. (Default: ```traefik```)
+Enable Rest backend with default settings. (Default: ```true```)
 
 `TRAEFIK_SERVERSTRANSPORT_FORWARDINGTIMEOUTS_DIALTIMEOUT`:  
 The amount of time to wait until a connection to a backend server can be established. If zero, no timeout exists. (Default: ```30```)

--- a/integration/fixtures/marathon/simple.toml
+++ b/integration/fixtures/marathon/simple.toml
@@ -8,11 +8,10 @@
 [entryPoints]
   [entryPoints.web]
     address = ":8000"
-  [entryPoints.api]
+  [entryPoints.traefik]
     address = ":9090"
 
 [api]
-  entryPoint = "api"
 
 [providers]
   [providers.marathon]

--- a/integration/fixtures/ratelimit/simple.toml
+++ b/integration/fixtures/ratelimit/simple.toml
@@ -3,7 +3,6 @@
   sendAnonymousUsage = false
 
 [api]
-  entrypoint="api"
 
 [log]
   level = "DEBUG"
@@ -11,9 +10,6 @@
 [entryPoints]
   [entryPoints.web]
     address = ":8081"
-
-  [entryPoints.api]
-    address = ":8080"
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/simple_test.go
+++ b/integration/simple_test.go
@@ -159,6 +159,7 @@ func (s *SimpleSuite) TestRequestAcceptGraceTimeout(c *check.C) {
 }
 
 func (s *SimpleSuite) TestApiOnSameEntryPoint(c *check.C) {
+	c.Skip("Waiting for new api handler implementation")
 	s.createComposeProject(c, "base")
 	s.composeProject.Start(c)
 
@@ -221,6 +222,8 @@ func (s *SimpleSuite) TestStatsWithMultipleEntryPoint(c *check.C) {
 }
 
 func (s *SimpleSuite) TestNoAuthOnPing(c *check.C) {
+	c.Skip("Waiting for new api handler implementation")
+
 	s.createComposeProject(c, "base")
 	s.composeProject.Start(c)
 

--- a/pkg/anonymize/anonymize_config_test.go
+++ b/pkg/anonymize/anonymize_config_test.go
@@ -119,8 +119,7 @@ func TestDo_globalConfiguration(t *testing.T) {
 	}
 
 	config.API = &static.API{
-		EntryPoint: "traefik",
-		Dashboard:  true,
+		Dashboard: true,
 		DashboardAssets: &assetfs.AssetFS{
 			Asset: func(path string) ([]byte, error) {
 				return nil, nil
@@ -133,7 +132,6 @@ func TestDo_globalConfiguration(t *testing.T) {
 			},
 			Prefix: "fii",
 		},
-		Middlewares: []string{"first", "second"},
 	}
 
 	config.Providers.File = &file.Provider{
@@ -186,9 +184,7 @@ func TestDo_globalConfiguration(t *testing.T) {
 
 	config.Metrics = &types.Metrics{
 		Prometheus: &types.Prometheus{
-			Buckets:     []float64{0.1, 0.3, 1.2, 5},
-			EntryPoint:  "MyEntryPoint",
-			Middlewares: []string{"m1", "m2"},
+			Buckets: []float64{0.1, 0.3, 1.2, 5},
 		},
 		DataDog: &types.DataDog{
 			Address:      "localhost:8181",
@@ -209,10 +205,7 @@ func TestDo_globalConfiguration(t *testing.T) {
 		},
 	}
 
-	config.Ping = &ping.Handler{
-		EntryPoint:  "MyEntryPoint",
-		Middlewares: []string{"m1", "m2", "m3"},
-	}
+	config.Ping = &ping.Handler{}
 
 	config.Tracing = &static.Tracing{
 		ServiceName:   "myServiceName",

--- a/pkg/api/handler.go
+++ b/pkg/api/handler.go
@@ -11,7 +11,6 @@ import (
 	"github.com/containous/traefik/pkg/config/runtime"
 	"github.com/containous/traefik/pkg/config/static"
 	"github.com/containous/traefik/pkg/log"
-	"github.com/containous/traefik/pkg/types"
 	"github.com/containous/traefik/pkg/version"
 	assetfs "github.com/elazarl/go-bindata-assetfs"
 )
@@ -50,7 +49,7 @@ type Handler struct {
 	// runtimeConfiguration is the data set used to create all the data representations exposed by the API.
 	runtimeConfiguration *runtime.Configuration
 	staticConfig         static.Configuration
-	statistics           *types.Statistics
+	// statistics           *types.Statistics
 	// stats                *thoasstats.Stats // FIXME stats
 	// StatsRecorder         *middlewares.StatsRecorder // FIXME stats
 	dashboardAssets *assetfs.AssetFS
@@ -65,8 +64,8 @@ func New(staticConfig static.Configuration, runtimeConfig *runtime.Configuration
 	}
 
 	return &Handler{
-		dashboard:            staticConfig.API.Dashboard,
-		statistics:           staticConfig.API.Statistics,
+		dashboard: staticConfig.API.Dashboard,
+		// statistics:           staticConfig.API.Statistics,
 		dashboardAssets:      staticConfig.API.DashboardAssets,
 		runtimeConfiguration: rConfig,
 		staticConfig:         staticConfig,

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -85,17 +85,15 @@ type ServersTransport struct {
 
 // API holds the API configuration
 type API struct {
-	EntryPoint      string            `description:"The entry point that the API handler will be bound to." json:"entryPoint,omitempty" toml:"entryPoint,omitempty" yaml:"entryPoint,omitempty" export:"true"`
-	Dashboard       bool              `description:"Activate dashboard." json:"dashboard,omitempty" toml:"dashboard,omitempty" yaml:"dashboard,omitempty" export:"true"`
-	Debug           bool              `description:"Enable additional endpoints for debugging and profiling." json:"debug,omitempty" toml:"debug,omitempty" yaml:"debug,omitempty" export:"true"`
-	Statistics      *types.Statistics `description:"Enable more detailed statistics." json:"statistics,omitempty" toml:"statistics,omitempty" yaml:"statistics,omitempty" export:"true" label:"allowEmpty"`
-	Middlewares     []string          `description:"Middleware list." json:"middlewares,omitempty" toml:"middlewares,omitempty" yaml:"middlewares,omitempty" export:"true"`
-	DashboardAssets *assetfs.AssetFS  `json:"-" toml:"-" yaml:"-" label:"-"`
+	Dashboard bool `description:"Activate dashboard." json:"dashboard,omitempty" toml:"dashboard,omitempty" yaml:"dashboard,omitempty" export:"true"`
+	Debug     bool `description:"Enable additional endpoints for debugging and profiling." json:"debug,omitempty" toml:"debug,omitempty" yaml:"debug,omitempty" export:"true"`
+	// TODO: Re-enable statistics
+	// Statistics      *types.Statistics `description:"Enable more detailed statistics." json:"statistics,omitempty" toml:"statistics,omitempty" yaml:"statistics,omitempty" export:"true" label:"allowEmpty"`
+	DashboardAssets *assetfs.AssetFS `json:"-" toml:"-" yaml:"-" label:"-"`
 }
 
 // SetDefaults sets the default values.
 func (a *API) SetDefaults() {
-	a.EntryPoint = "traefik"
 	a.Dashboard = true
 }
 
@@ -175,10 +173,10 @@ func (c *Configuration) SetEffectiveConfiguration() {
 		}
 	}
 
-	if (c.API != nil && c.API.EntryPoint == DefaultInternalEntryPointName) ||
-		(c.Ping != nil && c.Ping.EntryPoint == DefaultInternalEntryPointName) ||
-		(c.Metrics != nil && c.Metrics.Prometheus != nil && c.Metrics.Prometheus.EntryPoint == DefaultInternalEntryPointName) ||
-		(c.Providers.Rest != nil && c.Providers.Rest.EntryPoint == DefaultInternalEntryPointName) {
+	if (c.API != nil) ||
+		(c.Ping != nil) ||
+		(c.Metrics != nil && c.Metrics.Prometheus != nil) ||
+		(c.Providers.Rest != nil) {
 		if _, ok := c.EntryPoints[DefaultInternalEntryPointName]; !ok {
 			ep := &EntryPoint{Address: ":8080"}
 			ep.SetDefaults()

--- a/pkg/ping/ping.go
+++ b/pkg/ping/ping.go
@@ -10,14 +10,11 @@ import (
 
 // Handler expose ping routes.
 type Handler struct {
-	EntryPoint  string   `description:"Ping entryPoint." json:"entryPoint,omitempty" toml:"entryPoint,omitempty" yaml:"entryPoint,omitempty" export:"true"`
-	Middlewares []string `description:"Middleware list." json:"middlewares,omitempty" toml:"middlewares,omitempty" yaml:"middlewares,omitempty" export:"true"`
 	terminating bool
 }
 
 // SetDefaults sets the default values.
 func (h *Handler) SetDefaults() {
-	h.EntryPoint = "traefik"
 }
 
 // WithContext causes the ping endpoint to serve non 200 responses.

--- a/pkg/provider/rest/rest.go
+++ b/pkg/provider/rest/rest.go
@@ -19,12 +19,10 @@ var _ provider.Provider = (*Provider)(nil)
 // Provider is a provider.Provider implementation that provides a Rest API.
 type Provider struct {
 	configurationChan chan<- dynamic.Message
-	EntryPoint        string `description:"EntryPoint." json:"entryPoint,omitempty" toml:"entryPoint,omitempty" yaml:"entryPoint,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values.
 func (p *Provider) SetDefaults() {
-	p.EntryPoint = "traefik"
 }
 
 var templatesRenderer = render.New(render.Options{Directory: "nowhere"})

--- a/pkg/server/router/route_appender_aggregator.go
+++ b/pkg/server/router/route_appender_aggregator.go
@@ -23,32 +23,24 @@ func NewRouteAppenderAggregator(ctx context.Context, chainBuilder chainBuilder, 
 	entryPointName string, runtimeConfiguration *runtime.Configuration) *RouteAppenderAggregator {
 	aggregator := &RouteAppenderAggregator{}
 
+	if entryPointName != "traefik" {
+		return aggregator
+	}
+
 	if conf.Providers != nil && conf.Providers.Rest != nil {
 		aggregator.AddAppender(conf.Providers.Rest)
 	}
 
-	if conf.API != nil && conf.API.EntryPoint == entryPointName {
-		chain := chainBuilder.BuildChain(ctx, conf.API.Middlewares)
-		aggregator.AddAppender(&WithMiddleware{
-			appender:          api.New(conf, runtimeConfiguration),
-			routerMiddlewares: chain,
-		})
+	if conf.API != nil {
+		aggregator.AddAppender(api.New(conf, runtimeConfiguration))
 	}
 
-	if conf.Ping != nil && conf.Ping.EntryPoint == entryPointName {
-		chain := chainBuilder.BuildChain(ctx, conf.Ping.Middlewares)
-		aggregator.AddAppender(&WithMiddleware{
-			appender:          conf.Ping,
-			routerMiddlewares: chain,
-		})
+	if conf.Ping != nil {
+		aggregator.AddAppender(conf.Ping)
 	}
 
-	if conf.Metrics != nil && conf.Metrics.Prometheus != nil && conf.Metrics.Prometheus.EntryPoint == entryPointName {
-		chain := chainBuilder.BuildChain(ctx, conf.Metrics.Prometheus.Middlewares)
-		aggregator.AddAppender(&WithMiddleware{
-			appender:          metrics.PrometheusHandler{},
-			routerMiddlewares: chain,
-		})
+	if conf.Metrics != nil && conf.Metrics.Prometheus != nil {
+		aggregator.AddAppender(metrics.PrometheusHandler{})
 	}
 
 	return aggregator

--- a/pkg/server/router/route_appender_aggregator_test.go
+++ b/pkg/server/router/route_appender_aggregator_test.go
@@ -30,6 +30,7 @@ func (c *ChainBuilderMock) BuildChain(ctx context.Context, middles []string) *al
 }
 
 func TestNewRouteAppenderAggregator(t *testing.T) {
+	t.Skip("Waiting for new api handler implementation")
 	testCases := []struct {
 		desc       string
 		staticConf static.Configuration
@@ -40,12 +41,12 @@ func TestNewRouteAppenderAggregator(t *testing.T) {
 			desc: "API with auth, ping without auth",
 			staticConf: static.Configuration{
 				Global: &static.Global{},
-				API: &static.API{
-					EntryPoint:  "traefik",
-					Middlewares: []string{"dumb"},
+				API:    &static.API{
+					// EntryPoint:  "traefik",
+					// Middlewares: []string{"dumb"},
 				},
 				Ping: &ping.Handler{
-					EntryPoint: "traefik",
+					// EntryPoint: "traefik",
 				},
 				EntryPoints: static.EntryPoints{
 					"traefik": {},
@@ -69,8 +70,8 @@ func TestNewRouteAppenderAggregator(t *testing.T) {
 			desc: "Wrong entrypoint name",
 			staticConf: static.Configuration{
 				Global: &static.Global{},
-				API: &static.API{
-					EntryPoint: "no",
+				API:    &static.API{
+					// EntryPoint: "no",
 				},
 				EntryPoints: static.EntryPoints{
 					"traefik": {},

--- a/pkg/types/metrics.go
+++ b/pkg/types/metrics.go
@@ -15,8 +15,6 @@ type Metrics struct {
 // Prometheus can contain specific configuration used by the Prometheus Metrics exporter.
 type Prometheus struct {
 	Buckets              []float64 `description:"Buckets for latency metrics." json:"buckets,omitempty" toml:"buckets,omitempty" yaml:"buckets,omitempty" export:"true"`
-	EntryPoint           string    `description:"EntryPoint." json:"entryPoint,omitempty" toml:"entryPoint,omitempty" yaml:"entryPoint,omitempty" export:"true"`
-	Middlewares          []string  `description:"Middlewares." json:"middlewares,omitempty" toml:"middlewares,omitempty" yaml:"middlewares,omitempty" export:"true"`
 	AddEntryPointsLabels bool      `description:"Enable metrics on entry points." json:"addEntryPointsLabels,omitempty" toml:"addEntryPointsLabels,omitempty" yaml:"addEntryPointsLabels,omitempty" export:"true"`
 	AddServicesLabels    bool      `description:"Enable metrics on services." json:"addServicesLabels,omitempty" toml:"addServicesLabels,omitempty" yaml:"addServicesLabels,omitempty" export:"true"`
 }
@@ -24,7 +22,6 @@ type Prometheus struct {
 // SetDefaults sets the default values.
 func (p *Prometheus) SetDefaults() {
 	p.Buckets = []float64{0.1, 0.3, 1.2, 5}
-	p.EntryPoint = "traefik"
 	p.AddEntryPointsLabels = true
 	p.AddServicesLabels = true
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

This PR removes the Middlewares and Entrypoint fields of the API handler configuration. As we're probably going to redo the routing and TLS handling (among other things) of other handlers (such as Ping, Rest provider, Prometheus metrics, etc) in the same way we're going to do it for the API handler, this PR also removes similarly extraneous fields for these as well.

### Motivation

This change comes in preparation of a a rework of the API handler configuration, which will define how traffic is routed to it, how we handle TLS with it, etc.
We envision that the Entrypoint and Middlewares are not going to be part of its configuration anymore when we redo it, so remove them as of now, so that we don't have to break the configuration later on.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Co-authored-by: Julien Salleyron <julien.salleyron@gmail.com>

