### PR TITLE
Cherry pick v1.7 into v2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,13 @@
 **Misc:**
 - Cherry pick v1.7 into v2.0 ([#5192](https://github.com/containous/traefik/pull/5192) by [ldez](https://github.com/ldez))
 
+## [v1.7.14](https://github.com/containous/traefik/tree/v1.7.14) (2019-08-14)
+[All Commits](https://github.com/containous/traefik/compare/v1.7.13...v1.7.14)
+
+**Bug fixes:**
+- Update to go1.12.8 ([#5201](https://github.com/containous/traefik/pull/5201) by [ldez](https://github.com/ldez)). HTTP/2 Denial of Service [CVE-2019-9512](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9512) and [CVE-2019-9514](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9514)
+- **[server]** Make hijackConnectionTracker.Close thread safe ([#5194](https://github.com/containous/traefik/pull/5194) by [jlevesy](https://github.com/jlevesy))
+
 ## [v1.7.13](https://github.com/containous/traefik/tree/v1.7.13) (2019-08-07)
 [All Commits](https://github.com/containous/traefik/compare/v1.7.12...v1.7.13)
 

--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -168,6 +168,27 @@ Value of `kubernetes.io/ingress.class` annotation that identifies Ingress object
 If the parameter is non-empty, only Ingresses containing an annotation with the same value are processed.
 Otherwise, Ingresses missing the annotation, having an empty value, or the value `traefik` are processed.
 
+### `throttleDuration`
+
+_Optional, Default: 0 (no throttling)_
+
+```toml tab="File (TOML)"
+[providers.kubernetesCRD]
+  throttleDuration = "10s"
+  # ...
+```
+
+```yaml tab="File (YAML)"
+providers:
+  kubernetesCRD:
+    throttleDuration: "10s"
+    # ...
+```
+
+```bash tab="CLI"
+--providers.kubernetescrd.throttleDuration="10s"
+```
+
 ## Resource Configuration
 
 If you're in a hurry, maybe you'd rather go through the [dynamic](../reference/dynamic-configuration/kubernetes-crd.md) configuration reference.

--- a/docs/content/providers/kubernetes-ingress.md
+++ b/docs/content/providers/kubernetes-ingress.md
@@ -305,6 +305,27 @@ providers:
 
 Published Kubernetes Service to copy status from.
 
+### `throttleDuration`
+
+_Optional, Default: 0 (no throttling)_
+
+```toml tab="File (TOML)"
+[providers.kubernetesIngress]
+  throttleDuration = "10s"
+  # ...
+```
+
+```yaml tab="File (YAML)"
+providers:
+  kubernetesIngress:
+    throttleDuration: "10s"
+    # ...
+```
+
+```bash tab="CLI"
+--providers.kubernetesingress.throttleDuration="10s"
+```
+
 ## Further
 
 If one wants to know more about the various aspects of the Ingress spec that Traefik supports, many examples of Ingresses definitions are located in the tests [data](https://github.com/containous/traefik/tree/v2.0/pkg/provider/kubernetes/ingress/fixtures) of the Traefik repository.

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -46,7 +46,7 @@ Activate dashboard. (Default: ```true```)
 Enable additional endpoints for debugging and profiling. (Default: ```false```)
 
 `--api.insecure`:  
-Activate API on an insecure entryPoints named traefik. (Default: ```false```)
+Activate API directly on the entryPoint named traefik. (Default: ```false```)
 
 `--certificatesresolvers.<name>`:  
 Certificates resolvers configuration. (Default: ```false```)
@@ -312,6 +312,9 @@ Kubernetes label selector to use.
 `--providers.kubernetescrd.namespaces`:  
 Kubernetes namespaces.
 
+`--providers.kubernetescrd.throttleduration`:  
+Ingress refresh throttle duration (Default: ```0```)
+
 `--providers.kubernetescrd.token`:  
 Kubernetes bearer token (not needed for in-cluster client).
 
@@ -344,6 +347,9 @@ Kubernetes Ingress label selector to use.
 
 `--providers.kubernetesingress.namespaces`:  
 Kubernetes namespaces.
+
+`--providers.kubernetesingress.throttleduration`:  
+Ingress refresh throttle duration (Default: ```0```)
 
 `--providers.kubernetesingress.token`:  
 Kubernetes bearer token (not needed for in-cluster client).
@@ -445,7 +451,7 @@ Watch provider. (Default: ```true```)
 Enable Rest backend with default settings. (Default: ```false```)
 
 `--providers.rest.insecure`:  
-Activate REST Provider on an insecure entryPoints named traefik. (Default: ```false```)
+Activate REST Provider directly on the entryPoint named traefik. (Default: ```false```)
 
 `--serverstransport.forwardingtimeouts.dialtimeout`:  
 The amount of time to wait until a connection to a backend server can be established. If zero, no timeout exists. (Default: ```30```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -46,7 +46,7 @@ Activate dashboard. (Default: ```true```)
 Enable additional endpoints for debugging and profiling. (Default: ```false```)
 
 `TRAEFIK_API_INSECURE`:  
-Activate API on an insecure entryPoints named traefik. (Default: ```false```)
+Activate API directly on the entryPoint named traefik. (Default: ```false```)
 
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>`:  
 Certificates resolvers configuration. (Default: ```false```)
@@ -312,6 +312,9 @@ Kubernetes label selector to use.
 `TRAEFIK_PROVIDERS_KUBERNETESCRD_NAMESPACES`:  
 Kubernetes namespaces.
 
+`TRAEFIK_PROVIDERS_KUBERNETESCRD_THROTTLEDURATION`:  
+Ingress refresh throttle duration (Default: ```0```)
+
 `TRAEFIK_PROVIDERS_KUBERNETESCRD_TOKEN`:  
 Kubernetes bearer token (not needed for in-cluster client).
 
@@ -344,6 +347,9 @@ Kubernetes Ingress label selector to use.
 
 `TRAEFIK_PROVIDERS_KUBERNETESINGRESS_NAMESPACES`:  
 Kubernetes namespaces.
+
+`TRAEFIK_PROVIDERS_KUBERNETESINGRESS_THROTTLEDURATION`:  
+Ingress refresh throttle duration (Default: ```0```)
 
 `TRAEFIK_PROVIDERS_KUBERNETESINGRESS_TOKEN`:  
 Kubernetes bearer token (not needed for in-cluster client).
@@ -445,7 +451,7 @@ Watch provider. (Default: ```true```)
 Enable Rest backend with default settings. (Default: ```false```)
 
 `TRAEFIK_PROVIDERS_REST_INSECURE`:  
-Activate REST Provider on an insecure entryPoints named traefik. (Default: ```false```)
+Activate REST Provider directly on the entryPoint named traefik. (Default: ```false```)
 
 `TRAEFIK_SERVERSTRANSPORT_FORWARDINGTIMEOUTS_DIALTIMEOUT`:  
 The amount of time to wait until a connection to a backend server can be established. If zero, no timeout exists. (Default: ```30```)

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -83,6 +83,7 @@
     namespaces = ["foobar", "foobar"]
     labelSelector = "foobar"
     ingressClass = "foobar"
+    throttleDuration = "10s"
     [providers.kubernetesIngress.ingressEndpoint]
       ip = "foobar"
       hostname = "foobar"
@@ -95,6 +96,7 @@
     namespaces = ["foobar", "foobar"]
     labelSelector = "foobar"
     ingressClass = "foobar"
+    throttleDuration = "10s"
   [providers.rest]
     insecure = true
   [providers.rancher]

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -88,6 +88,7 @@ providers:
     - foobar
     labelSelector: foobar
     ingressClass: foobar
+    throttleDuration: 10s
     ingressEndpoint:
       ip: foobar
       hostname: foobar
@@ -102,6 +103,7 @@ providers:
     - foobar
     labelSelector: foobar
     ingressClass: foobar
+    throttleDuration: 10s
   rest:
     insecure: true
   rancher:

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -110,13 +110,16 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 			}
 
 			throttleDuration := time.Duration(p.ThrottleDuration)
-			eventsChanToRead := throttleEvents(ctxLog, throttleDuration, stop, eventsChan)
+			throttledChan := throttleEvents(ctxLog, throttleDuration, stop, eventsChan)
+			if throttledChan != nil {
+				eventsChan = throttledChan
+			}
 
 			for {
 				select {
 				case <-stop:
 					return nil
-				case event := <-eventsChanToRead:
+				case event := <-eventsChan:
 					// Note that event is the *first* event that came in during this
 					// throttling interval -- if we're hitting our throttle, we may have
 					// dropped events. This is fine, because we don't treat different

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -121,13 +121,16 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 			}
 
 			throttleDuration := time.Duration(p.ThrottleDuration)
-			eventsChanToRead := throttleEvents(ctxLog, throttleDuration, stop, eventsChan)
+			throttledChan := throttleEvents(ctxLog, throttleDuration, stop, eventsChan)
+			if throttledChan != nil {
+				eventsChan = throttledChan
+			}
 
 			for {
 				select {
 				case <-stop:
 					return nil
-				case event := <-eventsChanToRead:
+				case event := <-eventsChan:
 					// Note that event is the *first* event that came in during this
 					// throttling interval -- if we're hitting our throttle, we may have
 					// dropped events. This is fine, because we don't treat different

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -18,6 +18,7 @@ import (
 	"github.com/containous/traefik/v2/pkg/log"
 	"github.com/containous/traefik/v2/pkg/safe"
 	"github.com/containous/traefik/v2/pkg/tls"
+	"github.com/containous/traefik/v2/pkg/types"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -39,6 +40,7 @@ type Provider struct {
 	LabelSelector          string           `description:"Kubernetes Ingress label selector to use." json:"labelSelector,omitempty" toml:"labelSelector,omitempty" yaml:"labelSelector,omitempty" export:"true"`
 	IngressClass           string           `description:"Value of kubernetes.io/ingress.class annotation to watch for." json:"ingressClass,omitempty" toml:"ingressClass,omitempty" yaml:"ingressClass,omitempty" export:"true"`
 	IngressEndpoint        *EndpointIngress `description:"Kubernetes Ingress Endpoint." json:"ingressEndpoint,omitempty" toml:"ingressEndpoint,omitempty" yaml:"ingressEndpoint,omitempty"`
+	ThrottleDuration       types.Duration   `description:"Ingress refresh throttle duration" json:"throttleDuration,omitempty" toml:"throttleDuration,omitempty" yaml:"throttleDuration,omitempty"`
 	lastConfiguration      safe.Safe
 }
 
@@ -118,11 +120,19 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 				}
 			}
 
+			throttleDuration := time.Duration(p.ThrottleDuration)
+			eventsChanToRead := throttleEvents(ctxLog, throttleDuration, stop, eventsChan)
+
 			for {
 				select {
 				case <-stop:
 					return nil
-				case event := <-eventsChan:
+				case event := <-eventsChanToRead:
+					// Note that event is the *first* event that came in during this
+					// throttling interval -- if we're hitting our throttle, we may have
+					// dropped events. This is fine, because we don't treat different
+					// event types differently. But if we do in the future, we'll need to
+					// track more information about the dropped events.
 					conf := p.loadConfigurationFromIngresses(ctxLog, k8sClient)
 
 					if reflect.DeepEqual(p.lastConfiguration.Get(), conf) {
@@ -134,6 +144,11 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 							Configuration: conf,
 						}
 					}
+
+					// If we're throttling, we sleep here for the throttle duration to
+					// enforce that we don't refresh faster than our throttle. time.Sleep
+					// returns immediately if p.ThrottleDuration is 0 (no throttle).
+					time.Sleep(throttleDuration)
 				}
 			}
 		}
@@ -477,4 +492,37 @@ func (p *Provider) updateIngressStatus(i *v1beta1.Ingress, k8sClient Client) err
 	}
 
 	return k8sClient.UpdateIngressStatus(i.Namespace, i.Name, service.Status.LoadBalancer.Ingress[0].IP, service.Status.LoadBalancer.Ingress[0].Hostname)
+}
+
+func throttleEvents(ctx context.Context, throttleDuration time.Duration, stop chan bool, eventsChan <-chan interface{}) chan interface{} {
+	if throttleDuration == 0 {
+		return nil
+	}
+	// Create a buffered channel to hold the pending event (if we're delaying processing the event due to throttling)
+	eventsChanBuffered := make(chan interface{}, 1)
+
+	// Run a goroutine that reads events from eventChan and does a
+	// non-blocking write to pendingEvent. This guarantees that writing to
+	// eventChan will never block, and that pendingEvent will have
+	// something in it if there's been an event since we read from that channel.
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			case nextEvent := <-eventsChan:
+				select {
+				case eventsChanBuffered <- nextEvent:
+				default:
+					// We already have an event in eventsChanBuffered, so we'll
+					// do a refresh as soon as our throttle allows us to. It's fine
+					// to drop the event and keep whatever's in the buffer -- we
+					// don't do different things for different events
+					log.FromContext(ctx).Debugf("Dropping event kind %T due to throttling", nextEvent)
+				}
+			}
+		}
+	}()
+
+	return eventsChanBuffered
 }


### PR DESCRIPTION
### What does this PR do?

Cherry pick v1.7 into v2.0:

* [x] 4cae8bcb1 Finish kubernetes throttling refactoring
* [x] bee370ec6 - Throttle Kubernetes config refresh
* [x] f397342f1 - Prepare release v1.7.14  

Skip:
* [x] f4f62e7fb - Update Acme doc - Vultr Wildcard & Root
* [x] f1d016b89 - Typo in basic auth usersFile label consul-catalog
* [x] 4defbbe84 - Kubernetes support for Auth.HeaderField  
* [x] 989a59cc2 - Update to go1.12.8
* [x] c5b71592c - Make hijackConnectionTracker.Close thread safe

### Motivation

Be in sync.

### More

- ~~[ ] Added/updated tests~~
- ~~[ ] Added/updated documentation~~