### PR TITLE
Write HTTP server logs into the global logger.

### DIFF
--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	stdlog "log"
 	"net"
 	"net/http"
 	"sync"
@@ -16,9 +17,12 @@ import (
 	"github.com/containous/traefik/v2/pkg/middlewares/forwardedheaders"
 	"github.com/containous/traefik/v2/pkg/safe"
 	"github.com/containous/traefik/v2/pkg/tcp"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 )
+
+var httpServerLogger = stdlog.New(log.WithoutContext().WriterLevel(logrus.DebugLevel), "", 0)
 
 type httpForwarder struct {
 	net.Listener
@@ -352,7 +356,8 @@ func createHTTPServer(ln net.Listener, configuration *static.EntryPoint, withH2c
 	}
 
 	serverHTTP := &http.Server{
-		Handler: handler,
+		Handler:  handler,
+		ErrorLog: httpServerLogger,
 	}
 
 	listener := newHTTPForwarder(ln)


### PR DESCRIPTION
### What does this PR do?

Write HTTP server logs into the global logger.

### Motivation

Allow to move all logs in a file.

### More

- [ ] ~~Added/updated tests~~
- [ ] ~~Added/updated documentation~~
