### PR TITLE
Kubernetes support for Auth.HeaderField

### DIFF
--- a/autogen/gentemplates/gen.go
+++ b/autogen/gentemplates/gen.go
@@ -1365,7 +1365,9 @@ var _templatesKubernetesTmpl = []byte(`[backends]
 
     {{if $frontend.Auth }}
     [frontends."{{ $frontendName }}".auth]
-      headerField = "X-WebAuth-User"
+      {{if $frontend.Auth.HeaderField }}
+      headerField = "{{ $frontend.Auth.HeaderField }}"
+      {{end}}
 
       {{if $frontend.Auth.Basic }}
       [frontends."{{ $frontendName }}".auth.basic]

--- a/templates/kubernetes.tmpl
+++ b/templates/kubernetes.tmpl
@@ -59,7 +59,9 @@
 
     {{if $frontend.Auth }}
     [frontends."{{ $frontendName }}".auth]
-      headerField = "X-WebAuth-User"
+      {{if $frontend.Auth.HeaderField }}
+      headerField = "{{ $frontend.Auth.HeaderField }}"
+      {{end}}
 
       {{if $frontend.Auth.Basic }}
       [frontends."{{ $frontendName }}".auth.basic]


### PR DESCRIPTION
Template modified to support ingress.kubernetes.io/auth-header-field

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Change to the kubernetes template to take auth-header-field into account.

### Motivation

<!-- What inspired you to submit this pull request? -->
A kubernetes ingress with authentication always sends a header `X-WebAuth-User` with the username to the backend. The [documentation](https://docs.traefik.io/configuration/backends/kubernetes/#authentication) states, that the header name can be changed through the annoation `ingress.kubernetes.io/auth-header-field`. This annotation is currently read from the kubernetes api but ignored when building the frontend definition.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
The default behaviour of the code will change. The documentation does not exactly describe if that header field will be set without an annotation.