### PR TITLE
New API security

### DIFF
--- a/docs/content/observability/metrics/prometheus.md
+++ b/docs/content/observability/metrics/prometheus.md
@@ -85,3 +85,34 @@ metrics:
 ```bash tab="CLI"
 --metrics.prometheus.addServicesLabels=true
 ```
+
+#### `entryPoint`
+
+_Optional, Default=traefik_
+
+Entry point used to expose metrics.
+
+```toml tab="File (TOML)"
+[entryPoints]
+  [entryPoints.metrics]
+    address = ":8082"
+
+[metrics]
+  [metrics.prometheus]
+    entryPoint = "metrics"
+```
+
+```yaml tab="File (YAML)"
+entryPoints:
+  metrics:
+    address: ":8082"
+
+metrics:
+  prometheus:
+    entryPoint: metrics
+```
+
+```bash tab="CLI"
+--entryPoints.metrics.address=":8082"
+--metrics.prometheus..entryPoint="metrics"
+```

--- a/docs/content/operations/api.md
+++ b/docs/content/operations/api.md
@@ -1,8 +1,5 @@
 # API
 
-!!! important
-    In the RC version, you can't configure middlewares (basic authentication or white listing) anymore, but as security is important, this will change before the GA version.
-
 Traefik exposes a number of information through an API handler, such as the configuration of all routers, services, middlewares, etc.
 
 As with all features of Traefik, this handler can be enabled with the [static configuration](../getting-started/configuration-overview.md#the-static-configuration).
@@ -22,10 +19,9 @@ would be to apply the following protection mechanisms:
   keeping it restricted to internal networks
   (as in the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege), applied to networks).
 
-!!! important
-    In the beta version, you can't configure middlewares (basic authentication or white listing) anymore, but as security is important, this will change before the RC version.
-
 ## Configuration
+
+If you enable the API, a new special `service` named `api@internal` is created and then can be reference in a router.
 
 To enable the API handler:
 
@@ -40,6 +36,87 @@ api: {}
 ```bash tab="CLI"
 --api=true
 ```
+
+And then you will able to reference it like this.
+
+```yaml tab="Docker"
+  - "traefik.http.routers.api.rule=PathPrefix(`/api`) || PathPrefix(`/dashboard`)"
+  - "traefik.http.routers.api.service=api@internal"
+  - "traefik.http.routers.api.middlewares=auth"
+  - "traefik.http.middlewares.auth.basicauth.users=test:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/,test2:$$apr1$$d9hr9HBB$$4HxwgUir3HP4EsggP/QNo0"
+```
+
+```json tab="Marathon"
+"labels": {
+  "traefik.http.routers.api.rule": ""PathPrefix(`/api`) || PathPrefix(`/dashboard`)"
+  "traefik.http.routers.api.service": ""api@internal"
+  "traefik.http.routers.api.middlewares": ""auth"
+  "traefik.http.middlewares.auth.basicauth.users": ""test:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/,test2:$$apr1$$d9hr9HBB$$4HxwgUir3HP4EsggP/QNo0"
+
+}
+```
+
+```yaml tab="Rancher"
+# Declaring the user list
+labels:
+  - "traefik.http.routers.api.rule=PathPrefix(`/api`) || PathPrefix(`/dashboard`)"
+    - "traefik.http.routers.api.service=api@internal"
+    - "traefik.http.routers.api.middlewares=auth"
+    - "traefik.http.middlewares.auth.basicauth.users=test:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/,test2:$$apr1$$d9hr9HBB$$4HxwgUir3HP4EsggP/QNo0"
+```
+
+```toml tab="File (TOML)"
+[http.routers.my-api]
+    rule="PathPrefix(`/api`) || PathPrefix(`/dashboard`)"
+    service="api@internal"
+    middlewares=["auth"]
+
+[http.middlewares.auth.basicAuth]
+    users = [
+        "test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/", 
+        "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0",
+      ]
+```
+
+```yaml tab="File (YAML)"
+http:
+  routers:
+    api:
+      rule: PathPrefix(`/api`) || PathPrefix(`/dashboard`)
+      service: api@internal
+      middlewares:
+        - auth
+  middlewares:
+    auth:
+      basicAuth:
+        users:
+        - "test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/" 
+        - "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"
+```
+
+
+
+### `insecure`
+
+Enable the API in `insecure` mode, it means that API will be available directly on the entryPoint named `traefik`.
+
+!!! Note
+    If the entryPoint named traefik is not configure, it will be automatically created on port 8080.
+
+```toml tab="File (TOML)"
+[api]
+  insecure = true
+```
+
+```yaml tab="File (YAML)"
+api:
+  insecure: true
+```
+
+```bash tab="CLI"
+--api.insecure=true
+```
+
 
 ### `dashboard`
 

--- a/docs/content/operations/api.md
+++ b/docs/content/operations/api.md
@@ -52,7 +52,6 @@ And then you will able to reference it like this.
   "traefik.http.routers.api.service": "api@internal"
   "traefik.http.routers.api.middlewares": "auth"
   "traefik.http.middlewares.auth.basicauth.users": "test:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/,test2:$$apr1$$d9hr9HBB$$4HxwgUir3HP4EsggP/QNo0"
-
 }
 ```
 

--- a/docs/content/operations/api.md
+++ b/docs/content/operations/api.md
@@ -48,10 +48,10 @@ And then you will able to reference it like this.
 
 ```json tab="Marathon"
 "labels": {
-  "traefik.http.routers.api.rule": ""PathPrefix(`/api`) || PathPrefix(`/dashboard`)"
-  "traefik.http.routers.api.service": ""api@internal"
-  "traefik.http.routers.api.middlewares": ""auth"
-  "traefik.http.middlewares.auth.basicauth.users": ""test:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/,test2:$$apr1$$d9hr9HBB$$4HxwgUir3HP4EsggP/QNo0"
+  "traefik.http.routers.api.rule": "PathPrefix(`/api`) || PathPrefix(`/dashboard`)"
+  "traefik.http.routers.api.service": "api@internal"
+  "traefik.http.routers.api.middlewares": "auth"
+  "traefik.http.middlewares.auth.basicauth.users": "test:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/,test2:$$apr1$$d9hr9HBB$$4HxwgUir3HP4EsggP/QNo0"
 
 }
 ```

--- a/docs/content/operations/api.md
+++ b/docs/content/operations/api.md
@@ -94,8 +94,6 @@ http:
         - "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"
 ```
 
-
-
 ### `insecure`
 
 Enable the API in `insecure` mode, it means that API will be available directly on the entryPoint named `traefik`.
@@ -116,7 +114,6 @@ api:
 ```bash tab="CLI"
 --api.insecure=true
 ```
-
 
 ### `dashboard`
 

--- a/docs/content/operations/api.md
+++ b/docs/content/operations/api.md
@@ -95,10 +95,10 @@ http:
 
 ### `insecure`
 
-Enable the API in `insecure` mode, it means that API will be available directly on the entryPoint named `traefik`.
+Enable the API in `insecure` mode, which means that the API will be available directly on the entryPoint named `traefik`.
 
 !!! Note
-    If the entryPoint named traefik is not configure, it will be automatically created on port 8080.
+    If the entryPoint named `traefik` is not configured, it will be automatically created on port 8080.
 
 ```toml tab="File (TOML)"
 [api]

--- a/docs/content/operations/ping.md
+++ b/docs/content/operations/ping.md
@@ -5,7 +5,7 @@ Checking the Health of Your Traefik Instances
 
 ## Configuration Examples
 
-??? example "Enabling /ping"
+!!! example "Enabling /ping"
 
 ```toml tab="File (TOML)"
 [ping]
@@ -19,25 +19,39 @@ ping: {}
 --ping=true
 ```
 
-??? example "Enabling /ping on a dedicated EntryPoint"
-    
-    ```toml
-    [entryPoints]
-      [entryPoints.web]
-        address = ":80"
-      
-      [entryPoints.ping]
-        address = ":8082"
-    
-    [ping]
-      entryPoint = "ping"
-    ```
-| Path    | Method        | Description                                                                                         |
-|---------|---------------|-----------------------------------------------------------------------------------------------------|
-| `/ping` | `GET`, `HEAD` | A simple endpoint to check for Traefik process liveness. Return a code `200` with the content: `OK` |
-
 ## Configuration Options
 
 The `/ping` health-check URL is enabled with the command-line `--ping` or config file option `[ping]`.
 
 You can customize the `entryPoint` where the `/ping` is active with the `entryPoint` option (default value: `traefik`)
+
+| Path    | Method        | Description                                                                                         |
+|---------|---------------|-----------------------------------------------------------------------------------------------------|
+| `/ping` | `GET`, `HEAD` | A simple endpoint to check for Traefik process liveness. Return a code `200` with the content: `OK` |
+
+### `entryPoint`
+
+Enabling /ping on a dedicated EntryPoint.
+
+```toml tab="File (TOML)"
+[entryPoints]
+  [entryPoints.ping]
+    address = ":8082"
+
+[ping]
+  entryPoint = "ping"
+```
+
+```yaml tab="File (YAML)"
+entryPoints:
+  ping:
+    address: ":8082"
+
+ping:
+  entryPoint: "ping"
+```
+
+```bash tab="CLI"
+--entryPoints.ping.address=":8082"
+--ping.entryPoint="ping"
+```

--- a/docs/content/operations/ping.md
+++ b/docs/content/operations/ping.md
@@ -19,6 +19,19 @@ ping: {}
 --ping=true
 ```
 
+??? example "Enabling /ping on a dedicated EntryPoint"
+    
+    ```toml
+    [entryPoints]
+      [entryPoints.web]
+        address = ":80"
+      
+      [entryPoints.ping]
+        address = ":8082"
+    
+    [ping]
+      entryPoint = "ping"
+    ```
 | Path    | Method        | Description                                                                                         |
 |---------|---------------|-----------------------------------------------------------------------------------------------------|
 | `/ping` | `GET`, `HEAD` | A simple endpoint to check for Traefik process liveness. Return a code `200` with the content: `OK` |
@@ -26,3 +39,5 @@ ping: {}
 ## Configuration Options
 
 The `/ping` health-check URL is enabled with the command-line `--ping` or config file option `[ping]`.
+
+You can customize the `entryPoint` where the `/ping` is active with the `entryPoint` option (default value: `traefik`)

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -45,6 +45,9 @@ Activate dashboard. (Default: ```true```)
 `--api.debug`:  
 Enable additional endpoints for debugging and profiling. (Default: ```false```)
 
+`--api.insecure`:  
+Activate API on an insecure entryPoints named traefik. (Default: ```false```)
+
 `--certificatesresolvers.<name>`:  
 Certificates resolvers configuration. (Default: ```false```)
 
@@ -207,6 +210,9 @@ Enable metrics on services. (Default: ```true```)
 `--metrics.prometheus.buckets`:  
 Buckets for latency metrics. (Default: ```0.100000, 0.300000, 1.200000, 5.000000```)
 
+`--metrics.prometheus.entrypoint`:  
+EntryPoint (Default: ```traefik```)
+
 `--metrics.statsd`:  
 StatsD metrics exporter type. (Default: ```false```)
 
@@ -223,7 +229,10 @@ Enable metrics on services. (Default: ```true```)
 StatsD push interval. (Default: ```10```)
 
 `--ping`:  
-Enable ping. (Default: ```true```)
+Enable ping. (Default: ```false```)
+
+`--ping.entrypoint`:  
+EntryPoint (Default: ```traefik```)
 
 `--providers.docker`:  
 Enable Docker backend with default settings. (Default: ```false```)
@@ -433,7 +442,10 @@ Defines the polling interval in seconds. (Default: ```15```)
 Watch provider. (Default: ```true```)
 
 `--providers.rest`:  
-Enable Rest backend with default settings. (Default: ```true```)
+Enable Rest backend with default settings. (Default: ```false```)
+
+`--providers.rest.insecure`:  
+Activate REST Provider on an insecure entryPoints named traefik. (Default: ```false```)
 
 `--serverstransport.forwardingtimeouts.dialtimeout`:  
 The amount of time to wait until a connection to a backend server can be established. If zero, no timeout exists. (Default: ```30```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -45,6 +45,9 @@ Activate dashboard. (Default: ```true```)
 `TRAEFIK_API_DEBUG`:  
 Enable additional endpoints for debugging and profiling. (Default: ```false```)
 
+`TRAEFIK_API_INSECURE`:  
+Activate API on an insecure entryPoints named traefik. (Default: ```false```)
+
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>`:  
 Certificates resolvers configuration. (Default: ```false```)
 
@@ -207,6 +210,9 @@ Enable metrics on services. (Default: ```true```)
 `TRAEFIK_METRICS_PROMETHEUS_BUCKETS`:  
 Buckets for latency metrics. (Default: ```0.100000, 0.300000, 1.200000, 5.000000```)
 
+`TRAEFIK_METRICS_PROMETHEUS_ENTRYPOINT`:  
+EntryPoint (Default: ```traefik```)
+
 `TRAEFIK_METRICS_STATSD`:  
 StatsD metrics exporter type. (Default: ```false```)
 
@@ -223,7 +229,10 @@ Enable metrics on services. (Default: ```true```)
 StatsD push interval. (Default: ```10```)
 
 `TRAEFIK_PING`:  
-Enable ping. (Default: ```true```)
+Enable ping. (Default: ```false```)
+
+`TRAEFIK_PING_ENTRYPOINT`:  
+EntryPoint (Default: ```traefik```)
 
 `TRAEFIK_PROVIDERS_DOCKER`:  
 Enable Docker backend with default settings. (Default: ```false```)
@@ -433,7 +442,10 @@ Defines the polling interval in seconds. (Default: ```15```)
 Watch provider. (Default: ```true```)
 
 `TRAEFIK_PROVIDERS_REST`:  
-Enable Rest backend with default settings. (Default: ```true```)
+Enable Rest backend with default settings. (Default: ```false```)
+
+`TRAEFIK_PROVIDERS_REST_INSECURE`:  
+Activate REST Provider on an insecure entryPoints named traefik. (Default: ```false```)
 
 `TRAEFIK_SERVERSTRANSPORT_FORWARDINGTIMEOUTS_DIALTIMEOUT`:  
 The amount of time to wait until a connection to a backend server can be established. If zero, no timeout exists. (Default: ```30```)

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -96,6 +96,7 @@
     labelSelector = "foobar"
     ingressClass = "foobar"
   [providers.rest]
+    insecure = true
   [providers.rancher]
     constraints = "foobar"
     watch = true
@@ -107,6 +108,7 @@
     prefix = "foobar"
 
 [api]
+  insecure = true
   dashboard = true
   debug = true
 
@@ -115,6 +117,7 @@
     buckets = [42.0, 42.0]
     addEntryPointsLabels = true
     addServicesLabels = true
+    entryPoint = "foobar"
   [metrics.datadog]
     address = "foobar"
     pushInterval = "10s"
@@ -137,6 +140,7 @@
     addServicesLabels = true
 
 [ping]
+  entryPoint = "foobar"
 
 [log]
   level = "foobar"

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -102,7 +102,8 @@ providers:
     - foobar
     labelSelector: foobar
     ingressClass: foobar
-  rest: {}
+  rest:
+    insecure: true
   rancher:
     constraints: foobar
     watch: true
@@ -113,6 +114,7 @@ providers:
     intervalPoll: true
     prefix: foobar
 api:
+  insecure: true
   dashboard: true
   debug: true
 metrics:
@@ -122,6 +124,7 @@ metrics:
     - 42
     addEntryPointsLabels: true
     addServicesLabels: true
+    entryPoint: foobar
   datadog:
     address: foobar
     pushInterval: 42
@@ -142,7 +145,8 @@ metrics:
     password: foobar
     addEntryPointsLabels: true
     addServicesLabels: true
-ping: {}
+ping:
+  entryPoint: foobar
 log:
   level: foobar
   filePath: foobar

--- a/integration/fixtures/access_log_config.toml
+++ b/integration/fixtures/access_log_config.toml
@@ -22,7 +22,7 @@
     address = ":8008"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers]
   [providers.docker]

--- a/integration/fixtures/access_log_config.toml
+++ b/integration/fixtures/access_log_config.toml
@@ -22,6 +22,7 @@
     address = ":8008"
 
 [api]
+insecure=true
 
 [providers]
   [providers.docker]

--- a/integration/fixtures/acme/acme_base.toml
+++ b/integration/fixtures/acme/acme_base.toml
@@ -31,7 +31,7 @@
 {{end}}
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/acme/acme_base.toml
+++ b/integration/fixtures/acme/acme_base.toml
@@ -31,6 +31,7 @@
 {{end}}
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/acme/acme_domains.toml
+++ b/integration/fixtures/acme/acme_domains.toml
@@ -31,7 +31,7 @@
 {{end}}
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/acme/acme_domains.toml
+++ b/integration/fixtures/acme/acme_domains.toml
@@ -31,6 +31,7 @@
 {{end}}
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/acme/acme_multiple_resolvers.toml
+++ b/integration/fixtures/acme/acme_multiple_resolvers.toml
@@ -31,7 +31,7 @@
 {{end}}
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/acme/acme_multiple_resolvers.toml
+++ b/integration/fixtures/acme/acme_multiple_resolvers.toml
@@ -31,6 +31,7 @@
 {{end}}
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/acme/acme_tcp.toml
+++ b/integration/fixtures/acme/acme_tcp.toml
@@ -31,7 +31,7 @@
 {{end}}
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/acme/acme_tcp.toml
+++ b/integration/fixtures/acme/acme_tcp.toml
@@ -31,6 +31,7 @@
 {{end}}
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/acme/acme_tls.toml
+++ b/integration/fixtures/acme/acme_tls.toml
@@ -31,7 +31,7 @@
 {{end}}
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/acme/acme_tls.toml
+++ b/integration/fixtures/acme/acme_tls.toml
@@ -31,6 +31,7 @@
 {{end}}
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/acme/acme_tls_dynamic.toml
+++ b/integration/fixtures/acme/acme_tls_dynamic.toml
@@ -31,6 +31,7 @@
 {{end}}
 
 [api]
+insecure=true
 
 [providers]
   [providers.file]

--- a/integration/fixtures/acme/acme_tls_dynamic.toml
+++ b/integration/fixtures/acme/acme_tls_dynamic.toml
@@ -31,7 +31,7 @@
 {{end}}
 
 [api]
-insecure=true
+  insecure = true
 
 [providers]
   [providers.file]

--- a/integration/fixtures/acme/acme_tls_multiple_entrypoints.toml
+++ b/integration/fixtures/acme/acme_tls_multiple_entrypoints.toml
@@ -34,4 +34,4 @@
 {{end}}
 
 [api]
-insecure=true
+  insecure = true

--- a/integration/fixtures/acme/acme_tls_multiple_entrypoints.toml
+++ b/integration/fixtures/acme/acme_tls_multiple_entrypoints.toml
@@ -34,3 +34,4 @@
 {{end}}
 
 [api]
+insecure=true

--- a/integration/fixtures/docker/minimal.toml
+++ b/integration/fixtures/docker/minimal.toml
@@ -10,7 +10,7 @@
     address = ":8000"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers]
   [providers.docker]

--- a/integration/fixtures/docker/minimal.toml
+++ b/integration/fixtures/docker/minimal.toml
@@ -10,6 +10,7 @@
     address = ":8000"
 
 [api]
+insecure=true
 
 [providers]
   [providers.docker]

--- a/integration/fixtures/docker/simple.toml
+++ b/integration/fixtures/docker/simple.toml
@@ -10,7 +10,7 @@
     address = ":8000"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers]
   [providers.docker]

--- a/integration/fixtures/docker/simple.toml
+++ b/integration/fixtures/docker/simple.toml
@@ -10,6 +10,7 @@
     address = ":8000"
 
 [api]
+insecure=true
 
 [providers]
   [providers.docker]

--- a/integration/fixtures/grpc/config.toml
+++ b/integration/fixtures/grpc/config.toml
@@ -13,6 +13,7 @@
     address = ":4443"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/grpc/config.toml
+++ b/integration/fixtures/grpc/config.toml
@@ -13,7 +13,7 @@
     address = ":4443"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/grpc/config_h2c.toml
+++ b/integration/fixtures/grpc/config_h2c.toml
@@ -10,7 +10,7 @@
     address = ":8081"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/grpc/config_h2c.toml
+++ b/integration/fixtures/grpc/config_h2c.toml
@@ -10,6 +10,7 @@
     address = ":8081"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/grpc/config_h2c_termination.toml
+++ b/integration/fixtures/grpc/config_h2c_termination.toml
@@ -10,7 +10,7 @@
     address = ":4443"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/grpc/config_h2c_termination.toml
+++ b/integration/fixtures/grpc/config_h2c_termination.toml
@@ -10,6 +10,7 @@
     address = ":4443"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/grpc/config_insecure.toml
+++ b/integration/fixtures/grpc/config_insecure.toml
@@ -13,6 +13,7 @@
     address = ":4443"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/grpc/config_insecure.toml
+++ b/integration/fixtures/grpc/config_insecure.toml
@@ -13,7 +13,7 @@
     address = ":4443"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/grpc/config_retry.toml
+++ b/integration/fixtures/grpc/config_retry.toml
@@ -13,6 +13,7 @@
     address = ":4443"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/grpc/config_retry.toml
+++ b/integration/fixtures/grpc/config_retry.toml
@@ -13,7 +13,7 @@
     address = ":4443"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/healthcheck/multiple-entrypoints.toml
+++ b/integration/fixtures/healthcheck/multiple-entrypoints.toml
@@ -12,6 +12,7 @@
     address = ":9000"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/healthcheck/multiple-entrypoints.toml
+++ b/integration/fixtures/healthcheck/multiple-entrypoints.toml
@@ -12,7 +12,7 @@
     address = ":9000"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/healthcheck/port_overload.toml
+++ b/integration/fixtures/healthcheck/port_overload.toml
@@ -10,6 +10,7 @@
     address = ":8000"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/healthcheck/port_overload.toml
+++ b/integration/fixtures/healthcheck/port_overload.toml
@@ -10,7 +10,7 @@
     address = ":8000"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/healthcheck/simple.toml
+++ b/integration/fixtures/healthcheck/simple.toml
@@ -10,6 +10,7 @@
     address = ":8000"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/healthcheck/simple.toml
+++ b/integration/fixtures/healthcheck/simple.toml
@@ -10,7 +10,7 @@
     address = ":8000"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/https/clientca/https_1ca1config.toml
+++ b/integration/fixtures/https/clientca/https_1ca1config.toml
@@ -10,7 +10,7 @@
     address = ":4443"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/https/clientca/https_1ca1config.toml
+++ b/integration/fixtures/https/clientca/https_1ca1config.toml
@@ -10,6 +10,7 @@
     address = ":4443"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/https/clientca/https_2ca1config.toml
+++ b/integration/fixtures/https/clientca/https_2ca1config.toml
@@ -10,7 +10,7 @@
     address = ":4443"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/https/clientca/https_2ca1config.toml
+++ b/integration/fixtures/https/clientca/https_2ca1config.toml
@@ -10,6 +10,7 @@
     address = ":4443"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/https/clientca/https_2ca2config.toml
+++ b/integration/fixtures/https/clientca/https_2ca2config.toml
@@ -10,7 +10,7 @@
     address = ":4443"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/https/clientca/https_2ca2config.toml
+++ b/integration/fixtures/https/clientca/https_2ca2config.toml
@@ -10,6 +10,7 @@
     address = ":4443"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/https/dynamic_https_sni.toml
+++ b/integration/fixtures/https/dynamic_https_sni.toml
@@ -13,6 +13,7 @@
      address = ":8443"
 
 [api]
+insecure=true
 
 [providers]
   [providers.file]

--- a/integration/fixtures/https/dynamic_https_sni.toml
+++ b/integration/fixtures/https/dynamic_https_sni.toml
@@ -13,7 +13,7 @@
      address = ":8443"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers]
   [providers.file]

--- a/integration/fixtures/https/dynamic_https_sni_default_cert.toml
+++ b/integration/fixtures/https/dynamic_https_sni_default_cert.toml
@@ -10,7 +10,7 @@
     address = ":4443"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/https/dynamic_https_sni_default_cert.toml
+++ b/integration/fixtures/https/dynamic_https_sni_default_cert.toml
@@ -10,6 +10,7 @@
     address = ":4443"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/https/https_redirect.toml
+++ b/integration/fixtures/https/https_redirect.toml
@@ -13,6 +13,7 @@
     address = ":8443"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/https/https_redirect.toml
+++ b/integration/fixtures/https/https_redirect.toml
@@ -13,7 +13,7 @@
     address = ":8443"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/https/https_sni.toml
+++ b/integration/fixtures/https/https_sni.toml
@@ -10,7 +10,7 @@
     address = ":4443"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/https/https_sni.toml
+++ b/integration/fixtures/https/https_sni.toml
@@ -10,6 +10,7 @@
     address = ":4443"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/https/https_sni_case_insensitive_dynamic.toml
+++ b/integration/fixtures/https/https_sni_case_insensitive_dynamic.toml
@@ -10,7 +10,7 @@
     address = ":4443"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/https/https_sni_case_insensitive_dynamic.toml
+++ b/integration/fixtures/https/https_sni_case_insensitive_dynamic.toml
@@ -10,6 +10,7 @@
     address = ":4443"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/https/https_sni_default_cert.toml
+++ b/integration/fixtures/https/https_sni_default_cert.toml
@@ -10,7 +10,7 @@
     address = ":4443"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/https/https_sni_default_cert.toml
+++ b/integration/fixtures/https/https_sni_default_cert.toml
@@ -10,6 +10,7 @@
     address = ":4443"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/https/https_sni_strict.toml
+++ b/integration/fixtures/https/https_sni_strict.toml
@@ -10,7 +10,7 @@
     address = ":4443"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/https/https_sni_strict.toml
+++ b/integration/fixtures/https/https_sni_strict.toml
@@ -10,6 +10,7 @@
     address = ":4443"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/https/https_tls_options.toml
+++ b/integration/fixtures/https/https_tls_options.toml
@@ -10,7 +10,7 @@
     address = ":4443"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/https/https_tls_options.toml
+++ b/integration/fixtures/https/https_tls_options.toml
@@ -10,6 +10,7 @@
     address = ":4443"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/https/rootcas/https.toml
+++ b/integration/fixtures/https/rootcas/https.toml
@@ -29,7 +29,7 @@ fblo6RBxUQ==
     address = ":8081"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/https/rootcas/https.toml
+++ b/integration/fixtures/https/rootcas/https.toml
@@ -29,6 +29,7 @@ fblo6RBxUQ==
     address = ":8081"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/https/rootcas/https_with_file.toml
+++ b/integration/fixtures/https/rootcas/https_with_file.toml
@@ -14,6 +14,7 @@
     address = ":8081"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/https/rootcas/https_with_file.toml
+++ b/integration/fixtures/https/rootcas/https_with_file.toml
@@ -14,7 +14,7 @@
     address = ":8081"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/k8s_crd.toml
+++ b/integration/fixtures/k8s_crd.toml
@@ -6,6 +6,7 @@
   level = "DEBUG"
 
 [api]
+insecure=true
 
 [entryPoints]
   [entryPoints.footcp]

--- a/integration/fixtures/k8s_crd.toml
+++ b/integration/fixtures/k8s_crd.toml
@@ -6,7 +6,7 @@
   level = "DEBUG"
 
 [api]
-insecure=true
+  insecure = true
 
 [entryPoints]
   [entryPoints.footcp]

--- a/integration/fixtures/k8s_default.toml
+++ b/integration/fixtures/k8s_default.toml
@@ -3,7 +3,7 @@
   sendAnonymousUsage = false
 
 [api]
-insecure=true
+  insecure = true
 
 [log]
   level = "DEBUG"

--- a/integration/fixtures/k8s_default.toml
+++ b/integration/fixtures/k8s_default.toml
@@ -3,6 +3,7 @@
   sendAnonymousUsage = false
 
 [api]
+insecure=true
 
 [log]
   level = "DEBUG"

--- a/integration/fixtures/marathon/simple.toml
+++ b/integration/fixtures/marathon/simple.toml
@@ -12,6 +12,7 @@
     address = ":9090"
 
 [api]
+insecure=true
 
 [providers]
   [providers.marathon]

--- a/integration/fixtures/marathon/simple.toml
+++ b/integration/fixtures/marathon/simple.toml
@@ -12,7 +12,7 @@
     address = ":9090"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers]
   [providers.marathon]

--- a/integration/fixtures/mirror.toml
+++ b/integration/fixtures/mirror.toml
@@ -3,7 +3,7 @@
   sendAnonymousUsage = false
 
 [api]
-insecure=true
+  insecure = true
 
 [log]
   level = "DEBUG"

--- a/integration/fixtures/mirror.toml
+++ b/integration/fixtures/mirror.toml
@@ -3,6 +3,7 @@
   sendAnonymousUsage = false
 
 [api]
+insecure=true
 
 [log]
   level = "DEBUG"

--- a/integration/fixtures/multiple_provider.toml
+++ b/integration/fixtures/multiple_provider.toml
@@ -10,7 +10,7 @@
     address = ":8000"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers]
   [providers.docker]

--- a/integration/fixtures/multiple_provider.toml
+++ b/integration/fixtures/multiple_provider.toml
@@ -10,6 +10,7 @@
     address = ":8000"
 
 [api]
+insecure=true
 
 [providers]
   [providers.docker]

--- a/integration/fixtures/multiprovider.toml
+++ b/integration/fixtures/multiprovider.toml
@@ -14,6 +14,7 @@ insecure=true
 
 [providers]
   [providers.rest]
+    insecure = true
 
   [providers.file]
     filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/multiprovider.toml
+++ b/integration/fixtures/multiprovider.toml
@@ -6,7 +6,7 @@
   level = "DEBUG"
 
 [api]
-insecure=true
+  insecure = true
 
 [entryPoints]
   [entryPoints.web]

--- a/integration/fixtures/multiprovider.toml
+++ b/integration/fixtures/multiprovider.toml
@@ -6,6 +6,7 @@
   level = "DEBUG"
 
 [api]
+insecure=true
 
 [entryPoints]
   [entryPoints.web]

--- a/integration/fixtures/proxy-protocol/with.toml
+++ b/integration/fixtures/proxy-protocol/with.toml
@@ -12,7 +12,7 @@
       trustedIPs = ["{{.HaproxyIP}}"]
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/proxy-protocol/with.toml
+++ b/integration/fixtures/proxy-protocol/with.toml
@@ -12,6 +12,7 @@
       trustedIPs = ["{{.HaproxyIP}}"]
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/proxy-protocol/without.toml
+++ b/integration/fixtures/proxy-protocol/without.toml
@@ -12,6 +12,7 @@
       trustedIPs = ["1.2.3.4"]
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/proxy-protocol/without.toml
+++ b/integration/fixtures/proxy-protocol/without.toml
@@ -12,7 +12,7 @@
       trustedIPs = ["1.2.3.4"]
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/ratelimit/simple.toml
+++ b/integration/fixtures/ratelimit/simple.toml
@@ -3,7 +3,7 @@
   sendAnonymousUsage = false
 
 [api]
-insecure=true
+  insecure = true
 
 [log]
   level = "DEBUG"

--- a/integration/fixtures/ratelimit/simple.toml
+++ b/integration/fixtures/ratelimit/simple.toml
@@ -3,6 +3,7 @@
   sendAnonymousUsage = false
 
 [api]
+insecure=true
 
 [log]
   level = "DEBUG"

--- a/integration/fixtures/rest/simple.toml
+++ b/integration/fixtures/rest/simple.toml
@@ -10,6 +10,8 @@
     address = ":8000"
 
 [api]
+insecure=true
 
 [providers]
   [providers.rest]
+  insecure=true

--- a/integration/fixtures/rest/simple.toml
+++ b/integration/fixtures/rest/simple.toml
@@ -10,8 +10,8 @@
     address = ":8000"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers]
   [providers.rest]
-  insecure=true
+  insecure = true

--- a/integration/fixtures/rest/simple_secure.toml
+++ b/integration/fixtures/rest/simple_secure.toml
@@ -1,0 +1,26 @@
+[global]
+  checkNewVersion = false
+  sendAnonymousUsage = false
+
+[log]
+  level = "DEBUG"
+
+[entryPoints]
+  [entryPoints.web]
+    address = ":8000"
+
+[api]
+insecure=true
+
+[providers.rest]
+
+[providers.file]
+  filename = "{{ .SelfFilename }}"
+
+[http.routers.rest]
+    rule="PathPrefix(`/secure`)"
+    service="rest@internal"
+    middlewares=["strip"]
+
+[http.middlewares.strip.stripPrefix]
+    prefixes = [ "/secure" ]

--- a/integration/fixtures/rest/simple_secure.toml
+++ b/integration/fixtures/rest/simple_secure.toml
@@ -24,3 +24,4 @@
 
 [http.middlewares.strip.stripPrefix]
     prefixes = [ "/secure" ]
+    

--- a/integration/fixtures/rest/simple_secure.toml
+++ b/integration/fixtures/rest/simple_secure.toml
@@ -10,7 +10,7 @@
     address = ":8000"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.rest]
 

--- a/integration/fixtures/retry/simple.toml
+++ b/integration/fixtures/retry/simple.toml
@@ -10,6 +10,7 @@
     address = ":8000"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/retry/simple.toml
+++ b/integration/fixtures/retry/simple.toml
@@ -10,7 +10,7 @@
     address = ":8000"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/router_errors.toml
+++ b/integration/fixtures/router_errors.toml
@@ -10,7 +10,7 @@
     address = ":4443"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/router_errors.toml
+++ b/integration/fixtures/router_errors.toml
@@ -10,6 +10,7 @@
     address = ":4443"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/service_errors.toml
+++ b/integration/fixtures/service_errors.toml
@@ -10,7 +10,7 @@
     address = ":4443"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/service_errors.toml
+++ b/integration/fixtures/service_errors.toml
@@ -10,6 +10,7 @@
     address = ":4443"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/simple_auth.toml
+++ b/integration/fixtures/simple_auth.toml
@@ -13,6 +13,7 @@
     address = ":8001"
 
 [api]
+insecure=true
   middlewares = ["authentication@file"]
 
 [ping]

--- a/integration/fixtures/simple_auth.toml
+++ b/integration/fixtures/simple_auth.toml
@@ -13,7 +13,7 @@
     address = ":8001"
 
 [api]
-insecure=true
+  insecure = true
   middlewares = ["authentication@file"]
 
 [ping]

--- a/integration/fixtures/simple_hostresolver.toml
+++ b/integration/fixtures/simple_hostresolver.toml
@@ -10,7 +10,7 @@
     address = ":8000"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers]
   [providers.docker]

--- a/integration/fixtures/simple_hostresolver.toml
+++ b/integration/fixtures/simple_hostresolver.toml
@@ -10,6 +10,7 @@
     address = ":8000"
 
 [api]
+insecure=true
 
 [providers]
   [providers.docker]

--- a/integration/fixtures/simple_secure_api.toml
+++ b/integration/fixtures/simple_secure_api.toml
@@ -22,3 +22,4 @@
 
 [http.middlewares.strip.stripPrefix]
     prefixes = [ "/secure" ]
+    

--- a/integration/fixtures/simple_secure_api.toml
+++ b/integration/fixtures/simple_secure_api.toml
@@ -1,0 +1,24 @@
+[global]
+  checkNewVersion = false
+  sendAnonymousUsage = false
+
+[entryPoints]
+  [entryPoints.web]
+    address = ":8000"
+
+ [entryPoints.traefik]
+    address = ":8080"
+
+
+[api]
+
+[providers.file]
+  filename = "{{ .SelfFilename }}"
+
+[http.routers.api]
+    rule="PathPrefix(`/secure`)"
+    service="api@internal"
+    middlewares=["strip"]
+
+[http.middlewares.strip.stripPrefix]
+    prefixes = [ "/secure" ]

--- a/integration/fixtures/simple_stats.toml
+++ b/integration/fixtures/simple_stats.toml
@@ -10,6 +10,7 @@
     address = ":8000"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/simple_stats.toml
+++ b/integration/fixtures/simple_stats.toml
@@ -10,7 +10,7 @@
     address = ":8000"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/simple_web.toml
+++ b/integration/fixtures/simple_web.toml
@@ -10,3 +10,4 @@
     address = ":8000"
 
 [api]
+insecure=true

--- a/integration/fixtures/simple_web.toml
+++ b/integration/fixtures/simple_web.toml
@@ -10,4 +10,4 @@
     address = ":8000"
 
 [api]
-insecure=true
+  insecure = true

--- a/integration/fixtures/simple_whitelist.toml
+++ b/integration/fixtures/simple_whitelist.toml
@@ -12,6 +12,7 @@
       insecure=true
 
 [api]
+insecure=true
 
 [providers]
   [providers.docker]

--- a/integration/fixtures/simple_whitelist.toml
+++ b/integration/fixtures/simple_whitelist.toml
@@ -9,10 +9,10 @@
   [entryPoints.web]
     address = ":8000"
     [entryPoints.web.ForwardedHeaders]
-      insecure=true
+      insecure = true
 
 [api]
-insecure=true
+  insecure = true
 
 [providers]
   [providers.docker]

--- a/integration/fixtures/tcp/catch-all-no-tls-with-https.toml
+++ b/integration/fixtures/tcp/catch-all-no-tls-with-https.toml
@@ -10,7 +10,7 @@
     address = ":8093"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/tcp/catch-all-no-tls-with-https.toml
+++ b/integration/fixtures/tcp/catch-all-no-tls-with-https.toml
@@ -10,6 +10,7 @@
     address = ":8093"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/tcp/catch-all-no-tls.toml
+++ b/integration/fixtures/tcp/catch-all-no-tls.toml
@@ -10,7 +10,7 @@
     address = ":8093"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/tcp/catch-all-no-tls.toml
+++ b/integration/fixtures/tcp/catch-all-no-tls.toml
@@ -10,6 +10,7 @@
     address = ":8093"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/tcp/mixed.toml
+++ b/integration/fixtures/tcp/mixed.toml
@@ -10,7 +10,7 @@
     address = ":8093"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/tcp/mixed.toml
+++ b/integration/fixtures/tcp/mixed.toml
@@ -10,6 +10,7 @@
     address = ":8093"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/tcp/multi-tls-options.toml
+++ b/integration/fixtures/tcp/multi-tls-options.toml
@@ -10,7 +10,7 @@
     address = ":8093"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/tcp/multi-tls-options.toml
+++ b/integration/fixtures/tcp/multi-tls-options.toml
@@ -10,6 +10,7 @@
     address = ":8093"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/tcp/non-tls-fallback.toml
+++ b/integration/fixtures/tcp/non-tls-fallback.toml
@@ -10,7 +10,7 @@
     address = ":8093"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/tcp/non-tls-fallback.toml
+++ b/integration/fixtures/tcp/non-tls-fallback.toml
@@ -10,6 +10,7 @@
     address = ":8093"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/tcp/non-tls.toml
+++ b/integration/fixtures/tcp/non-tls.toml
@@ -10,7 +10,7 @@
     address = ":8093"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/tcp/non-tls.toml
+++ b/integration/fixtures/tcp/non-tls.toml
@@ -10,6 +10,7 @@
     address = ":8093"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/timeout/forwarding_timeouts.toml
+++ b/integration/fixtures/timeout/forwarding_timeouts.toml
@@ -17,7 +17,7 @@
   format = "json"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/timeout/forwarding_timeouts.toml
+++ b/integration/fixtures/timeout/forwarding_timeouts.toml
@@ -17,6 +17,7 @@
   format = "json"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/timeout/keepalive.toml
+++ b/integration/fixtures/timeout/keepalive.toml
@@ -13,7 +13,7 @@
     address = ":8000"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/timeout/keepalive.toml
+++ b/integration/fixtures/timeout/keepalive.toml
@@ -13,6 +13,7 @@
     address = ":8000"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/tlsclientheaders/simple.toml
+++ b/integration/fixtures/tlsclientheaders/simple.toml
@@ -13,6 +13,7 @@
     address = ":8443"
 
 [api]
+insecure=true
 
 [providers]
   [providers.docker]

--- a/integration/fixtures/tlsclientheaders/simple.toml
+++ b/integration/fixtures/tlsclientheaders/simple.toml
@@ -13,7 +13,7 @@
     address = ":8443"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers]
   [providers.docker]

--- a/integration/fixtures/tracing/simple-jaeger-collector.toml
+++ b/integration/fixtures/tracing/simple-jaeger-collector.toml
@@ -6,7 +6,7 @@
   level = "DEBUG"
 
 [api]
-insecure=true
+  insecure = true
 
 [entryPoints]
   [entryPoints.web]

--- a/integration/fixtures/tracing/simple-jaeger-collector.toml
+++ b/integration/fixtures/tracing/simple-jaeger-collector.toml
@@ -6,6 +6,7 @@
   level = "DEBUG"
 
 [api]
+insecure=true
 
 [entryPoints]
   [entryPoints.web]

--- a/integration/fixtures/tracing/simple-jaeger.toml
+++ b/integration/fixtures/tracing/simple-jaeger.toml
@@ -6,7 +6,7 @@
   level = "DEBUG"
 
 [api]
-insecure=true
+  insecure = true
 
 [entryPoints]
   [entryPoints.web]

--- a/integration/fixtures/tracing/simple-jaeger.toml
+++ b/integration/fixtures/tracing/simple-jaeger.toml
@@ -6,6 +6,7 @@
   level = "DEBUG"
 
 [api]
+insecure=true
 
 [entryPoints]
   [entryPoints.web]

--- a/integration/fixtures/tracing/simple-zipkin.toml
+++ b/integration/fixtures/tracing/simple-zipkin.toml
@@ -6,7 +6,7 @@
   level = "DEBUG"
 
 [api]
-insecure=true
+  insecure = true
 
 [entryPoints]
   [entryPoints.web]

--- a/integration/fixtures/tracing/simple-zipkin.toml
+++ b/integration/fixtures/tracing/simple-zipkin.toml
@@ -6,6 +6,7 @@
   level = "DEBUG"
 
 [api]
+insecure=true
 
 [entryPoints]
   [entryPoints.web]

--- a/integration/fixtures/traefik_log_config.toml
+++ b/integration/fixtures/traefik_log_config.toml
@@ -14,7 +14,7 @@
     address = ":8000"
 
 [api]
-insecure=true
+  insecure = true
   dashboard = false
 
 [providers]

--- a/integration/fixtures/traefik_log_config.toml
+++ b/integration/fixtures/traefik_log_config.toml
@@ -14,6 +14,7 @@
     address = ":8000"
 
 [api]
+insecure=true
   dashboard = false
 
 [providers]

--- a/integration/fixtures/websocket/config.toml
+++ b/integration/fixtures/websocket/config.toml
@@ -10,6 +10,7 @@
     address = ":8000"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/websocket/config.toml
+++ b/integration/fixtures/websocket/config.toml
@@ -10,7 +10,7 @@
     address = ":8000"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/websocket/config_https.toml
+++ b/integration/fixtures/websocket/config_https.toml
@@ -13,7 +13,7 @@
     address = ":8000"
 
 [api]
-insecure=true
+  insecure = true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/websocket/config_https.toml
+++ b/integration/fixtures/websocket/config_https.toml
@@ -13,6 +13,7 @@
     address = ":8000"
 
 [api]
+insecure=true
 
 [providers.file]
   filename = "{{ .SelfFilename }}"

--- a/integration/fixtures/wrr.toml
+++ b/integration/fixtures/wrr.toml
@@ -3,7 +3,7 @@
   sendAnonymousUsage = false
 
 [api]
-insecure=true
+  insecure = true
 
 [log]
   level = "DEBUG"

--- a/integration/fixtures/wrr.toml
+++ b/integration/fixtures/wrr.toml
@@ -3,6 +3,7 @@
   sendAnonymousUsage = false
 
 [api]
+insecure=true
 
 [log]
   level = "DEBUG"

--- a/integration/fixtures/wrr_sticky.toml
+++ b/integration/fixtures/wrr_sticky.toml
@@ -3,7 +3,7 @@
   sendAnonymousUsage = false
 
 [api]
-insecure=true
+  insecure = true
 
 [log]
   level = "DEBUG"

--- a/integration/fixtures/wrr_sticky.toml
+++ b/integration/fixtures/wrr_sticky.toml
@@ -3,6 +3,7 @@
   sendAnonymousUsage = false
 
 [api]
+insecure=true
 
 [log]
   level = "DEBUG"

--- a/integration/rest_test.go
+++ b/integration/rest_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/containous/traefik/v2/integration/try"
@@ -20,7 +21,7 @@ func (s *RestSuite) SetUpSuite(c *check.C) {
 	s.composeProject.Start(c)
 }
 
-func (s *RestSuite) TestSimpleConfiguration(c *check.C) {
+func (s *RestSuite) TestSimpleConfigurationInsecure(c *check.C) {
 	cmd, display := s.traefikCmd(withConfigFile("fixtures/rest/simple.toml"))
 
 	defer display(c)
@@ -97,6 +98,103 @@ func (s *RestSuite) TestSimpleConfiguration(c *check.C) {
 		c.Assert(err, checker.IsNil)
 
 		request, err := http.NewRequest(http.MethodPut, "http://127.0.0.1:8080/api/providers/rest", bytes.NewReader(json))
+		c.Assert(err, checker.IsNil)
+
+		response, err := http.DefaultClient.Do(request)
+		c.Assert(err, checker.IsNil)
+		c.Assert(response.StatusCode, checker.Equals, http.StatusOK)
+
+		err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1000*time.Millisecond, try.BodyContains(test.ruleMatch))
+		c.Assert(err, checker.IsNil)
+
+		err = try.GetRequest("http://127.0.0.1:8000/", 1000*time.Millisecond, try.StatusCodeIs(http.StatusOK))
+		c.Assert(err, checker.IsNil)
+	}
+}
+
+func (s *RestSuite) TestSimpleConfiguration(c *check.C) {
+	file := s.adaptFile(c, "fixtures/rest/simple_secure.toml", struct{}{})
+	defer os.Remove(file)
+
+	cmd, display := s.traefikCmd(withConfigFile(file))
+
+	defer display(c)
+	err := cmd.Start()
+	c.Assert(err, checker.IsNil)
+	defer cmd.Process.Kill()
+
+	// Expected a 404 as we did not configure anything.
+	err = try.GetRequest("http://127.0.0.1:8000/", 1000*time.Millisecond, try.StatusCodeIs(http.StatusNotFound))
+	c.Assert(err, checker.IsNil)
+
+	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 2000*time.Millisecond, try.BodyContains("PathPrefix(`/secure`)"))
+	c.Assert(err, checker.IsNil)
+
+	testCase := []struct {
+		desc      string
+		config    *dynamic.Configuration
+		ruleMatch string
+	}{
+		{
+			desc: "deploy http configuration",
+			config: &dynamic.Configuration{
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"router1": {
+							EntryPoints: []string{"web"},
+							Middlewares: []string{},
+							Service:     "service1",
+							Rule:        "PathPrefix(`/`)",
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"service1": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://" + s.composeProject.Container(c, "whoami1").NetworkSettings.IPAddress + ":80",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ruleMatch: "PathPrefix(`/`)",
+		},
+		{
+			desc: "deploy tcp configuration",
+			config: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers: map[string]*dynamic.TCPRouter{
+						"router1": {
+							EntryPoints: []string{"web"},
+							Service:     "service1",
+							Rule:        "HostSNI(`*`)",
+						},
+					},
+					Services: map[string]*dynamic.TCPService{
+						"service1": {
+							LoadBalancer: &dynamic.TCPLoadBalancerService{
+								Servers: []dynamic.TCPServer{
+									{
+										Address: s.composeProject.Container(c, "whoami1").NetworkSettings.IPAddress + ":80",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ruleMatch: "HostSNI(`*`)",
+		},
+	}
+
+	for _, test := range testCase {
+		json, err := json.Marshal(test.config)
+		c.Assert(err, checker.IsNil)
+
+		request, err := http.NewRequest(http.MethodPut, "http://127.0.0.1:8000/secure/api/providers/rest", bytes.NewReader(json))
 		c.Assert(err, checker.IsNil)
 
 		response, err := http.DefaultClient.Do(request)

--- a/integration/rest_test.go
+++ b/integration/rest_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/containous/traefik/v2/integration/try"
@@ -129,6 +130,13 @@ func (s *RestSuite) TestSimpleConfiguration(c *check.C) {
 
 	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 2000*time.Millisecond, try.BodyContains("PathPrefix(`/secure`)"))
 	c.Assert(err, checker.IsNil)
+
+	request, err := http.NewRequest(http.MethodPut, "http://127.0.0.1:8080/api/providers/rest", strings.NewReader("{}"))
+	c.Assert(err, checker.IsNil)
+
+	response, err := http.DefaultClient.Do(request)
+	c.Assert(err, checker.IsNil)
+	c.Assert(response.StatusCode, checker.Equals, http.StatusNotFound)
 
 	testCase := []struct {
 		desc      string

--- a/pkg/api/handler.go
+++ b/pkg/api/handler.go
@@ -55,6 +55,15 @@ type Handler struct {
 	dashboardAssets *assetfs.AssetFS
 }
 
+// NewBuilder return a http.Handler builder based on runtime.Configuration
+func NewBuilder(staticConfig static.Configuration) func(*runtime.Configuration) http.Handler {
+	return func(configuration *runtime.Configuration) http.Handler {
+		router := mux.NewRouter()
+		New(staticConfig, configuration).Append(router)
+		return router
+	}
+}
+
 // New returns a Handler defined by staticConfig, and if provided, by runtimeConfig.
 // It finishes populating the information provided in the runtimeConfig.
 func New(staticConfig static.Configuration, runtimeConfig *runtime.Configuration) *Handler {

--- a/pkg/api/handler.go
+++ b/pkg/api/handler.go
@@ -55,7 +55,7 @@ type Handler struct {
 	dashboardAssets *assetfs.AssetFS
 }
 
-// NewBuilder return a http.Handler builder based on runtime.Configuration
+// NewBuilder returns a http.Handler builder based on runtime.Configuration
 func NewBuilder(staticConfig static.Configuration) func(*runtime.Configuration) http.Handler {
 	return func(configuration *runtime.Configuration) http.Handler {
 		router := mux.NewRouter()

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -85,6 +85,7 @@ type ServersTransport struct {
 
 // API holds the API configuration
 type API struct {
+	Insecure  bool `description:"Activate API on an insecure entryPoints named traefik." json:"insecure,omitempty" toml:"insecure,omitempty" yaml:"insecure,omitempty" export:"true"`
 	Dashboard bool `description:"Activate dashboard." json:"dashboard,omitempty" toml:"dashboard,omitempty" yaml:"dashboard,omitempty" export:"true"`
 	Debug     bool `description:"Enable additional endpoints for debugging and profiling." json:"debug,omitempty" toml:"debug,omitempty" yaml:"debug,omitempty" export:"true"`
 	// TODO: Re-enable statistics
@@ -173,9 +174,9 @@ func (c *Configuration) SetEffectiveConfiguration() {
 		}
 	}
 
-	if (c.API != nil) ||
-		(c.Ping != nil) ||
-		(c.Metrics != nil && c.Metrics.Prometheus != nil) ||
+	if (c.API != nil && c.API.Insecure) ||
+		(c.Ping != nil && c.Ping.EntryPoint == DefaultInternalEntryPointName) ||
+		(c.Metrics != nil && c.Metrics.Prometheus != nil && c.Metrics.Prometheus.EntryPoint == DefaultInternalEntryPointName) ||
 		(c.Providers.Rest != nil) {
 		if _, ok := c.EntryPoints[DefaultInternalEntryPointName]; !ok {
 			ep := &EntryPoint{Address: ":8080"}

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -85,7 +85,7 @@ type ServersTransport struct {
 
 // API holds the API configuration
 type API struct {
-	Insecure  bool `description:"Activate API on an insecure entryPoints named traefik." json:"insecure,omitempty" toml:"insecure,omitempty" yaml:"insecure,omitempty" export:"true"`
+	Insecure  bool `description:"Activate API directly on the entryPoint named traefik." json:"insecure,omitempty" toml:"insecure,omitempty" yaml:"insecure,omitempty" export:"true"`
 	Dashboard bool `description:"Activate dashboard." json:"dashboard,omitempty" toml:"dashboard,omitempty" yaml:"dashboard,omitempty" export:"true"`
 	Debug     bool `description:"Enable additional endpoints for debugging and profiling." json:"debug,omitempty" toml:"debug,omitempty" yaml:"debug,omitempty" export:"true"`
 	// TODO: Re-enable statistics

--- a/pkg/ping/ping.go
+++ b/pkg/ping/ping.go
@@ -10,11 +10,13 @@ import (
 
 // Handler expose ping routes.
 type Handler struct {
+	EntryPoint  string `description:"EntryPoint" export:"true" json:"entryPoint,omitempty" toml:"entryPoint,omitempty" yaml:"entryPoint,omitempty"`
 	terminating bool
 }
 
 // SetDefaults sets the default values.
 func (h *Handler) SetDefaults() {
+	h.EntryPoint = "traefik"
 }
 
 // WithContext causes the ping endpoint to serve non 200 responses.

--- a/pkg/provider/rest/rest.go
+++ b/pkg/provider/rest/rest.go
@@ -18,7 +18,7 @@ var _ provider.Provider = (*Provider)(nil)
 
 // Provider is a provider.Provider implementation that provides a Rest API.
 type Provider struct {
-	Insecure          bool `description:"Activate REST Provider on an insecure entryPoints named traefik." json:"insecure,omitempty" toml:"insecure,omitempty" yaml:"insecure,omitempty" export:"true"`
+	Insecure          bool `description:"Activate REST Provider directly on the entryPoint named traefik." json:"insecure,omitempty" toml:"insecure,omitempty" yaml:"insecure,omitempty" export:"true"`
 	configurationChan chan<- dynamic.Message
 }
 

--- a/pkg/provider/rest/rest.go
+++ b/pkg/provider/rest/rest.go
@@ -18,6 +18,7 @@ var _ provider.Provider = (*Provider)(nil)
 
 // Provider is a provider.Provider implementation that provides a Rest API.
 type Provider struct {
+	Insecure          bool `description:"Activate REST Provider on an insecure entryPoints named traefik." json:"insecure,omitempty" toml:"insecure,omitempty" yaml:"insecure,omitempty" export:"true"`
 	configurationChan chan<- dynamic.Message
 }
 
@@ -30,6 +31,13 @@ var templatesRenderer = render.New(render.Options{Directory: "nowhere"})
 // Init the provider.
 func (p *Provider) Init() error {
 	return nil
+}
+
+// Handler creates an http.Handler for the Rest API
+func (p *Provider) Handler() http.Handler {
+	router := mux.NewRouter()
+	p.Append(router)
+	return router
 }
 
 // Append add rest provider routes on a router.

--- a/pkg/server/router/route_appender_aggregator.go
+++ b/pkg/server/router/route_appender_aggregator.go
@@ -35,7 +35,7 @@ func NewRouteAppenderAggregator(ctx context.Context, conf static.Configuration,
 		return aggregator
 	}
 
-	if conf.Providers != nil && conf.Providers.Rest != nil {
+	if conf.Providers != nil && conf.Providers.Rest != nil && conf.Providers.Rest.Insecure {
 		aggregator.AddAppender(conf.Providers.Rest)
 	}
 

--- a/pkg/server/router/route_appender_aggregator_test.go
+++ b/pkg/server/router/route_appender_aggregator_test.go
@@ -6,72 +6,23 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/containous/alice"
 	"github.com/containous/traefik/v2/pkg/config/static"
-	"github.com/containous/traefik/v2/pkg/ping"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 )
 
-type ChainBuilderMock struct {
-	middles map[string]alice.Constructor
-}
-
-func (c *ChainBuilderMock) BuildChain(ctx context.Context, middles []string) *alice.Chain {
-	chain := alice.New()
-
-	for _, mName := range middles {
-		if constructor, ok := c.middles[mName]; ok {
-			chain = chain.Append(constructor)
-		}
-	}
-
-	return &chain
-}
-
 func TestNewRouteAppenderAggregator(t *testing.T) {
-	t.Skip("Waiting for new api handler implementation")
 	testCases := []struct {
 		desc       string
 		staticConf static.Configuration
-		middles    map[string]alice.Constructor
 		expected   map[string]int
 	}{
 		{
-			desc: "API with auth, ping without auth",
+			desc: "Secure API",
 			staticConf: static.Configuration{
 				Global: &static.Global{},
-				API:    &static.API{
-					// EntryPoint:  "traefik",
-					// Middlewares: []string{"dumb"},
-				},
-				Ping: &ping.Handler{
-					// EntryPoint: "traefik",
-				},
-				EntryPoints: static.EntryPoints{
-					"traefik": {},
-				},
-			},
-			middles: map[string]alice.Constructor{
-				"dumb": func(_ http.Handler) (http.Handler, error) {
-					return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-						w.WriteHeader(http.StatusUnauthorized)
-					}), nil
-				},
-			},
-			expected: map[string]int{
-				"/wrong": http.StatusBadGateway,
-				"/ping":  http.StatusOK,
-				// "/.well-known/acme-challenge/token": http.StatusNotFound, // FIXME
-				"/api/rawdata": http.StatusUnauthorized,
-			},
-		},
-		{
-			desc: "Wrong entrypoint name",
-			staticConf: static.Configuration{
-				Global: &static.Global{},
-				API:    &static.API{
-					// EntryPoint: "no",
+				API: &static.API{
+					Insecure: false,
 				},
 				EntryPoints: static.EntryPoints{
 					"traefik": {},
@@ -81,6 +32,21 @@ func TestNewRouteAppenderAggregator(t *testing.T) {
 				"/api/providers": http.StatusBadGateway,
 			},
 		},
+		{
+			desc: "Insecure API",
+			staticConf: static.Configuration{
+				Global: &static.Global{},
+				API: &static.API{
+					Insecure: true,
+				},
+				EntryPoints: static.EntryPoints{
+					"traefik": {},
+				},
+			},
+			expected: map[string]int{
+				"/api/rawdata": http.StatusOK,
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -88,11 +54,9 @@ func TestNewRouteAppenderAggregator(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			chainBuilder := &ChainBuilderMock{middles: test.middles}
-
 			ctx := context.Background()
 
-			router := NewRouteAppenderAggregator(ctx, chainBuilder, test.staticConf, "traefik", nil)
+			router := NewRouteAppenderAggregator(ctx, test.staticConf, "traefik", nil)
 
 			internalMuxRouter := mux.NewRouter()
 			router.Append(internalMuxRouter)

--- a/pkg/server/router/route_appender_factory.go
+++ b/pkg/server/router/route_appender_factory.go
@@ -6,7 +6,6 @@ import (
 	"github.com/containous/traefik/v2/pkg/config/runtime"
 	"github.com/containous/traefik/v2/pkg/config/static"
 	"github.com/containous/traefik/v2/pkg/provider/acme"
-	"github.com/containous/traefik/v2/pkg/server/middleware"
 	"github.com/containous/traefik/v2/pkg/types"
 )
 
@@ -27,8 +26,8 @@ type RouteAppenderFactory struct {
 }
 
 // NewAppender Creates a new RouteAppender
-func (r *RouteAppenderFactory) NewAppender(ctx context.Context, middlewaresBuilder *middleware.Builder, runtimeConfiguration *runtime.Configuration) types.RouteAppender {
-	aggregator := NewRouteAppenderAggregator(ctx, middlewaresBuilder, r.staticConfiguration, r.entryPointName, runtimeConfiguration)
+func (r *RouteAppenderFactory) NewAppender(ctx context.Context, runtimeConfiguration *runtime.Configuration) types.RouteAppender {
+	aggregator := NewRouteAppenderAggregator(ctx, r.staticConfiguration, r.entryPointName, runtimeConfiguration)
 
 	for _, p := range r.acmeProvider {
 		if p != nil && p.HTTPChallenge != nil && p.HTTPChallenge.EntryPoint == r.entryPointName {

--- a/pkg/server/router/router_test.go
+++ b/pkg/server/router/router_test.go
@@ -306,7 +306,7 @@ func TestRouterManager_Get(t *testing.T) {
 					Middlewares: test.middlewaresConfig,
 				},
 			})
-			serviceManager := service.NewManager(rtConf.Services, http.DefaultTransport, nil, nil)
+			serviceManager := service.NewManager(rtConf.Services, http.DefaultTransport, nil, nil, nil, nil)
 			middlewaresBuilder := middleware.NewBuilder(rtConf.Middlewares, serviceManager)
 			responseModifierFactory := responsemodifiers.NewBuilder(rtConf.Middlewares)
 			routerManager := NewManager(rtConf, serviceManager, middlewaresBuilder, responseModifierFactory)
@@ -407,7 +407,7 @@ func TestAccessLog(t *testing.T) {
 					Middlewares: test.middlewaresConfig,
 				},
 			})
-			serviceManager := service.NewManager(rtConf.Services, http.DefaultTransport, nil, nil)
+			serviceManager := service.NewManager(rtConf.Services, http.DefaultTransport, nil, nil, nil, nil)
 			middlewaresBuilder := middleware.NewBuilder(rtConf.Middlewares, serviceManager)
 			responseModifierFactory := responsemodifiers.NewBuilder(rtConf.Middlewares)
 			routerManager := NewManager(rtConf, serviceManager, middlewaresBuilder, responseModifierFactory)
@@ -693,7 +693,7 @@ func TestRuntimeConfiguration(t *testing.T) {
 					Middlewares: test.middlewareConfig,
 				},
 			})
-			serviceManager := service.NewManager(rtConf.Services, http.DefaultTransport, nil, nil)
+			serviceManager := service.NewManager(rtConf.Services, http.DefaultTransport, nil, nil, nil, nil)
 			middlewaresBuilder := middleware.NewBuilder(rtConf.Middlewares, serviceManager)
 			responseModifierFactory := responsemodifiers.NewBuilder(map[string]*runtime.MiddlewareInfo{})
 			routerManager := NewManager(rtConf, serviceManager, middlewaresBuilder, responseModifierFactory)
@@ -767,7 +767,7 @@ func BenchmarkRouterServe(b *testing.B) {
 			Middlewares: map[string]*dynamic.Middleware{},
 		},
 	})
-	serviceManager := service.NewManager(rtConf.Services, &staticTransport{res}, nil, nil)
+	serviceManager := service.NewManager(rtConf.Services, &staticTransport{res}, nil, nil, nil, nil)
 	middlewaresBuilder := middleware.NewBuilder(rtConf.Middlewares, serviceManager)
 	responseModifierFactory := responsemodifiers.NewBuilder(rtConf.Middlewares)
 	routerManager := NewManager(rtConf, serviceManager, middlewaresBuilder, responseModifierFactory)
@@ -808,7 +808,7 @@ func BenchmarkService(b *testing.B) {
 			Services: serviceConfig,
 		},
 	})
-	serviceManager := service.NewManager(rtConf.Services, &staticTransport{res}, nil, nil)
+	serviceManager := service.NewManager(rtConf.Services, &staticTransport{res}, nil, nil, nil, nil)
 	w := httptest.NewRecorder()
 	req := testhelpers.MustNewRequest(http.MethodGet, "http://foo.bar/", nil)
 

--- a/pkg/server/service/service_test.go
+++ b/pkg/server/service/service_test.go
@@ -80,7 +80,7 @@ func TestGetLoadBalancer(t *testing.T) {
 }
 
 func TestGetLoadBalancerServiceHandler(t *testing.T) {
-	sm := NewManager(nil, http.DefaultTransport, nil, nil)
+	sm := NewManager(nil, http.DefaultTransport, nil, nil, nil, nil)
 
 	server1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-From", "first")
@@ -332,7 +332,7 @@ func TestManager_Build(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			manager := NewManager(test.configs, http.DefaultTransport, nil, nil)
+			manager := NewManager(test.configs, http.DefaultTransport, nil, nil, nil, nil)
 
 			ctx := context.Background()
 			if len(test.providerName) > 0 {
@@ -353,7 +353,7 @@ func TestMultipleTypeOnBuildHTTP(t *testing.T) {
 				Weighted:     &dynamic.WeightedRoundRobin{},
 			},
 		},
-	}, http.DefaultTransport, nil, nil)
+	}, http.DefaultTransport, nil, nil, nil, nil)
 
 	_, err := manager.BuildHTTP(context.Background(), "test@file", nil)
 	assert.Error(t, err, "cannot create service: multi-types service not supported, consider declaring two different pieces of service instead")

--- a/pkg/types/metrics.go
+++ b/pkg/types/metrics.go
@@ -17,6 +17,7 @@ type Prometheus struct {
 	Buckets              []float64 `description:"Buckets for latency metrics." json:"buckets,omitempty" toml:"buckets,omitempty" yaml:"buckets,omitempty" export:"true"`
 	AddEntryPointsLabels bool      `description:"Enable metrics on entry points." json:"addEntryPointsLabels,omitempty" toml:"addEntryPointsLabels,omitempty" yaml:"addEntryPointsLabels,omitempty" export:"true"`
 	AddServicesLabels    bool      `description:"Enable metrics on services." json:"addServicesLabels,omitempty" toml:"addServicesLabels,omitempty" yaml:"addServicesLabels,omitempty" export:"true"`
+	EntryPoint           string    `description:"EntryPoint" export:"true" json:"entryPoint,omitempty" toml:"entryPoint,omitempty" yaml:"entryPoint,omitempty"`
 }
 
 // SetDefaults sets the default values.
@@ -24,6 +25,7 @@ func (p *Prometheus) SetDefaults() {
 	p.Buckets = []float64{0.1, 0.3, 1.2, 5}
 	p.AddEntryPointsLabels = true
 	p.AddServicesLabels = true
+	p.EntryPoint = "traefik"
 }
 
 // Datadog contains address and metrics pushing interval configuration.


### PR DESCRIPTION
### What does this PR do?

This PR changes the default behavior of the API. When you just enable the API, it will create a new internal service named `api@internal`, and you can configure a secure router to be able to use the API. 
If you just want to try the API in a development environment, you can enable the insecure API (`api.insecure=true`).

### Motivation
The API contains sensitive data, that's why we want more security on this part.



### More

- [x] Added/updated tests
- [x] Added/updated documentation

<!-- Anything else we should know when reviewing? -->
