### PR TITLE
Do not initialize list of middlewares if not needed

### DIFF
--- a/pkg/server/middleware/middlewares.go
+++ b/pkg/server/middleware/middlewares.go
@@ -142,9 +142,9 @@ func (b *Builder) buildConstructor(ctx context.Context, middlewareName string) (
 			return nil, badConf
 		}
 
-		qualifiedNames := make([]string, len(config.Chain.Middlewares))
-		for i, name := range config.Chain.Middlewares {
-			qualifiedNames[i] = internal.GetQualifiedName(ctx, name)
+		var qualifiedNames []string
+		for _, name := range config.Chain.Middlewares {
+			qualifiedNames = append(qualifiedNames, internal.GetQualifiedName(ctx, name))
 		}
 		config.Chain.Middlewares = qualifiedNames
 		middleware = func(next http.Handler) (http.Handler, error) {

--- a/pkg/server/router/router.go
+++ b/pkg/server/router/router.go
@@ -143,9 +143,9 @@ func (m *Manager) buildRouterHandler(ctx context.Context, routerName string, rou
 }
 
 func (m *Manager) buildHTTPHandler(ctx context.Context, router *runtime.RouterInfo, routerName string) (http.Handler, error) {
-	qualifiedNames := make([]string, len(router.Middlewares))
-	for i, name := range router.Middlewares {
-		qualifiedNames[i] = internal.GetQualifiedName(ctx, name)
+	var qualifiedNames []string
+	for _, name := range router.Middlewares {
+		qualifiedNames = append(qualifiedNames, internal.GetQualifiedName(ctx, name))
 	}
 	router.Middlewares = qualifiedNames
 	rm := m.modifierBuilder.Build(ctx, qualifiedNames)


### PR DESCRIPTION

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

This PR makes sure that when a router does not refer to any middleware, the corresponding list in the config stays a nil slice instead of being initialised to an empty (non-nil) slice.

Otherwise, when a router refers to no middleware, we would still build
an empty (but non nil) slice of middlewares in the config.
Which means, when a (e.g. docker swarm) event sends us a config that is
in theory identical, it would still look different from the current one
because it would have a nil slice, whereas the current one would have an
empty slice. Therefore, all the handlers would be unnecessarily
rebuilt.

This was particularly visible with docker swarm, because, as opposed to
the other providers, it regularly polls to check for a config change,
instead of waiting for an event from the orchestrator or app.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

Fixes #5419 

<!-- What inspired you to submit this pull request? -->

### More

- ~[ ] Added/updated tests~
- ~[ ] Added/updated documentation~

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Co-authored-by: Ludovic Fernandez <ldez@users.noreply.github.com>
