### PR TITLE
Update ACME storage docs to remove reference to KV store in CE

### DIFF
--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -390,7 +390,7 @@ docker run -v "/my/host/acme:/etc/traefik/acme" traefik
 ```
 
 !!! warning
-    For concurrency reason, this file cannot be shared across multiple instances of Traefik. Use a key value store entry instead.
+    For concurrency reason, this file cannot be shared across multiple instances of Traefik. Clustered operation is available in Traefik EE.
 
 ## Fallback
 

--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -390,7 +390,7 @@ docker run -v "/my/host/acme:/etc/traefik/acme" traefik
 ```
 
 !!! warning
-    For concurrency reason, this file cannot be shared across multiple instances of Traefik. Clustered operation is available in Traefik EE.
+    For concurrency reason, this file cannot be shared across multiple instances of Traefik.
 
 ## Fallback
 


### PR DESCRIPTION
### What does this PR do?

Remove reference to KV storage for Traefik CE. Per https://github.com/containous/traefik/issues/5426

### More

- [ ] Added/updated tests
- [x] Added/updated documentation