### PR TITLE
Add overview to API documentation

### DIFF
--- a/docs/content/operations/api.md
+++ b/docs/content/operations/api.md
@@ -159,25 +159,25 @@ api:
 
 All the following endpoints must be accessed with a `GET` HTTP request.
 
-| Path                           | Description                                                                               |
-|--------------------------------|-------------------------------------------------------------------------------------------|
-| `/api/http/routers`            | Lists all the HTTP routers information.                                                   |
-| `/api/http/routers/{name}`     | Returns the information of the HTTP router specified by `name`.                           |
-| `/api/http/services`           | Lists all the HTTP services information.                                                  |
-| `/api/http/services/{name}`    | Returns the information of the HTTP service specified by `name`.                          |
-| `/api/http/middlewares`        | Lists all the HTTP middlewares information.                                               |
-| `/api/http/middlewares/{name}` | Returns the information of the HTTP middleware specified by `name`.                       |
-| `/api/tcp/routers`             | Lists all the TCP routers information.                                                    |
-| `/api/tcp/routers/{name}`      | Returns the information of the TCP router specified by `name`.                            |
-| `/api/tcp/services`            | Lists all the TCP services information.                                                   |
-| `/api/tcp/services/{name}`     | Returns the information of the TCP service specified by `name`.                           |
-| `/api/entrypoints`             | Lists all the entry points information.                                                   |
-| `/api/entrypoints/{name}`      | Returns the information of the entry point specified by `name`.                           |
-| `/api/overview`                | Returns statistic information about http and tcp aswell as enabled features and providers |
-| `/api/version`                 | Returns information about Traefik version.                                                |
-| `/debug/vars`                  | See the [expvar](https://golang.org/pkg/expvar/) Go documentation.                        |
-| `/debug/pprof/`                | See the [pprof Index](https://golang.org/pkg/net/http/pprof/#Index) Go documentation.     |
-| `/debug/pprof/cmdline`         | See the [pprof Cmdline](https://golang.org/pkg/net/http/pprof/#Cmdline) Go documentation. |
-| `/debug/pprof/profile`         | See the [pprof Profile](https://golang.org/pkg/net/http/pprof/#Profile) Go documentation. |
-| `/debug/pprof/symbol`          | See the [pprof Symbol](https://golang.org/pkg/net/http/pprof/#Symbol) Go documentation.   |
-| `/debug/pprof/trace`           | See the [pprof Trace](https://golang.org/pkg/net/http/pprof/#Trace) Go documentation.     |
+| Path                           | Description                                                                                 |
+|--------------------------------|---------------------------------------------------------------------------------------------|
+| `/api/http/routers`            | Lists all the HTTP routers information.                                                     |
+| `/api/http/routers/{name}`     | Returns the information of the HTTP router specified by `name`.                             |
+| `/api/http/services`           | Lists all the HTTP services information.                                                    |
+| `/api/http/services/{name}`    | Returns the information of the HTTP service specified by `name`.                            |
+| `/api/http/middlewares`        | Lists all the HTTP middlewares information.                                                 |
+| `/api/http/middlewares/{name}` | Returns the information of the HTTP middleware specified by `name`.                         |
+| `/api/tcp/routers`             | Lists all the TCP routers information.                                                      |
+| `/api/tcp/routers/{name}`      | Returns the information of the TCP router specified by `name`.                              |
+| `/api/tcp/services`            | Lists all the TCP services information.                                                     |
+| `/api/tcp/services/{name}`     | Returns the information of the TCP service specified by `name`.                             |
+| `/api/entrypoints`             | Lists all the entry points information.                                                     |
+| `/api/entrypoints/{name}`      | Returns the information of the entry point specified by `name`.                             |
+| `/api/overview`                | Returns statistic information about http and tcp as well as enabled features and providers. |
+| `/api/version`                 | Returns information about Traefik version.                                                  |
+| `/debug/vars`                  | See the [expvar](https://golang.org/pkg/expvar/) Go documentation.                          |
+| `/debug/pprof/`                | See the [pprof Index](https://golang.org/pkg/net/http/pprof/#Index) Go documentation.       |
+| `/debug/pprof/cmdline`         | See the [pprof Cmdline](https://golang.org/pkg/net/http/pprof/#Cmdline) Go documentation.   |
+| `/debug/pprof/profile`         | See the [pprof Profile](https://golang.org/pkg/net/http/pprof/#Profile) Go documentation.   |
+| `/debug/pprof/symbol`          | See the [pprof Symbol](https://golang.org/pkg/net/http/pprof/#Symbol) Go documentation.     |
+| `/debug/pprof/trace`           | See the [pprof Trace](https://golang.org/pkg/net/http/pprof/#Trace) Go documentation.       |

--- a/docs/content/operations/api.md
+++ b/docs/content/operations/api.md
@@ -173,6 +173,7 @@ All the following endpoints must be accessed with a `GET` HTTP request.
 | `/api/tcp/services/{name}`     | Returns the information of the TCP service specified by `name`.                           |
 | `/api/entrypoints`             | Lists all the entry points information.                                                   |
 | `/api/entrypoints/{name}`      | Returns the information of the entry point specified by `name`.                           |
+| `/api/overview`                | Returns statistic information about http and tcp aswell as enabled features and providers |
 | `/api/version`                 | Returns information about Traefik version.                                                |
 | `/debug/vars`                  | See the [expvar](https://golang.org/pkg/expvar/) Go documentation.                        |
 | `/debug/pprof/`                | See the [pprof Index](https://golang.org/pkg/net/http/pprof/#Index) Go documentation.     |


### PR DESCRIPTION
### What does this PR do?

Add the missing `/api/overview` to the list with a description what I think it does.

### Motivation

Ran into a problem where I wanted just the API calls of traefik beeing routed through the `/api` ingress and found out, that the entry was missing from the documentation.

### More

- [x] Added/updated documentation
