### PR TITLE
Consider default cert domain in certificate store

### DIFF
--- a/tls/certificate_store.go
+++ b/tls/certificate_store.go
@@ -56,28 +56,6 @@ func (c CertificateStore) GetAllDomains() []string {
 	return allCerts
 }
 
-func getCertificateDomains(cert *tls.Certificate) []string {
-	var names []string
-
-	if cert == nil {
-		return names
-	}
-
-	x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
-	if err != nil {
-		return nil
-	}
-
-	if len(x509Cert.Subject.CommonName) > 0 {
-		names = append(names, x509Cert.Subject.CommonName)
-	}
-	for _, san := range x509Cert.DNSNames {
-		names = append(names, san)
-	}
-
-	return names
-}
-
 // GetBestCertificate returns the best match certificate, and caches the response
 func (c CertificateStore) GetBestCertificate(clientHello *tls.ClientHelloInfo) *tls.Certificate {
 	domainToCheck := strings.ToLower(strings.TrimSpace(clientHello.ServerName))
@@ -141,6 +119,27 @@ func (c CertificateStore) ResetCache() {
 	if c.CertCache != nil {
 		c.CertCache.Flush()
 	}
+}
+
+func getCertificateDomains(cert *tls.Certificate) []string {
+	if cert == nil {
+		return nil
+	}
+
+	x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return nil
+	}
+
+	var names []string
+	if len(x509Cert.Subject.CommonName) > 0 {
+		names = append(names, x509Cert.Subject.CommonName)
+	}
+	for _, san := range x509Cert.DNSNames {
+		names = append(names, san)
+	}
+
+	return names
 }
 
 // MatchDomain return true if a domain match the cert domain

--- a/tls/certificate_store.go
+++ b/tls/certificate_store.go
@@ -51,12 +51,12 @@ func (c CertificateStore) GetAllDomains() []string {
 
 	// Get Default certificate
 	if c.DefaultCertificate != nil {
-		allCerts = append(allCerts, c.getCertificateDomains(c.DefaultCertificate)...)
+		allCerts = append(allCerts, getCertificateDomains(c.DefaultCertificate)...)
 	}
 	return allCerts
 }
 
-func (c CertificateStore) getCertificateDomains(cert *tls.Certificate) []string {
+func getCertificateDomains(cert *tls.Certificate) []string {
 	var names []string
 
 	if cert == nil {

--- a/tls/certificate_store_test.go
+++ b/tls/certificate_store_test.go
@@ -62,22 +62,22 @@ func TestGetAllDomains(t *testing.T) {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
-			var defaultCert *tls.Certificate
-			staticMap := map[string]*tls.Certificate{}
-			dynamicMap := map[string]*tls.Certificate{}
 
+			staticMap := map[string]*tls.Certificate{}
 			if test.staticCert != "" {
 				cert, err := loadTestCert(test.staticCert, false)
 				require.NoError(t, err)
 				staticMap[strings.ToLower(test.staticCert)] = cert
 			}
 
+			dynamicMap := map[string]*tls.Certificate{}
 			if test.dynamicCert != "" {
 				cert, err := loadTestCert(test.dynamicCert, false)
 				require.NoError(t, err)
 				dynamicMap[strings.ToLower(test.dynamicCert)] = cert
 			}
 
+			var defaultCert *tls.Certificate
 			if test.defaultCert != "" {
 				cert, err := loadTestCert(test.defaultCert, false)
 				require.NoError(t, err)
@@ -200,15 +200,15 @@ func TestGetBestCertificate(t *testing.T) {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
-			staticMap := map[string]*tls.Certificate{}
-			dynamicMap := map[string]*tls.Certificate{}
 
+			staticMap := map[string]*tls.Certificate{}
 			if test.staticCert != "" {
 				cert, err := loadTestCert(test.staticCert, test.uppercase)
 				require.NoError(t, err)
 				staticMap[strings.ToLower(test.staticCert)] = cert
 			}
 
+			dynamicMap := map[string]*tls.Certificate{}
 			if test.dynamicCert != "" {
 				cert, err := loadTestCert(test.dynamicCert, test.uppercase)
 				require.NoError(t, err)


### PR DESCRIPTION
### What does this PR do?

This allows for the default certificate to be considered when getting all domains from a TLS certificate store.


### Motivation

When getting all domains for a store, the default cert domain should be included in the domains list. This is applicable when generating ACME domains, it should not generate a certificate for a domain that falls under the default domain.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Nicolas Mengin <nmengin.pro@gmail.com>