### PR TITLE
Update golangci-lint

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -23,6 +23,10 @@
   [linters-settings.misspell]
     locale = "US"
 
+  [linters-settings.funlen]
+    lines = 230 # default 60
+    statements = 120 # default 40
+
 [linters]
   enable-all = true
   disable = [
@@ -37,7 +41,6 @@
     "gochecknoinits",
     "gochecknoglobals",
     "bodyclose", # Too many false-positive and panics.
-    "typecheck", # v1.17.1 and Go1.13 => bug
   ]
 
 [issues]
@@ -50,8 +53,8 @@
     "should have a package comment, unless it's in another file for this package",
   ]
  [[issues.exclude-rules]]
-    path = ".+_test.go"
-    linters = ["goconst"]
+    path = "(.+)_test.go"
+    linters = ["goconst", "funlen"]
  [[issues.exclude-rules]]
     path = "integration/.+_test.go"
     text = "Error return value of `cmd\\.Process\\.Kill` is not checked"

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -19,7 +19,7 @@ RUN mkdir -p /usr/local/bin \
     && chmod +x /usr/local/bin/go-bindata
 
 # Download golangci-lint binary to bin folder in $GOPATH
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.17.1
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.18.0
 
 # Download golangci-lint and misspell binary to bin folder in $GOPATH
 RUN GO111MODULE=off go get github.com/client9/misspell/cmd/misspell

--- a/integration/https_test.go
+++ b/integration/https_test.go
@@ -501,8 +501,8 @@ func (s *HTTPSSuite) TestWithClientCertificateAuthentication(c *check.C) {
 // TestWithClientCertificateAuthentication
 // Use two CA:s and test that clients with client signed by either of them can connect
 func (s *HTTPSSuite) TestWithClientCertificateAuthenticationMultipleCAs(c *check.C) {
-	server1 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) { rw.Write([]byte("server1")) }))
-	server2 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) { rw.Write([]byte("server2")) }))
+	server1 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) { _, _ = rw.Write([]byte("server1")) }))
+	server2 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) { _, _ = rw.Write([]byte("server2")) }))
 	defer func() {
 		server1.Close()
 		server2.Close()
@@ -598,8 +598,8 @@ func (s *HTTPSSuite) TestWithClientCertificateAuthenticationMultipleCAs(c *check
 // TestWithClientCertificateAuthentication
 // Use two CA:s in two different files and test that clients with client signed by either of them can connect
 func (s *HTTPSSuite) TestWithClientCertificateAuthenticationMultipleCAsMultipleFiles(c *check.C) {
-	server1 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) { rw.Write([]byte("server1")) }))
-	server2 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) { rw.Write([]byte("server2")) }))
+	server1 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) { _, _ = rw.Write([]byte("server1")) }))
+	server2 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) { _, _ = rw.Write([]byte("server2")) }))
 	defer func() {
 		server1.Close()
 		server2.Close()

--- a/integration/simple_test.go
+++ b/integration/simple_test.go
@@ -747,8 +747,7 @@ func (s *SimpleSuite) TestMirrorCanceled(c *check.C) {
 		client := &http.Client{
 			Timeout: time.Second,
 		}
-		_, err = client.Do(req)
-		c.Assert(err, checker.IsNil)
+		_, _ = client.Do(req)
 	}
 
 	countTotal := atomic.LoadInt32(&count)

--- a/integration/simple_test.go
+++ b/integration/simple_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -745,9 +744,11 @@ func (s *SimpleSuite) TestMirrorCanceled(c *check.C) {
 		req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8000/whoami", nil)
 		c.Assert(err, checker.IsNil)
 
-		newCtx, _ := context.WithTimeout(req.Context(), time.Second)
-		req = req.WithContext(newCtx)
-		http.DefaultClient.Do(req)
+		client := &http.Client{
+			Timeout: time.Second,
+		}
+		_, err = client.Do(req)
+		c.Assert(err, checker.IsNil)
 	}
 
 	countTotal := atomic.LoadInt32(&count)

--- a/pkg/provider/kubernetes/crd/traefik/v1alpha1/middleware.go
+++ b/pkg/provider/kubernetes/crd/traefik/v1alpha1/middleware.go
@@ -89,6 +89,7 @@ type ForwardAuth struct {
 	TLS                 *ClientTLS `json:"tls,omitempty"`
 }
 
+// ClientTLS holds TLS specific configurations as client.
 type ClientTLS struct {
 	CASecret           string `json:"caSecret,omitempty"`
 	CAOptional         bool   `json:"caOptional,omitempty"`

--- a/pkg/server/router/route_appender_aggregator.go
+++ b/pkg/server/router/route_appender_aggregator.go
@@ -13,11 +13,6 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// chainBuilder The contract of the middleware builder
-type chainBuilder interface {
-	BuildChain(ctx context.Context, middlewares []string) *alice.Chain
-}
-
 // NewRouteAppenderAggregator Creates a new RouteAppenderAggregator
 func NewRouteAppenderAggregator(ctx context.Context, conf static.Configuration,
 	entryPointName string, runtimeConfiguration *runtime.Configuration) *RouteAppenderAggregator {

--- a/pkg/server/service/loadbalancer/mirror/mirror.go
+++ b/pkg/server/service/loadbalancer/mirror/mirror.go
@@ -63,7 +63,7 @@ func (m *Mirroring) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			if handler.count*100 < total*uint64(handler.percent) {
 				handler.count++
 				handler.lock.Unlock()
-				// When a request served by m.handler is successful, req.Context will be cancelled,
+				// When a request served by m.handler is successful, req.Context will be canceled,
 				// which would trigger a cancellation of the ongoing mirrored requests.
 				// Therefore, we give a new, non-cancellable context  to each of the mirrored calls,
 				// so they can terminate by themselves.


### PR DESCRIPTION
### What does this PR do?

Update golangci-lint

### Motivation

Use a golangci-lint compatible with go 1.13

### More

- [ ] ~~Added/updated tests~~
- [ ] ~~Added/updated documentation~~
