### PR TITLE
Fix `url.Parse` due to go1.12.8 changes.

### DIFF
--- a/pkg/middlewares/retry/retry_test.go
+++ b/pkg/middlewares/retry/retry_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/http/httptrace"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -38,7 +39,7 @@ func TestRetry(t *testing.T) {
 			desc:                  "no retry when max request attempts is one",
 			config:                dynamic.Retry{Attempts: 1},
 			wantRetryAttempts:     0,
-			wantResponseStatus:    http.StatusInternalServerError,
+			wantResponseStatus:    http.StatusBadGateway,
 			amountFaultyEndpoints: 1,
 		},
 		{
@@ -59,7 +60,7 @@ func TestRetry(t *testing.T) {
 			desc:                  "max attempts exhausted delivers the 5xx response",
 			config:                dynamic.Retry{Attempts: 3},
 			wantRetryAttempts:     2,
-			wantResponseStatus:    http.StatusInternalServerError,
+			wantResponseStatus:    http.StatusBadGateway,
 			amountFaultyEndpoints: 3,
 		},
 	}
@@ -83,13 +84,14 @@ func TestRetry(t *testing.T) {
 			loadBalancer, err := roundrobin.New(forwarder)
 			require.NoError(t, err)
 
-			basePort := 33444
+			// out of range port
+			basePort := 1133444
 			for i := 0; i < test.amountFaultyEndpoints; i++ {
 				// 192.0.2.0 is a non-routable IP for testing purposes.
 				// See: https://stackoverflow.com/questions/528538/non-routable-ip-address/18436928#18436928
 				// We only use the port specification here because the URL is used as identifier
 				// in the load balancer and using the exact same URL would not add a new server.
-				err = loadBalancer.UpsertServer(testhelpers.MustParseURL("http://192.0.2.0:" + string(basePort+i)))
+				err = loadBalancer.UpsertServer(testhelpers.MustParseURL("http://192.0.2.0:" + strconv.Itoa(basePort+i)))
 				require.NoError(t, err)
 			}
 
@@ -277,13 +279,14 @@ func TestRetryWebsocket(t *testing.T) {
 				t.Fatalf("Error creating load balancer: %v", err)
 			}
 
-			basePort := 33444
+			// out of range port
+			basePort := 1133444
 			for i := 0; i < test.amountFaultyEndpoints; i++ {
 				// 192.0.2.0 is a non-routable IP for testing purposes.
 				// See: https://stackoverflow.com/questions/528538/non-routable-ip-address/18436928#18436928
 				// We only use the port specification here because the URL is used as identifier
 				// in the load balancer and using the exact same URL would not add a new server.
-				_ = loadBalancer.UpsertServer(testhelpers.MustParseURL("http://192.0.2.0:" + string(basePort+i)))
+				_ = loadBalancer.UpsertServer(testhelpers.MustParseURL("http://192.0.2.0:" + strconv.Itoa(basePort+i)))
 			}
 
 			// add the functioning server to the end of the load balancer list


### PR DESCRIPTION
### What does this PR do?

Fixes `url.Parse` due to go1.12.8 changes.

### Motivation

See #5201

### More

- [x] Added/updated tests
- [ ] ~~Added/updated documentation~~
