### PR TITLE
Flag names don't need a consistent case.

### DIFF
--- a/pkg/config/parser/labels_decode.go
+++ b/pkg/config/parser/labels_decode.go
@@ -65,7 +65,7 @@ func decodeToNode(root *Node, path []string, value string) {
 
 func containsNode(nodes []*Node, name string) *Node {
 	for _, n := range nodes {
-		if name == n.Name {
+		if strings.EqualFold(name, n.Name) {
 			return n
 		}
 	}

--- a/pkg/config/parser/labels_decode_test.go
+++ b/pkg/config/parser/labels_decode_test.go
@@ -118,6 +118,22 @@ func TestDecodeToNode(t *testing.T) {
 			}},
 		},
 		{
+			desc: "several entries, level 2, case insensitive",
+			in: map[string]string{
+				"traefik.foo.aaa": "bar",
+				"traefik.Foo.bbb": "bur",
+			},
+			expected: expected{node: &Node{
+				Name: "traefik",
+				Children: []*Node{
+					{Name: "Foo", Children: []*Node{
+						{Name: "bbb", Value: "bur"},
+						{Name: "aaa", Value: "bar"},
+					}},
+				},
+			}},
+		},
+		{
 			desc: "several entries, level 2, 3 children",
 			in: map[string]string{
 				"traefik.foo.aaa": "bar",


### PR DESCRIPTION

### What does this PR do?

Before this PR, the flags are case sensitive but the flags require a consistent case.

By example:

the following flags doesn't have a consistent case on `certificatesresolvers`:
```
--certificatesresolvers.default.acme.email=my@email.com
--certificatesResolvers.default.acme.storage=/my-acme.json
--certifiCatesresolvers.default.acme.httpchallenge.entrypoint=http
```
=> only one flag is read (not expected) 

With this PR, the flags names don't need to have a consistent case.

### Motivation

Fixes #5360

### More

- [x] Added/updated tests
- [ ] ~~Added/updated documentation~~
