### PR TITLE
Default to CLF when accesslog format is unsupported

### DIFF
--- a/docs/content/observability/access-logs.md
+++ b/docs/content/observability/access-logs.md
@@ -26,12 +26,11 @@ accessLog: {}
 By default access logs are written to the standard output.
 To write the logs into a log file, use the `filePath` option.
 
-in the Common Log Format (CLF), extended with additional fields.
-
 ### `format`
  
 By default, logs are written using the Common Log Format (CLF).
 To write logs in JSON, use `json` in the `format` option.
+If the given format is unsupported, the default (CLF) is used instead.
 
 !!! note "Common Log Format"
     

--- a/pkg/middlewares/accesslog/logger.go
+++ b/pkg/middlewares/accesslog/logger.go
@@ -77,7 +77,7 @@ func NewHandler(config *types.AccessLog) (*Handler, error) {
 	case JSONFormat:
 		formatter = new(logrus.JSONFormatter)
 	default:
-		log.WithoutContext().Warnf("unsupported access log format: %q, defaulting to common format instead.", config.Format)
+		log.WithoutContext().Errorf("unsupported access log format: %q, defaulting to common format instead.", config.Format)
 		formatter = new(CommonLogFormatter)
 	}
 

--- a/pkg/middlewares/accesslog/logger.go
+++ b/pkg/middlewares/accesslog/logger.go
@@ -77,7 +77,8 @@ func NewHandler(config *types.AccessLog) (*Handler, error) {
 	case JSONFormat:
 		formatter = new(logrus.JSONFormatter)
 	default:
-		return nil, fmt.Errorf("unsupported access log format: %s", config.Format)
+		log.WithoutContext().Warnf("unsupported access log format: %q, defaulting to common format instead.", config.Format)
+		formatter = new(CommonLogFormatter)
 	}
 
 	logger := &logrus.Logger{


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

This PR makes the accesslog middleware default to Common Log Format when the provided format is unsupported (e.g. user made a config mistake). Previously we used to return an error in that case, now we log instead and provide a working middleware with CLF.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

To have a sane fallback in case of PEBKAC.

<!-- What inspired you to submit this pull request? -->


### More

- ~[ ] Added/updated tests~
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
