### PR TITLE
 doc: add example to specify certResolver

### DIFF
--- a/docs/content/migration/v1-to-v2.md
+++ b/docs/content/migration/v1-to-v2.md
@@ -226,6 +226,10 @@ Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one o
         # will terminate the TLS request
         [http.routers.Router-1.tls]
           options = "myTLSOptions"
+          certResolver = "myCertResolver"
+          [[http.routers.Router-1.tls.domains]]
+            main = "tls.example.com"
+            sans = ["*.example.com"]
     
     [[tls.certificates]]
       certFile = "/path/to/domain.cert"


### PR DESCRIPTION
### What does this PR do?

This PR add instructions on how to specify certResolver on http.router.


### Motivation

I was walking in the dark for quite some time. This PR could help anyone who is also wondering how to make acme works in v2.


### More

- [ ] Added/updated tests
- [x] Added/updated documentation
