### PR TITLE
Clarifies how to configure and access the dashboard in the api & dashboard documentations

### DIFF
--- a/docs/content/migration/v1-to-v2.md
+++ b/docs/content/migration/v1-to-v2.md
@@ -3,13 +3,13 @@
 How to Migrate from Traefik v1 to Traefik v2.
 {: .subtitle }
 
-The version 2 of Traefik introduces a number of breaking changes,
+The version 2 of Traefik introduces a number of breaking changes, 
 which require one to update their configuration when they migrate from v1 to v2.
-The goal of this page is to recapitulate all of these changes, and in particular to give examples,
+The goal of this page is to recapitulate all of these changes, and in particular to give examples, 
 feature by feature, of how the configuration looked like in v1, and how it now looks like in v2.
 
 !!! info "Migration Helper"
-
+    
     We created a tool to help during the migration: [traefik-migration-tool](https://github.com/containous/traefik-migration-tool)
 
     This tool allows to:
@@ -32,7 +32,7 @@ Then any router can refer to an instance of the wanted middleware.
 !!! example "One frontend with basic auth and one backend, become one router, one service, and one basic auth middleware."
 
     !!! info "v1"
-
+    
     ```yaml tab="Docker"
     labels:
       - "traefik.frontend.rule=Host:test.localhost;PathPrefix:/test"
@@ -68,33 +68,33 @@ Then any router can refer to an instance of the wanted middleware.
       [frontends.frontend1]
         entryPoints = ["http"]
         backend = "backend1"
-
+    
         [frontends.frontend1.routes]
           [frontends.frontend1.routes.route0]
             rule = "Host:test.localhost"
           [frontends.frontend1.routes.route0]
             rule = "PathPrefix:/test"
-
+        
         [frontends.frontend1.auth]
           [frontends.frontend1.auth.basic]
             users = [
               "test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/",
               "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0",
             ]
-
+    
     [backends]
       [backends.backend1]
         [backends.backend1.servers.server0]
           url = "http://10.10.10.1:80"
         [backends.backend1.servers.server1]
           url = "http://10.10.10.2:80"
-
+    
         [backends.backend1.loadBalancer]
           method = "wrr"
     ```
-
+    
     !!! info "v2"
-
+    
     ```yaml tab="Docker"
     labels:
       - "traefik.http.routers.router0.rule=Host(`bar.com`) && PathPrefix(`/test`)"
@@ -103,26 +103,26 @@ Then any router can refer to an instance of the wanted middleware.
     ```
 
     ```yaml tab="K8s IngressRoute"
-    # The definitions below require the definitions for the Middleware and IngressRoute kinds.
+    # The definitions below require the definitions for the Middleware and IngressRoute kinds.  
     # https://docs.traefik.io/v2.0/providers/kubernetes-crd/#traefik-ingressroute-definition
     apiVersion: traefik.containo.us/v1alpha1
     kind: Middleware
     metadata:
       name: basicauth
       namespace: foo
-
+    
     spec:
       basicAuth:
         users:
           - test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/
           - test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0
-
+    
     ---
     apiVersion: traefik.containo.us/v1alpha1
     kind: IngressRoute
     metadata:
       name: ingressroutebar
-
+    
     spec:
       entryPoints:
         - http
@@ -145,17 +145,17 @@ Then any router can refer to an instance of the wanted middleware.
         rule = "Host(`test.localhost`) && PathPrefix(`/test`)"
         middlewares = ["auth"]
         service = "my-service"
-
+    
     [http.services]
       [[http.services.my-service.loadBalancer.servers]]
         url = "http://10.10.10.1:80"
       [[http.services.my-service.loadBalancer.servers]]
         url = "http://10.10.10.2:80"
-
+    
     [http.middlewares]
       [http.middlewares.auth.basicAuth]
         users = [
-          "test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/",
+          "test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/", 
           "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0",
         ]
     ```
@@ -168,14 +168,14 @@ Then any router can refer to an instance of the wanted middleware.
           service: my-service
           middlewares:
             - auth
-
+    
       services:
         my-service:
           loadBalancer:
             servers:
               - url: http://10.10.10.1:80
               - url: http://10.10.10.2:80
-
+    
       middlewares:
         auth:
           basicAuth:
@@ -193,13 +193,13 @@ Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one o
 !!! example "TLS on web-secure entryPoint becomes TLS option on Router-1"
 
     !!! info "v1"
-
+    
     ```toml tab="File (TOML)"
     # static configuration
     [entryPoints]
       [entryPoints.web-secure]
         address = ":443"
-
+    
         [entryPoints.web-secure.tls]
           minVersion = "VersionTLS12"
           cipherSuites = [
@@ -210,13 +210,13 @@ Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one o
             certFile = "path/to/my.cert"
             keyFile = "path/to/my.key"
     ```
-
+    
     ```bash tab="CLI"
     --entryPoints='Name:web-secure Address::443 TLS:path/to/my.cert,path/to/my.key TLS.MinVersion:VersionTLS12 TLS.CipherSuites:TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA384'
     ```
-
+    
     !!! info "v2"
-
+    
     ```toml tab="File (TOML)"
     # dynamic configuration
     [http.routers]
@@ -226,15 +226,15 @@ Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one o
         # will terminate the TLS request
         [http.routers.Router-1.tls]
           options = "myTLSOptions"
-
+    
     [[tls.certificates]]
       certFile = "/path/to/domain.cert"
       keyFile = "/path/to/domain.key"
-
+    
     [tls.options]
       [tls.options.default]
         minVersion = "VersionTLS12"
-
+    
       [tls.options.myTLSOptions]
         minVersion = "VersionTLS13"
         cipherSuites = [
@@ -242,7 +242,7 @@ Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one o
               "TLS_RSA_WITH_AES_256_GCM_SHA384"
             ]
     ```
-
+    
     ```yaml tab="File (YAML)"
     http:
       routers:
@@ -252,7 +252,7 @@ Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one o
           # will terminate the TLS request
           tls:
             options: myTLSOptions
-
+    
     tls:
       certificates:
         - certFile: /path/to/domain.cert
@@ -264,28 +264,28 @@ Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one o
             - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
             - TLS_RSA_WITH_AES_256_GCM_SHA384
     ```
-
+    
     ```yaml tab="K8s IngressRoute"
-    # The definitions below require the definitions for the TLSOption and IngressRoute kinds.
+    # The definitions below require the definitions for the TLSOption and IngressRoute kinds.  
     # https://docs.traefik.io/v2.0/providers/kubernetes-crd/#traefik-ingressroute-definition
     apiVersion: traefik.containo.us/v1alpha1
     kind: TLSOption
     metadata:
       name: mytlsoption
       namespace: default
-
+    
     spec:
       minVersion: VersionTLS13
       cipherSuites:
         - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         - TLS_RSA_WITH_AES_256_GCM_SHA384
-
+    
     ---
     apiVersion: traefik.containo.us/v1alpha1
     kind: IngressRoute
     metadata:
       name: ingressroutebar
-
+    
     spec:
       entryPoints:
         - web
@@ -296,11 +296,11 @@ Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one o
             - name: whoami
               port: 80
       tls:
-        options:
+        options: 
           name: mytlsoption
           namespace: default
     ```
-
+    
     ```yaml tab="Docker"
     labels:
       # myTLSOptions must be defined by another provider, in this instance in the File Provider.
@@ -311,18 +311,18 @@ Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one o
 ## HTTP to HTTPS Redirection is now configured on Routers
 
 Previously on Traefik v1, the redirection was applied on an entry point or on a frontend.
-With Traefik v2 it is applied on a [Router](../routing/routers/index.md).
+With Traefik v2 it is applied on a [Router](../routing/routers/index.md). 
 
 To apply a redirection, one of the redirect middlewares, [RedirectRegex](../middlewares/redirectregex.md) or [RedirectScheme](../middlewares/redirectscheme.md), has to be configured and added to the router middlewares list.
 
 !!! example "HTTP to HTTPS redirection"
 
     !!! info "v1"
-
+    
     ```toml tab="File (TOML)"
     # static configuration
     defaultEntryPoints = ["http", "https"]
-
+    
     [entryPoints]
       [entryPoints.http]
         address = ":80"
@@ -336,14 +336,14 @@ To apply a redirection, one of the redirect middlewares, [RedirectRegex](../midd
             certFile = "examples/traefik.crt"
             keyFile = "examples/traefik.key"
     ```
-
+    
     ```bash tab="CLI"
     --entrypoints=Name:web Address::80 Redirect.EntryPoint:web-secure
     --entryPoints='Name:web-secure Address::443 TLS:path/to/my.cert,path/to/my.key'
     ```
-
+    
     !!! info "v2"
-
+    
     ```yaml tab="Docker"
     labels:
     - traefik.http.routers.web.rule=Host(`foo.com`)
@@ -359,7 +359,7 @@ To apply a redirection, one of the redirect middlewares, [RedirectRegex](../midd
     kind: IngressRoute
     metadata:
       name: http-redirect-ingressRoute
-
+    
     spec:
       entryPoints:
         - web
@@ -371,13 +371,13 @@ To apply a redirection, one of the redirect middlewares, [RedirectRegex](../midd
               port: 80
           middlewares:
             - name: redirect
-
+    
     ---
     apiVersion: traefik.containo.us/v1alpha1
     kind: IngressRoute
     metadata:
       name: https-ingressRoute
-
+    
     spec:
       entryPoints:
         - web-secure
@@ -388,7 +388,7 @@ To apply a redirection, one of the redirect middlewares, [RedirectRegex](../midd
             - name: whoami
               port: 80
       tls: {}
-
+      
     ---
     apiVersion: traefik.containo.us/v1alpha1
     kind: Middleware
@@ -397,68 +397,68 @@ To apply a redirection, one of the redirect middlewares, [RedirectRegex](../midd
     spec:
       redirectScheme:
         scheme: https
-
+      
     ```
 
     ```toml tab="File (TOML)"
     ## static configuration
     # traefik.toml
-
+    
     [entryPoints.web]
       address = ":80"
-
+    
     [entryPoints.web-secure]
       address = ":443"
-
+    
     ##---------------------##
-
+    
     ## dynamic configuration
     # dynamic-conf.toml
-
+    
     [http.routers]
       [http.routers.router0]
         rule = "Host(`foo.com`)"
         service = "my-service"
         entrypoints = ["web"]
         middlewares = ["redirect"]
-
+    
     [http.routers.router1]
         rule = "Host(`foo.com`)"
         service = "my-service"
         entrypoints = ["web-secure"]
         [http.routers.router1.tls]
-
+        
     [http.services]
       [[http.services.my-service.loadBalancer.servers]]
         url = "http://10.10.10.1:80"
       [[http.services.my-service.loadBalancer.servers]]
         url = "http://10.10.10.2:80"
-
+    
     [http.middlewares]
       [http.middlewares.redirect.redirectScheme]
         scheme = "https"
-
+    
     [[tls.certificates]]
       certFile = "/path/to/domain.cert"
-      keyFile = "/path/to/domain.key"
+      keyFile = "/path/to/domain.key"    
     ```
-
+    
     ```yaml tab="File (YAML)"
     ## static configuration
     # traefik.yml
-
+    
     entryPoints:
       web:
         address: ":80"
-
+    
       web-secure:
         address: ":443"
-
+    
     ##---------------------##
-
+    
     ## dynamic configuration
     # dynamic-conf.yml
-
+    
     http:
       routers:
         router0:
@@ -468,31 +468,31 @@ To apply a redirection, one of the redirect middlewares, [RedirectRegex](../midd
           middlewares:
             - redirect
           service: my-service
-
+    
         router1:
           rule: "Host(`foo.com`)"
           entryPoints:
             - web-secure
           service: my-service
           tls: {}
-
+    
       services:
         my-service:
           loadBalancer:
             servers:
               - url: http://10.10.10.1:80
               - url: http://10.10.10.2:80
-
+    
       middlewares:
         redirect:
           redirectScheme:
             scheme: https
-
+    
     tls:
       certificates:
         - certFile: /app/certs/server/server.pem
           keyFile: /app/certs/server/server.pem
-    ```
+    ``` 
 
 ## ACME (LetsEncrypt)
 
@@ -501,11 +501,11 @@ To apply a redirection, one of the redirect middlewares, [RedirectRegex](../midd
 !!! example "ACME from provider to a specific Certificate Resolver"
 
     !!! info "v1"
-
+    
     ```toml tab="File (TOML)"
     # static configuration
     defaultEntryPoints = ["web-secure","web"]
-
+    
     [entryPoints.web]
     address = ":80"
       [entryPoints.web.redirect]
@@ -513,7 +513,7 @@ To apply a redirection, one of the redirect middlewares, [RedirectRegex](../midd
     [entryPoints.web-secure]
       address = ":443"
       [entryPoints.https.tls]
-
+    
     [acme]
       email = "your-email-here@my-awesome-app.org"
       storage = "acme.json"
@@ -522,7 +522,7 @@ To apply a redirection, one of the redirect middlewares, [RedirectRegex](../midd
       [acme.httpChallenge]
         entryPoint = "web"
     ```
-
+    
     ```bash tab="CLI"
     --defaultentrypoints=web-secure,web
     --entryPoints=Name:web Address::80 Redirect.EntryPoint:web-secure
@@ -533,18 +533,18 @@ To apply a redirection, one of the redirect middlewares, [RedirectRegex](../midd
     --acme.onHostRule=true
     --acme.httpchallenge.entrypoint=http
     ```
-
+    
     !!! info "v2"
-
+    
     ```toml tab="File (TOML)"
     # static configuration
     [entryPoints]
       [entryPoints.web]
         address = ":80"
-
+    
       [entryPoints.web-secure]
         address = ":443"
-
+    
     [certificatesResolvers.sample.acme]
       email = "your-email@your-domain.org"
       storage = "acme.json"
@@ -552,15 +552,15 @@ To apply a redirection, one of the redirect middlewares, [RedirectRegex](../midd
         # used during the challenge
         entryPoint = "web"
     ```
-
+    
     ```yaml tab="File (YAML)"
     entryPoints:
       web:
         address: ":80"
-
+    
       web-secure:
         address: ":443"
-
+    
     certificatesResolvers:
       sample:
         acme:
@@ -569,8 +569,8 @@ To apply a redirection, one of the redirect middlewares, [RedirectRegex](../midd
           httpChallenge:
             # used during the challenge
             entryPoint: web
-    ```
-
+    ``` 
+    
     ```bash tab="CLI"
     --entryPoints.web.address=":80"
     --entryPoints.websecure.address=":443"
@@ -587,24 +587,24 @@ There is no more log configuration at the root level.
 !!! example "Simple log configuration"
 
     !!! info "v1"
-
+    
     ```toml tab="File (TOML)"
     # static configuration
     logLevel = "DEBUG"
-
+    
     [traefikLog]
       filePath = "/path/to/traefik.log"
       format   = "json"
     ```
-
+    
     ```bash tab="CLI"
     --logLevel="DEBUG"
     --traefikLog.filePath="/path/to/traefik.log"
     --traefikLog.format="json"
     ```
-
+    
     !!! info "v2"
-
+    
     ```toml tab="File (TOML)"
     # static configuration
     [log]
@@ -612,15 +612,15 @@ There is no more log configuration at the root level.
       filePath = "/path/to/log-file.log"
       format = "json"
     ```
-
+    
     ```yaml tab="File (YAML)"
     # static configuration
     log:
       level: DEBUG
       filePath: /path/to/log-file.log
       format: json
-    ```
-
+    ``` 
+    
     ```bash tab="CLI"
     --log.level="DEBUG"
     --log.filePath="/path/to/traefik.log"
@@ -630,11 +630,11 @@ There is no more log configuration at the root level.
 ## Tracing
 
 Traefik v2 retains OpenTracing support. The `backend` root option from the v1 is gone, you just have to set your [tracing configuration](../observability/tracing/overview.md).
-
+	
 !!! example "Simple Jaeger tracing configuration"
 
     !!! info "v1"
-
+    
     ```toml tab="File (TOML)"
     # static configuration
     [tracing]
@@ -646,18 +646,18 @@ Traefik v2 retains OpenTracing support. The `backend` root option from the v1 is
         samplingType = "const"
         localAgentHostPort = "12.0.0.1:6831"
     ```
-
+    
     ```bash tab="CLI"
     --tracing.backend="jaeger"
     --tracing.servicename="tracing"
     --tracing.jaeger.localagenthostport="12.0.0.1:6831"
     --tracing.jaeger.samplingparam="1.0"
     --tracing.jaeger.samplingserverurl="http://12.0.0.1:5778/sampling"
-    --tracing.jaeger.samplingtype="const"
+    --tracing.jaeger.samplingtype="const" 
     ```
-
+    
     !!! info "v2"
-
+    
     ```toml tab="File (TOML)"
     # static configuration
     [tracing]
@@ -668,7 +668,7 @@ Traefik v2 retains OpenTracing support. The `backend` root option from the v1 is
         samplingType = "const"
         localAgentHostPort = "12.0.0.1:6831"
     ```
-
+    
     ```yaml tab="File (YAML)"
     # static configuration
     tracing:
@@ -678,8 +678,8 @@ Traefik v2 retains OpenTracing support. The `backend` root option from the v1 is
         samplingServerURL: 'http://12.0.0.1:5778/sampling'
         samplingType: const
         localAgentHostPort: '12.0.0.1:6831'
-    ```
-
+    ``` 
+    
     ```bash tab="CLI"
     --tracing.servicename="tracing"
     --tracing.jaeger.localagenthostport="12.0.0.1:6831"
@@ -691,33 +691,33 @@ Traefik v2 retains OpenTracing support. The `backend` root option from the v1 is
 ## Metrics
 
 The v2 retains metrics tools and allows metrics to be configured for the entrypoints and/or services.
-For a basic configuration, the [metrics configuration](../observability/metrics/overview.md) remains the same.
+For a basic configuration, the [metrics configuration](../observability/metrics/overview.md) remains the same.     
 
 !!! example "Simple Prometheus metrics configuration"
 
     !!! info "v1"
-
+    
     ```toml tab="File (TOML)"
     # static configuration
     [metrics.prometheus]
       buckets = [0.1,0.3,1.2,5.0]
       entryPoint = "traefik"
     ```
-
+    
     ```bash tab="CLI"
     --metrics.prometheus.buckets=[0.1,0.3,1.2,5.0]
     --metrics.prometheus.entrypoint="traefik"
     ```
-
+    
     !!! info "v2"
-
+    
     ```toml tab="File (TOML)"
     # static configuration
     [metrics.prometheus]
       buckets = [0.1,0.3,1.2,5.0]
       entryPoint = "metrics"
     ```
-
+    
     ```yaml tab="File (YAML)"
     # static configuration
     metrics:
@@ -728,8 +728,8 @@ For a basic configuration, the [metrics configuration](../observability/metrics/
           - 1.2
           - 5
         entryPoint: metrics
-    ```
-
+    ``` 
+    
     ```bash tab="CLI"
     --metrics.prometheus.buckets=[0.1,0.3,1.2,5.0]
     --metrics.prometheus.entrypoint="metrics"
@@ -741,9 +741,9 @@ To avoid any source of confusion, there are no more configuration at the root le
 Each root item has been moved to a related section or removed.
 
 !!! example "From root to dedicated section"
-
+ 
     !!! info "v1"
-
+ 
     ```toml tab="File (TOML)"
     # static configuration
     checkNewVersion = false
@@ -758,7 +758,7 @@ Each root item has been moved to a related section or removed.
     defaultEntryPoints = ["web", "web-secure"]
     keepTrailingSlash = false
     ```
-
+    
     ```bash tab="CLI"
     --checknewversion=false
     --sendanonymoususage=true
@@ -772,46 +772,46 @@ Each root item has been moved to a related section or removed.
     --defaultentrypoints="web","web-secure"
     --keeptrailingslash=true
     ```
-
+    
     !!! info "v2"
-
+    
     ```toml tab="File (TOML)"
     # static configuration
     [global]
       checkNewVersion = true
       sendAnonymousUsage = true
-
+    
     [log]
       level = "DEBUG"
-
+    
     [serversTransport]
       insecureSkipVerify = true
       rootCAs = [ "/mycert.cert" ]
       maxIdleConnsPerHost = 42
-
+    
     [providers]
-      providersThrottleDuration = 42
+      providersThrottleDuration = 42    
     ```
-
+    
     ```yaml tab="File (YAML)"
     # static configuration
     global:
       checkNewVersion: true
       sendAnonymousUsage: true
-
+    
     log:
       level: DEBUG
-
+    
     serversTransport:
       insecureSkipVerify: true
       rootCAs:
         - /mycert.cert
       maxIdleConnsPerHost: 42
-
+    
     providers:
       providersThrottleDuration: 42
-    ```
-
+    ``` 
+    
     ```bash tab="CLI"
     --global.checknewversion=true
     --global.sendanonymoususage=true
@@ -821,10 +821,10 @@ Each root item has been moved to a related section or removed.
     --serverstransport.maxidleconnsperhost=42
     --providers.providersthrottleduration=42
     ```
-
+    
 ## Dashboard
 
-You need to activate the API to access the [dashboard](../operations/dashboard.md).
+You need to activate the [API](../operations/dashboard.md#enabling-the-dashboard) to access the dashboard.
 As the dashboard access is now secured by default you can either:
 
 * define a  [specific router](../operations/api.md#configuration) with the `api@internal` service and one authentication middleware like the following example
@@ -833,15 +833,15 @@ As the dashboard access is now secured by default you can either:
 !!! info "Dashboard with k8s and dedicated router"
 
     As `api@internal` is not a Kubernetes service, you have to use the file provider or the `insecure` API option.
-
+    
 !!! example "Activate and access the dashboard"
 
     !!! info "v1"
-
+    
     ```toml tab="File (TOML)"
     ## static configuration
     # traefik.toml
-
+    
     [entryPoints.web-secure]
       address = ":443"
       [entryPoints.web-secure.tls]
@@ -850,18 +850,18 @@ As the dashboard access is now secured by default you can either:
           users = [
             "test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/"
           ]
-
+    
     [api]
       entryPoint = "web-secure"
     ```
-
+    
     ```bash tab="CLI"
     --entryPoints='Name:web-secure Address::443 TLS Auth.Basic.Users:test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/'
     --api
     ```
-
+    
     !!! info "v2"
-
+    
     ```yaml tab="Docker"
     # dynamic configuration
     labels:
@@ -876,52 +876,52 @@ As the dashboard access is now secured by default you can either:
     ```toml tab="File (TOML)"
     ## static configuration
     # traefik.toml
-
+    
     [entryPoints.web-secure]
       address = ":443"
-
+    
     [api]
-
+    
     [providers.file]
         filename = "/dynamic-conf.toml"
-
+    
     ##---------------------##
-
+    
     ## dynamic configuration
     # dynamic-conf.toml
-
+    
     [http.routers.api]
       rule = "Host(`traefik.docker.localhost`)"
       entrypoints = ["web-secure"]
       service = "api@internal"
       middlewares = ["myAuth"]
       [http.routers.api.tls]
-
+    
     [http.middlewares.myAuth.basicAuth]
       users = [
         "test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/"
       ]
     ```
-
+    
     ```yaml tab="File (YAML)"
     ## static configuration
     # traefik.yaml
-
+    
     entryPoints:
       web-secure:
         address: ':443'
-
+        
     api: {}
-
+    
     providers:
       file:
         filename: /dynamic-conf.yaml
-
+   
     ##---------------------##
-
+    
     ## dynamic configuration
     # dynamic-conf.yaml
-
+    
      http:
       routers:
         api:
@@ -932,14 +932,14 @@ As the dashboard access is now secured by default you can either:
           middlewares:
             - myAuth
           tls: {}
-
+          
       middlewares:
         myAuth:
           basicAuth:
             users:
               - 'test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/'
-    ```
-
+    ``` 
+    
 ## Providers
 
 Supported [providers](../providers/overview.md), for now:

--- a/docs/content/migration/v1-to-v2.md
+++ b/docs/content/migration/v1-to-v2.md
@@ -3,13 +3,13 @@
 How to Migrate from Traefik v1 to Traefik v2.
 {: .subtitle }
 
-The version 2 of Traefik introduces a number of breaking changes, 
+The version 2 of Traefik introduces a number of breaking changes,
 which require one to update their configuration when they migrate from v1 to v2.
-The goal of this page is to recapitulate all of these changes, and in particular to give examples, 
+The goal of this page is to recapitulate all of these changes, and in particular to give examples,
 feature by feature, of how the configuration looked like in v1, and how it now looks like in v2.
 
 !!! info "Migration Helper"
-    
+
     We created a tool to help during the migration: [traefik-migration-tool](https://github.com/containous/traefik-migration-tool)
 
     This tool allows to:
@@ -32,7 +32,7 @@ Then any router can refer to an instance of the wanted middleware.
 !!! example "One frontend with basic auth and one backend, become one router, one service, and one basic auth middleware."
 
     !!! info "v1"
-    
+
     ```yaml tab="Docker"
     labels:
       - "traefik.frontend.rule=Host:test.localhost;PathPrefix:/test"
@@ -68,33 +68,33 @@ Then any router can refer to an instance of the wanted middleware.
       [frontends.frontend1]
         entryPoints = ["http"]
         backend = "backend1"
-    
+
         [frontends.frontend1.routes]
           [frontends.frontend1.routes.route0]
             rule = "Host:test.localhost"
           [frontends.frontend1.routes.route0]
             rule = "PathPrefix:/test"
-        
+
         [frontends.frontend1.auth]
           [frontends.frontend1.auth.basic]
             users = [
               "test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/",
               "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0",
             ]
-    
+
     [backends]
       [backends.backend1]
         [backends.backend1.servers.server0]
           url = "http://10.10.10.1:80"
         [backends.backend1.servers.server1]
           url = "http://10.10.10.2:80"
-    
+
         [backends.backend1.loadBalancer]
           method = "wrr"
     ```
-    
+
     !!! info "v2"
-    
+
     ```yaml tab="Docker"
     labels:
       - "traefik.http.routers.router0.rule=Host(`bar.com`) && PathPrefix(`/test`)"
@@ -103,26 +103,26 @@ Then any router can refer to an instance of the wanted middleware.
     ```
 
     ```yaml tab="K8s IngressRoute"
-    # The definitions below require the definitions for the Middleware and IngressRoute kinds.  
+    # The definitions below require the definitions for the Middleware and IngressRoute kinds.
     # https://docs.traefik.io/v2.0/providers/kubernetes-crd/#traefik-ingressroute-definition
     apiVersion: traefik.containo.us/v1alpha1
     kind: Middleware
     metadata:
       name: basicauth
       namespace: foo
-    
+
     spec:
       basicAuth:
         users:
           - test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/
           - test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0
-    
+
     ---
     apiVersion: traefik.containo.us/v1alpha1
     kind: IngressRoute
     metadata:
       name: ingressroutebar
-    
+
     spec:
       entryPoints:
         - http
@@ -145,17 +145,17 @@ Then any router can refer to an instance of the wanted middleware.
         rule = "Host(`test.localhost`) && PathPrefix(`/test`)"
         middlewares = ["auth"]
         service = "my-service"
-    
+
     [http.services]
       [[http.services.my-service.loadBalancer.servers]]
         url = "http://10.10.10.1:80"
       [[http.services.my-service.loadBalancer.servers]]
         url = "http://10.10.10.2:80"
-    
+
     [http.middlewares]
       [http.middlewares.auth.basicAuth]
         users = [
-          "test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/", 
+          "test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/",
           "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0",
         ]
     ```
@@ -168,14 +168,14 @@ Then any router can refer to an instance of the wanted middleware.
           service: my-service
           middlewares:
             - auth
-    
+
       services:
         my-service:
           loadBalancer:
             servers:
               - url: http://10.10.10.1:80
               - url: http://10.10.10.2:80
-    
+
       middlewares:
         auth:
           basicAuth:
@@ -193,13 +193,13 @@ Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one o
 !!! example "TLS on web-secure entryPoint becomes TLS option on Router-1"
 
     !!! info "v1"
-    
+
     ```toml tab="File (TOML)"
     # static configuration
     [entryPoints]
       [entryPoints.web-secure]
         address = ":443"
-    
+
         [entryPoints.web-secure.tls]
           minVersion = "VersionTLS12"
           cipherSuites = [
@@ -210,13 +210,13 @@ Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one o
             certFile = "path/to/my.cert"
             keyFile = "path/to/my.key"
     ```
-    
+
     ```bash tab="CLI"
     --entryPoints='Name:web-secure Address::443 TLS:path/to/my.cert,path/to/my.key TLS.MinVersion:VersionTLS12 TLS.CipherSuites:TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA384'
     ```
-    
+
     !!! info "v2"
-    
+
     ```toml tab="File (TOML)"
     # dynamic configuration
     [http.routers]
@@ -226,15 +226,15 @@ Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one o
         # will terminate the TLS request
         [http.routers.Router-1.tls]
           options = "myTLSOptions"
-    
+
     [[tls.certificates]]
       certFile = "/path/to/domain.cert"
       keyFile = "/path/to/domain.key"
-    
+
     [tls.options]
       [tls.options.default]
         minVersion = "VersionTLS12"
-    
+
       [tls.options.myTLSOptions]
         minVersion = "VersionTLS13"
         cipherSuites = [
@@ -242,7 +242,7 @@ Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one o
               "TLS_RSA_WITH_AES_256_GCM_SHA384"
             ]
     ```
-    
+
     ```yaml tab="File (YAML)"
     http:
       routers:
@@ -252,7 +252,7 @@ Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one o
           # will terminate the TLS request
           tls:
             options: myTLSOptions
-    
+
     tls:
       certificates:
         - certFile: /path/to/domain.cert
@@ -264,28 +264,28 @@ Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one o
             - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
             - TLS_RSA_WITH_AES_256_GCM_SHA384
     ```
-    
+
     ```yaml tab="K8s IngressRoute"
-    # The definitions below require the definitions for the TLSOption and IngressRoute kinds.  
+    # The definitions below require the definitions for the TLSOption and IngressRoute kinds.
     # https://docs.traefik.io/v2.0/providers/kubernetes-crd/#traefik-ingressroute-definition
     apiVersion: traefik.containo.us/v1alpha1
     kind: TLSOption
     metadata:
       name: mytlsoption
       namespace: default
-    
+
     spec:
       minVersion: VersionTLS13
       cipherSuites:
         - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         - TLS_RSA_WITH_AES_256_GCM_SHA384
-    
+
     ---
     apiVersion: traefik.containo.us/v1alpha1
     kind: IngressRoute
     metadata:
       name: ingressroutebar
-    
+
     spec:
       entryPoints:
         - web
@@ -296,11 +296,11 @@ Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one o
             - name: whoami
               port: 80
       tls:
-        options: 
+        options:
           name: mytlsoption
           namespace: default
     ```
-    
+
     ```yaml tab="Docker"
     labels:
       # myTLSOptions must be defined by another provider, in this instance in the File Provider.
@@ -311,18 +311,18 @@ Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one o
 ## HTTP to HTTPS Redirection is now configured on Routers
 
 Previously on Traefik v1, the redirection was applied on an entry point or on a frontend.
-With Traefik v2 it is applied on a [Router](../routing/routers/index.md). 
+With Traefik v2 it is applied on a [Router](../routing/routers/index.md).
 
 To apply a redirection, one of the redirect middlewares, [RedirectRegex](../middlewares/redirectregex.md) or [RedirectScheme](../middlewares/redirectscheme.md), has to be configured and added to the router middlewares list.
 
 !!! example "HTTP to HTTPS redirection"
 
     !!! info "v1"
-    
+
     ```toml tab="File (TOML)"
     # static configuration
     defaultEntryPoints = ["http", "https"]
-    
+
     [entryPoints]
       [entryPoints.http]
         address = ":80"
@@ -336,14 +336,14 @@ To apply a redirection, one of the redirect middlewares, [RedirectRegex](../midd
             certFile = "examples/traefik.crt"
             keyFile = "examples/traefik.key"
     ```
-    
+
     ```bash tab="CLI"
     --entrypoints=Name:web Address::80 Redirect.EntryPoint:web-secure
     --entryPoints='Name:web-secure Address::443 TLS:path/to/my.cert,path/to/my.key'
     ```
-    
+
     !!! info "v2"
-    
+
     ```yaml tab="Docker"
     labels:
     - traefik.http.routers.web.rule=Host(`foo.com`)
@@ -359,7 +359,7 @@ To apply a redirection, one of the redirect middlewares, [RedirectRegex](../midd
     kind: IngressRoute
     metadata:
       name: http-redirect-ingressRoute
-    
+
     spec:
       entryPoints:
         - web
@@ -371,13 +371,13 @@ To apply a redirection, one of the redirect middlewares, [RedirectRegex](../midd
               port: 80
           middlewares:
             - name: redirect
-    
+
     ---
     apiVersion: traefik.containo.us/v1alpha1
     kind: IngressRoute
     metadata:
       name: https-ingressRoute
-    
+
     spec:
       entryPoints:
         - web-secure
@@ -388,7 +388,7 @@ To apply a redirection, one of the redirect middlewares, [RedirectRegex](../midd
             - name: whoami
               port: 80
       tls: {}
-      
+
     ---
     apiVersion: traefik.containo.us/v1alpha1
     kind: Middleware
@@ -397,68 +397,68 @@ To apply a redirection, one of the redirect middlewares, [RedirectRegex](../midd
     spec:
       redirectScheme:
         scheme: https
-      
+
     ```
 
     ```toml tab="File (TOML)"
     ## static configuration
     # traefik.toml
-    
+
     [entryPoints.web]
       address = ":80"
-    
+
     [entryPoints.web-secure]
       address = ":443"
-    
+
     ##---------------------##
-    
+
     ## dynamic configuration
     # dynamic-conf.toml
-    
+
     [http.routers]
       [http.routers.router0]
         rule = "Host(`foo.com`)"
         service = "my-service"
         entrypoints = ["web"]
         middlewares = ["redirect"]
-    
+
     [http.routers.router1]
         rule = "Host(`foo.com`)"
         service = "my-service"
         entrypoints = ["web-secure"]
         [http.routers.router1.tls]
-        
+
     [http.services]
       [[http.services.my-service.loadBalancer.servers]]
         url = "http://10.10.10.1:80"
       [[http.services.my-service.loadBalancer.servers]]
         url = "http://10.10.10.2:80"
-    
+
     [http.middlewares]
       [http.middlewares.redirect.redirectScheme]
         scheme = "https"
-    
+
     [[tls.certificates]]
       certFile = "/path/to/domain.cert"
-      keyFile = "/path/to/domain.key"    
+      keyFile = "/path/to/domain.key"
     ```
-    
+
     ```yaml tab="File (YAML)"
     ## static configuration
     # traefik.yml
-    
+
     entryPoints:
       web:
         address: ":80"
-    
+
       web-secure:
         address: ":443"
-    
+
     ##---------------------##
-    
+
     ## dynamic configuration
     # dynamic-conf.yml
-    
+
     http:
       routers:
         router0:
@@ -468,31 +468,31 @@ To apply a redirection, one of the redirect middlewares, [RedirectRegex](../midd
           middlewares:
             - redirect
           service: my-service
-    
+
         router1:
           rule: "Host(`foo.com`)"
           entryPoints:
             - web-secure
           service: my-service
           tls: {}
-    
+
       services:
         my-service:
           loadBalancer:
             servers:
               - url: http://10.10.10.1:80
               - url: http://10.10.10.2:80
-    
+
       middlewares:
         redirect:
           redirectScheme:
             scheme: https
-    
+
     tls:
       certificates:
         - certFile: /app/certs/server/server.pem
           keyFile: /app/certs/server/server.pem
-    ``` 
+    ```
 
 ## ACME (LetsEncrypt)
 
@@ -501,11 +501,11 @@ To apply a redirection, one of the redirect middlewares, [RedirectRegex](../midd
 !!! example "ACME from provider to a specific Certificate Resolver"
 
     !!! info "v1"
-    
+
     ```toml tab="File (TOML)"
     # static configuration
     defaultEntryPoints = ["web-secure","web"]
-    
+
     [entryPoints.web]
     address = ":80"
       [entryPoints.web.redirect]
@@ -513,7 +513,7 @@ To apply a redirection, one of the redirect middlewares, [RedirectRegex](../midd
     [entryPoints.web-secure]
       address = ":443"
       [entryPoints.https.tls]
-    
+
     [acme]
       email = "your-email-here@my-awesome-app.org"
       storage = "acme.json"
@@ -522,7 +522,7 @@ To apply a redirection, one of the redirect middlewares, [RedirectRegex](../midd
       [acme.httpChallenge]
         entryPoint = "web"
     ```
-    
+
     ```bash tab="CLI"
     --defaultentrypoints=web-secure,web
     --entryPoints=Name:web Address::80 Redirect.EntryPoint:web-secure
@@ -533,18 +533,18 @@ To apply a redirection, one of the redirect middlewares, [RedirectRegex](../midd
     --acme.onHostRule=true
     --acme.httpchallenge.entrypoint=http
     ```
-    
+
     !!! info "v2"
-    
+
     ```toml tab="File (TOML)"
     # static configuration
     [entryPoints]
       [entryPoints.web]
         address = ":80"
-    
+
       [entryPoints.web-secure]
         address = ":443"
-    
+
     [certificatesResolvers.sample.acme]
       email = "your-email@your-domain.org"
       storage = "acme.json"
@@ -552,15 +552,15 @@ To apply a redirection, one of the redirect middlewares, [RedirectRegex](../midd
         # used during the challenge
         entryPoint = "web"
     ```
-    
+
     ```yaml tab="File (YAML)"
     entryPoints:
       web:
         address: ":80"
-    
+
       web-secure:
         address: ":443"
-    
+
     certificatesResolvers:
       sample:
         acme:
@@ -569,8 +569,8 @@ To apply a redirection, one of the redirect middlewares, [RedirectRegex](../midd
           httpChallenge:
             # used during the challenge
             entryPoint: web
-    ``` 
-    
+    ```
+
     ```bash tab="CLI"
     --entryPoints.web.address=":80"
     --entryPoints.websecure.address=":443"
@@ -587,24 +587,24 @@ There is no more log configuration at the root level.
 !!! example "Simple log configuration"
 
     !!! info "v1"
-    
+
     ```toml tab="File (TOML)"
     # static configuration
     logLevel = "DEBUG"
-    
+
     [traefikLog]
       filePath = "/path/to/traefik.log"
       format   = "json"
     ```
-    
+
     ```bash tab="CLI"
     --logLevel="DEBUG"
     --traefikLog.filePath="/path/to/traefik.log"
     --traefikLog.format="json"
     ```
-    
+
     !!! info "v2"
-    
+
     ```toml tab="File (TOML)"
     # static configuration
     [log]
@@ -612,15 +612,15 @@ There is no more log configuration at the root level.
       filePath = "/path/to/log-file.log"
       format = "json"
     ```
-    
+
     ```yaml tab="File (YAML)"
     # static configuration
     log:
       level: DEBUG
       filePath: /path/to/log-file.log
       format: json
-    ``` 
-    
+    ```
+
     ```bash tab="CLI"
     --log.level="DEBUG"
     --log.filePath="/path/to/traefik.log"
@@ -630,11 +630,11 @@ There is no more log configuration at the root level.
 ## Tracing
 
 Traefik v2 retains OpenTracing support. The `backend` root option from the v1 is gone, you just have to set your [tracing configuration](../observability/tracing/overview.md).
-	
+
 !!! example "Simple Jaeger tracing configuration"
 
     !!! info "v1"
-    
+
     ```toml tab="File (TOML)"
     # static configuration
     [tracing]
@@ -646,18 +646,18 @@ Traefik v2 retains OpenTracing support. The `backend` root option from the v1 is
         samplingType = "const"
         localAgentHostPort = "12.0.0.1:6831"
     ```
-    
+
     ```bash tab="CLI"
     --tracing.backend="jaeger"
     --tracing.servicename="tracing"
     --tracing.jaeger.localagenthostport="12.0.0.1:6831"
     --tracing.jaeger.samplingparam="1.0"
     --tracing.jaeger.samplingserverurl="http://12.0.0.1:5778/sampling"
-    --tracing.jaeger.samplingtype="const" 
+    --tracing.jaeger.samplingtype="const"
     ```
-    
+
     !!! info "v2"
-    
+
     ```toml tab="File (TOML)"
     # static configuration
     [tracing]
@@ -668,7 +668,7 @@ Traefik v2 retains OpenTracing support. The `backend` root option from the v1 is
         samplingType = "const"
         localAgentHostPort = "12.0.0.1:6831"
     ```
-    
+
     ```yaml tab="File (YAML)"
     # static configuration
     tracing:
@@ -678,8 +678,8 @@ Traefik v2 retains OpenTracing support. The `backend` root option from the v1 is
         samplingServerURL: 'http://12.0.0.1:5778/sampling'
         samplingType: const
         localAgentHostPort: '12.0.0.1:6831'
-    ``` 
-    
+    ```
+
     ```bash tab="CLI"
     --tracing.servicename="tracing"
     --tracing.jaeger.localagenthostport="12.0.0.1:6831"
@@ -691,33 +691,33 @@ Traefik v2 retains OpenTracing support. The `backend` root option from the v1 is
 ## Metrics
 
 The v2 retains metrics tools and allows metrics to be configured for the entrypoints and/or services.
-For a basic configuration, the [metrics configuration](../observability/metrics/overview.md) remains the same.     
+For a basic configuration, the [metrics configuration](../observability/metrics/overview.md) remains the same.
 
 !!! example "Simple Prometheus metrics configuration"
 
     !!! info "v1"
-    
+
     ```toml tab="File (TOML)"
     # static configuration
     [metrics.prometheus]
       buckets = [0.1,0.3,1.2,5.0]
       entryPoint = "traefik"
     ```
-    
+
     ```bash tab="CLI"
     --metrics.prometheus.buckets=[0.1,0.3,1.2,5.0]
     --metrics.prometheus.entrypoint="traefik"
     ```
-    
+
     !!! info "v2"
-    
+
     ```toml tab="File (TOML)"
     # static configuration
     [metrics.prometheus]
       buckets = [0.1,0.3,1.2,5.0]
       entryPoint = "metrics"
     ```
-    
+
     ```yaml tab="File (YAML)"
     # static configuration
     metrics:
@@ -728,8 +728,8 @@ For a basic configuration, the [metrics configuration](../observability/metrics/
           - 1.2
           - 5
         entryPoint: metrics
-    ``` 
-    
+    ```
+
     ```bash tab="CLI"
     --metrics.prometheus.buckets=[0.1,0.3,1.2,5.0]
     --metrics.prometheus.entrypoint="metrics"
@@ -741,9 +741,9 @@ To avoid any source of confusion, there are no more configuration at the root le
 Each root item has been moved to a related section or removed.
 
 !!! example "From root to dedicated section"
- 
+
     !!! info "v1"
- 
+
     ```toml tab="File (TOML)"
     # static configuration
     checkNewVersion = false
@@ -758,7 +758,7 @@ Each root item has been moved to a related section or removed.
     defaultEntryPoints = ["web", "web-secure"]
     keepTrailingSlash = false
     ```
-    
+
     ```bash tab="CLI"
     --checknewversion=false
     --sendanonymoususage=true
@@ -772,46 +772,46 @@ Each root item has been moved to a related section or removed.
     --defaultentrypoints="web","web-secure"
     --keeptrailingslash=true
     ```
-    
+
     !!! info "v2"
-    
+
     ```toml tab="File (TOML)"
     # static configuration
     [global]
       checkNewVersion = true
       sendAnonymousUsage = true
-    
+
     [log]
       level = "DEBUG"
-    
+
     [serversTransport]
       insecureSkipVerify = true
       rootCAs = [ "/mycert.cert" ]
       maxIdleConnsPerHost = 42
-    
+
     [providers]
-      providersThrottleDuration = 42    
+      providersThrottleDuration = 42
     ```
-    
+
     ```yaml tab="File (YAML)"
     # static configuration
     global:
       checkNewVersion: true
       sendAnonymousUsage: true
-    
+
     log:
       level: DEBUG
-    
+
     serversTransport:
       insecureSkipVerify: true
       rootCAs:
         - /mycert.cert
       maxIdleConnsPerHost: 42
-    
+
     providers:
       providersThrottleDuration: 42
-    ``` 
-    
+    ```
+
     ```bash tab="CLI"
     --global.checknewversion=true
     --global.sendanonymoususage=true
@@ -821,10 +821,10 @@ Each root item has been moved to a related section or removed.
     --serverstransport.maxidleconnsperhost=42
     --providers.providersthrottleduration=42
     ```
-    
+
 ## Dashboard
 
-You need to activate the [API](../operations/dashboard.md#enabling-the-dashboard) to access the dashboard.
+You need to activate the API to access the [dashboard](../operations/dashboard.md).
 As the dashboard access is now secured by default you can either:
 
 * define a  [specific router](../operations/api.md#configuration) with the `api@internal` service and one authentication middleware like the following example
@@ -833,15 +833,15 @@ As the dashboard access is now secured by default you can either:
 !!! info "Dashboard with k8s and dedicated router"
 
     As `api@internal` is not a Kubernetes service, you have to use the file provider or the `insecure` API option.
-    
+
 !!! example "Activate and access the dashboard"
 
     !!! info "v1"
-    
+
     ```toml tab="File (TOML)"
     ## static configuration
     # traefik.toml
-    
+
     [entryPoints.web-secure]
       address = ":443"
       [entryPoints.web-secure.tls]
@@ -850,18 +850,18 @@ As the dashboard access is now secured by default you can either:
           users = [
             "test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/"
           ]
-    
+
     [api]
       entryPoint = "web-secure"
     ```
-    
+
     ```bash tab="CLI"
     --entryPoints='Name:web-secure Address::443 TLS Auth.Basic.Users:test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/'
     --api
     ```
-    
+
     !!! info "v2"
-    
+
     ```yaml tab="Docker"
     # dynamic configuration
     labels:
@@ -876,52 +876,52 @@ As the dashboard access is now secured by default you can either:
     ```toml tab="File (TOML)"
     ## static configuration
     # traefik.toml
-    
+
     [entryPoints.web-secure]
       address = ":443"
-    
+
     [api]
-    
+
     [providers.file]
         filename = "/dynamic-conf.toml"
-    
+
     ##---------------------##
-    
+
     ## dynamic configuration
     # dynamic-conf.toml
-    
+
     [http.routers.api]
       rule = "Host(`traefik.docker.localhost`)"
       entrypoints = ["web-secure"]
       service = "api@internal"
       middlewares = ["myAuth"]
       [http.routers.api.tls]
-    
+
     [http.middlewares.myAuth.basicAuth]
       users = [
         "test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/"
       ]
     ```
-    
+
     ```yaml tab="File (YAML)"
     ## static configuration
     # traefik.yaml
-    
+
     entryPoints:
       web-secure:
         address: ':443'
-        
+
     api: {}
-    
+
     providers:
       file:
         filename: /dynamic-conf.yaml
-   
+
     ##---------------------##
-    
+
     ## dynamic configuration
     # dynamic-conf.yaml
-    
+
      http:
       routers:
         api:
@@ -932,14 +932,14 @@ As the dashboard access is now secured by default you can either:
           middlewares:
             - myAuth
           tls: {}
-          
+
       middlewares:
         myAuth:
           basicAuth:
             users:
               - 'test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/'
-    ``` 
-    
+    ```
+
 ## Providers
 
 Supported [providers](../providers/overview.md), for now:

--- a/docs/content/migration/v1-to-v2.md
+++ b/docs/content/migration/v1-to-v2.md
@@ -824,7 +824,7 @@ Each root item has been moved to a related section or removed.
     
 ## Dashboard
 
-You need to activate the [API](../operations/dashboard.md#enabling-the-dashboard) to access the dashboard.
+You need to activate the API to access the [dashboard](../operations/dashboard.md).
 As the dashboard access is now secured by default you can either:
 
 * define a  [specific router](../operations/api.md#configuration) with the `api@internal` service and one authentication middleware like the following example

--- a/docs/content/operations/dashboard.md
+++ b/docs/content/operations/dashboard.md
@@ -3,21 +3,36 @@
 See What's Going On
 {: .subtitle }
 
-The dashboard is the central place that shows you the current active routes handled by Traefik. 
+The dashboard is the central place that shows you the current active routes handled by Traefik.
 
 <figure>
     <img src="../../assets/img/webui-dashboard.png" alt="Dashboard - Providers" />
     <figcaption>The dashboard in action</figcaption>
 </figure>
 
-By default, the dashboard is available on `/dashboard` on port `:8080`.
-There is also a redirect of `/` to `/dashboard`, but one should not rely on that property as it is bound to change,
-and it might make for confusing routing rules anyway.
+The dashboard is available at the same location as the [API](./api.md) but on the path `/dashboard/` by default.
 
-!!! info "Did You Know?"
-    It is possible to customize the dashboard endpoint. 
+!!! warning "The trailing slash `/` in `/dashboard/` is mandatory"
+
+There are 2 ways to configure and access the dashboard:
+
+- Insecure mode: by using the [insecure mode of the API](./api.md#insecure),
+  then you can use the port `:8080` of Traefik and reach the dashboard at the URL `http://<Traefik IP>:8080/dashboard/`.
+
+!!! tip "Changing the default port `8080` for insecured mode"
+    By default, the insecure mode uses the default entrypoint named
+    It is possible to customize the dashboard endpoint.
     To learn how, refer to the [API documentation](./api.md)
-    
+
+- Secured mode: by defining a router for Traefik's dashboard, associated to the service `api@internal`,
+  then you can access the router through Traefik itself with your own routing rule.
+  Read more on this on the section ["API/Dashboard Security"](#apidashboard-security).
+
+!!! note ""
+    There is also a redirect of the path `/` to the path `/dashboard/`,
+    but one should not rely on that property as it is bound to change,
+    and it might make for confusing routing rules anyway.
+
 ## Enabling the Dashboard
 
 To enable the dashboard, you need to enable [Traefik's API](./api.md).
@@ -51,12 +66,12 @@ api:
 --api.dashboard=true
 ```
 
-!!! important "API/Dashboard Security" 
-    
-    To secure your dashboard, the use of a `service` named `api@internal` is mandatory and requires the definition of a router using one or more security [middlewares](../middlewares/overview.md)
-    like authentication ([basicAuth](../middlewares/basicauth.md) , [digestAuth](../middlewares/digestauth.md), [forwardAuth](../middlewares/forwardauth.md)) or [whitelisting](../middlewares/ipwhitelist.md).  
-    More information about `api@internal` can be found in the [API documentation](./api.md#configuration)
+## API/Dashboard Security
+
+To secure your dashboard, the use of a `service` named `api@internal` is mandatory and requires the definition of a router using one or more security [middlewares](../middlewares/overview.md)
+like authentication ([basicAuth](../middlewares/basicauth.md) , [digestAuth](../middlewares/digestauth.md), [forwardAuth](../middlewares/forwardauth.md)) or [whitelisting](../middlewares/ipwhitelist.md).
+More information about `api@internal` can be found in the [API documentation](./api.md#configuration)
 
 !!! info "Did You Know?"
-    The API provides more features than the Dashboard. 
+    The API provides more features than the Dashboard.
     To learn more about it, refer to the [API documentation](./api.md)

--- a/docs/content/operations/dashboard.md
+++ b/docs/content/operations/dashboard.md
@@ -16,15 +16,15 @@ The dashboard is available at the same location as the [API](./api.md) but on th
 
 There are 2 ways to configure and access the dashboard:
 
-- [Secured mode (Recommended)](#secured-mode)
-- [Insecured mode](#insecured-mode)
+- [Secure mode (Recommended)](#secure-mode)
+- [Insecure mode](#insecure-mode)
 
 !!! note ""
     There is also a redirect of the path `/` to the path `/dashboard/`,
     but one should not rely on that property as it is bound to change,
     and it might make for confusing routing rules anyway.
 
-## Secured Mode
+## Secure Mode
 
 This is the **recommended** method.
 
@@ -59,7 +59,7 @@ api:
 --api.dashboard=true
 ```
 
-Then specifies a router associated to the service `api@internal` to allow:
+Then specify a router associated to the service `api@internal` to allow:
 
 - Defining one or more security features through [middlewares](../middlewares/overview.md)
   like authentication ([basicAuth](../middlewares/basicauth.md) , [digestAuth](../middlewares/digestauth.md),
@@ -71,9 +71,9 @@ Then specifies a router associated to the service `api@internal` to allow:
 Please visit the ["Configuration" section of the API documentation](./api.md#configuration)
 to learn about configuring a router with the service `api@internal` and enabling the security features.
 
-## Insecured Mode
+## Insecure Mode
 
-This mode is not recommend because it does not allow usage of security features.
+This mode is not recommended because it does not allow the use of security features.
 
 To enable the "insecure mode", use the following options from [Traefik's API](./api.md#insecure):
 
@@ -93,5 +93,5 @@ api:
 --api.dashboard=true --api.insecure=true
 ```
 
-You can know access the dashboard on the port `8080` of the Traefik instance,
-ath the following URL: `http://<Traefik IP>:8080/dashboard/` (trailing slash is mandatory).
+You can now access the dashboard on the port `8080` of the Traefik instance,
+at the following URL: `http://<Traefik IP>:8080/dashboard/` (trailing slash is mandatory).

--- a/docs/content/operations/dashboard.md
+++ b/docs/content/operations/dashboard.md
@@ -16,26 +16,19 @@ The dashboard is available at the same location as the [API](./api.md) but on th
 
 There are 2 ways to configure and access the dashboard:
 
-- Insecure mode: by using the [insecure mode of the API](./api.md#insecure),
-  then you can use the port `:8080` of Traefik and reach the dashboard at the URL `http://<Traefik IP>:8080/dashboard/`.
-
-!!! tip "Changing the default port `8080` for insecured mode"
-    By default, the insecure mode uses the default entrypoint named
-    It is possible to customize the dashboard endpoint.
-    To learn how, refer to the [API documentation](./api.md)
-
-- Secured mode: by defining a router for Traefik's dashboard, associated to the service `api@internal`,
-  then you can access the router through Traefik itself with your own routing rule.
-  Read more on this on the section ["API/Dashboard Security"](#apidashboard-security).
+- [Secured mode (Recommended)](#secured-mode)
+- [Insecured mode](#insecured-mode)
 
 !!! note ""
     There is also a redirect of the path `/` to the path `/dashboard/`,
     but one should not rely on that property as it is bound to change,
     and it might make for confusing routing rules anyway.
 
-## Enabling the Dashboard
+## Secured Mode
 
-To enable the dashboard, you need to enable [Traefik's API](./api.md).
+This is the **recommended** method.
+
+Start by enabling the dashboard by using the following option from [Traefik's API](./api.md):
 
 ```toml tab="File (TOML)"
 [api]
@@ -66,12 +59,39 @@ api:
 --api.dashboard=true
 ```
 
-## API/Dashboard Security
+Then specifies a router associated to the service `api@internal` to allow:
 
-To secure your dashboard, the use of a `service` named `api@internal` is mandatory and requires the definition of a router using one or more security [middlewares](../middlewares/overview.md)
-like authentication ([basicAuth](../middlewares/basicauth.md) , [digestAuth](../middlewares/digestauth.md), [forwardAuth](../middlewares/forwardauth.md)) or [whitelisting](../middlewares/ipwhitelist.md).
-More information about `api@internal` can be found in the [API documentation](./api.md#configuration)
+- Defining one or more security features through [middlewares](../middlewares/overview.md)
+  like authentication ([basicAuth](../middlewares/basicauth.md) , [digestAuth](../middlewares/digestauth.md),
+  [forwardAuth](../middlewares/forwardauth.md)) or [whitelisting](../middlewares/ipwhitelist.md).
 
-!!! info "Did You Know?"
-    The API provides more features than the Dashboard.
-    To learn more about it, refer to the [API documentation](./api.md)
+- Defining your own [HTTP routing rule](../../routing/routers/#rule) for accessing the dashboard,
+  through Traefik itself (sometimes referred as "Traefik-ception").
+
+Please visit the ["Configuration" section of the API documentation](./api.md#configuration)
+to learn about configuring a router with the service `api@internal` and enabling the security features.
+
+## Insecured Mode
+
+This mode is not recommend because it does not allow usage of security features.
+
+To enable the "insecure mode", use the following options from [Traefik's API](./api.md#insecure):
+
+```toml tab="File (TOML)"
+[api]
+  dashboard = true
+  insecure = true
+```
+
+```yaml tab="File (YAML)"
+api:
+  dashboard: true
+  insecure: true
+```
+
+```bash tab="CLI"
+--api.dashboard=true --api.insecure=true
+```
+
+You can know access the dashboard on the port `8080` of the Traefik instance,
+ath the following URL: `http://<Traefik IP>:8080/dashboard/` (trailing slash is mandatory).


### PR DESCRIPTION
### What does this PR do?

This PR updates the API and Dashboard documentation pages to clarify how 
to set up and access the dashboard.

Closes #5561 .

### Motivation

- Community support led to misunderstandings, and users were facing a `404 Not Found` page instead of the dashboard.

### More

- ~[ ] Added/updated tests~
- [x] Added/updated documentation

### Additional Notes

> `/` ! Ah-ah! Savior of the universe
