### PR TITLE
Fix Kubernetes Namespace alert

### DIFF
--- a/docs/content/middlewares/overview.md
+++ b/docs/content/middlewares/overview.md
@@ -136,11 +136,11 @@ then you'll have to append to the middleware name, the `@` separator, followed b
 
 !!! important "Kubernetes Namespace"
 
-	As Kubernetes also has its own notion of namespace, one should not confuse the "provider namespace"
-with the "kubernetes namespace" of a resource when in the context of a cross-provider usage.
-In this case, since the definition of the middleware is not in kubernetes,
-specifying a "kubernetes namespace" when referring to the resource does not make any sense,
-and therefore this specification would be ignored even if present.
+    As Kubernetes also has its own notion of namespace, one should not confuse the "provider namespace"
+    with the "kubernetes namespace" of a resource when in the context of a cross-provider usage.
+    In this case, since the definition of the middleware is not in kubernetes,
+    specifying a "kubernetes namespace" when referring to the resource does not make any sense,
+    and therefore this specification would be ignored even if present.
 
 !!! abstract "Referencing a Middleware from Another Provider"
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

This PR fixes an issue with the documentation, specifically it makes the Kubernetes alert to contain the rest of the text. The issue is represented in the following image:
![Screenshot 2019-09-24 at 13 00 13](https://user-images.githubusercontent.com/4939519/65506196-52c6d300-decb-11e9-9219-ab856fe39efc.png)

This PR fixes the box and adds the missing text:
![Screenshot 2019-09-24 at 13 02 56](https://user-images.githubusercontent.com/4939519/65506372-b3eea680-decb-11e9-95f3-52abcf0c67b4.png)




### Motivation

<!-- What inspired you to submit this pull request? -->
The documentation has an issue. It took me a few seconds to understand the error whilst I was reading it.

### More

- [ ] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
