### PR TITLE
Actually send header and code during WriteHeader, if needed

### DIFF
--- a/middlewares/errorpages/error_pages.go
+++ b/middlewares/errorpages/error_pages.go
@@ -159,8 +159,8 @@ type codeCatcherWithCloseNotify struct {
 
 // CloseNotify returns a channel that receives at most a
 // single value (true) when the client connection has gone away.
-func (r *codeCatcherWithCloseNotify) CloseNotify() <-chan bool {
-	return r.responseWriter.(http.CloseNotifier).CloseNotify()
+func (cc *codeCatcherWithCloseNotify) CloseNotify() <-chan bool {
+	return cc.responseWriter.(http.CloseNotifier).CloseNotify()
 }
 
 func newCodeCatcher(rw http.ResponseWriter, httpCodeRanges types.HTTPCodeRanges) responseInterceptor {
@@ -218,12 +218,10 @@ func (cc *codeCatcher) Write(buf []byte) (int, error) {
 }
 
 func (cc *codeCatcher) WriteHeader(code int) {
-	if cc.headersSent {
+	if cc.headersSent || cc.caughtFilteredCode {
 		return
 	}
-	if cc.caughtFilteredCode {
-		return
-	}
+
 	cc.code = code
 	for _, block := range cc.httpCodeRanges {
 		if cc.code >= block[0] && cc.code <= block[1] {

--- a/middlewares/errorpages/error_pages_test.go
+++ b/middlewares/errorpages/error_pages_test.go
@@ -47,6 +47,18 @@ func TestHandler(t *testing.T) {
 			},
 		},
 		{
+			desc:        "a 304, so no Write called",
+			errorPage:   &types.ErrorPage{Backend: "error", Query: "/test", Status: []string{"500-501", "503-599"}},
+			backendCode: http.StatusNotModified,
+			backendErrorHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintln(w, "whatever, should not be called")
+			}),
+			validate: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusNotModified, recorder.Code, "HTTP status")
+				assert.Contains(t, recorder.Body.String(), "")
+			},
+		},
+		{
 			desc:        "in the range",
 			errorPage:   &types.ErrorPage{Backend: "error", Query: "/test", Status: []string{"500-501", "503-599"}},
 			backendCode: http.StatusInternalServerError,
@@ -120,6 +132,9 @@ func TestHandler(t *testing.T) {
 
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(test.backendCode)
+				if test.backendCode == http.StatusNotModified {
+					return
+				}
 				fmt.Fprintln(w, http.StatusText(test.backendCode))
 			})
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

Before this change, the codeCatcher relied on the fact that Write would
always be called, and hence was in charge of actually sending the headers
that WriteHeader had "cached" when it had been called.

However, in the case of e.g. a 304, since the response should not have
any body, there is no reason for the caller (i.e. another proxy or
middleware in the chain of calls) to call the codeCatcher's Write.
Therefore, neither the headers, and hence nor the the response code,
were actually forwarded to the client.

Consequently, this change moves the responsibility of actually
forwarding the headers and response code to where it belongs, i.e. in
WriteHeader.

In addition, this change adds a wrapper of the codeCatcher, so that we
can satisfy the CloseNotify interface as well.

N.B: in hindsight, I think it might be possible to reproduce #5385 even before 753d1739659d5561915849c8ec9cd2251410bf89 , if one is vicious enough to include the 304 code in the range of watched error codes.

<!-- A brief description of the change being made with this pull request. -->


### Motivation

To properly handle 304 responses (and probably other headers related bugs lurking around).

<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- ~[] Added/updated documentation~

### Additional Notes

Fixes #5385

Co-authored-by: Julien Salleyron <julien.salleyron@gmail.com>

<!-- Anything else we should know when reviewing? -->
