### PR TITLE
Fix misleading text

### DIFF
--- a/docs/content/middlewares/redirectscheme.md
+++ b/docs/content/middlewares/redirectscheme.md
@@ -7,7 +7,7 @@ Redirecting the Client to a Different Scheme/Port
 TODO: add schema
 -->
 
-RegexRedirect redirect request from a scheme to another.
+RedirectScheme redirect request from a scheme to another.
 
 ## Configuration Examples
 


### PR DESCRIPTION
Update text from RegexRedirect to RedirectScheme. The word used is wrong since the documentation is an example using `redirect scheme`