### PR TITLE
Add a warning note regarding optional TLS mutual auth

### DIFF
--- a/docs/configuration/entrypoints.md
+++ b/docs/configuration/entrypoints.md
@@ -240,7 +240,8 @@ TLS Mutual Authentication can be `optional` or not.
 * If `optional = false`, Traefik will only accept clients that present a certificate signed by a specified Certificate Authority (CA).
 
 !!! warning
-  While the TLS [1.1](https://tools.ietf.org/html/rfc4346#section-7.4.6) and [1.2](https://tools.ietf.org/html/rfc5246#section-7.4.6) RFCs specify that clients should proceed with handshaking by sending an empty list should they have no certs for the CAs specified by the server, not all do so in practice. Use this feature with caution should you require maximum compatibility with a wide variety of client user agents which may not strictly implement these specs.
+    While the TLS [1.1](https://tools.ietf.org/html/rfc4346#section-7.4.6) and [1.2](https://tools.ietf.org/html/rfc5246#section-7.4.6) RFCs specify that clients should proceed with handshaking by sending an empty list should they have no certs for the CAs specified by the server, not all do so in practice.
+    Use this feature with caution should you require maximum compatibility with a wide variety of client user agents which may not strictly implement these specs.
 
 `ClientCAFiles` can be configured with multiple `CA:s` in the same file or use multiple files containing one or several `CA:s`.
 The `CA:s` has to be in PEM format.

--- a/docs/configuration/entrypoints.md
+++ b/docs/configuration/entrypoints.md
@@ -239,11 +239,13 @@ TLS Mutual Authentication can be `optional` or not.
 * If `optional = true`, if a certificate is provided, verifies if it is signed by a specified Certificate Authority (CA). Otherwise proceeds without any certificate.
 * If `optional = false`, Traefik will only accept clients that present a certificate signed by a specified Certificate Authority (CA).
 
+!!! warning
+  While the TLS [1.1](https://tools.ietf.org/html/rfc4346#section-7.4.6) and [1.2](https://tools.ietf.org/html/rfc5246#section-7.4.6) RFCs specify that clients should proceed with handshaking by sending an empty list should they have no certs for the CAs specified by the server, not all do so in practice. Use this feature with caution should you require maximum compatibility with a wide variety of client user agents which may not strictly implement these specs.
+
 `ClientCAFiles` can be configured with multiple `CA:s` in the same file or use multiple files containing one or several `CA:s`.
 The `CA:s` has to be in PEM format.
 
-By default, `ClientCAFiles` is not optional, all clients will be required to present a valid cert.
-The requirement will apply to all server certs in the entrypoint.
+By default, `ClientCAFiles` is not optional, all clients will be required to present a valid cert. The requirement will apply to all server certs in the entrypoint.
 
 In the example below both `snitest.com` and `snitest.org` will require client certs
 


### PR DESCRIPTION
### What does this PR do?

Adds a warning to the TLS mutual authentication section regarding non-universal client support for optional client certificates during handshaking.

### Motivation

We got burned by certain clients which do not treat this option as truly optional; see [this Chromium ticket](https://bugs.chromium.org/p/chromium/issues/detail?id=1002638) for an example of this incompatibility in the wild.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation