### PR TITLE
Don't panic with undefined middleware

### DIFF
--- a/pkg/responsemodifiers/response_modifier.go
+++ b/pkg/responsemodifiers/response_modifier.go
@@ -24,7 +24,7 @@ func (f *Builder) Build(ctx context.Context, names []string) func(*http.Response
 	for _, middleName := range names {
 		if conf, ok := f.configs[middleName]; ok {
 			if conf == nil || conf.Middleware == nil {
-				getLogger(ctx, middleName, "undefined").Error("Invalid middleware configuration (ResponseModifier)")
+				getLogger(ctx, middleName, "undefined").Error("Invalid Middleware configuration (ResponseModifier)")
 				continue
 			}
 

--- a/pkg/responsemodifiers/response_modifier.go
+++ b/pkg/responsemodifiers/response_modifier.go
@@ -23,6 +23,11 @@ func (f *Builder) Build(ctx context.Context, names []string) func(*http.Response
 
 	for _, middleName := range names {
 		if conf, ok := f.configs[middleName]; ok {
+			if conf == nil || conf.Middleware == nil {
+				getLogger(ctx, middleName, "undefined").Error("Invalid middleware configuration (ResponseModifier)")
+				continue
+			}
+
 			if conf.Headers != nil {
 				getLogger(ctx, middleName, "Headers").Debug("Creating Middleware (ResponseModifier)")
 

--- a/pkg/responsemodifiers/response_modifier_test.go
+++ b/pkg/responsemodifiers/response_modifier_test.go
@@ -47,7 +47,7 @@ func TestBuilderBuild(t *testing.T) {
 			assertResponse: func(t *testing.T, resp *http.Response) {
 				t.Helper()
 
-				assert.Equal(t, resp.Header.Get("X-Foo"), "foo")
+				assert.Equal(t, "foo", resp.Header.Get("X-Foo"))
 			},
 		},
 		{
@@ -85,7 +85,7 @@ func TestBuilderBuild(t *testing.T) {
 			assertResponse: func(t *testing.T, resp *http.Response) {
 				t.Helper()
 
-				assert.Equal(t, resp.Header.Get("Referrer-Policy"), "no-referrer")
+				assert.Equal(t, "no-referrer", resp.Header.Get("Referrer-Policy"))
 			},
 		},
 		{
@@ -107,8 +107,8 @@ func TestBuilderBuild(t *testing.T) {
 			assertResponse: func(t *testing.T, resp *http.Response) {
 				t.Helper()
 
-				assert.Equal(t, resp.Header.Get("X-Foo"), "foo")
-				assert.Equal(t, resp.Header.Get("X-Bar"), "bar")
+				assert.Equal(t, "foo", resp.Header.Get("X-Foo"))
+				assert.Equal(t, "bar", resp.Header.Get("X-Bar"))
 			},
 		},
 		{
@@ -130,7 +130,7 @@ func TestBuilderBuild(t *testing.T) {
 			assertResponse: func(t *testing.T, resp *http.Response) {
 				t.Helper()
 
-				assert.Equal(t, resp.Header.Get("X-Foo"), "foo")
+				assert.Equal(t, "foo", resp.Header.Get("X-Foo"))
 			},
 		},
 		{
@@ -157,8 +157,17 @@ func TestBuilderBuild(t *testing.T) {
 			assertResponse: func(t *testing.T, resp *http.Response) {
 				t.Helper()
 
-				assert.Equal(t, resp.Header.Get("X-Foo"), "foo")
+				assert.Equal(t, "foo", resp.Header.Get("X-Foo"))
 			},
+		},
+		{
+			desc:          "nil middleware",
+			middlewares:   []string{"foo"},
+			buildResponse: stubResponse,
+			conf: map[string]*dynamic.Middleware{
+				"foo": nil,
+			},
+			assertResponse: func(t *testing.T, resp *http.Response) {},
 		},
 	}
 

--- a/pkg/server/middleware/middlewares.go
+++ b/pkg/server/middleware/middlewares.go
@@ -102,6 +102,10 @@ func checkRecursion(ctx context.Context, middlewareName string) (context.Context
 // it is the responsibility of the caller to make sure that b.configs[middlewareName].Middleware exists
 func (b *Builder) buildConstructor(ctx context.Context, middlewareName string) (alice.Constructor, error) {
 	config := b.configs[middlewareName]
+	if config == nil || config.Middleware == nil {
+		return nil, fmt.Errorf("invalid middleware %q configuration", middlewareName)
+	}
+
 	var middleware alice.Constructor
 	badConf := errors.New("cannot create middleware: multi-types middleware not supported, consider declaring two different pieces of middleware instead")
 
@@ -314,7 +318,7 @@ func (b *Builder) buildConstructor(ctx context.Context, middlewareName string) (
 	}
 
 	if middleware == nil {
-		return nil, errors.New("middleware does not exist")
+		return nil, fmt.Errorf("middleware %q does not exist", middlewareName)
 	}
 
 	return tracing.Wrap(ctx, middleware), nil

--- a/pkg/server/middleware/middlewares_test.go
+++ b/pkg/server/middleware/middlewares_test.go
@@ -369,7 +369,6 @@ func TestBuilder_buildConstructor(t *testing.T) {
 			t.Parallel()
 
 			constructor, err := middlewaresBuilder.buildConstructor(context.Background(), test.middlewareID)
-
 			require.NoError(t, err)
 
 			middleware, err2 := constructor(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))


### PR DESCRIPTION
### What does this PR do?

fix: undefined middleware.

### Motivation
```
DEBU[2019-09-03T11:44:52+02:00] Configuration received from provider file: {"http":{"routers":{"router0":{"entryPoints":["http"],"middlewares":["test-middleware"],"service":"service-foo","rule":"Path(`/bar`)"}},"middlewares":{"test-middleware":null},"services":{"service-foo":{"loadBalancer":{"servers":[{"url":"http://127.0.0.1:3030"}],"passHostHeader":false}}}},"tcp":{},"tls":{}}  providerName=file
ERRO[2019-09-03T11:44:52+02:00] Error in Go routine: runtime error: invalid memory address or nil pointer dereference 
ERRO[2019-09-03T11:44:52+02:00] Stack: goroutine 88 [running]:
runtime/debug.Stack(0xc00013a000, 0x24bdd12, 0x17)
	/usr/local/go/src/runtime/debug/stack.go:24 +0x9d
github.com/containous/traefik/v2/pkg/safe.defaultRecoverGoroutine(0x208cf40, 0x3e64dc0)
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:159 +0x9d
github.com/containous/traefik/v2/pkg/safe.GoWithRecover.func1.1(0x2598a00)
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:150 +0x57
panic(0x208cf40, 0x3e64dc0)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/containous/traefik/v2/pkg/responsemodifiers.(*Builder).Build(0xc000170080, 0x290db80, 0xc000666bd0, 0xc0004721d0, 0x1, 0x1, 0x24a2c80)
	/go/src/github.com/containous/traefik/pkg/responsemodifiers/response_modifier.go:26 +0xe7
github.com/containous/traefik/v2/pkg/server/router.(*Manager).buildHTTPHandler(0xc0008f1b78, 0x290db80, 0xc000666bd0, 0xc0006660f0, 0xc000485a20, 0xc, 0xc000666bd0, 0x1f72800, 0xc00065b5c8, 0xc00065b5c8)
	/go/src/github.com/containous/traefik/pkg/server/router/router.go:150 +0x181
github.com/containous/traefik/v2/pkg/server/router.(*Manager).buildRouterHandler(0xc0008f1b78, 0x290db80, 0xc000666bd0, 0xc000485a20, 0xc, 0xc0006660f0, 0xc000666bd0, 0x2440980, 0xc0002741c0, 0xc00065b6d0)
	/go/src/github.com/containous/traefik/pkg/server/router/router.go:127 +0xd2
github.com/containous/traefik/v2/pkg/server/router.(*Manager).buildEntryPointHandler(0xc0008f1b78, 0x290db80, 0xc0006668d0, 0xc000666570, 0x1, 0x290db80, 0xc0006668d0, 0xc000666540)
	/go/src/github.com/containous/traefik/pkg/server/router/router.go:97 +0x22e
github.com/containous/traefik/v2/pkg/server/router.(*Manager).BuildHandlers(0xc0008f1b78, 0x290db00, 0xc0000d2008, 0xc0000fa160, 0x2, 0x2, 0x0, 0x0)
	/go/src/github.com/containous/traefik/pkg/server/router/router.go:65 +0x1f4
github.com/containous/traefik/v2/pkg/server.(*Server).createHTTPHandlers(0xc00002b2b0, 0x290db00, 0xc0000d2008, 0xc000666060, 0xc0000fa160, 0x2, 0x2, 0x2, 0xc0008b8120)
	/go/src/github.com/containous/traefik/pkg/server/server_configuration.go:105 +0x2eb
github.com/containous/traefik/v2/pkg/server.(*Server).loadConfigurationTCP(0xc00002b2b0, 0xc0000fdd70, 0x3ead580)
	/go/src/github.com/containous/traefik/pkg/server/server_configuration.go:78 +0x283
github.com/containous/traefik/v2/pkg/server.(*Server).loadConfiguration(0xc00002b2b0, 0x24977d4, 0x4, 0xc0008500c0)
	/go/src/github.com/containous/traefik/pkg/server/server_configuration.go:41 +0x11f
github.com/containous/traefik/v2/pkg/server.(*Server).listenConfigurations(0xc00002b2b0, 0xc00005c150)
	/go/src/github.com/containous/traefik/pkg/server/server_configuration.go:244 +0x51
github.com/containous/traefik/v2/pkg/server.(*Server).Start.func3(0xc00005c150)
	/go/src/github.com/containous/traefik/pkg/server/server.go:172 +0x34
github.com/containous/traefik/v2/pkg/safe.(*Pool).Go.func1()
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:90 +0x7b
github.com/containous/traefik/v2/pkg/safe.GoWithRecover.func1(0x2598a00, 0xc0002d0750)
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:153 +0x57
created by github.com/containous/traefik/v2/pkg/safe.GoWithRecover
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:147 +0x49 
```

### More

- [x] Added/updated tests
- [ ] ~~Added/updated documentation~~
