### PR TITLE
Return an actual server status updater

### DIFF
--- a/pkg/server/service/service.go
+++ b/pkg/server/service/service.go
@@ -310,7 +310,7 @@ func (m *Manager) getLoadBalancer(ctx context.Context, serviceName string, servi
 		return nil, fmt.Errorf("error configuring load balancer for service %s: %v", serviceName, err)
 	}
 
-	return lb, nil
+	return lbsu, nil
 }
 
 func (m *Manager) upsertServers(ctx context.Context, lb healthcheck.BalancerHandler, servers []dynamic.Server) error {


### PR DESCRIPTION
### What does this PR do?

The status of the loadbalancer servers were not updated accordingly to the health check.
This PR fixes this issue by applying the loadbalancer status updater wrapper on the original loadbalancer.

### Motivation

Fixes #5231 

### More

- [ ] ~Added/updated tests~
- [ ] ~Added/updated documentation~
