### PR TITLE
fix: boolean flag parsing with map.

### DIFF
--- a/pkg/config/flag/flagparser.go
+++ b/pkg/config/flag/flagparser.go
@@ -121,9 +121,9 @@ func (f *flagSet) setValue(name string, value string) {
 }
 
 func (f *flagSet) getFlagType(name string) reflect.Kind {
-	n := strings.ToLower(name)
+	neutral := strings.ToLower(name)
 
-	kind, ok := f.flagTypes[n]
+	kind, ok := f.flagTypes[neutral]
 	if ok {
 		return kind
 	}
@@ -131,7 +131,7 @@ func (f *flagSet) getFlagType(name string) reflect.Kind {
 	for n, k := range f.flagTypes {
 		if strings.Contains(n, parser.MapNamePlaceholder) {
 			p := strings.NewReplacer(".", `\.`, parser.MapNamePlaceholder, `([^.]+)`).Replace(n)
-			if regexp.MustCompile(p).MatchString(n) {
+			if regexp.MustCompile(p).MatchString(neutral) {
 				return k
 			}
 		}

--- a/pkg/config/flag/flagparser.go
+++ b/pkg/config/flag/flagparser.go
@@ -3,6 +3,7 @@ package flag
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 
 	"github.com/containous/traefik/v2/pkg/config/parser"
@@ -80,8 +81,8 @@ func (f *flagSet) parseOne() (bool, error) {
 		return true, nil
 	}
 
-	n := strings.ToLower(name)
-	if f.flagTypes[n] == reflect.Bool || f.flagTypes[n] == reflect.Ptr {
+	flagType := f.getFlagType(name)
+	if flagType == reflect.Bool || flagType == reflect.Ptr {
 		f.setValue(name, "true")
 		return true, nil
 	}
@@ -111,10 +112,30 @@ func (f *flagSet) setValue(name string, value string) {
 	}
 
 	v, ok := f.values[key]
-	if ok && f.flagTypes[strings.ToLower(name)] == reflect.Slice {
+	if ok && f.getFlagType(name) == reflect.Slice {
 		f.values[key] = v + "," + value
 		return
 	}
 
 	f.values[key] = value
+}
+
+func (f *flagSet) getFlagType(name string) reflect.Kind {
+	n := strings.ToLower(name)
+
+	kind, ok := f.flagTypes[n]
+	if ok {
+		return kind
+	}
+
+	for n, k := range f.flagTypes {
+		if strings.Contains(n, parser.MapNamePlaceholder) {
+			p := strings.NewReplacer(".", `\.`, parser.MapNamePlaceholder, `([^.]+)`).Replace(n)
+			if regexp.MustCompile(p).MatchString(n) {
+				return k
+			}
+		}
+	}
+
+	return reflect.Invalid
 }

--- a/pkg/config/flag/flagparser_test.go
+++ b/pkg/config/flag/flagparser_test.go
@@ -250,7 +250,7 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
-			desc: "map struct with sub-map case senstitive",
+			desc: "map struct with sub-map case sensitive",
 			args: []string{"--foo.Name1.bar.name2.value=firstValue", "--foo.naMe1.bar.name2.value=secondValue"},
 			element: &struct {
 				Foo map[string]struct {
@@ -271,6 +271,20 @@ func TestParse(t *testing.T) {
 			}{},
 			expected: map[string]string{
 				"traefik.foo.Name1.bar.name2.value": "secondValue",
+			},
+		},
+		{
+			desc: "pointer of struct and map without explicit value",
+			args: []string{"--foo.default.bar.fuu"},
+			element: &struct {
+				Foo map[string]struct {
+					Bar *struct {
+						Fuu *struct{ Value string }
+					}
+				}
+			}{},
+			expected: map[string]string{
+				"traefik.foo.default.bar.fuu": "true",
 			},
 		},
 		{


### PR DESCRIPTION
### What does this PR do?

Fix boolean (or pointer) flag parsing when the flag is related to map.

Example:
With the flag `--certificatesresolvers.default.acme.tlschallenge` the related key for the type is  `--certificatesresolvers.<name>.acme.tlschallenge`, so the name (`default`) must be neutralized to allow matching with the type.

### Motivation

Fixes #5333

### More

- [x] Added/updated tests
- [ ] ~~Added/updated documentation~~
