### PR TITLE
Add the pass host header section to the services documentation

### DIFF
--- a/docs/content/routing/providers/docker.md
+++ b/docs/content/routing/providers/docker.md
@@ -237,7 +237,8 @@ you'd add the label `traefik.http.services.<name-of-your-choice>.loadbalancer.pa
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.passhostheader`"
-    <!-- TODO doc passHostHeader in services page -->
+    
+    See [pass Host header](../services/index.md#pass-host-header) for more information.
     
     ```yaml
     - "traefik.http.services.myservice.loadbalancer.passhostheader=true"

--- a/docs/content/routing/providers/marathon.md
+++ b/docs/content/routing/providers/marathon.md
@@ -157,7 +157,8 @@ For example, to change the passHostHeader behavior, you'd add the label `"traefi
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.passhostheader`"
-    <!-- TODO doc passHostHeader in services page -->
+    
+    See [pass Host header](../services/index.md#pass-host-header) for more information.
     
     ```json
     "traefik.http.services.myservice.loadbalancer.passhostheader": "true"

--- a/docs/content/routing/providers/rancher.md
+++ b/docs/content/routing/providers/rancher.md
@@ -163,7 +163,8 @@ you'd add the label `traefik.http.services.{name-of-your-choice}.loadbalancer.pa
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.passhostheader`"
-    <!-- TODO doc passHostHeader in services page -->
+    
+    See [pass Host header](../services/index.md#pass-host-header) for more information.
     
     ```yaml
     - "traefik.http.services.myservice.loadbalancer.passhostheader=true"

--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -324,16 +324,16 @@ Below are the available options for the health check mechanism:
 
 #### Pass Host Header
 
-You can optionally enable `passHostHeader` to forward client Host header to server. 
+You can optionally disable `passHostHeader` to not forward client Host header to server. 
 
-??? example "Pass the host header -- Using the [File Provider](../../providers/file.md)"
+??? example "Don't forward the host header -- Using the [File Provider](../../providers/file.md)"
 
     ```toml tab="TOML"
     ## Dynamic configuration
     [http.services]
       [http.services.Service01]
         [http.services.Service01.loadBalancer]
-          passHostHeader = true
+          passHostHeader = false
     ```
     
     ```yaml tab="YAML"
@@ -342,7 +342,7 @@ You can optionally enable `passHostHeader` to forward client Host header to serv
       services:
         Service01:
           loadBalancer:
-            passHostHeader: true
+            passHostHeader: false
     ```
 
 ### Weighted Round Robin (service)

--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -324,7 +324,9 @@ Below are the available options for the health check mechanism:
 
 #### Pass Host Header
 
-You can optionally disable `passHostHeader` to not forward client Host header to server. 
+The `passHostHeader` allows to forward client Host header to server.
+
+By default, `passHostHeader` is true.
 
 ??? example "Don't forward the host header -- Using the [File Provider](../../providers/file.md)"
 

--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -322,6 +322,29 @@ Below are the available options for the health check mechanism:
                 My-Header: bar
     ```
 
+#### Pass Host Header
+
+You can optionally enable `passHostHeader` to forward client Host header to server. 
+
+??? example "Pass the host header -- Using the [File Provider](../../providers/file.md)"
+
+    ```toml tab="TOML"
+    ## Dynamic configuration
+    [http.services]
+      [http.services.Service01]
+        [http.services.Service01.loadBalancer]
+          passHostHeader = true
+    ```
+    
+    ```yaml tab="YAML"
+    ## Dynamic configuration
+    http:
+      services:
+        Service01:
+          loadBalancer:
+            passHostHeader: true
+    ```
+
 ### Weighted Round Robin (service)
 
 The WRR is able to load balance the requests between multiple services based on weights.


### PR DESCRIPTION

### What does this PR do?

Add the pass host header section to the services documentation with a file provider example.

### Motivation

Have a better documentation.


### More

- [ ] ~Added/updated tests~
- [x] Added/updated documentation
