### PR TITLE
Fix trailing slash with check new version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/go-check/check v0.0.0-00010101000000-000000000000
 	github.com/go-kit/kit v0.9.0
 	github.com/golang/protobuf v1.3.2
-	github.com/google/go-github/v27 v27.0.4
+	github.com/google/go-github/v28 v28.0.0
 	github.com/googleapis/gnostic v0.1.0 // indirect
 	github.com/gorilla/mux v1.6.2
 	github.com/gorilla/websocket v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Z
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/google/go-github/v27 v27.0.4 h1:N/EEqsvJLgqTbepTiMBz+12KhwLovv6YvwpRezd+4Fg=
-github.com/google/go-github/v27 v27.0.4/go.mod h1:/0Gr8pJ55COkmv+S/yPKCczSkUPIM/LnFyubufRNIS0=
+github.com/google/go-github/v28 v28.0.0 h1:+UjHI4+1W/vsXR4jJBWt0ZA74XHbvt5yBAvsf1M3bgM=
+github.com/google/go-github/v28 v28.0.0/go.mod h1:+5GboIspo7F0NG2qsvfYh7en6F3EK37uyqv+c35AR3s=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf h1:+RRA9JqSOZFfKrOeqr2z77+8R2RKyh8PG66dcu1V0ck=

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 
 	"github.com/containous/traefik/v2/pkg/log"
-	"github.com/google/go-github/v27/github"
+	"github.com/google/go-github/v28/github"
 	"github.com/gorilla/mux"
 	goversion "github.com/hashicorp/go-version"
 	"github.com/unrolled/render"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -54,7 +54,7 @@ func CheckNewVersion() {
 		return
 	}
 	client := github.NewClient(nil)
-	updateURL, err := url.Parse("https://update.traefik.io")
+	updateURL, err := url.Parse("https://update.traefik.io/")
 	if err != nil {
 		log.Warnf("Error checking new version: %s", err)
 		return


### PR DESCRIPTION
### What does this PR do?

This PR fix #5256

Before go module the dependency [github.com/google/go-github](https://github.com/google/go-github) was in version [fe7d11f8add400587b6718d9f39a62e42cb04c28](https://github.com/google/go-github/blob/fe7d11f8add400587b6718d9f39a62e42cb04c28/github/github.go#L241-L271)

https://github.com/containous/traefik/pull/5191/files#diff-bd247e83efc3c45ae9e8c47233249f18L808

Today this dependency is in version [v27.0.4](https://github.com/google/go-github/blob/v27.0.4/github/github.go#L338-L371)

And there is a check for the trailing slash
```go
if !strings.HasSuffix(c.BaseURL.Path, "/") {
	return nil, fmt.Errorf("BaseURL must have a trailing slash, but %q does not", c.BaseURL)
}
```

### Motivation

Be able to check new version
