### PR TITLE
Fix case-sensitive header in websocket

### DIFF
--- a/pkg/server/service/proxy.go
+++ b/pkg/server/service/proxy.go
@@ -57,6 +57,11 @@ func buildProxy(passHostHeader bool, responseForwarding *dynamic.ResponseForward
 				outReq.Host = outReq.URL.Host
 			}
 
+			// Even if the websocket RFC says that headers should be case-insensitive,
+			// some servers need Sec-WebSocket-Key to be case-sensitive.
+			// https://tools.ietf.org/html/rfc6455#page-20
+			outReq.Header["Sec-WebSocket-Key"] = outReq.Header["Sec-Websocket-Key"]
+			delete(outReq.Header, "Sec-Websocket-Key")
 		},
 		Transport:      defaultRoundTripper,
 		FlushInterval:  time.Duration(flushInterval),


### PR DESCRIPTION
### What does this PR do?
Force `Sec-WebSocket-Key` header case to fix Handshake problem on websocket. 

### Motivation
It works with more websocket server implementation.
Fixes #5330 

### More

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~


<!-- Anything else we should know when reviewing? -->
