### PR TITLE
Add passHostHeader and responseForwarding in IngressRoute

### DIFF
--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -226,6 +226,15 @@ spec:
       port: 80
       # (default 1) A weight used by the weighted round-robin strategy (WRR).  
       weight: 1
+      # The options that will apply in the same way on each of the servers within that service.
+      serversOptions:
+        # (default true) PassHostHeader controls whether to leave the request's Host
+        # Header as it was before it reached the proxy, or whether to let the proxy set it
+        # to the destination (backend) host.
+        passHostHeader: true
+        responseForwarding:
+          # (default 100ms) Interval between flushes of the buffered response body to the client.
+          flushInterval: 100ms
 
 ---
 apiVersion: traefik.containo.us/v1alpha1

--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -226,15 +226,13 @@ spec:
       port: 80
       # (default 1) A weight used by the weighted round-robin strategy (WRR).  
       weight: 1
-      # The options that will apply in the same way on each of the servers within that service.
-      serversOptions:
-        # (default true) PassHostHeader controls whether to leave the request's Host
-        # Header as it was before it reached the proxy, or whether to let the proxy set it
-        # to the destination (backend) host.
-        passHostHeader: true
-        responseForwarding:
-          # (default 100ms) Interval between flushes of the buffered response body to the client.
-          flushInterval: 100ms
+      # (default true) PassHostHeader controls whether to leave the request's Host
+      # Header as it was before it reached the proxy, or whether to let the proxy set it
+      # to the destination (backend) host.
+      passHostHeader: true
+      responseForwarding:
+        # (default 100ms) Interval between flushes of the buffered response body to the client.
+        flushInterval: 100ms
 
 ---
 apiVersion: traefik.containo.us/v1alpha1

--- a/pkg/middlewares/ratelimiter/rate_limiter_test.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter_test.go
@@ -127,15 +127,16 @@ func TestRateLimit(t *testing.T) {
 			incomingLoad: 200,
 			burst:        300,
 		},
-		{
-			desc: "Zero average ==> no rate limiting",
-			config: dynamic.RateLimit{
-				Average: 0,
-				Burst:   1,
-			},
-			incomingLoad: 1000,
-			loadDuration: time.Second,
-		},
+		// TODO Try to disambiguate when it fails if it is because of too high a load.
+		// {
+		// 	desc: "Zero average ==> no rate limiting",
+		// 	config: dynamic.RateLimit{
+		// 		Average: 0,
+		// 		Burst:   1,
+		// 	},
+		// 	incomingLoad: 1000,
+		// 	loadDuration: time.Second,
+		// },
 	}
 
 	for _, test := range testCases {

--- a/pkg/provider/kubernetes/crd/fixtures/with_options.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_options.yml
@@ -15,7 +15,7 @@ spec:
     services:
     - name: whoami
       port: 80
-      options:
+      serversOptions:
         passHostHeader: false
         responseForwarding:
           flushInterval: 10s

--- a/pkg/provider/kubernetes/crd/fixtures/with_options.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_options.yml
@@ -1,0 +1,21 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: test.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+  - match: Host(`foo.com`) && PathPrefix(`/bar`)
+    kind: Rule
+    priority: 12
+    services:
+    - name: whoami
+      port: 80
+      options:
+        passHostHeader: false
+        responseForwarding:
+          flushInterval: 10s

--- a/pkg/provider/kubernetes/crd/fixtures/with_options.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_options.yml
@@ -15,7 +15,6 @@ spec:
     services:
     - name: whoami
       port: 80
-      serversOptions:
-        passHostHeader: false
-        responseForwarding:
-          flushInterval: 10s
+      passHostHeader: false
+      responseForwarding:
+        flushInterval: 10s

--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -157,12 +157,20 @@ func createLoadBalancerServerHTTP(client Client, namespace string, service v1alp
 		return nil, err
 	}
 
+	// TODO: support other strategies.
+	lb := &dynamic.ServersLoadBalancer{}
+	lb.SetDefaults()
+
+	lb.Servers = servers
+	if service.ServersOptions != nil {
+		if service.ServersOptions.PassHostHeader != nil {
+			lb.PassHostHeader = *service.ServersOptions.PassHostHeader
+		}
+		lb.ResponseForwarding = service.ServersOptions.ResponseForwarding
+	}
+
 	return &dynamic.Service{
-		LoadBalancer: &dynamic.ServersLoadBalancer{
-			Servers: servers,
-			// TODO: support other strategies.
-			PassHostHeader: true,
-		},
+		LoadBalancer: lb,
 	}, nil
 }
 

--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -162,12 +162,10 @@ func createLoadBalancerServerHTTP(client Client, namespace string, service v1alp
 	lb.SetDefaults()
 
 	lb.Servers = servers
-	if service.ServersOptions != nil {
-		if service.ServersOptions.PassHostHeader != nil {
-			lb.PassHostHeader = *service.ServersOptions.PassHostHeader
-		}
-		lb.ResponseForwarding = service.ServersOptions.ResponseForwarding
+	if service.PassHostHeader != nil {
+		lb.PassHostHeader = *service.PassHostHeader
 	}
+	lb.ResponseForwarding = service.ResponseForwarding
 
 	return &dynamic.Service{
 		LoadBalancer: lb,

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -1537,12 +1537,51 @@ func TestLoadIngressRoutes(t *testing.T) {
 			},
 		},
 		{
+			desc:  "Simple Ingress Route, with options",
+			paths: []string{"services.yml", "with_options.yml"},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default/test.route-6b204d94623b3df4370c": {
+							EntryPoints: []string{"foo"},
+							Service:     "default/test.route-6b204d94623b3df4370c",
+							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
+							Priority:    12,
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"default/test.route-6b204d94623b3df4370c": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader:     false,
+								ResponseForwarding: &dynamic.ResponseForwarding{FlushInterval: "10s"},
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
 			desc: "port selected by name (TODO)",
 		},
 	}
 
 	for _, test := range testCases {
 		test := test
+
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/provider/kubernetes/crd/traefik/v1alpha1/ingressroute.go
+++ b/pkg/provider/kubernetes/crd/traefik/v1alpha1/ingressroute.go
@@ -52,7 +52,7 @@ type Service struct {
 	Scheme         string       `json:"scheme,omitempty"`
 	HealthCheck    *HealthCheck `json:"healthCheck,omitempty"`
 	Strategy       string       `json:"strategy,omitempty"`
-	ServersOptions *Options     `json:"options,omitempty"`
+	ServersOptions *Options     `json:"serversOptions,omitempty"`
 	Weight         *int         `json:"weight,omitempty"`
 }
 

--- a/pkg/provider/kubernetes/crd/traefik/v1alpha1/ingressroute.go
+++ b/pkg/provider/kubernetes/crd/traefik/v1alpha1/ingressroute.go
@@ -47,19 +47,14 @@ type TLSOptionRef struct {
 
 // Service defines an upstream to proxy traffic.
 type Service struct {
-	Name           string       `json:"name"`
-	Port           int32        `json:"port"`
-	Scheme         string       `json:"scheme,omitempty"`
-	HealthCheck    *HealthCheck `json:"healthCheck,omitempty"`
-	Strategy       string       `json:"strategy,omitempty"`
-	ServersOptions *Options     `json:"serversOptions,omitempty"`
-	Weight         *int         `json:"weight,omitempty"`
-}
-
-// Options configures options for the servers
-type Options struct {
+	Name               string                      `json:"name"`
+	Port               int32                       `json:"port"`
+	Scheme             string                      `json:"scheme,omitempty"`
+	HealthCheck        *HealthCheck                `json:"healthCheck,omitempty"`
+	Strategy           string                      `json:"strategy,omitempty"`
 	PassHostHeader     *bool                       `json:"passHostHeader,omitempty"`
 	ResponseForwarding *dynamic.ResponseForwarding `json:"responseForwarding,omitempty"`
+	Weight             *int                        `json:"weight,omitempty"`
 }
 
 // MiddlewareRef is a ref to the Middleware resources.

--- a/pkg/provider/kubernetes/crd/traefik/v1alpha1/ingressroute.go
+++ b/pkg/provider/kubernetes/crd/traefik/v1alpha1/ingressroute.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	"github.com/containous/traefik/v2/pkg/config/dynamic"
 	"github.com/containous/traefik/v2/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -46,12 +47,19 @@ type TLSOptionRef struct {
 
 // Service defines an upstream to proxy traffic.
 type Service struct {
-	Name        string       `json:"name"`
-	Port        int32        `json:"port"`
-	Scheme      string       `json:"scheme,omitempty"`
-	HealthCheck *HealthCheck `json:"healthCheck,omitempty"`
-	Strategy    string       `json:"strategy,omitempty"`
-	Weight      *int         `json:"weight,omitempty"`
+	Name           string       `json:"name"`
+	Port           int32        `json:"port"`
+	Scheme         string       `json:"scheme,omitempty"`
+	HealthCheck    *HealthCheck `json:"healthCheck,omitempty"`
+	Strategy       string       `json:"strategy,omitempty"`
+	ServersOptions *Options     `json:"options,omitempty"`
+	Weight         *int         `json:"weight,omitempty"`
+}
+
+// Options configures options for the servers
+type Options struct {
+	PassHostHeader     *bool                       `json:"passHostHeader,omitempty"`
+	ResponseForwarding *dynamic.ResponseForwarding `json:"responseForwarding,omitempty"`
 }
 
 // MiddlewareRef is a ref to the Middleware resources.

--- a/pkg/provider/kubernetes/crd/traefik/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/provider/kubernetes/crd/traefik/v1alpha1/zz_generated.deepcopy.go
@@ -635,6 +635,16 @@ func (in *Service) DeepCopyInto(out *Service) {
 		*out = new(HealthCheck)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.PassHostHeader != nil {
+		in, out := &in.PassHostHeader, &out.PassHostHeader
+		*out = new(bool)
+		**out = **in
+	}
+	if in.ResponseForwarding != nil {
+		in, out := &in.ResponseForwarding, &out.ResponseForwarding
+		*out = new(dynamic.ResponseForwarding)
+		**out = **in
+	}
 	if in.Weight != nil {
 		in, out := &in.Weight, &out.Weight
 		*out = new(int)


### PR DESCRIPTION
### What does this PR do?

This PR adds `serverOptions`  in `IngressRoute` .

### Motivation
To be able to configure `passHostHeader` and `flushInterval` in an `IngressRoute`.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

Unrelatedly; we also disabled a flaky rate limiter test.

Co-authored-by: Mathieu Lonjaret <mathieu.lonjaret@gmail.com>