### PR TITLE
Add a response forwarding section to the service documentation 

### DIFF
--- a/docs/content/routing/providers/docker.md
+++ b/docs/content/routing/providers/docker.md
@@ -333,9 +333,8 @@ you'd add the label `traefik.http.services.<name-of-your-choice>.loadbalancer.pa
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.responseforwarding.flushinterval`"
-    <!-- TODO doc responseforwarding in services page -->
     
-    FlushInterval specifies the flush interval to flush to the client while copying the response body.
+    See [response fowarding](../services/index.md#response-forwarding) for more information.
     
     ```yaml
     - "traefik.http.services.myservice.loadbalancer.responseforwarding.flushinterval=10"

--- a/docs/content/routing/providers/docker.md
+++ b/docs/content/routing/providers/docker.md
@@ -334,7 +334,7 @@ you'd add the label `traefik.http.services.<name-of-your-choice>.loadbalancer.pa
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.responseforwarding.flushinterval`"
     
-    See [response fowarding](../services/index.md#response-forwarding) for more information.
+    See [response forwarding](../services/index.md#response-forwarding) for more information.
     
     ```yaml
     - "traefik.http.services.myservice.loadbalancer.responseforwarding.flushinterval=10"

--- a/docs/content/routing/providers/marathon.md
+++ b/docs/content/routing/providers/marathon.md
@@ -254,7 +254,7 @@ For example, to change the passHostHeader behavior, you'd add the label `"traefi
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.responseforwarding.flushinterval`"
     
-    See [response fowarding](../services/index.md#response-forwarding) for more information.
+    See [response forwarding](../services/index.md#response-forwarding) for more information.
 
     ```json
     "traefik.http.services.myservice.loadbalancer.responseforwarding.flushinterval": "10"

--- a/docs/content/routing/providers/marathon.md
+++ b/docs/content/routing/providers/marathon.md
@@ -253,10 +253,9 @@ For example, to change the passHostHeader behavior, you'd add the label `"traefi
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.responseforwarding.flushinterval`"
-    <!-- TODO doc responseforwarding in services page -->
     
-    FlushInterval specifies the flush interval to flush to the client while copying the response body.
-    
+    See [response fowarding](../services/index.md#response-forwarding) for more information.
+
     ```json
     "traefik.http.services.myservice.loadbalancer.responseforwarding.flushinterval": "10"
     ```

--- a/docs/content/routing/providers/rancher.md
+++ b/docs/content/routing/providers/rancher.md
@@ -259,10 +259,9 @@ you'd add the label `traefik.http.services.{name-of-your-choice}.loadbalancer.pa
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.responseforwarding.flushinterval`"
-    <!-- TODO doc responseforwarding in services page -->
     
-    FlushInterval specifies the flush interval to flush to the client while copying the response body.
-    
+    See [response fowarding](../services/index.md#response-forwarding) for more information.
+
     ```yaml
     - "traefik.http.services.myservice.loadbalancer.responseforwarding.flushinterval=10"
     ```

--- a/docs/content/routing/providers/rancher.md
+++ b/docs/content/routing/providers/rancher.md
@@ -260,7 +260,7 @@ you'd add the label `traefik.http.services.{name-of-your-choice}.loadbalancer.pa
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.responseforwarding.flushinterval`"
     
-    See [response fowarding](../services/index.md#response-forwarding) for more information.
+    See [response forwarding](../services/index.md#response-forwarding) for more information.
 
     ```yaml
     - "traefik.http.services.myservice.loadbalancer.responseforwarding.flushinterval=10"

--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -349,7 +349,7 @@ By default, `passHostHeader` is true.
    
 #### Response Forwarding
 
-Configure response forwarding to define how forwards serves back the response of requests to remote server.
+This section is about configuring how Traefik forwards the response from the backend server to the client.
 
 Below are the available options for the Response Forwarding mechanism:
 

--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -346,7 +346,38 @@ By default, `passHostHeader` is true.
           loadBalancer:
             passHostHeader: false
     ```
+   
+#### Response Forwarding
 
+Configure response forwarding to define how forwards serves back the response of requests to remote server.
+
+Below are the available options for the Response Forwarding mechanism:
+
+- `FlushInterval` specifies the flush interval to flush to the client while copying the response body.
+  It is a duration in milliseconds, defaulting to 100.
+  A negative value means to flush immediately after each write to the client.
+  The FlushInterval is ignored when ReverseProxy recognizes a response as a streaming response; for such responses, writes are flushed to the client immediately.
+  
+??? example "Use a custom FlushInterval -- Using the [File Provider](../../providers/file.md)"
+
+    ```toml tab="TOML"
+    ## Dynamic configuration
+    [http.services]
+      [http.services.Service-1]
+        [http.services.Service-1.loadBalancer.responseForwarding]
+          flushInterval = "1s"
+    ```
+    
+    ```yaml tab="YAML"
+    ## Dynamic configuration
+    http:
+      services:
+        Service-1:
+          loadBalancer:
+            responseForwarding:
+              flushInterval: 1s
+    ```
+    
 ### Weighted Round Robin (service)
 
 The WRR is able to load balance the requests between multiple services based on weights.

--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -353,12 +353,13 @@ Configure response forwarding to define how forwards serves back the response of
 
 Below are the available options for the Response Forwarding mechanism:
 
-- `FlushInterval` specifies the flush interval to flush to the client while copying the response body.
+- `FlushInterval` specifies the interval in between flushes to the client while copying the response body.
   It is a duration in milliseconds, defaulting to 100.
   A negative value means to flush immediately after each write to the client.
-  The FlushInterval is ignored when ReverseProxy recognizes a response as a streaming response; for such responses, writes are flushed to the client immediately.
+  The FlushInterval is ignored when ReverseProxy recognizes a response as a streaming response;
+  for such responses, writes are flushed to the client immediately.
   
-??? example "Use a custom FlushInterval -- Using the [File Provider](../../providers/file.md)"
+??? example "Using a custom FlushInterval -- Using the [File Provider](../../providers/file.md)"
 
     ```toml tab="TOML"
     ## Dynamic configuration


### PR DESCRIPTION
### What does this PR do?

Add a Response Forwarding section to the service documentation with a File Provider example.

### Motivation

To have a better documentation.

### More

- [ ] ~Added/updated tests~
- [x] Added/updated documentation
