### PR TITLE
Make documented traefik image version explicit

### DIFF
--- a/docs/user-guide/swarm-mode.md
+++ b/docs/user-guide/swarm-mode.md
@@ -85,7 +85,7 @@ docker-machine ssh manager "docker service create \
 	--publish 80:80 --publish 8080:8080 \
 	--mount	type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \
 	--network traefik-net \
-	traefik:<stable version from https://hub.docker.com/_/traefik> \
+	traefik:1.7 \
 	--docker \
 	--docker.swarmMode \
 	--docker.domain=traefik \


### PR DESCRIPTION
### What does this PR do?

Sets an explicit traefik image tag in the ["Deploy Traefik" section](https://docs.traefik.io/user-guide/swarm-mode/#deploy-traefik) of the swarm-mode user guide.

### Motivation

The current specifier `traefik:<stable version from https://hub.docker.com/_/traefik>` has led to friction (see #4239) as people may accidently reference the incompatible 2.0 tag.

Since this is the 1.7 branch it should be safe to document the 1.7 tag.
