### PR TITLE
Removed extra colon before the 8080 docker port

### DIFF
--- a/docs/content/user-guides/docker-compose/acme-http/docker-compose.yml
+++ b/docs/content/user-guides/docker-compose/acme-http/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     ports:
       - "80:80"
       - "443:443"
-      - ":8080:8080"
+      - "8080:8080"
     volumes:
       - "./letsencrypt:/letsencrypt"
       - "/var/run/docker.sock:/var/run/docker.sock:ro"


### PR DESCRIPTION
Removes the extra colon.  Otherwise the docker will not compose.
(First time contibutor, hopefully this is the right process)