### PR TITLE
Apply the case of the CLI flags for the configuration

### DIFF
--- a/pkg/cli/commands_test.go
+++ b/pkg/cli/commands_test.go
@@ -665,6 +665,23 @@ func Test_execute_configuration_file(t *testing.T) {
 		},
 	}
 	assert.Equal(t, expected, element)
+
+	// check with `configfile` in lower case
+	args = []string{"", "sub1", "--configfile=./fixtures/config.toml"}
+
+	err = execute(rootCmd, args, true)
+	require.NoError(t, err)
+
+	expected = &Yo{
+		Foo: "bar",
+		Fii: "bir",
+		Fuu: "test",
+		Yi: &Yi{
+			Foo: "foo",
+			Fii: "fii",
+		},
+	}
+	assert.Equal(t, expected, element)
 }
 
 func Test_execute_help(t *testing.T) {

--- a/pkg/cli/commands_test.go
+++ b/pkg/cli/commands_test.go
@@ -625,63 +625,62 @@ func Test_execute_configuration(t *testing.T) {
 }
 
 func Test_execute_configuration_file(t *testing.T) {
-	rootCmd := &Command{
-		Name:          "root",
-		Description:   "This is a test",
-		Configuration: nil,
-		Run: func(_ []string) error {
-			return nil
+	testCases := []struct {
+		desc string
+		args []string
+	}{
+		{
+			desc: "configFile arg in camel case",
+			args: []string{"", "sub1", "--configFile=./fixtures/config.toml"},
+		},
+		{
+			desc: "configfile arg in lower case",
+			args: []string{"", "sub1", "--configfile=./fixtures/config.toml"},
 		},
 	}
 
-	element := &Yo{
-		Fuu: "test",
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			rootCmd := &Command{
+				Name:          "root",
+				Description:   "This is a test",
+				Configuration: nil,
+				Run: func(_ []string) error {
+					return nil
+				},
+			}
+
+			element := &Yo{
+				Fuu: "test",
+			}
+
+			sub1 := &Command{
+				Name:          "sub1",
+				Description:   "sub1",
+				Configuration: element,
+				Resources:     []ResourceLoader{&FileLoader{}, &FlagLoader{}},
+				Run: func(args []string) error {
+					return nil
+				},
+			}
+			err := rootCmd.AddCommand(sub1)
+			require.NoError(t, err)
+
+			err = execute(rootCmd, test.args, true)
+			require.NoError(t, err)
+
+			expected := &Yo{
+				Foo: "bar",
+				Fii: "bir",
+				Fuu: "test",
+				Yi: &Yi{
+					Foo: "foo",
+					Fii: "fii",
+				},
+			}
+			assert.Equal(t, expected, element)
+		})
 	}
-
-	sub1 := &Command{
-		Name:          "sub1",
-		Description:   "sub1",
-		Configuration: element,
-		Resources:     []ResourceLoader{&FileLoader{}, &FlagLoader{}},
-		Run: func(args []string) error {
-			return nil
-		},
-	}
-	err := rootCmd.AddCommand(sub1)
-	require.NoError(t, err)
-
-	args := []string{"", "sub1", "--configFile=./fixtures/config.toml"}
-
-	err = execute(rootCmd, args, true)
-	require.NoError(t, err)
-
-	expected := &Yo{
-		Foo: "bar",
-		Fii: "bir",
-		Fuu: "test",
-		Yi: &Yi{
-			Foo: "foo",
-			Fii: "fii",
-		},
-	}
-	assert.Equal(t, expected, element)
-
-	// check with `configfile` in lower case
-	args = []string{"", "sub1", "--configfile=./fixtures/config.toml"}
-
-	err = execute(rootCmd, args, true)
-	require.NoError(t, err)
-
-	expected = &Yo{
-		Foo: "bar",
-		Fii: "bir",
-		Fuu: "test",
-		Yi: &Yi{
-			Foo: "foo",
-			Fii: "fii",
-		},
-	}
-	assert.Equal(t, expected, element)
 }
 
 func Test_execute_help(t *testing.T) {

--- a/pkg/cli/loader_file.go
+++ b/pkg/cli/loader_file.go
@@ -35,7 +35,10 @@ func (f *FileLoader) Load(args []string, cmd *Command) (bool, error) {
 	}
 
 	if f.ConfigFileFlag != "" {
-		configFileFlag = "traefik." + strings.ToLower(f.ConfigFileFlag)
+		configFileFlag = "traefik." + f.ConfigFileFlag
+		if _, ok := ref[strings.ToLower(configFileFlag)]; ok {
+			configFileFlag = "traefik." + strings.ToLower(f.ConfigFileFlag)
+		}
 	}
 
 	configFile, err := loadConfigFiles(ref[configFileFlag], cmd.Configuration)

--- a/pkg/cli/loader_file.go
+++ b/pkg/cli/loader_file.go
@@ -30,6 +30,10 @@ func (f *FileLoader) Load(args []string, cmd *Command) (bool, error) {
 	}
 
 	configFileFlag := "traefik.configfile"
+	if _, ok := ref["traefik.configFile"]; ok {
+		configFileFlag = "traefik.configFile"
+	}
+
 	if f.ConfigFileFlag != "" {
 		configFileFlag = "traefik." + strings.ToLower(f.ConfigFileFlag)
 	}

--- a/pkg/config/flag/flag_test.go
+++ b/pkg/config/flag/flag_test.go
@@ -137,6 +137,20 @@ func TestDecode(t *testing.T) {
 			},
 		},
 		{
+			desc: "map string case sensitive",
+			args: []string{"--foo.caseSensitiveName=barBoo"},
+			element: &struct {
+				Foo map[string]string
+			}{},
+			expected: &struct {
+				Foo map[string]string
+			}{
+				Foo: map[string]string{
+					"caseSensitiveName": "barBoo",
+				},
+			},
+		},
+		{
 			desc: "map struct",
 			args: []string{"--foo.name.value=bar"},
 			element: &struct {

--- a/pkg/config/flag/flagparser.go
+++ b/pkg/config/flag/flagparser.go
@@ -101,17 +101,16 @@ func (f *flagSet) parseOne() (bool, error) {
 }
 
 func (f *flagSet) setValue(name string, value string) {
-	s := parser.DefaultRootName + "." + name
-	n := strings.ToLower(parser.DefaultRootName + "." + name)
+	srcKey := parser.DefaultRootName + "." + name
+	neutralKey := strings.ToLower(srcKey)
 
-	key, ok := f.keys[n]
+	key, ok := f.keys[neutralKey]
 	if !ok {
-		f.keys[n] = s
-		key = s
+		f.keys[neutralKey] = srcKey
+		key = srcKey
 	}
 
 	v, ok := f.values[key]
-
 	if ok && f.flagTypes[strings.ToLower(name)] == reflect.Slice {
 		f.values[key] = v + "," + value
 		return

--- a/pkg/config/flag/flagparser.go
+++ b/pkg/config/flag/flagparser.go
@@ -16,6 +16,7 @@ func Parse(args []string, element interface{}) (map[string]string, error) {
 		flagTypes: getFlagTypes(element),
 		args:      args,
 		values:    make(map[string]string),
+		keys:      make(map[string]string),
 	}
 
 	for {
@@ -35,6 +36,7 @@ type flagSet struct {
 	flagTypes map[string]reflect.Kind
 	args      []string
 	values    map[string]string
+	keys      map[string]string
 }
 
 func (f *flagSet) parseOne() (bool, error) {
@@ -78,7 +80,8 @@ func (f *flagSet) parseOne() (bool, error) {
 		return true, nil
 	}
 
-	if f.flagTypes[name] == reflect.Bool || f.flagTypes[name] == reflect.Ptr {
+	n := strings.ToLower(name)
+	if f.flagTypes[n] == reflect.Bool || f.flagTypes[n] == reflect.Ptr {
 		f.setValue(name, "true")
 		return true, nil
 	}
@@ -98,13 +101,21 @@ func (f *flagSet) parseOne() (bool, error) {
 }
 
 func (f *flagSet) setValue(name string, value string) {
+	s := parser.DefaultRootName + "." + name
 	n := strings.ToLower(parser.DefaultRootName + "." + name)
-	v, ok := f.values[n]
 
-	if ok && f.flagTypes[name] == reflect.Slice {
-		f.values[n] = v + "," + value
+	key, ok := f.keys[n]
+	if !ok {
+		f.keys[n] = s
+		key = s
+	}
+
+	v, ok := f.values[key]
+
+	if ok && f.flagTypes[strings.ToLower(name)] == reflect.Slice {
+		f.values[key] = v + "," + value
 		return
 	}
 
-	f.values[n] = value
+	f.values[key] = value
 }

--- a/pkg/config/flag/flagparser_test.go
+++ b/pkg/config/flag/flagparser_test.go
@@ -30,6 +30,16 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			desc: "bool value capitalized",
+			args: []string{"--Foo"},
+			element: &struct {
+				Foo bool
+			}{},
+			expected: map[string]string{
+				"traefik.Foo": "true",
+			},
+		},
+		{
 			desc: "equal",
 			args: []string{"--foo=bar"},
 			element: &struct {
@@ -40,6 +50,16 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			desc: "equal",
+			args: []string{"--Foo=Bar"},
+			element: &struct {
+				Foo string
+			}{},
+			expected: map[string]string{
+				"traefik.Foo": "Bar",
+			},
+		},
+		{
 			desc: "space separated",
 			args: []string{"--foo", "bar"},
 			element: &struct {
@@ -47,6 +67,16 @@ func TestParse(t *testing.T) {
 			}{},
 			expected: map[string]string{
 				"traefik.foo": "bar",
+			},
+		},
+		{
+			desc: "space separated capitalized",
+			args: []string{"--Foo", "Bar"},
+			element: &struct {
+				Foo string
+			}{},
+			expected: map[string]string{
+				"traefik.Foo": "Bar",
 			},
 		},
 		{
@@ -89,6 +119,16 @@ func TestParse(t *testing.T) {
 			}{},
 			expected: map[string]string{
 				"traefik.foo.name": "bar",
+			},
+		},
+		{
+			desc: "map string capitalized",
+			args: []string{"--foo.Name=Bar"},
+			element: &struct {
+				Foo map[string]string
+			}{},
+			expected: map[string]string{
+				"traefik.foo.Name": "Bar",
 			},
 		},
 		{
@@ -197,6 +237,50 @@ func TestParse(t *testing.T) {
 			}{},
 			expected: map[string]string{
 				"traefik.foo": "true",
+			},
+		},
+		{
+			desc: "map string case sensitive",
+			args: []string{"--foo.caseSensitiveName=barBoo"},
+			element: &struct {
+				Foo map[string]string
+			}{},
+			expected: map[string]string{
+				"traefik.foo.caseSensitiveName": "barBoo",
+			},
+		},
+		{
+			desc: "map struct with sub-map case senstitive",
+			args: []string{"--foo.Name1.bar.name2.value=firstValue", "--foo.naMe1.bar.name2.value=secondValue"},
+			element: &struct {
+				Foo map[string]struct {
+					Bar map[string]struct{ Value string }
+				}
+			}{},
+			expected: map[string]string{
+				"traefik.foo.Name1.bar.name2.value": "secondValue",
+			},
+		},
+		{
+			desc: "map struct with sub-map and different case",
+			args: []string{"--foo.Name1.bar.name2.value=firstValue", "--foo.naMe1.bar.name2.value=secondValue"},
+			element: &struct {
+				Foo map[string]struct {
+					Bar map[string]struct{ Value string }
+				}
+			}{},
+			expected: map[string]string{
+				"traefik.foo.Name1.bar.name2.value": "secondValue",
+			},
+		},
+		{
+			desc: "slice with several flags 2 and different cases.",
+			args: []string{"--foo", "bar", "--Foo", "baz"},
+			element: &struct {
+				Foo []string
+			}{},
+			expected: map[string]string{
+				"traefik.foo": "bar,baz",
 			},
 		},
 	}


### PR DESCRIPTION
### What does this PR do?

Take the CLI flags case into account to apply the static configuration.

### Motivation

For the static configuration, some elements are case sensitive (like access log fields), so we need to apply the right static configuration from the command line.

### More

- [x] Added/updated tests
- [ ] ~~Added/updated documentation~~
