### PR TITLE
[Documentation] domains indentation under tls

### DIFF
--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -746,7 +746,7 @@ tcp:
       rule: "HostSNI(`snitest.com`)"
       tls:
         certResolver: "bar"
-      domains:
-      - main: "snitest.com"
-        sans: "*.snitest.com"
+        domains:
+        - main: "snitest.com"
+          sans: "*.snitest.com"
 ```


### PR DESCRIPTION
When it's not configured under the TLS section, it gets omitted from the config parsing and leads to requesting a cert with the FQDN of the host rule only, leading to plenty of certificate requests to Let's Encrypt.

Following the old documentation:
```
traefik_1  | time="2019-08-03T19:16:18Z" level=debug msg="Configuration received from provider file: {\"http\":{\"routers\":{\"SERVICE\":{\"entryPoints\":[\"https\"],\"service\":\"SERVICE\",\"rule\":\"Host(\`subdomain.SOME.DOMAIN.com`)\",\"tls\":{\"certResolver\":\"default\"}}},\"services\":{\"SERVICE\":{\"loadBalancer\":{\"servers\":[{\"url\":\"http://X.X.X.X:XX\"}],\"passHostHeader\":false}}}},\"tcp\":{},\"tls\":{}}" providerName=file
```

Following documentation after this change:
```
traefik_1  | time="2019-08-03T19:25:04Z" level=debug msg="Configuration received from provider file: {\"http\":{\"routers\":{\"ROUTER\":{\"entryPoints\":[\"https\"],\"service\":\"SERVICE\",\"rule\":\"Host(`subdomain.SOME.DOMAIN.com`)\",\"tls\":{\"certResolver\":\"default\",\"domains\":[{\"main\":\"*.SOME.DOMAIN.com\"}]}}},\"services\":{\"SERVICE\":{\"loadBalancer\":{\"servers\":[{\"url\":\"http://X.X.X.X:XX\"}],\"passHostHeader\":false}}}},\"tcp\":{},\"tls\":{}}" providerName=file
```