### PR TITLE
fix: docker service name.

### DIFF
--- a/integration/docker_compose_test.go
+++ b/integration/docker_compose_test.go
@@ -77,7 +77,7 @@ func (s *DockerComposeSuite) TestComposeScale(c *check.C) {
 	services := rtconf.Services
 	c.Assert(services, checker.HasLen, 1)
 	for k, v := range services {
-		c.Assert(k, checker.Equals, composeService+"_integrationtest"+composeProject+"@docker")
+		c.Assert(k, checker.Equals, composeService+"-integrationtest"+composeProject+"@docker")
 		c.Assert(v.LoadBalancer.Servers, checker.HasLen, serviceCount)
 		// We could break here, but we don't just to keep us honest.
 	}

--- a/pkg/provider/docker/config.go
+++ b/pkg/provider/docker/config.go
@@ -325,7 +325,7 @@ func getPort(container dockerData, serverPort string) string {
 }
 
 func getServiceName(container dockerData) string {
-	serviceName := container.ServiceName
+	serviceName := strings.TrimPrefix(container.ServiceName, "/")
 
 	if values, err := getStringMultipleStrict(container.Labels, labelDockerComposeProject, labelDockerComposeService); err == nil {
 		serviceName = values[labelDockerComposeService] + "_" + values[labelDockerComposeProject]

--- a/pkg/provider/docker/config.go
+++ b/pkg/provider/docker/config.go
@@ -325,11 +325,11 @@ func getPort(container dockerData, serverPort string) string {
 }
 
 func getServiceName(container dockerData) string {
-	serviceName := strings.TrimPrefix(container.ServiceName, "/")
+	serviceName := container.ServiceName
 
 	if values, err := getStringMultipleStrict(container.Labels, labelDockerComposeProject, labelDockerComposeService); err == nil {
 		serviceName = values[labelDockerComposeService] + "_" + values[labelDockerComposeProject]
 	}
 
-	return serviceName
+	return provider.Normalize(serviceName)
 }

--- a/pkg/provider/docker/docker.go
+++ b/pkg/provider/docker/docker.go
@@ -142,7 +142,12 @@ func (p *Provider) createClient() (client.APIClient, error) {
 		apiVersion = SwarmAPIVersion
 	}
 
-	return client.NewClient(p.Endpoint, apiVersion, httpClient, httpHeaders)
+	return client.NewClientWithOpts(
+		client.WithHost(p.Endpoint),
+		client.WithVersion(apiVersion),
+		client.WithHTTPClient(httpClient),
+		client.WithHTTPHeaders(httpHeaders),
+	)
 }
 
 // Provide allows the docker provider to provide configurations to traefik using the given configuration channel.


### PR DESCRIPTION
### What does this PR do?

fix: docker service name.

### Motivation

In some case the docker service name can start with `/`.


Fixes #5489

### More

- [ ] ~~Added/updated tests~~
- [ ] ~~Added/updated documentation~~
