### PR TITLE
Replace ambiguous cli help message wording

### DIFF
--- a/cmd/healthcheck/healthcheck.go
+++ b/cmd/healthcheck/healthcheck.go
@@ -15,7 +15,7 @@ import (
 func NewCmd(traefikConfiguration *static.Configuration, loaders []cli.ResourceLoader) *cli.Command {
 	return &cli.Command{
 		Name:          "healthcheck",
-		Description:   `Calls Traefik /ping to check the health of Traefik (the endpoint must be enabled).`,
+		Description:   `Calls Traefik /ping endpoint (disabled by default) to check the health of Traefik.`,
 		Configuration: traefikConfiguration,
 		Run:           runCmd(traefikConfiguration),
 		Resources:     loaders,

--- a/cmd/healthcheck/healthcheck.go
+++ b/cmd/healthcheck/healthcheck.go
@@ -15,7 +15,7 @@ import (
 func NewCmd(traefikConfiguration *static.Configuration, loaders []cli.ResourceLoader) *cli.Command {
 	return &cli.Command{
 		Name:          "healthcheck",
-		Description:   `Calls Traefik /ping to check the health of Traefik (the API must be enabled).`,
+		Description:   `Calls Traefik /ping to check the health of Traefik (the endpoint must be enabled).`,
 		Configuration: traefikConfiguration,
 		Run:           runCmd(traefikConfiguration),
 		Resources:     loaders,

--- a/docs/content/operations/cli.md
+++ b/docs/content/operations/cli.md
@@ -44,7 +44,7 @@ or any other health check orchestration mechanism.
 Usage:
 
 ```bash
-traefik healthcheck [command] [flags] [arguments]
+traefik healthcheck --ping
 ```
 
 Example:

--- a/docs/content/operations/cli.md
+++ b/docs/content/operations/cli.md
@@ -44,7 +44,7 @@ or any other health check orchestration mechanism.
 Usage:
 
 ```bash
-traefik healthcheck --ping
+traefik healthcheck [command] [flags] [arguments]
 ```
 
 Example:

--- a/docs/content/operations/ping.md
+++ b/docs/content/operations/ping.md
@@ -29,6 +29,9 @@ You can customize the `entryPoint` where the `/ping` is active with the `entryPo
 |---------|---------------|-----------------------------------------------------------------------------------------------------|
 | `/ping` | `GET`, `HEAD` | A simple endpoint to check for Traefik process liveness. Return a code `200` with the content: `OK` |
 
+!!! note
+    The [`cli`](../cli/) comes with a `healthcheck` command which can be used for calling this endpoint.
+
 ### `entryPoint`
 
 Enabling /ping on a dedicated EntryPoint.

--- a/docs/content/operations/ping.md
+++ b/docs/content/operations/ping.md
@@ -30,7 +30,7 @@ You can customize the `entryPoint` where the `/ping` is active with the `entryPo
 | `/ping` | `GET`, `HEAD` | A simple endpoint to check for Traefik process liveness. Return a code `200` with the content: `OK` |
 
 !!! note
-    The [`cli`](../cli/) comes with a `healthcheck` command which can be used for calling this endpoint.
+    The `cli` comes with a [`healthcheck`](./cli.md#healthcheck) command which can be used for calling this endpoint.
 
 ### `entryPoint`
 


### PR DESCRIPTION
The term `API` could be mistaken with the Traefik web interface
exposing the configuration of router, services and middlewares
(As in https://docs.traefik.io/v2.0/operations/api/).

This pr replaces this term with the word `endpoint`, which is also
used in the documentation for this feature
(https://docs.traefik.io/v2.0/operations/ping/).

Fixes: #5226
