### PR TITLE
Add missing KeyUsages for default generated certificate

### DIFF
--- a/tls/generate/generate.go
+++ b/tls/generate/generate.go
@@ -85,7 +85,7 @@ func derCert(privKey *rsa.PrivateKey, expiration time.Time, domain string) ([]by
 		NotBefore: time.Now(),
 		NotAfter:  expiration,
 
-		KeyUsage:              x509.KeyUsageKeyEncipherment,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageKeyAgreement | x509.KeyUsageDataEncipherment,
 		BasicConstraintsValid: true,
 		DNSNames:              []string{domain},
 	}


### PR DESCRIPTION
### What does this PR do?

Adds missing KeyUsages for the default generated certificate

### Motivation

Fixes #5006 

### Additional Notes

Chrome Pre-v75 did not strictly enforce the keyUsage parameter for self-signed certificates, as the user already had to allow them.

I have added in:
- Digital Signature (Required by chrome)
- Key Agreement (can be used with DH ciphers)
- Data Encipherment (for encrypting data)

More information can be found in:
(https://www.ibm.com/support/knowledgecenter/sl/SSKTMJ_9.0.1/admin/conf_keyusageextensionsandextendedkeyusage_r.html)
and (https://www.ietf.org/rfc/rfc3280.txt) section `4.2.1.3  Key Usage`