### PR TITLE
Disable collect data by default.

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -286,24 +286,16 @@ func checkNewVersion() {
 }
 
 func stats(staticConfiguration *static.Configuration) {
-	if staticConfiguration.Global.SendAnonymousUsage == nil {
-		log.WithoutContext().Error(`
-You haven't specified the sendAnonymousUsage option, it will be enabled by default.
-`)
-		sendAnonymousUsage := true
-		staticConfiguration.Global.SendAnonymousUsage = &sendAnonymousUsage
-	}
+	logger := log.WithoutContext()
 
-	if *staticConfiguration.Global.SendAnonymousUsage {
-		log.WithoutContext().Info(`
-Stats collection is enabled.
-Many thanks for contributing to Traefik's improvement by allowing us to receive anonymous information from your configuration.
-Help us improve Traefik by leaving this feature on :)
-More details on: https://docs.traefik.io/v2.0/contributing/data-collection/
-`)
+	if staticConfiguration.Global.SendAnonymousUsage {
+		logger.Info(`Stats collection is enabled.`)
+		logger.Info(`Many thanks for contributing to Traefik's improvement by allowing us to receive anonymous information from your configuration.`)
+		logger.Info(`Help us improve Traefik by leaving this feature on :)`)
+		logger.Info(`More details on: https://docs.traefik.io/v2.0/contributing/data-collection/`)
 		collect(staticConfiguration)
 	} else {
-		log.WithoutContext().Info(`
+		logger.Info(`
 Stats collection is disabled.
 Help us improve Traefik by turning this feature on :)
 More details on: https://docs.traefik.io/v2.0/contributing/data-collection/

--- a/docs/content/contributing/data-collection.md
+++ b/docs/content/contributing/data-collection.md
@@ -8,9 +8,6 @@ Understanding How Traefik is Being Used
 Understanding how you use Traefik is very important to us: it helps us improve the solution in many different ways.  
 For this very reason, the sendAnonymousUsage option is mandatory: we want you to take time to consider whether or not you wish to share anonymous data with us so we can benefit from your experience and use cases.
 
-!!! warning
-    Before the GA, leaving this option unset will not prevent Traefik from running but will generate an error log indicating that it enables data collection by default.
-
 !!! example "Enabling Data Collection"
     
     ```toml tab="File (TOML)"
@@ -71,14 +68,6 @@ Once a day (the first call begins 10 minutes after the start of Traefik), we col
         cert = "dockerCert"
         key = "dockerKey"
         insecureSkipVerify = true
-    
-    [providers.ecs]
-      domain = "foo.bar"
-      exposedByDefault = true
-      clusters = ["foo-bar"]
-      region = "us-west-2"
-      accessKeyID = "AccessKeyID"
-      secretAccessKey = "SecretAccessKey"
     ```
 
 ??? example "Resulting Obfuscated Configuration"
@@ -92,7 +81,6 @@ Once a day (the first call begins 10 minutes after the start of Traefik), we col
     
     [providers.docker]
       endpoint = "xxxx"
-      domain = "xxxx"
       exposedByDefault = true
       swarmMode = true
     
@@ -101,14 +89,6 @@ Once a day (the first call begins 10 minutes after the start of Traefik), we col
         cert = "xxxx"
         key = "xxxx"
         insecureSkipVerify = false
-    
-    [providers.ecs]
-      domain = "xxxx"
-      exposedByDefault = true
-      clusters = []
-      region = "us-west-2"
-      accessKeyID = "xxxx"
-      secretAccessKey = "xxxx"
     ```
 
 ## The Code for Data Collection

--- a/pkg/anonymize/anonymize_config_test.go
+++ b/pkg/anonymize/anonymize_config_test.go
@@ -26,10 +26,9 @@ import (
 func TestDo_globalConfiguration(t *testing.T) {
 	config := &static.Configuration{}
 
-	sendAnonymousUsage := true
 	config.Global = &static.Global{
 		CheckNewVersion:    true,
-		SendAnonymousUsage: &sendAnonymousUsage,
+		SendAnonymousUsage: true,
 	}
 
 	config.AccessLog = &types.AccessLog{

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -71,8 +71,8 @@ type CertificateResolver struct {
 
 // Global holds the global configuration.
 type Global struct {
-	CheckNewVersion    bool  `description:"Periodically check if a new version has been released." json:"checkNewVersion,omitempty" toml:"checkNewVersion,omitempty" yaml:"checkNewVersion,omitempty" label:"allowEmpty" export:"true"`
-	SendAnonymousUsage *bool `description:"Periodically send anonymous usage statistics. If the option is not specified, it will be enabled by default." json:"sendAnonymousUsage,omitempty" toml:"sendAnonymousUsage,omitempty" yaml:"sendAnonymousUsage,omitempty" label:"allowEmpty" export:"true"`
+	CheckNewVersion    bool `description:"Periodically check if a new version has been released." json:"checkNewVersion,omitempty" toml:"checkNewVersion,omitempty" yaml:"checkNewVersion,omitempty" label:"allowEmpty" export:"true"`
+	SendAnonymousUsage bool `description:"Periodically send anonymous usage statistics. If the option is not specified, it will be enabled by default." json:"sendAnonymousUsage,omitempty" toml:"sendAnonymousUsage,omitempty" yaml:"sendAnonymousUsage,omitempty" label:"allowEmpty" export:"true"`
 }
 
 // ServersTransport options to configure communication between Traefik and the servers


### PR DESCRIPTION

### What does this PR do?

Disable collect data by default.

### Motivation

> Before the GA, leaving this option unset will not prevent Traefik from running but will generate an error log indicating that it enables data collection by default.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

