### PR TITLE
Remove the arguments from the usage help message

### DIFF
--- a/docs/content/operations/cli.md
+++ b/docs/content/operations/cli.md
@@ -6,7 +6,7 @@ The Traefik Command Line
 ## General
 
 ```bash
-traefik [command] [flags] [arguments]
+traefik [command] [flags]
 ```
 
 Use `traefik [command] --help` for help on any command.
@@ -40,7 +40,7 @@ or any other health check orchestration mechanism.
 Usage:
 
 ```bash
-traefik healthcheck [command] [flags] [arguments]
+traefik healthcheck [command] [flags]
 ```
 
 Example:

--- a/pkg/cli/help.go
+++ b/pkg/cli/help.go
@@ -14,7 +14,7 @@ import (
 
 const tmplHelp = `{{ .Cmd.Name }}	{{ .Cmd.Description }}
 
-Usage: {{ .Cmd.Name }} [command] [flags] [arguments]
+Usage: {{ .Cmd.Name }} [command] [flags]
 
 Use "{{ .Cmd.Name }} [command] --help" for help on any command.
 {{if .SubCommands }}


### PR DESCRIPTION
Traefik does not have or use any arguments.
