### PR TITLE
Documentation improvement for minikube users crd acme user guide

### DIFF
--- a/docs/content/user-guides/crd-acme/05-minikubeingress.yml
+++ b/docs/content/user-guides/crd-acme/05-minikubeingress.yml
@@ -1,0 +1,26 @@
+# Minikube only
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: nginx-ingress
+  namespace: kube-system
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+    - host: your.domain.com
+      http:
+        paths:
+          - backend:
+              serviceName: traefik
+              servicePort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: traefik
+  namespace: kube-system
+spec:
+  type: ExternalName
+  # The 'default' in  'traefik.default.svc.cluster.local' should be the namespace traefik was deployed to
+  externalName: traefik.default.svc.cluster.local

--- a/docs/content/user-guides/crd-acme/index.md
+++ b/docs/content/user-guides/crd-acme/index.md
@@ -80,6 +80,9 @@ Look it up.
 
 ### Traefik Routers
 
+Note that if you are using minikube the tls ingress will not work out of the box because there will be no way for the cert provider callback the minikube instance on your local machine to complete the acme challenge and verify ownership of the domain. 
+Instead test the non-tls configuration only and add an entry in `/etc/hosts` for your local domain, eg `your.domain.com` pointing to the minikube ip.
+
 We can now finally apply the actual ingressRoutes, with:
 
 ```bash
@@ -102,3 +105,22 @@ curl [-k] http://your.domain.com:8000/notls
 ```
 
 Note that you'll have to use `-k` as long as you're using the staging server of Let's Encrypt, since it is not in the root DNS servers.
+
+### Minikube
+
+If you are using Minikube you will need an additional configuration to route from the nginx ingress controller to the traefik service. 
+
+###### Caveats
+If you have deployed traefik to a namespace other than `default` be sure to update the `ExternalName` resource below to point to the namespace that the traefik service is deployed in.
+
+If you have deployed traefik to the `kube-system` namespace then you can remove the `ExternalName` resource below as this is only used to route traefik from the `kube-system` namespace to the namespace that traefik was deployed to.
+
+When you are done making any necessary modifications apply with:
+
+```bash
+kubectl apply -f 05-minikubeingress.yml
+```
+
+```yaml
+--8<-- "content/user-guides/crd-acme/05-minikubeingress.yml"
+```


### PR DESCRIPTION
### What does this PR do?

Updates the documentation to help users following the kubernetes crd acme guide with minikube

### Motivation

I had to figure out how to configure minikube on my own which was painful. Users that are testing something out for the first time often don't want to do so in a shared environment because they don't have access to do so. Minikube is a popular choice for testing and the guide should cover configuration which is not obvious to a new k8s user. 

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

N/A
