### PR TITLE
Avoid closing stdout when the accesslog handler is closed

### DIFF
--- a/middlewares/accesslog/logger.go
+++ b/middlewares/accesslog/logger.go
@@ -208,6 +208,10 @@ func (l *LogHandler) Close() error {
 func (l *LogHandler) Rotate() error {
 	var err error
 
+	if l.config.FilePath == "" {
+		return nil
+	}
+
 	if l.file != nil {
 		defer func(f *os.File) {
 			f.Close()

--- a/middlewares/accesslog/logger.go
+++ b/middlewares/accesslog/logger.go
@@ -219,18 +219,15 @@ func (l *LogHandler) Close() error {
 // Rotate closes and reopens the log file to allow for rotation
 // by an external source.
 func (l *LogHandler) Rotate() error {
-	var err error
-
 	if l.config.FilePath == "" {
 		return nil
 	}
 
 	if l.file != nil {
-		defer func(f io.Closer) {
-			f.Close()
-		}(l.file)
+		defer func(f io.Closer) { _ = f.Close() }(l.file)
 	}
 
+	var err error
 	l.file, err = os.OpenFile(l.config.FilePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0664)
 	if err != nil {
 		return err


### PR DESCRIPTION
### What does this PR do?

When StdOut is used as the Access Log handlers file, on close or rotation, StdOut can and does get closed.

### Motivation

Closing StdOut is almost never a good.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Co-authored-by: Ludovic Fernandez <ldez@users.noreply.github.com>
Co-authored-by: jlevesy <julien.levesy@containo.us>