### PR TITLE
Update Zipkin OpenTracing driver to latest 0.4.3 release

### DIFF
--- a/docs/content/observability/tracing/zipkin.md
+++ b/docs/content/observability/tracing/zipkin.md
@@ -18,46 +18,24 @@ tracing:
 
 #### `httpEndpoint`
 
-_Required, Default="http://localhost:9411/api/v1/spans"_
+_Required, Default="http://localhost:9411/api/v2/spans"_
 
 Zipkin HTTP endpoint used to send data.
 
 ```toml tab="File (TOML)"
 [tracing]
   [tracing.zipkin]
-    httpEndpoint = "http://localhost:9411/api/v1/spans"
+    httpEndpoint = "http://localhost:9411/api/v2/spans"
 ```
 
 ```yaml tab="File (YAML)"
 tracing:
   zipkin:
-    httpEndpoint: http://localhost:9411/api/v1/spans
+    httpEndpoint: http://localhost:9411/api/v2/spans
 ```
 
 ```bash tab="CLI"
---tracing.zipkin.httpEndpoint="http://localhost:9411/api/v1/spans"
-```
-
-#### `debug`
-
-_Optional, Default=false_
-
-Enable Zipkin debug.
-
-```toml tab="File (TOML)"
-[tracing]
-  [tracing.zipkin]
-    debug = true
-```
-
-```yaml tab="File (YAML)"
-tracing:
-  zipkin:
-    debug: true
-```
-
-```bash tab="CLI"
---tracing.zipkin.debug=true
+--tracing.zipkin.httpEndpoint="http://localhost:9411/api/v2/spans"
 ```
 
 #### `sameSpan`
@@ -86,7 +64,7 @@ tracing:
 
 _Optional, Default=true_
 
-Use Zipkin 128 bit root span IDs.
+Use Zipkin 128 bit trace IDs.
 
 ```toml tab="File (TOML)"
 [tracing]

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -561,11 +561,8 @@ Set the maximum character limit for Span names (default 0 = no limit). (Default:
 `--tracing.zipkin`:  
 Settings for Zipkin. (Default: ```false```)
 
-`--tracing.zipkin.debug`:  
-Enable Zipkin debug. (Default: ```false```)
-
 `--tracing.zipkin.httpendpoint`:  
-HTTP Endpoint to report traces to. (Default: ```http://localhost:9411/api/v1/spans```)
+HTTP Endpoint to report traces to. (Default: ```http://localhost:9411/api/v2/spans```)
 
 `--tracing.zipkin.id128bit`:  
 Use Zipkin 128 bit root span IDs. (Default: ```true```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -561,11 +561,8 @@ Set the maximum character limit for Span names (default 0 = no limit). (Default:
 `TRAEFIK_TRACING_ZIPKIN`:  
 Settings for Zipkin. (Default: ```false```)
 
-`TRAEFIK_TRACING_ZIPKIN_DEBUG`:  
-Enable Zipkin debug. (Default: ```false```)
-
 `TRAEFIK_TRACING_ZIPKIN_HTTPENDPOINT`:  
-HTTP Endpoint to report traces to. (Default: ```http://localhost:9411/api/v1/spans```)
+HTTP Endpoint to report traces to. (Default: ```http://localhost:9411/api/v2/spans```)
 
 `TRAEFIK_TRACING_ZIPKIN_ID128BIT`:  
 Use Zipkin 128 bit root span IDs. (Default: ```true```)

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -181,7 +181,6 @@
     httpEndpoint = "foobar"
     sameSpan = true
     id128Bit = true
-    debug = true
     sampleRate = 42.0
   [tracing.datadog]
     localAgentHostPort = "foobar"

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -186,7 +186,6 @@ tracing:
     httpEndpoint: foobar
     sameSpan: true
     id128Bit: true
-    debug: true
     sampleRate: 42
   datadog:
     localAgentHostPort: foobar

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/golang/protobuf v1.3.2
 	github.com/google/go-github/v28 v28.0.0
 	github.com/googleapis/gnostic v0.1.0 // indirect
-	github.com/gorilla/mux v1.6.2
+	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/websocket v1.4.0
 	github.com/hashicorp/go-version v1.2.0
 	github.com/huandu/xstrings v1.2.0 // indirect
@@ -65,10 +65,9 @@ require (
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runc v1.0.0-rc8 // indirect
-	github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492 // indirect
 	github.com/opentracing/basictracer-go v1.0.0 // indirect
 	github.com/opentracing/opentracing-go v1.1.0
-	github.com/openzipkin-contrib/zipkin-go-opentracing v0.3.5
+	github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.3
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/philhofer/fwd v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/opentracing/basictracer-go v1.0.0 // indirect
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.3
+	github.com/openzipkin/zipkin-go v0.2.1
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/philhofer/fwd v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -161,6 +161,7 @@ github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZi
 github.com/elazarl/go-bindata-assetfs v1.0.0 h1:G/bYguwHIzWq9ZoyUQqrjTmJbbYn3j3CKKpKinvZLFk=
 github.com/elazarl/go-bindata-assetfs v1.0.0/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
+github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/evanphx/json-patch v0.0.0-20190203023257-5858425f7550/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5IcNrDCXZ6OoTAWu7M=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -193,6 +194,7 @@ github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0 h1:xU6/SpYbvkNYiptHJYEDRseDLvYE7wSqhYYNy0QSUzI=
@@ -317,6 +319,7 @@ github.com/linode/linodego v0.10.0 h1:AMdb82HVgY8o3mjBXJcUv9B+fnJjfDMn2rNRGbX+jv
 github.com/linode/linodego v0.10.0/go.mod h1:cziNP7pbvE3mXIPneHj0oRY8L1WtGEIKlZ8LANE4eXA=
 github.com/looplab/fsm v0.1.0 h1:Qte7Zdn/5hBNbXzP7yxVU4OIFHWXBovyTT2LaBTyC20=
 github.com/looplab/fsm v0.1.0/go.mod h1:m2VaOfDHxqXBBMgc26m6yUOwkFn8H2AlJDE+jd/uafI=
+github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailgun/timetools v0.0.0-20141028012446-7e6055773c51 h1:Kg/NPZLLC3aAFr1YToMs98dbCdhootQ1hZIvZU28hAQ=
@@ -385,7 +388,9 @@ github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsq
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin-contrib/zipkin-go-opentracing v0.3.5 h1:82Tnq9OJpn+h5xgGpss5/mOv3KXdjtkdorFSOUusjM8=
 github.com/openzipkin-contrib/zipkin-go-opentracing v0.3.5/go.mod h1:uVHyebswE1cCXr2A73cRM2frx5ld1RJUCJkFNZ90ZiI=
+github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.3/go.mod h1:/wsWhb9smxSfWAKL3wpBW7V8scJMt8N8gnaMCS9E/cA=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
+github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/oracle/oci-go-sdk v7.0.0+incompatible h1:oj5ESjXwwkFRdhZSnPlShvLWYdt/IZ65RQxveYM3maA=
 github.com/oracle/oci-go-sdk v7.0.0+incompatible/go.mod h1:VQb79nF8Z2cwLkLS35ukwStZIg5F66tcBccjip/j888=
 github.com/ovh/go-ovh v0.0.0-20181109152953-ba5adb4cf014 h1:37VE5TYj2m/FLA9SNr4z0+A0JefvTmR60Zwf8XSEV7c=
@@ -396,6 +401,7 @@ github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR
 github.com/philhofer/fwd v1.0.0 h1:UbZqGr5Y38ApvM/V/jEljVxwocdweyH+vmYvRPBnbqQ=
 github.com/philhofer/fwd v1.0.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
 github.com/pierrec/lz4 v0.0.0-20190327172049-315a67e90e41/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
+github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -441,6 +447,7 @@ github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a h1:pa8hGb/2
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/spf13/pflag v1.0.1 h1:aCvUg6QPl3ibpQUxyLkrEkCHtPqYJL4x9AuhqVqFis4=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -604,6 +611,7 @@ google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3
 google.golang.org/grpc v1.18.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.19.1/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
+google.golang.org/grpc v1.20.0/go.mod h1:chYK+tFQF0nDUGJgXMSgLCQk3phJEuONr2DCgLDdAQM=
 google.golang.org/grpc v1.20.1 h1:Hz2g2wirWK7H0qIIhGIqRGTuMwTE8HEKFnDZZ7lm9NU=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.22.1 h1:/7cs52RnTJmD43s3uxzlq2U7nqVTd/37viQwMrMNlOM=

--- a/go.sum
+++ b/go.sum
@@ -386,10 +386,10 @@ github.com/opentracing/basictracer-go v1.0.0 h1:YyUAhaEfjoWXclZVJ9sGoNct7j4TVk7l
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
-github.com/openzipkin-contrib/zipkin-go-opentracing v0.3.5 h1:82Tnq9OJpn+h5xgGpss5/mOv3KXdjtkdorFSOUusjM8=
-github.com/openzipkin-contrib/zipkin-go-opentracing v0.3.5/go.mod h1:uVHyebswE1cCXr2A73cRM2frx5ld1RJUCJkFNZ90ZiI=
+github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.3 h1:XudIMByQMXJ6oDHy4SipNyo35LxjA69Z7v1nL0aAZvA=
 github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.3/go.mod h1:/wsWhb9smxSfWAKL3wpBW7V8scJMt8N8gnaMCS9E/cA=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
+github.com/openzipkin/zipkin-go v0.2.1 h1:noL5/5Uf1HpVl3wNsfkZhIKbSWCVi5jgqkONNx8PXcA=
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/oracle/oci-go-sdk v7.0.0+incompatible h1:oj5ESjXwwkFRdhZSnPlShvLWYdt/IZ65RQxveYM3maA=
 github.com/oracle/oci-go-sdk v7.0.0+incompatible/go.mod h1:VQb79nF8Z2cwLkLS35ukwStZIg5F66tcBccjip/j888=

--- a/integration/fixtures/tracing/simple-zipkin.toml
+++ b/integration/fixtures/tracing/simple-zipkin.toml
@@ -14,8 +14,7 @@
 [tracing]
   servicename = "tracing"
   [tracing.zipkin]
-    httpEndpoint = "http://{{.IP}}:9411/api/v1/spans"
-    debug = true
+    httpEndpoint = "http://{{.IP}}:9411/api/v2/spans"
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/resources/compose/tracing.yml
+++ b/integration/resources/compose/tracing.yml
@@ -1,5 +1,5 @@
 zipkin:
-  image: openzipkin/zipkin:2.12.6
+  image: openzipkin/zipkin:2.16.2
   environment:
     STORAGE_TYPE: mem
     JAVA_OPTS: -Dlogging.level.zipkin=DEBUG

--- a/pkg/anonymize/anonymize_config_test.go
+++ b/pkg/anonymize/anonymize_config_test.go
@@ -223,7 +223,6 @@ func TestDo_globalConfiguration(t *testing.T) {
 			HTTPEndpoint: "fff",
 			SameSpan:     true,
 			ID128Bit:     true,
-			Debug:        true,
 			SampleRate:   53,
 		},
 		Datadog: &datadog.Config{

--- a/pkg/config/file/file_node_test.go
+++ b/pkg/config/file/file_node_test.go
@@ -282,7 +282,6 @@ func Test_decodeFileToNode_Toml(t *testing.T) {
 				{Name: "serviceName", Value: "foobar"},
 				{Name: "spanNameLimit", Value: "42"},
 				{Name: "zipkin", Children: []*parser.Node{
-					{Name: "debug", Value: "true"},
 					{Name: "httpEndpoint", Value: "foobar"},
 					{Name: "id128Bit", Value: "true"},
 					{Name: "sameSpan", Value: "true"},
@@ -517,7 +516,6 @@ func Test_decodeFileToNode_Yaml(t *testing.T) {
 				{Name: "serviceName", Value: "foobar"},
 				{Name: "spanNameLimit", Value: "42"},
 				{Name: "zipkin", Children: []*parser.Node{
-					{Name: "debug", Value: "true"},
 					{Name: "httpEndpoint", Value: "foobar"},
 					{Name: "id128Bit", Value: "true"},
 					{Name: "sameSpan", Value: "true"},

--- a/pkg/config/file/fixtures/sample.toml
+++ b/pkg/config/file/fixtures/sample.toml
@@ -177,7 +177,6 @@
     httpEndpoint = "foobar"
     sameSpan = true
     id128Bit = true
-    debug = true
     sampleRate = 42.0
   [tracing.datadog]
     localAgentHostPort = "foobar"

--- a/pkg/config/file/fixtures/sample.yml
+++ b/pkg/config/file/fixtures/sample.yml
@@ -188,7 +188,6 @@ tracing:
     httpEndpoint: foobar
     sameSpan: true
     id128Bit: true
-    debug: true
     sampleRate: 42
   datadog:
     localAgentHostPort: foobar

--- a/pkg/tracing/zipkin/zipkin.go
+++ b/pkg/tracing/zipkin/zipkin.go
@@ -7,7 +7,7 @@ import (
 	"github.com/containous/traefik/v2/pkg/log"
 	"github.com/opentracing/opentracing-go"
 	zipkinot "github.com/openzipkin-contrib/zipkin-go-opentracing"
-	zipkin "github.com/openzipkin/zipkin-go"
+	"github.com/openzipkin/zipkin-go"
 	"github.com/openzipkin/zipkin-go/reporter/http"
 )
 

--- a/pkg/tracing/zipkin/zipkin.go
+++ b/pkg/tracing/zipkin/zipkin.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/containous/traefik/v2/pkg/log"
 	"github.com/opentracing/opentracing-go"
-	zipkin "github.com/openzipkin-contrib/zipkin-go-opentracing"
+	zipkinot "github.com/openzipkin-contrib/zipkin-go-opentracing"
+	zipkin "github.com/openzipkin/zipkin-go"
+	"github.com/openzipkin/zipkin-go/reporter/http"
 )
 
 // Name sets the name of this tracer.
@@ -17,43 +19,53 @@ type Config struct {
 	HTTPEndpoint string  `description:"HTTP Endpoint to report traces to." json:"httpEndpoint,omitempty" toml:"httpEndpoint,omitempty" yaml:"httpEndpoint,omitempty"`
 	SameSpan     bool    `description:"Use Zipkin SameSpan RPC style traces." json:"sameSpan,omitempty" toml:"sameSpan,omitempty" yaml:"sameSpan,omitempty" export:"true"`
 	ID128Bit     bool    `description:"Use Zipkin 128 bit root span IDs." json:"id128Bit,omitempty" toml:"id128Bit,omitempty" yaml:"id128Bit,omitempty" export:"true"`
-	Debug        bool    `description:"Enable Zipkin debug." json:"debug,omitempty" toml:"debug,omitempty" yaml:"debug,omitempty" export:"true"`
 	SampleRate   float64 `description:"The rate between 0.0 and 1.0 of requests to trace." json:"sampleRate,omitempty" toml:"sampleRate,omitempty" yaml:"sampleRate,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values.
 func (c *Config) SetDefaults() {
-	c.HTTPEndpoint = "http://localhost:9411/api/v1/spans"
+	c.HTTPEndpoint = "http://localhost:9411/api/v2/spans"
 	c.SameSpan = false
 	c.ID128Bit = true
-	c.Debug = false
 	c.SampleRate = 1.0
 }
 
 // Setup sets up the tracer
 func (c *Config) Setup(serviceName string) (opentracing.Tracer, io.Closer, error) {
-	collector, err := zipkin.NewHTTPCollector(c.HTTPEndpoint)
+	// create our local endpoint
+	endpoint, err := zipkin.NewEndpoint(serviceName, "0.0.0.0:0")
 	if err != nil {
 		return nil, nil, err
 	}
 
-	recorder := zipkin.NewRecorder(collector, c.Debug, "0.0.0.0:0", serviceName)
+	// create our sampler
+	sampler, err := zipkin.NewBoundarySampler(c.SampleRate, time.Now().Unix())
+	if err != nil {
+		return nil, nil, err
+	}
 
-	tracer, err := zipkin.NewTracer(
-		recorder,
-		zipkin.ClientServerSameSpan(c.SameSpan),
-		zipkin.TraceID128Bit(c.ID128Bit),
-		zipkin.DebugMode(c.Debug),
-		zipkin.WithSampler(zipkin.NewBoundarySampler(c.SampleRate, time.Now().Unix())),
+	// create the span reporter
+	reporter := http.NewReporter(c.HTTPEndpoint)
+
+	// create the native Zipkin tracer
+	nativeTracer, err := zipkin.NewTracer(
+		reporter,
+		zipkin.WithLocalEndpoint(endpoint),
+		zipkin.WithSharedSpans(c.SameSpan),
+		zipkin.WithTraceID128Bit(c.ID128Bit),
+		zipkin.WithSampler(sampler),
 	)
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// wrap the Zipkin native tracer with the OpenTracing Bridge
+	tracer := zipkinot.Wrap(nativeTracer)
 
 	// Without this, child spans are getting the NOOP tracer
 	opentracing.SetGlobalTracer(tracer)
 
 	log.WithoutContext().Debug("Zipkin tracer configured")
 
-	return tracer, collector, nil
+	return tracer, reporter, nil
 }


### PR DESCRIPTION
### What does this PR do?

This PR changes the Zipkin dependency to use the latest Zipkin Go OpenTracing Bridge which builds on the native Zipkin Go tracer instead of the now deprecated zipkin-go-opentracing implementation. 

### Motivation

Zipkin has moved away from the old V1 data model to the new V2 data model allowing for improved efficiency, faster encoding and smaller transmit payloads. Up to release 0.4.0 the zipkin-go-opentracing package held its own internal implementation which was purely V1 based. The latest release of zipkin-go-opentracing uses the native Zipkin Go tracer which uses the V2 datamodel and provides the bridge to the OpenTracing API. 

The change from v0.3.5 to v0.4.3 holds a breaking change in the bootstrap code of the tracer. This PR fixes that by bootstrapping the native Zipkin Go tracer and wrapping it with the OpenTracing Bridge. 

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

This PR unlocks the ability to add more configuration options for Zipkin to Traefik in a later stage. It is possible to select different styles of samplers as well as adding additional reporting transports (kafka, protobuf over json, grpc).

Fixes #5260