### PR TITLE
Make hijackConnectionTracker.Close thread safe

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -85,6 +85,8 @@ func (h *hijackConnectionTracker) Shutdown(ctx context.Context) error {
 
 // Close close all the connections in the tracked connections list
 func (h *hijackConnectionTracker) Close() {
+	h.lock.Lock()
+	defer h.lock.Unlock()
 	for conn := range h.conns {
 		if err := conn.Close(); err != nil {
 			log.Errorf("Error while closing Hijacked conn: %v", err)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

This PR fixes a potential panic on the `hijackConnectionTracker.Close` method.
The access to the `conns` attribute wasn't protected against concurrent calls,
potentially causing a `concurrent map writes` panic.

### Motivation

This is causing a panic on our side.

### More

- [ ] ~Added/updated tests~
- [ ] ~Added/updated documentation~