### PR TITLE
Update go version to go 1.13rc2

### DIFF
--- a/.semaphoreci/setup.sh
+++ b/.semaphoreci/setup.sh
@@ -21,7 +21,7 @@ if [ -n "$SHOULD_TEST" ]; then docker version; fi
 
 export GO_VERSION=1.12
 if [ -f "./go.mod" ]; then GO_VERSION="$(grep '^go .*' go.mod | awk '{print $2}')"; export GO_VERSION; fi
-if [ "${GO_VERSION}" == '1.13' ]; then export GO_VERSION=1.13rc1; fi
+if [ "${GO_VERSION}" == '1.13' ]; then export GO_VERSION=1.13rc2; fi
 echo "Selected Go version: ${GO_VERSION}"
 
 if [ -f "./.semaphoreci/golang.sh" ]; then ./.semaphoreci/golang.sh; fi

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13rc1-alpine
+FROM golang:1.13rc2-alpine
 
 RUN apk --update upgrade \
     && apk --no-cache --no-progress add git mercurial bash gcc musl-dev curl tar ca-certificates tzdata \

--- a/docs/content/contributing/building-testing.md
+++ b/docs/content/contributing/building-testing.md
@@ -28,7 +28,7 @@ Successfully tagged traefik-webui:latest
 [...]
 docker build  -t "traefik-dev:4475--feature-documentation" -f build.Dockerfile .
 Sending build context to Docker daemon    279MB
-Step 1/10 : FROM golang:1.13rc1-alpine
+Step 1/10 : FROM golang:1.13rc2-alpine
  ---> f4bfb3d22bda
 [...]
 Successfully built 5c3c1a911277

--- a/exp.Dockerfile
+++ b/exp.Dockerfile
@@ -12,7 +12,7 @@ RUN yarn install
 RUN npm run build
 
 # BUILD
-FROM golang:1.13rc1-alpine as gobuild
+FROM golang:1.13rc2-alpine as gobuild
 
 RUN apk --update upgrade \
     && apk --no-cache --no-progress add git mercurial bash gcc musl-dev curl tar ca-certificates tzdata \


### PR DESCRIPTION
### What does this PR do?

This PR update the go version to `1.13rc2`

### Motivation

Be up-to-date

### More

- [x] Added/updated tests
- [x] Added/updated documentation
