### PR TITLE
fix buffering middleware

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -299,14 +299,14 @@ You haven't specified the sendAnonymousUsage option, it will be enabled by defau
 Stats collection is enabled.
 Many thanks for contributing to Traefik's improvement by allowing us to receive anonymous information from your configuration.
 Help us improve Traefik by leaving this feature on :)
-More details on: https://docs.traefik.io/basics/#collected-data
+More details on: https://docs.traefik.io/v2.0/contributing/data-collection/
 `)
 		collect(staticConfiguration)
 	} else {
 		log.WithoutContext().Info(`
 Stats collection is disabled.
 Help us improve Traefik by turning this feature on :)
-More details on: https://docs.traefik.io/basics/#collected-data
+More details on: https://docs.traefik.io/v2.0/contributing/data-collection/
 `)
 	}
 }

--- a/pkg/server/middleware/middlewares.go
+++ b/pkg/server/middleware/middlewares.go
@@ -123,7 +123,7 @@ func (b *Builder) buildConstructor(ctx context.Context, middlewareName string) (
 	}
 
 	// Buffering
-	if config.Buffering != nil && config.InFlightReq.Amount != 0 {
+	if config.Buffering != nil {
 		if middleware != nil {
 			return nil, badConf
 		}
@@ -213,7 +213,7 @@ func (b *Builder) buildConstructor(ctx context.Context, middlewareName string) (
 	}
 
 	// InFlightReq
-	if config.InFlightReq != nil && config.InFlightReq.Amount != 0 {
+	if config.InFlightReq != nil {
 		if middleware != nil {
 			return nil, badConf
 		}

--- a/pkg/server/middleware/middlewares_test.go
+++ b/pkg/server/middleware/middlewares_test.go
@@ -314,6 +314,14 @@ func TestBuilder_buildConstructor(t *testing.T) {
 				Prefix: "foo/",
 			},
 		},
+		"buff-foo": {
+			Buffering: &dynamic.Buffering{
+				MaxRequestBodyBytes:  1,
+				MemRequestBodyBytes:  2,
+				MaxResponseBodyBytes: 3,
+				MemResponseBodyBytes: 5,
+			},
+		},
 	}
 
 	rtConf := runtime.NewConfig(dynamic.Configuration{
@@ -336,6 +344,11 @@ func TestBuilder_buildConstructor(t *testing.T) {
 		{
 			desc:          "Should create a circuit breaker with a valid expression",
 			middlewareID:  "cb-foo",
+			expectedError: false,
+		},
+		{
+			desc:          "Should create a buffering middleware",
+			middlewareID:  "buff-foo",
 			expectedError: false,
 		},
 		{


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

fix buffering middleware

### Motivation

```
DEBU[2019-09-02T15:52:55+02:00] Configuration received from provider file: {"http":{"routers":{"router0":{"entryPoints":["http"],"middlewares":["test-stripprefix"],"service":"service-foo","rule":"Path(`/bar`)"}},"middlewares":{"test-stripprefix":{"buffering":{"maxRequestBodyBytes":250000}}},"services":{"service-foo":{"loadBalancer":{"servers":[{"url":"http://127.0.0.1:3030"}],"passHostHeader":false}}}},"tcp":{},"tls":{}}  providerName=file
DEBU[2019-09-02T15:52:55+02:00] Creating middleware                           middlewareName=pipelining entryPointName=http routerName=router0@file serviceName=service-foo middlewareType=Pipelining
DEBU[2019-09-02T15:52:55+02:00] Creating load-balancer                        entryPointName=http routerName=router0@file serviceName=service-foo
DEBU[2019-09-02T15:52:55+02:00] Creating server 0 http://127.0.0.1:3030       routerName=router0@file serviceName=service-foo serverName=0 entryPointName=http
DEBU[2019-09-02T15:52:55+02:00] Added outgoing tracing middleware service-foo  routerName=router0@file entryPointName=http middlewareName=tracing middlewareType=TracingForwarder
ERRO[2019-09-02T15:52:55+02:00] Error in Go routine: runtime error: invalid memory address or nil pointer dereference 
ERRO[2019-09-02T15:52:55+02:00] Stack: goroutine 16 [running]:
runtime/debug.Stack(0xc000124000, 0x24bdd12, 0x17)
	/usr/local/go/src/runtime/debug/stack.go:24 +0x9d
github.com/containous/traefik/v2/pkg/safe.defaultRecoverGoroutine(0x208cf40, 0x3e64dc0)
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:159 +0x9d
github.com/containous/traefik/v2/pkg/safe.GoWithRecover.func1.1(0x2598a00)
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:150 +0x57
panic(0x208cf40, 0x3e64dc0)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/containous/traefik/v2/pkg/server/middleware.(*Builder).buildConstructor(0xc0001704e0, 0x290db80, 0xc0004c6d80, 0xc0002760a0, 0x15, 0xc0004c6d80, 0x0, 0x0)
	/go/src/github.com/containous/traefik/pkg/server/middleware/middlewares.go:126 +0x130
github.com/containous/traefik/v2/pkg/server/middleware.(*Builder).BuildChain.func1(0x28ae280, 0xc0004c6d50, 0x28ae280, 0xc0004c6d50, 0x0, 0x0)
	/go/src/github.com/containous/traefik/pkg/server/middleware/middlewares.go:73 +0x1e0
github.com/containous/alice.Chain.Then(0xc00014cbc0, 0x2, 0x2, 0x28ae000, 0xc00014cba0, 0x1, 0x1, 0x1, 0x0)
	/go/pkg/mod/github.com/containous/alice@v0.0.0-20181107144136-d83ebdd94cbd/chain.go:51 +0x8f
github.com/containous/traefik/v2/pkg/server/router.(*Manager).buildHTTPHandler(0xc000477b78, 0x290db80, 0xc0004c69f0, 0xc0004c65d0, 0xc000447a40, 0xc, 0xc0004c69f0, 0x1f72800, 0xc0005635c8, 0xc0005635c8)
	/go/src/github.com/containous/traefik/pkg/server/router/router.go:167 +0x576
github.com/containous/traefik/v2/pkg/server/router.(*Manager).buildRouterHandler(0xc000477b78, 0x290db80, 0xc0004c69f0, 0xc000447a40, 0xc, 0xc0004c65d0, 0xc0004c69f0, 0x2440980, 0xc0004841c0, 0xc0000236d0)
	/go/src/github.com/containous/traefik/pkg/server/router/router.go:127 +0xd2
github.com/containous/traefik/v2/pkg/server/router.(*Manager).buildEntryPointHandler(0xc000477b78, 0x290db80, 0xc0004c68a0, 0xc0004c6780, 0x1, 0x290db80, 0xc0004c68a0, 0xc0004c6750)
	/go/src/github.com/containous/traefik/pkg/server/router/router.go:97 +0x22e
github.com/containous/traefik/v2/pkg/server/router.(*Manager).BuildHandlers(0xc000477b78, 0x290db00, 0xc0000d2008, 0xc000170460, 0x2, 0x2, 0x0, 0x0)
	/go/src/github.com/containous/traefik/pkg/server/router/router.go:65 +0x1f4
github.com/containous/traefik/v2/pkg/server.(*Server).createHTTPHandlers(0xc000034340, 0x290db00, 0xc0000d2008, 0xc0004c6570, 0xc000170460, 0x2, 0x2, 0x2, 0xc000503fb0)
	/go/src/github.com/containous/traefik/pkg/server/server_configuration.go:105 +0x2eb
github.com/containous/traefik/v2/pkg/server.(*Server).loadConfigurationTCP(0xc000034340, 0xc0003dfda0, 0x3ead580)
	/go/src/github.com/containous/traefik/pkg/server/server_configuration.go:78 +0x283
github.com/containous/traefik/v2/pkg/server.(*Server).loadConfiguration(0xc000034340, 0x24977d4, 0x4, 0xc0004ca2a0)
	/go/src/github.com/containous/traefik/pkg/server/server_configuration.go:41 +0x11f
github.com/containous/traefik/v2/pkg/server.(*Server).listenConfigurations(0xc000034340, 0xc0001b22a0)
	/go/src/github.com/containous/traefik/pkg/server/server_configuration.go:244 +0x51
github.com/containous/traefik/v2/pkg/server.(*Server).Start.func3(0xc0001b22a0)
	/go/src/github.com/containous/traefik/pkg/server/server.go:172 +0x34
github.com/containous/traefik/v2/pkg/safe.(*Pool).Go.func1()
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:90 +0x7b
github.com/containous/traefik/v2/pkg/safe.GoWithRecover.func1(0x2598a00, 0xc00026cff0)
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:153 +0x57
created by github.com/containous/traefik/v2/pkg/safe.GoWithRecover
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:147 +0x49 
```


### More

- [x] Added/updated tests
- [ ] ~~Added/updated documentation~~
