### PR TITLE
Fix recovered panic when websocket is mirrored

### DIFF
--- a/pkg/server/service/loadbalancer/mirror/mirror.go
+++ b/pkg/server/service/loadbalancer/mirror/mirror.go
@@ -1,8 +1,10 @@
 package mirror
 
 import (
+	"bufio"
 	"context"
 	"errors"
+	"net"
 	"net/http"
 	"sync"
 
@@ -75,7 +77,7 @@ func (m *Mirroring) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 // AddMirror adds an httpHandler to mirror to.
 func (m *Mirroring) AddMirror(handler http.Handler, percent int) error {
-	if percent < 0 || percent >= 100 {
+	if percent < 0 || percent > 100 {
 		return errors.New("percent must be between 0 and 100")
 	}
 	m.mirrorHandlers = append(m.mirrorHandlers, &mirrorHandler{Handler: handler, percent: percent})
@@ -83,6 +85,12 @@ func (m *Mirroring) AddMirror(handler http.Handler, percent int) error {
 }
 
 type blackholeResponseWriter struct{}
+
+func (b blackholeResponseWriter) Flush() {}
+
+func (b blackholeResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return nil, nil, errors.New("you can hijack connection on blackholeResponseWriter")
+}
 
 func (b blackholeResponseWriter) Header() http.Header {
 	return http.Header{}
@@ -92,8 +100,7 @@ func (b blackholeResponseWriter) Write(bytes []byte) (int, error) {
 	return len(bytes), nil
 }
 
-func (b blackholeResponseWriter) WriteHeader(statusCode int) {
-}
+func (b blackholeResponseWriter) WriteHeader(statusCode int) {}
 
 type contextStopPropagation struct {
 	context.Context


### PR DESCRIPTION
### What does this PR do?
blackholeResponseWriter now implements `http.Hijacker` and `http.Flusher` interface.

### Motivation
Fix a recovered panic when websocket is mirrored.

### More

- [x] Added/updated tests

### Additional Notes
When websocket is mirrored, we mirror the upgrade request but not the websocket messages after that.