### PR TITLE
Correct Kubernetes Ingress and IngressRoute port heuristic for choosing HTTPS

### DIFF
--- a/pkg/provider/kubernetes/crd/fixtures/services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/services.yml
@@ -68,6 +68,7 @@ spec:
   ports:
     - name: web-secure
       port: 443
+      targetPort: 8443
   selector:
     app: containous
     task: whoami2
@@ -85,7 +86,7 @@ subsets:
       - ip: 10.10.0.6
     ports:
       - name: web-secure
-        port: 443
+        port: 8443
 
 ---
 apiVersion: v1

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -273,7 +273,7 @@ func loadServers(client Client, namespace string, svc v1alpha1.Service) ([]dynam
 			case "http", "https", "h2c":
 				protocol = svc.Scheme
 			case "":
-				if port == 443 || strings.HasPrefix(portSpec.Name, "https") {
+				if portSpec.Port == 443 || strings.HasPrefix(portSpec.Name, "https") {
 					protocol = "https"
 				}
 			default:

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -1324,10 +1324,10 @@ func TestLoadIngressRoutes(t *testing.T) {
 							LoadBalancer: &dynamic.LoadBalancerService{
 								Servers: []dynamic.Server{
 									{
-										URL: "https://10.10.0.5:443",
+										URL: "https://10.10.0.5:8443",
 									},
 									{
-										URL: "https://10.10.0.6:443",
+										URL: "https://10.10.0.6:8443",
 									},
 								},
 								PassHostHeader: true,

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(port-==-443)_endpoint.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(port-==-443)_endpoint.yml
@@ -8,8 +8,8 @@ subsets:
 - addresses:
   - ip: 10.10.0.1
   ports:
-  - port: 443
+  - port: 8443
 - addresses:
   - ip: 10.21.0.1
   ports:
-  - port: 443
+  - port: 8443

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(port-==-443)_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(port-==-443)_service.yml
@@ -7,4 +7,5 @@ metadata:
 spec:
   ports:
   - port: 443
+    targetPort: 8443
   clusterIp: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -216,7 +216,7 @@ func loadService(client Client, namespace string, backend v1beta1.IngressBackend
 			}
 
 			protocol := "http"
-			if port == 443 || strings.HasPrefix(portName, "https") {
+			if portSpec.Port == 443 || strings.HasPrefix(portName, "https") {
 				protocol = "https"
 			}
 

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -732,10 +732,10 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
 									{
-										URL: "https://10.10.0.1:443",
+										URL: "https://10.10.0.1:8443",
 									},
 									{
-										URL: "https://10.21.0.1:443",
+										URL: "https://10.21.0.1:8443",
 									},
 								},
 							},


### PR DESCRIPTION
### What does this PR do?

When applying the port value heuristic to decide whether to contact a Kubernetes _Service_'s _Endpoints_ using HTTP or HTTPS, inspect the _Service_'s front-end port instead of the upstream servers' port values. That is, for example, when Traefik services an _Ingress_ or _IngressRoute_ object pointing at a _Service_ that forwards from port 443 to servers listening on port 8443, it should use HTTPS.

### Motivation

Fixes #5164 (though not yet honoring the "ingress.kubernetes.io/protocol" annotation yet [like in Traefik version 1.7](https://github.com/containous/traefik/blob/v1.7/provider/kubernetes/kubernetes.go#L355-L363))

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Should we include the "ingress.kubernetes.io/protocol" annotation here? At present, this patch addresses only the _Service_ port value.