### PR TITLE
Fix kubernetes id name

### DIFF
--- a/integration/testdata/rawdata-crd.json
+++ b/integration/testdata/rawdata-crd.json
@@ -1,28 +1,28 @@
 {
 	"routers": {
-		"default/test.route-6b204d94623b3df4370c@kubernetescrd": {
+		"default-test.route-6b204d94623b3df4370c@kubernetescrd": {
 			"entryPoints": [
 				"web"
 			],
-			"service": "default/test.route-6b204d94623b3df4370c",
+			"service": "default-test.route-6b204d94623b3df4370c",
 			"rule": "Host(`foo.com`) \u0026\u0026 PathPrefix(`/bar`)",
 			"priority": 12,
 			"tls": {
-				"options": "default/mytlsoption"
+				"options": "default-mytlsoption"
 			},
 			"status": "enabled",
 			"using": [
 				"web"
 			]
 		},
-		"default/test2.route-23c7f4c450289ee29016@kubernetescrd": {
+		"default-test2.route-23c7f4c450289ee29016@kubernetescrd": {
 			"entryPoints": [
 				"web"
 			],
 			"middlewares": [
-				"default/mychain@kubernetescrd"
+				"default-mychain@kubernetescrd"
 			],
-			"service": "default/test2.route-23c7f4c450289ee29016",
+			"service": "default-test2.route-23c7f4c450289ee29016",
 			"rule": "Host(`foo.com`) \u0026\u0026 PathPrefix(`/tobestripped`)",
 			"status": "enabled",
 			"using": [
@@ -31,18 +31,18 @@
 		}
 	},
 	"middlewares": {
-		"default/mychain@kubernetescrd": {
+		"default-mychain@kubernetescrd": {
 			"chain": {
 				"middlewares": [
-					"default/stripprefix@kubernetescrd"
+					"default-stripprefix@kubernetescrd"
 				]
 			},
 			"status": "enabled",
 			"usedBy": [
-				"default/test2.route-23c7f4c450289ee29016@kubernetescrd"
+				"default-test2.route-23c7f4c450289ee29016@kubernetescrd"
 			]
 		},
-		"default/stripprefix@kubernetescrd": {
+		"default-stripprefix@kubernetescrd": {
 			"stripPrefix": {
 				"prefixes": [
 					"/tobestripped"
@@ -52,7 +52,7 @@
 		}
 	},
 	"services": {
-		"default/test.route-6b204d94623b3df4370c@kubernetescrd": {
+		"default-test.route-6b204d94623b3df4370c@kubernetescrd": {
 			"loadBalancer": {
 				"servers": [
 					{
@@ -66,14 +66,14 @@
 			},
 			"status": "enabled",
 			"usedBy": [
-				"default/test.route-6b204d94623b3df4370c@kubernetescrd"
+				"default-test.route-6b204d94623b3df4370c@kubernetescrd"
 			],
 			"serverStatus": {
 				"http://10.42.0.2:80": "UP",
 				"http://10.42.0.6:80": "UP"
 			}
 		},
-		"default/test2.route-23c7f4c450289ee29016@kubernetescrd": {
+		"default-test2.route-23c7f4c450289ee29016@kubernetescrd": {
 			"loadBalancer": {
 				"servers": [
 					{
@@ -87,7 +87,7 @@
 			},
 			"status": "enabled",
 			"usedBy": [
-				"default/test2.route-23c7f4c450289ee29016@kubernetescrd"
+				"default-test2.route-23c7f4c450289ee29016@kubernetescrd"
 			],
 			"serverStatus": {
 				"http://10.42.0.2:80": "UP",
@@ -96,15 +96,15 @@
 		}
 	},
 	"tcpRouters": {
-		"default/test3.route-673acf455cb2dab0b43a@kubernetescrd": {
+		"default-test3.route-673acf455cb2dab0b43a@kubernetescrd": {
 			"entryPoints": [
 				"footcp"
 			],
-			"service": "default/test3.route-673acf455cb2dab0b43a",
+			"service": "default-test3.route-673acf455cb2dab0b43a",
 			"rule": "HostSNI(`*`)",
 			"tls": {
 				"passthrough": false,
-				"options": "default/mytlsoption"
+				"options": "default-mytlsoption"
 			},
 			"status": "enabled",
 			"using": [
@@ -113,7 +113,7 @@
 		}
 	},
 	"tcpServices": {
-		"default/test3.route-673acf455cb2dab0b43a@kubernetescrd": {
+		"default-test3.route-673acf455cb2dab0b43a@kubernetescrd": {
 			"loadBalancer": {
 				"terminationDelay": 100,
 				"servers": [
@@ -127,7 +127,7 @@
 			},
 			"status": "enabled",
 			"usedBy": [
-				"default/test3.route-673acf455cb2dab0b43a@kubernetescrd"
+				"default-test3.route-673acf455cb2dab0b43a@kubernetescrd"
 			]
 		}
 	}

--- a/integration/testdata/rawdata-ingress.json
+++ b/integration/testdata/rawdata-ingress.json
@@ -1,7 +1,7 @@
 {
 	"routers": {
-		"whoami-test-https/whoami-tls@kubernetes": {
-			"service": "default/whoami/http",
+		"whoami-test-https-whoami-tls@kubernetes": {
+			"service": "default-whoami-http",
 			"rule": "Host(`whoami.test.https`) \u0026\u0026 PathPrefix(`/whoami`)",
 			"tls": {},
 			"status": "enabled",
@@ -10,8 +10,8 @@
 				"web"
 			]
 		},
-		"whoami-test-https/whoami@kubernetes": {
-			"service": "default/whoami/http",
+		"whoami-test-https-whoami@kubernetes": {
+			"service": "default-whoami-http",
 			"rule": "Host(`whoami.test.https`) \u0026\u0026 PathPrefix(`/whoami`)",
 			"status": "enabled",
 			"using": [
@@ -19,8 +19,8 @@
 				"web"
 			]
 		},
-		"whoami-test/whoami@kubernetes": {
-			"service": "default/whoami/http",
+		"whoami-test-whoami@kubernetes": {
+			"service": "default-whoami-http",
 			"rule": "Host(`whoami.test`) \u0026\u0026 PathPrefix(`/whoami`)",
 			"status": "enabled",
 			"using": [
@@ -30,7 +30,7 @@
 		}
 	},
 	"services": {
-		"default/whoami/http@kubernetes": {
+		"default-whoami-http@kubernetes": {
 			"loadBalancer": {
 				"servers": [
 					{
@@ -44,9 +44,9 @@
 			},
 			"status": "enabled",
 			"usedBy": [
-				"whoami-test-https/whoami-tls@kubernetes",
-				"whoami-test-https/whoami@kubernetes",
-				"whoami-test/whoami@kubernetes"
+				"whoami-test-https-whoami-tls@kubernetes",
+				"whoami-test-https-whoami@kubernetes",
+				"whoami-test-whoami@kubernetes"
 			],
 			"serverStatus": {
 				"http://10.42.0.2:80": "UP",

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -511,7 +511,7 @@ func makeID(namespace, name string) string {
 		return name
 	}
 
-	return namespace + "/" + name
+	return namespace + "-" + name
 }
 
 func shouldProcessIngress(ingressClass string, ingressClassAnnotation string) bool {

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -47,14 +47,14 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 				},
 				TCP: &dynamic.TCPConfiguration{
 					Routers: map[string]*dynamic.TCPRouter{
-						"default/test.route-fdd3e9338e47a45efefc": {
+						"default-test.route-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.route-fdd3e9338e47a45efefc",
+							Service:     "default-test.route-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 						},
 					},
 					Services: map[string]*dynamic.TCPService{
-						"default/test.route-fdd3e9338e47a45efefc": {
+						"default-test.route-fdd3e9338e47a45efefc": {
 							LoadBalancer: &dynamic.TCPServersLoadBalancer{
 								Servers: []dynamic.TCPServer{
 									{
@@ -79,19 +79,19 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 			expected: &dynamic.Configuration{
 				TCP: &dynamic.TCPConfiguration{
 					Routers: map[string]*dynamic.TCPRouter{
-						"default/test.route-fdd3e9338e47a45efefc": {
+						"default-test.route-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.route-fdd3e9338e47a45efefc",
+							Service:     "default-test.route-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 						},
-						"default/test.route-f44ce589164e656d231c": {
+						"default-test.route-f44ce589164e656d231c": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.route-f44ce589164e656d231c",
+							Service:     "default-test.route-f44ce589164e656d231c",
 							Rule:        "HostSNI(`bar.com`)",
 						},
 					},
 					Services: map[string]*dynamic.TCPService{
-						"default/test.route-fdd3e9338e47a45efefc": {
+						"default-test.route-fdd3e9338e47a45efefc": {
 							LoadBalancer: &dynamic.TCPServersLoadBalancer{
 								Servers: []dynamic.TCPServer{
 									{
@@ -105,7 +105,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 								},
 							},
 						},
-						"default/test.route-f44ce589164e656d231c": {
+						"default-test.route-f44ce589164e656d231c": {
 							LoadBalancer: &dynamic.TCPServersLoadBalancer{
 								Servers: []dynamic.TCPServer{
 									{
@@ -135,28 +135,28 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 			expected: &dynamic.Configuration{
 				TCP: &dynamic.TCPConfiguration{
 					Routers: map[string]*dynamic.TCPRouter{
-						"default/test.route-fdd3e9338e47a45efefc": {
+						"default-test.route-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.route-fdd3e9338e47a45efefc",
+							Service:     "default-test.route-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 						},
 					},
 					Services: map[string]*dynamic.TCPService{
-						"default/test.route-fdd3e9338e47a45efefc": {
+						"default-test.route-fdd3e9338e47a45efefc": {
 							Weighted: &dynamic.TCPWeightedRoundRobin{
 								Services: []dynamic.TCPWRRService{
 									{
-										Name:   "default/test.route-fdd3e9338e47a45efefc-whoamitcp-8000",
+										Name:   "default-test.route-fdd3e9338e47a45efefc-whoamitcp-8000",
 										Weight: func(i int) *int { return &i }(2),
 									},
 									{
-										Name:   "default/test.route-fdd3e9338e47a45efefc-whoamitcp2-8080",
+										Name:   "default-test.route-fdd3e9338e47a45efefc-whoamitcp2-8080",
 										Weight: func(i int) *int { return &i }(3),
 									},
 								},
 							},
 						},
-						"default/test.route-fdd3e9338e47a45efefc-whoamitcp-8000": {
+						"default-test.route-fdd3e9338e47a45efefc-whoamitcp-8000": {
 							LoadBalancer: &dynamic.TCPServersLoadBalancer{
 								Servers: []dynamic.TCPServer{
 									{
@@ -168,7 +168,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 								},
 							},
 						},
-						"default/test.route-fdd3e9338e47a45efefc-whoamitcp2-8080": {
+						"default-test.route-fdd3e9338e47a45efefc-whoamitcp2-8080": {
 							LoadBalancer: &dynamic.TCPServersLoadBalancer{
 								Servers: []dynamic.TCPServer{
 									{
@@ -255,15 +255,15 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 				},
 				TCP: &dynamic.TCPConfiguration{
 					Routers: map[string]*dynamic.TCPRouter{
-						"default/test.route-fdd3e9338e47a45efefc": {
+						"default-test.route-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.route-fdd3e9338e47a45efefc",
+							Service:     "default-test.route-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 							TLS:         &dynamic.RouterTCPTLSConfig{},
 						},
 					},
 					Services: map[string]*dynamic.TCPService{
-						"default/test.route-fdd3e9338e47a45efefc": {
+						"default-test.route-fdd3e9338e47a45efefc": {
 							LoadBalancer: &dynamic.TCPServersLoadBalancer{
 								Servers: []dynamic.TCPServer{
 									{
@@ -292,9 +292,9 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 			expected: &dynamic.Configuration{
 				TCP: &dynamic.TCPConfiguration{
 					Routers: map[string]*dynamic.TCPRouter{
-						"default/test.route-fdd3e9338e47a45efefc": {
+						"default-test.route-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.route-fdd3e9338e47a45efefc",
+							Service:     "default-test.route-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 							TLS: &dynamic.RouterTCPTLSConfig{
 								Passthrough: true,
@@ -302,7 +302,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 						},
 					},
 					Services: map[string]*dynamic.TCPService{
-						"default/test.route-fdd3e9338e47a45efefc": {
+						"default-test.route-fdd3e9338e47a45efefc": {
 							LoadBalancer: &dynamic.TCPServersLoadBalancer{
 								Servers: []dynamic.TCPServer{
 									{
@@ -332,7 +332,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 			expected: &dynamic.Configuration{
 				TLS: &dynamic.TLSConfiguration{
 					Options: map[string]tls.Options{
-						"default/foo": {
+						"default-foo": {
 							MinVersion: "VersionTLS12",
 							CipherSuites: []string{
 								"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
@@ -351,17 +351,17 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 				},
 				TCP: &dynamic.TCPConfiguration{
 					Routers: map[string]*dynamic.TCPRouter{
-						"default/test.route-fdd3e9338e47a45efefc": {
+						"default-test.route-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.route-fdd3e9338e47a45efefc",
+							Service:     "default-test.route-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 							TLS: &dynamic.RouterTCPTLSConfig{
-								Options: "default/foo",
+								Options: "default-foo",
 							},
 						},
 					},
 					Services: map[string]*dynamic.TCPService{
-						"default/test.route-fdd3e9338e47a45efefc": {
+						"default-test.route-fdd3e9338e47a45efefc": {
 							LoadBalancer: &dynamic.TCPServersLoadBalancer{
 								Servers: []dynamic.TCPServer{
 									{
@@ -390,7 +390,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 			expected: &dynamic.Configuration{
 				TLS: &dynamic.TLSConfiguration{
 					Options: map[string]tls.Options{
-						"myns/foo": {
+						"myns-foo": {
 							MinVersion: "VersionTLS12",
 							CipherSuites: []string{
 								"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
@@ -409,17 +409,17 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 				},
 				TCP: &dynamic.TCPConfiguration{
 					Routers: map[string]*dynamic.TCPRouter{
-						"default/test.route-fdd3e9338e47a45efefc": {
+						"default-test.route-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.route-fdd3e9338e47a45efefc",
+							Service:     "default-test.route-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 							TLS: &dynamic.RouterTCPTLSConfig{
-								Options: "myns/foo",
+								Options: "myns-foo",
 							},
 						},
 					},
 					Services: map[string]*dynamic.TCPService{
-						"default/test.route-fdd3e9338e47a45efefc": {
+						"default-test.route-fdd3e9338e47a45efefc": {
 							LoadBalancer: &dynamic.TCPServersLoadBalancer{
 								Servers: []dynamic.TCPServer{
 									{
@@ -448,7 +448,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 			expected: &dynamic.Configuration{
 				TLS: &dynamic.TLSConfiguration{
 					Options: map[string]tls.Options{
-						"default/foo": {
+						"default-foo": {
 							MinVersion: "VersionTLS12",
 							CipherSuites: []string{
 								"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
@@ -466,17 +466,17 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 				},
 				TCP: &dynamic.TCPConfiguration{
 					Routers: map[string]*dynamic.TCPRouter{
-						"default/test.route-fdd3e9338e47a45efefc": {
+						"default-test.route-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.route-fdd3e9338e47a45efefc",
+							Service:     "default-test.route-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 							TLS: &dynamic.RouterTCPTLSConfig{
-								Options: "default/foo",
+								Options: "default-foo",
 							},
 						},
 					},
 					Services: map[string]*dynamic.TCPService{
-						"default/test.route-fdd3e9338e47a45efefc": {
+						"default-test.route-fdd3e9338e47a45efefc": {
 							LoadBalancer: &dynamic.TCPServersLoadBalancer{
 								Servers: []dynamic.TCPServer{
 									{
@@ -505,24 +505,24 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 			expected: &dynamic.Configuration{
 				TLS: &dynamic.TLSConfiguration{
 					Options: map[string]tls.Options{
-						"default/foo": {
+						"default-foo": {
 							MinVersion: "VersionTLS12",
 						},
 					},
 				},
 				TCP: &dynamic.TCPConfiguration{
 					Routers: map[string]*dynamic.TCPRouter{
-						"default/test.route-fdd3e9338e47a45efefc": {
+						"default-test.route-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.route-fdd3e9338e47a45efefc",
+							Service:     "default-test.route-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 							TLS: &dynamic.RouterTCPTLSConfig{
-								Options: "default/unknown",
+								Options: "default-unknown",
 							},
 						},
 					},
 					Services: map[string]*dynamic.TCPService{
-						"default/test.route-fdd3e9338e47a45efefc": {
+						"default-test.route-fdd3e9338e47a45efefc": {
 							LoadBalancer: &dynamic.TCPServersLoadBalancer{
 								Servers: []dynamic.TCPServer{
 									{
@@ -551,24 +551,24 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 			expected: &dynamic.Configuration{
 				TLS: &dynamic.TLSConfiguration{
 					Options: map[string]tls.Options{
-						"default/foo": {
+						"default-foo": {
 							MinVersion: "VersionTLS12",
 						},
 					},
 				},
 				TCP: &dynamic.TCPConfiguration{
 					Routers: map[string]*dynamic.TCPRouter{
-						"default/test.route-fdd3e9338e47a45efefc": {
+						"default-test.route-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.route-fdd3e9338e47a45efefc",
+							Service:     "default-test.route-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 							TLS: &dynamic.RouterTCPTLSConfig{
-								Options: "unknown/foo",
+								Options: "unknown-foo",
 							},
 						},
 					},
 					Services: map[string]*dynamic.TCPService{
-						"default/test.route-fdd3e9338e47a45efefc": {
+						"default-test.route-fdd3e9338e47a45efefc": {
 							LoadBalancer: &dynamic.TCPServersLoadBalancer{
 								Servers: []dynamic.TCPServer{
 									{
@@ -597,15 +597,15 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 			expected: &dynamic.Configuration{
 				TCP: &dynamic.TCPConfiguration{
 					Routers: map[string]*dynamic.TCPRouter{
-						"default/test.route-fdd3e9338e47a45efefc": {
+						"default-test.route-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.route-fdd3e9338e47a45efefc",
+							Service:     "default-test.route-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 							TLS:         &dynamic.RouterTCPTLSConfig{},
 						},
 					},
 					Services: map[string]*dynamic.TCPService{
-						"default/test.route-fdd3e9338e47a45efefc": {
+						"default-test.route-fdd3e9338e47a45efefc": {
 							LoadBalancer: &dynamic.TCPServersLoadBalancer{
 								Servers: []dynamic.TCPServer{
 									{
@@ -636,14 +636,14 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 				TLS: &dynamic.TLSConfiguration{},
 				TCP: &dynamic.TCPConfiguration{
 					Routers: map[string]*dynamic.TCPRouter{
-						"default/test.route-fdd3e9338e47a45efefc": {
+						"default-test.route-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.route-fdd3e9338e47a45efefc",
+							Service:     "default-test.route-fdd3e9338e47a45efefc",
 							Rule:        "HostSNI(`foo.com`)",
 						},
 					},
 					Services: map[string]*dynamic.TCPService{
-						"default/test.route-fdd3e9338e47a45efefc": {
+						"default-test.route-fdd3e9338e47a45efefc": {
 							LoadBalancer: &dynamic.TCPServersLoadBalancer{
 								Servers: []dynamic.TCPServer{
 									{
@@ -718,16 +718,16 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"default/test.route-6b204d94623b3df4370c": {
+						"default-test.route-6b204d94623b3df4370c": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.route-6b204d94623b3df4370c",
+							Service:     "default-test.route-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
 					Services: map[string]*dynamic.Service{
-						"default/test.route-6b204d94623b3df4370c": {
+						"default-test.route-6b204d94623b3df4370c": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
@@ -755,28 +755,28 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"default/test2.route-23c7f4c450289ee29016": {
+						"default-test2.route-23c7f4c450289ee29016": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test2.route-23c7f4c450289ee29016",
+							Service:     "default-test2.route-23c7f4c450289ee29016",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/tobestripped`)",
 							Priority:    12,
-							Middlewares: []string{"default/stripprefix", "foo/addprefix"},
+							Middlewares: []string{"default-stripprefix", "foo-addprefix"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{
-						"default/stripprefix": {
+						"default-stripprefix": {
 							StripPrefix: &dynamic.StripPrefix{
 								Prefixes: []string{"/tobestripped"},
 							},
 						},
-						"foo/addprefix": {
+						"foo-addprefix": {
 							AddPrefix: &dynamic.AddPrefix{
 								Prefix: "/tobeadded",
 							},
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"default/test2.route-23c7f4c450289ee29016": {
+						"default-test2.route-23c7f4c450289ee29016": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
@@ -805,28 +805,28 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"default/test2.route-23c7f4c450289ee29016": {
+						"default-test2.route-23c7f4c450289ee29016": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test2.route-23c7f4c450289ee29016",
+							Service:     "default-test2.route-23c7f4c450289ee29016",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/tobestripped`)",
 							Priority:    12,
-							Middlewares: []string{"default/stripprefix", "foo/addprefix", "basicauth@file", "redirect@file"},
+							Middlewares: []string{"default-stripprefix", "foo-addprefix", "basicauth@file", "redirect@file"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{
-						"default/stripprefix": {
+						"default-stripprefix": {
 							StripPrefix: &dynamic.StripPrefix{
 								Prefixes: []string{"/tobestripped"},
 							},
 						},
-						"foo/addprefix": {
+						"foo-addprefix": {
 							AddPrefix: &dynamic.AddPrefix{
 								Prefix: "/tobeadded",
 							},
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"default/test2.route-23c7f4c450289ee29016": {
+						"default-test2.route-23c7f4c450289ee29016": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
@@ -853,22 +853,22 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"default/test.route-6b204d94623b3df4370c": {
+						"default-test.route-6b204d94623b3df4370c": {
 							EntryPoints: []string{"web"},
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
-							Service:     "default/test.route-6b204d94623b3df4370c",
+							Service:     "default-test.route-6b204d94623b3df4370c",
 							Priority:    14,
 						},
-						"default/test.route-77c62dfe9517144aeeaa": {
+						"default-test.route-77c62dfe9517144aeeaa": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test.route-77c62dfe9517144aeeaa",
+							Service:     "default-test.route-77c62dfe9517144aeeaa",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/foo`)",
 							Priority:    12,
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
 					Services: map[string]*dynamic.Service{
-						"default/test.route-6b204d94623b3df4370c": {
+						"default-test.route-6b204d94623b3df4370c": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
@@ -881,7 +881,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 								PassHostHeader: true,
 							},
 						},
-						"default/test.route-77c62dfe9517144aeeaa": {
+						"default-test.route-77c62dfe9517144aeeaa": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
@@ -910,30 +910,30 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"default/test.route-77c62dfe9517144aeeaa": {
+						"default-test.route-77c62dfe9517144aeeaa": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test.route-77c62dfe9517144aeeaa",
+							Service:     "default-test.route-77c62dfe9517144aeeaa",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/foo`)",
 							Priority:    12,
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
 					Services: map[string]*dynamic.Service{
-						"default/test.route-77c62dfe9517144aeeaa": {
+						"default-test.route-77c62dfe9517144aeeaa": {
 							Weighted: &dynamic.WeightedRoundRobin{
 								Services: []dynamic.WRRService{
 									{
-										Name:   "default/test.route-77c62dfe9517144aeeaa-whoami-80",
+										Name:   "default-test.route-77c62dfe9517144aeeaa-whoami-80",
 										Weight: func(i int) *int { return &i }(1),
 									},
 									{
-										Name:   "default/test.route-77c62dfe9517144aeeaa-whoami2-8080",
+										Name:   "default-test.route-77c62dfe9517144aeeaa-whoami2-8080",
 										Weight: func(i int) *int { return &i }(1),
 									},
 								},
 							},
 						},
-						"default/test.route-77c62dfe9517144aeeaa-whoami-80": {
+						"default-test.route-77c62dfe9517144aeeaa-whoami-80": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
@@ -946,7 +946,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 								PassHostHeader: true,
 							},
 						},
-						"default/test.route-77c62dfe9517144aeeaa-whoami2-8080": {
+						"default-test.route-77c62dfe9517144aeeaa-whoami2-8080": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
@@ -974,30 +974,30 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"default/test.route-77c62dfe9517144aeeaa": {
+						"default-test.route-77c62dfe9517144aeeaa": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test.route-77c62dfe9517144aeeaa",
+							Service:     "default-test.route-77c62dfe9517144aeeaa",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/foo`)",
 							Priority:    12,
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
 					Services: map[string]*dynamic.Service{
-						"default/test.route-77c62dfe9517144aeeaa": {
+						"default-test.route-77c62dfe9517144aeeaa": {
 							Weighted: &dynamic.WeightedRoundRobin{
 								Services: []dynamic.WRRService{
 									{
-										Name:   "default/test.route-77c62dfe9517144aeeaa-whoami-80",
+										Name:   "default-test.route-77c62dfe9517144aeeaa-whoami-80",
 										Weight: Int(10),
 									},
 									{
-										Name:   "default/test.route-77c62dfe9517144aeeaa-whoami2-8080",
+										Name:   "default-test.route-77c62dfe9517144aeeaa-whoami2-8080",
 										Weight: Int(0),
 									},
 								},
 							},
 						},
-						"default/test.route-77c62dfe9517144aeeaa-whoami-80": {
+						"default-test.route-77c62dfe9517144aeeaa-whoami-80": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
@@ -1010,7 +1010,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 								PassHostHeader: true,
 							},
 						},
-						"default/test.route-77c62dfe9517144aeeaa-whoami2-8080": {
+						"default-test.route-77c62dfe9517144aeeaa-whoami2-8080": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
@@ -1112,9 +1112,9 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"default/test.route-6b204d94623b3df4370c": {
+						"default-test.route-6b204d94623b3df4370c": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test.route-6b204d94623b3df4370c",
+							Service:     "default-test.route-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 							TLS:         &dynamic.RouterTLSConfig{},
@@ -1122,7 +1122,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
 					Services: map[string]*dynamic.Service{
-						"default/test.route-6b204d94623b3df4370c": {
+						"default-test.route-6b204d94623b3df4370c": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
@@ -1145,7 +1145,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 			expected: &dynamic.Configuration{
 				TLS: &dynamic.TLSConfiguration{
 					Options: map[string]tls.Options{
-						"default/foo": {
+						"default-foo": {
 							MinVersion: "VersionTLS12",
 							CipherSuites: []string{
 								"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
@@ -1168,19 +1168,19 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"default/test.route-6b204d94623b3df4370c": {
+						"default-test.route-6b204d94623b3df4370c": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test.route-6b204d94623b3df4370c",
+							Service:     "default-test.route-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 							TLS: &dynamic.RouterTLSConfig{
-								Options: "default/foo",
+								Options: "default-foo",
 							},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
 					Services: map[string]*dynamic.Service{
-						"default/test.route-6b204d94623b3df4370c": {
+						"default-test.route-6b204d94623b3df4370c": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
@@ -1203,7 +1203,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 			expected: &dynamic.Configuration{
 				TLS: &dynamic.TLSConfiguration{
 					Options: map[string]tls.Options{
-						"myns/foo": {
+						"myns-foo": {
 							MinVersion: "VersionTLS12",
 							CipherSuites: []string{
 								"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
@@ -1226,19 +1226,19 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"default/test.route-6b204d94623b3df4370c": {
+						"default-test.route-6b204d94623b3df4370c": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test.route-6b204d94623b3df4370c",
+							Service:     "default-test.route-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 							TLS: &dynamic.RouterTLSConfig{
-								Options: "myns/foo",
+								Options: "myns-foo",
 							},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
 					Services: map[string]*dynamic.Service{
-						"default/test.route-6b204d94623b3df4370c": {
+						"default-test.route-6b204d94623b3df4370c": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
@@ -1261,7 +1261,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 			expected: &dynamic.Configuration{
 				TLS: &dynamic.TLSConfiguration{
 					Options: map[string]tls.Options{
-						"default/foo": {
+						"default-foo": {
 							MinVersion: "VersionTLS12",
 							CipherSuites: []string{
 								"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
@@ -1283,19 +1283,19 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"default/test.route-6b204d94623b3df4370c": {
+						"default-test.route-6b204d94623b3df4370c": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test.route-6b204d94623b3df4370c",
+							Service:     "default-test.route-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 							TLS: &dynamic.RouterTLSConfig{
-								Options: "default/foo",
+								Options: "default-foo",
 							},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
 					Services: map[string]*dynamic.Service{
-						"default/test.route-6b204d94623b3df4370c": {
+						"default-test.route-6b204d94623b3df4370c": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
@@ -1318,7 +1318,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 			expected: &dynamic.Configuration{
 				TLS: &dynamic.TLSConfiguration{
 					Options: map[string]tls.Options{
-						"default/foo": {
+						"default-foo": {
 							MinVersion: "VersionTLS12",
 						},
 					},
@@ -1329,19 +1329,19 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"default/test.route-6b204d94623b3df4370c": {
+						"default-test.route-6b204d94623b3df4370c": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test.route-6b204d94623b3df4370c",
+							Service:     "default-test.route-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 							TLS: &dynamic.RouterTLSConfig{
-								Options: "default/unknown",
+								Options: "default-unknown",
 							},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
 					Services: map[string]*dynamic.Service{
-						"default/test.route-6b204d94623b3df4370c": {
+						"default-test.route-6b204d94623b3df4370c": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
@@ -1364,7 +1364,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 			expected: &dynamic.Configuration{
 				TLS: &dynamic.TLSConfiguration{
 					Options: map[string]tls.Options{
-						"default/foo": {
+						"default-foo": {
 							MinVersion: "VersionTLS12",
 						},
 					},
@@ -1375,19 +1375,19 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"default/test.route-6b204d94623b3df4370c": {
+						"default-test.route-6b204d94623b3df4370c": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test.route-6b204d94623b3df4370c",
+							Service:     "default-test.route-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 							TLS: &dynamic.RouterTLSConfig{
-								Options: "unknown/foo",
+								Options: "unknown-foo",
 							},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
 					Services: map[string]*dynamic.Service{
-						"default/test.route-6b204d94623b3df4370c": {
+						"default-test.route-6b204d94623b3df4370c": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
@@ -1415,9 +1415,9 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"default/test.route-6b204d94623b3df4370c": {
+						"default-test.route-6b204d94623b3df4370c": {
 							EntryPoints: []string{"web"},
-							Service:     "default/test.route-6b204d94623b3df4370c",
+							Service:     "default-test.route-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 							TLS:         &dynamic.RouterTLSConfig{},
@@ -1425,7 +1425,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
 					Services: map[string]*dynamic.Service{
-						"default/test.route-6b204d94623b3df4370c": {
+						"default-test.route-6b204d94623b3df4370c": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
@@ -1453,16 +1453,16 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"default/test.route-6b204d94623b3df4370c": {
+						"default-test.route-6b204d94623b3df4370c": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.route-6b204d94623b3df4370c",
+							Service:     "default-test.route-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
 					Services: map[string]*dynamic.Service{
-						"default/test.route-6b204d94623b3df4370c": {
+						"default-test.route-6b204d94623b3df4370c": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
@@ -1490,16 +1490,16 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"default/test.route-6b204d94623b3df4370c": {
+						"default-test.route-6b204d94623b3df4370c": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.route-6b204d94623b3df4370c",
+							Service:     "default-test.route-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
 					Services: map[string]*dynamic.Service{
-						"default/test.route-6b204d94623b3df4370c": {
+						"default-test.route-6b204d94623b3df4370c": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
@@ -1528,17 +1528,17 @@ func TestLoadIngressRoutes(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{},
 					Middlewares: map[string]*dynamic.Middleware{
-						"default/basicauth": {
+						"default-basicauth": {
 							BasicAuth: &dynamic.BasicAuth{
 								Users: dynamic.Users{"test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/", "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"},
 							},
 						},
-						"default/digestauth": {
+						"default-digestauth": {
 							DigestAuth: &dynamic.DigestAuth{
 								Users: dynamic.Users{"test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/", "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"},
 							},
 						},
-						"default/forwardauth": {
+						"default-forwardauth": {
 							ForwardAuth: &dynamic.ForwardAuth{
 								Address: "test.com",
 								TLS: &dynamic.ClientTLS{
@@ -1565,16 +1565,16 @@ func TestLoadIngressRoutes(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{},
 					Middlewares: map[string]*dynamic.Middleware{
-						"default/errorpage": {
+						"default-errorpage": {
 							Errors: &dynamic.ErrorPage{
 								Status:  []string{"404", "500"},
-								Service: "default/errorpage-errorpage-service",
+								Service: "default-errorpage-errorpage-service",
 								Query:   "query",
 							},
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"default/errorpage-errorpage-service": {
+						"default-errorpage-errorpage-service": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
@@ -1601,16 +1601,16 @@ func TestLoadIngressRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"default/test.route-6b204d94623b3df4370c": {
+						"default-test.route-6b204d94623b3df4370c": {
 							EntryPoints: []string{"foo"},
-							Service:     "default/test.route-6b204d94623b3df4370c",
+							Service:     "default-test.route-6b204d94623b3df4370c",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
 							Priority:    12,
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
 					Services: map[string]*dynamic.Service{
-						"default/test.route-6b204d94623b3df4370c": {
+						"default-test.route-6b204d94623b3df4370c": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -336,14 +336,18 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 					rules = append(rules, "PathPrefix(`"+p.Path+"`)")
 				}
 
-				conf.HTTP.Routers[strings.Replace(rule.Host, ".", "-", -1)+p.Path] = &dynamic.Router{
+				routerKey := strings.Replace(rule.Host, ".", "-", -1) + strings.Replace(p.Path, "/", "-", 1)
+				if strings.HasPrefix(routerKey, "-") {
+					routerKey = strings.Replace(routerKey, "-", "", 1)
+				}
+				conf.HTTP.Routers[routerKey] = &dynamic.Router{
 					Rule:    strings.Join(rules, " && "),
 					Service: serviceName,
 				}
 
 				if len(ingress.Spec.TLS) > 0 {
 					// TLS enabled for this ingress, add TLS router
-					conf.HTTP.Routers[strings.Replace(rule.Host, ".", "-", -1)+p.Path+"-tls"] = &dynamic.Router{
+					conf.HTTP.Routers[routerKey+"-tls"] = &dynamic.Router{
 						Rule:    strings.Join(rules, " && "),
 						Service: serviceName,
 						TLS:     &dynamic.RouterTLSConfig{},

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -325,7 +325,7 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 					continue
 				}
 
-				serviceName := ingress.Namespace + "/" + p.Backend.ServiceName + "/" + p.Backend.ServicePort.String()
+				serviceName := ingress.Namespace + "-" + p.Backend.ServiceName + "-" + p.Backend.ServicePort.String()
 				serviceName = strings.ReplaceAll(serviceName, ".", "-")
 				var rules []string
 				if len(rule.Host) > 0 {
@@ -381,7 +381,7 @@ func getTLS(ctx context.Context, ingress *v1beta1.Ingress, k8sClient Client, tls
 			continue
 		}
 
-		configKey := ingress.Namespace + "/" + t.SecretName
+		configKey := ingress.Namespace + "-" + t.SecretName
 		if _, tlsExists := tlsConfigs[configKey]; !tlsExists {
 			secret, exists, err := k8sClient.GetSecret(ingress.Namespace, t.SecretName)
 			if err != nil {

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -43,7 +43,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"/bar": {
+						"bar": {
 							Rule:    "PathPrefix(`/bar`)",
 							Service: "testing-service1-80",
 						},
@@ -73,11 +73,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"/bar": {
+						"bar": {
 							Rule:    "PathPrefix(`/bar`)",
 							Service: "testing-service1-80",
 						},
-						"/foo": {
+						"foo": {
 							Rule:    "PathPrefix(`/foo`)",
 							Service: "testing-service1-80",
 						},
@@ -107,11 +107,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"/bar": {
+						"bar": {
 							Rule:    "PathPrefix(`/bar`)",
 							Service: "testing-service1-80",
 						},
-						"/foo": {
+						"foo": {
 							Rule:    "PathPrefix(`/foo`)",
 							Service: "testing-service1-80",
 						},
@@ -141,7 +141,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"traefik-tchouk/bar": {
+						"traefik-tchouk-bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
 							Service: "testing-service1-80",
 						},
@@ -197,11 +197,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"traefik-tchouk/bar": {
+						"traefik-tchouk-bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
 							Service: "testing-service1-80",
 						},
-						"traefik-tchouk/foo": {
+						"traefik-tchouk-foo": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/foo`)",
 							Service: "testing-service1-80",
 						},
@@ -231,11 +231,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"traefik-tchouk/bar": {
+						"traefik-tchouk-bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
 							Service: "testing-service1-80",
 						},
-						"traefik-courgette/carotte": {
+						"traefik-courgette-carotte": {
 							Rule:    "Host(`traefik.courgette`) && PathPrefix(`/carotte`)",
 							Service: "testing-service1-80",
 						},
@@ -265,11 +265,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"/bar": {
+						"bar": {
 							Rule:    "PathPrefix(`/bar`)",
 							Service: "testing-service1-80",
 						},
-						"/foo": {
+						"foo": {
 							Rule:    "PathPrefix(`/foo`)",
 							Service: "testing-service1-80",
 						},
@@ -310,7 +310,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"traefik-courgette/carotte": {
+						"traefik-courgette-carotte": {
 							Rule:    "Host(`traefik.courgette`) && PathPrefix(`/carotte`)",
 							Service: "testing-service1-80",
 						},
@@ -351,11 +351,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"traefik-tchouk/bar": {
+						"traefik-tchouk-bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
 							Service: "testing-service1-80",
 						},
-						"traefik-courgette/carotte": {
+						"traefik-courgette-carotte": {
 							Rule:    "Host(`traefik.courgette`) && PathPrefix(`/carotte`)",
 							Service: "testing-service2-8082",
 						},
@@ -451,7 +451,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"traefik-tchouk/bar": {
+						"traefik-tchouk-bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
 							Service: "testing-service1-80",
 						},
@@ -481,7 +481,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"traefik-tchouk/bar": {
+						"traefik-tchouk-bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
 							Service: "testing-service1-tchouk",
 						},
@@ -511,7 +511,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"traefik-tchouk/bar": {
+						"traefik-tchouk-bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
 							Service: "testing-service1-tchouk",
 						},
@@ -541,11 +541,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"traefik-tchouk/bar": {
+						"traefik-tchouk-bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
 							Service: "testing-service1-tchouk",
 						},
-						"traefik-tchouk/foo": {
+						"traefik-tchouk-foo": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/foo`)",
 							Service: "testing-service1-carotte",
 						},
@@ -588,11 +588,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"traefik-tchouk/bar": {
+						"traefik-tchouk-bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
 							Service: "testing-service1-tchouk",
 						},
-						"toto-traefik-tchouk/bar": {
+						"toto-traefik-tchouk-bar": {
 							Rule:    "Host(`toto.traefik.tchouk`) && PathPrefix(`/bar`)",
 							Service: "toto-service1-tchouk",
 						},
@@ -657,7 +657,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"traefik-tchouk/bar": {
+						"traefik-tchouk-bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
 							Service: "testing-service1-8080",
 						},
@@ -726,7 +726,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"/bar": {
+						"bar": {
 							Rule:    "PathPrefix(`/bar`)",
 							Service: "testing-service1-443",
 						},
@@ -756,7 +756,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"/bar": {
+						"bar": {
 							Rule:    "PathPrefix(`/bar`)",
 							Service: "testing-service1-8443",
 						},
@@ -787,7 +787,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 
 					Routers: map[string]*dynamic.Router{
-						"/bar": {
+						"bar": {
 							Rule:    "PathPrefix(`/bar`)",
 							Service: "testing-service1-8443",
 						},
@@ -848,7 +848,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"/bar": {
+						"bar": {
 							Rule:    "PathPrefix(`/bar`)",
 							Service: "testing-service1-80",
 						},

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -45,11 +45,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"/bar": {
 							Rule:    "PathPrefix(`/bar`)",
-							Service: "testing/service1/80",
+							Service: "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"testing/service1/80": {
+						"testing-service1-80": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -75,15 +75,15 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"/bar": {
 							Rule:    "PathPrefix(`/bar`)",
-							Service: "testing/service1/80",
+							Service: "testing-service1-80",
 						},
 						"/foo": {
 							Rule:    "PathPrefix(`/foo`)",
-							Service: "testing/service1/80",
+							Service: "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"testing/service1/80": {
+						"testing-service1-80": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -109,15 +109,15 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"/bar": {
 							Rule:    "PathPrefix(`/bar`)",
-							Service: "testing/service1/80",
+							Service: "testing-service1-80",
 						},
 						"/foo": {
 							Rule:    "PathPrefix(`/foo`)",
-							Service: "testing/service1/80",
+							Service: "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"testing/service1/80": {
+						"testing-service1-80": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -143,11 +143,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"traefik-tchouk/bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
-							Service: "testing/service1/80",
+							Service: "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"testing/service1/80": {
+						"testing-service1-80": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -172,11 +172,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"example-com": {
 							Rule:    "Host(`example.com`)",
-							Service: "testing/example-com/80",
+							Service: "testing-example-com-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"testing/example-com/80": {
+						"testing-example-com-80": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -199,15 +199,15 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"traefik-tchouk/bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
-							Service: "testing/service1/80",
+							Service: "testing-service1-80",
 						},
 						"traefik-tchouk/foo": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/foo`)",
-							Service: "testing/service1/80",
+							Service: "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"testing/service1/80": {
+						"testing-service1-80": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -233,15 +233,15 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"traefik-tchouk/bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
-							Service: "testing/service1/80",
+							Service: "testing-service1-80",
 						},
 						"traefik-courgette/carotte": {
 							Rule:    "Host(`traefik.courgette`) && PathPrefix(`/carotte`)",
-							Service: "testing/service1/80",
+							Service: "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"testing/service1/80": {
+						"testing-service1-80": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -267,15 +267,15 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"/bar": {
 							Rule:    "PathPrefix(`/bar`)",
-							Service: "testing/service1/80",
+							Service: "testing-service1-80",
 						},
 						"/foo": {
 							Rule:    "PathPrefix(`/foo`)",
-							Service: "testing/service1/80",
+							Service: "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"testing/service1/80": {
+						"testing-service1-80": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -312,11 +312,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"traefik-courgette/carotte": {
 							Rule:    "Host(`traefik.courgette`) && PathPrefix(`/carotte`)",
-							Service: "testing/service1/80",
+							Service: "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"testing/service1/80": {
+						"testing-service1-80": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -353,15 +353,15 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"traefik-tchouk/bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
-							Service: "testing/service1/80",
+							Service: "testing-service1-80",
 						},
 						"traefik-courgette/carotte": {
 							Rule:    "Host(`traefik.courgette`) && PathPrefix(`/carotte`)",
-							Service: "testing/service2/8082",
+							Service: "testing-service2-8082",
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"testing/service1/80": {
+						"testing-service1-80": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -374,7 +374,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 								},
 							},
 						},
-						"testing/service2/8082": {
+						"testing-service2-8082": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -453,11 +453,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"traefik-tchouk/bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
-							Service: "testing/service1/80",
+							Service: "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"testing/service1/80": {
+						"testing-service1-80": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -483,11 +483,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"traefik-tchouk/bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
-							Service: "testing/service1/tchouk",
+							Service: "testing-service1-tchouk",
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"testing/service1/tchouk": {
+						"testing-service1-tchouk": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -513,11 +513,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"traefik-tchouk/bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
-							Service: "testing/service1/tchouk",
+							Service: "testing-service1-tchouk",
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"testing/service1/tchouk": {
+						"testing-service1-tchouk": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -543,15 +543,15 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"traefik-tchouk/bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
-							Service: "testing/service1/tchouk",
+							Service: "testing-service1-tchouk",
 						},
 						"traefik-tchouk/foo": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/foo`)",
-							Service: "testing/service1/carotte",
+							Service: "testing-service1-carotte",
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"testing/service1/tchouk": {
+						"testing-service1-tchouk": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -564,7 +564,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 								},
 							},
 						},
-						"testing/service1/carotte": {
+						"testing-service1-carotte": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -590,15 +590,15 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"traefik-tchouk/bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
-							Service: "testing/service1/tchouk",
+							Service: "testing-service1-tchouk",
 						},
 						"toto-traefik-tchouk/bar": {
 							Rule:    "Host(`toto.traefik.tchouk`) && PathPrefix(`/bar`)",
-							Service: "toto/service1/tchouk",
+							Service: "toto-service1-tchouk",
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"testing/service1/tchouk": {
+						"testing-service1-tchouk": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -611,7 +611,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 								},
 							},
 						},
-						"toto/service1/tchouk": {
+						"toto-service1-tchouk": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -659,11 +659,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"traefik-tchouk/bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
-							Service: "testing/service1/8080",
+							Service: "testing-service1-8080",
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"testing/service1/8080": {
+						"testing-service1-8080": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -686,16 +686,16 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"example-com": {
 							Rule:    "Host(`example.com`)",
-							Service: "testing/example-com/80",
+							Service: "testing-example-com-80",
 						},
 						"example-com-tls": {
 							Rule:    "Host(`example.com`)",
-							Service: "testing/example-com/80",
+							Service: "testing-example-com-80",
 							TLS:     &dynamic.RouterTLSConfig{},
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"testing/example-com/80": {
+						"testing-example-com-80": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -728,11 +728,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"/bar": {
 							Rule:    "PathPrefix(`/bar`)",
-							Service: "testing/service1/443",
+							Service: "testing-service1-443",
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"testing/service1/443": {
+						"testing-service1-443": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -758,11 +758,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"/bar": {
 							Rule:    "PathPrefix(`/bar`)",
-							Service: "testing/service1/8443",
+							Service: "testing-service1-8443",
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"testing/service1/8443": {
+						"testing-service1-8443": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -789,11 +789,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"/bar": {
 							Rule:    "PathPrefix(`/bar`)",
-							Service: "testing/service1/8443",
+							Service: "testing-service1-8443",
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"testing/service1/8443": {
+						"testing-service1-8443": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -850,11 +850,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"/bar": {
 							Rule:    "PathPrefix(`/bar`)",
-							Service: "testing/service1/80",
+							Service: "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"testing/service1/80": {
+						"testing-service1-80": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -1088,13 +1088,13 @@ func TestGetTLS(t *testing.T) {
 				},
 			},
 			result: map[string]*tls.CertAndStores{
-				"testing/test-secret": {
+				"testing-test-secret": {
 					Certificate: tls.Certificate{
 						CertFile: tls.FileOrContent("tls-crt"),
 						KeyFile:  tls.FileOrContent("tls-key"),
 					},
 				},
-				"testing/test-secret2": {
+				"testing-test-secret2": {
 					Certificate: tls.Certificate{
 						CertFile: tls.FileOrContent("tls-crt"),
 						KeyFile:  tls.FileOrContent("tls-key"),


### PR DESCRIPTION
## What does this PR do?

This PR replace `/` by `-` for ID in kubernetes providers to be able to navigate easily in the webui

### Motivation

Be able to navigate in the webui

### More

- [x] Added/updated tests
- [x] Added/updated documentation
