### PR TITLE
Improve Access Logs Documentation page

### DIFF
--- a/docs/configuration/logs.md
+++ b/docs/configuration/logs.md
@@ -231,7 +231,7 @@ format = "json"
 ### Customize Headers
 
 Access logs prints the headers of each request, as fields of the access log line.
-You can customize which and how the headers are printed, likewise the other fileds (see ["Customize Fields" section](#customize-fields)).
+You can customize which and how the headers are printed, likewise the other fields (see ["Customize Fields" section](#customize-fields)).
 
 Each header has a "mode" which defines how it is written in the access log lines.
 The possible values for the mode are:


### PR DESCRIPTION
Signed-off-by: dduportal <1522731+dduportal@users.noreply.github.com>

### What does this PR do?

This PR improves the documentation page for the configuration of Access Logs.

### Motivation

- Feedback from this user: <https://github.com/containous/traefik/issues/5221#issuecomment-522454024>
- Found that customization of access logs fields, as well as access log headers were complicated to understand for end users.

### More

- ~[ ] Added/updated tests~
- [x] Added/updated documentation

### Additional Notes

This content is for `v1.7` branch, but it should be reusable after the next merge back to the `v2.0`.