### PR TITLE
[Docs] YAML indent for domains under TLS section

### DIFF
--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -453,9 +453,9 @@ http:
       rule: "Host(`snitest.com`) && Path(`/bar`)"
       tls:
         certResolver: "bar"
-      domains:
-      - main: "snitest.com"
-        sans: "*.snitest.com"
+        domains:
+        - main: "snitest.com"
+          sans: "*.snitest.com"
 ```
 
 [ACME v2](https://community.letsencrypt.org/t/acme-v2-and-wildcard-certificate-support-is-live/55579) supports wildcard certificates.
@@ -746,7 +746,7 @@ tcp:
       rule: "HostSNI(`snitest.com`)"
       tls:
         certResolver: "bar"
-      domains:
-      - main: "snitest.com"
-        sans: "*.snitest.com"
+        domains:
+        - main: "snitest.com"
+          sans: "*.snitest.com"
 ```


### PR DESCRIPTION
### What does this PR do?

Fixes the indentation of the YAML snippet to show that the domains section is actually under the TLS section.

### Motivation

When it's not configured under the TLS section, it gets omitted from the config parsing and leads to requesting a cert with the FQDN of the host rule only, leading to plenty of certificate requests to Let's Encrypt.

Following the old documentation:
```
traefik_1  | time="2019-08-03T19:16:18Z" level=debug msg="Configuration received from provider file: {\"http\":{\"routers\":{\"SERVICE\":{\"entryPoints\":[\"https\"],\"service\":\"SERVICE\",\"rule\":\"Host(`subdomain.SOME.DOMAIN.com`)\",\"tls\":{\"certResolver\":\"default\"}}},\"services\":{\"SERVICE\":{\"loadBalancer\":{\"servers\":[{\"url\":\"http://X.X.X.X:XX\"}],\"passHostHeader\":false}}}},\"tcp\":{},\"tls\":{}}" providerName=file
```

Following documentation after this change:
```
traefik_1  | time="2019-08-03T19:25:04Z" level=debug msg="Configuration received from provider file: {\"http\":{\"routers\":{\"ROUTER\":{\"entryPoints\":[\"https\"],\"service\":\"SERVICE\",\"rule\":\"Host(`subdomain.SOME.DOMAIN.com`)\",\"tls\":{\"certResolver\":\"default\",\"domains\":[{\"main\":\"*.SOME.DOMAIN.com\"}]}}},\"services\":{\"SERVICE\":{\"loadBalancer\":{\"servers\":[{\"url\":\"http://X.X.X.X:XX\"}],\"passHostHeader\":false}}}},\"tcp\":{},\"tls\":{}}" providerName=file
```