### PR TITLE
Backport Go 1.13 integration test fixes

### DIFF
--- a/integration/https_test.go
+++ b/integration/https_test.go
@@ -341,24 +341,32 @@ func (s *HTTPSSuite) TestWithClientCertificateAuthenticationMultipeCAs(c *check.
 	err = try.GetRequest("http://127.0.0.1:8080/api/providers", 500*time.Millisecond, try.BodyContains("Host:snitest.org"))
 	c.Assert(err, checker.IsNil)
 
+	req, err := http.NewRequest(http.MethodGet, "https://127.0.0.1:4443", nil)
+	c.Assert(err, checker.IsNil)
+	req.Host = "snitest.com"
+
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: true,
 		ServerName:         "snitest.com",
 		Certificates:       []tls.Certificate{},
 	}
+
+	client := http.Client{
+		Transport: &http.Transport{TLSClientConfig: tlsConfig},
+		Timeout:   1 * time.Second,
+	}
+
 	// Connection without client certificate should fail
-	_, err = tls.Dial("tcp", "127.0.0.1:4443", tlsConfig)
-	c.Assert(err, checker.NotNil, check.Commentf("should not be allowed to connect to server"))
+	_, err = client.Do(req)
+	c.Assert(err, checker.NotNil)
 
 	// Connect with client signed by ca1
 	cert, err := tls.LoadX509KeyPair("fixtures/https/clientca/client1.crt", "fixtures/https/clientca/client1.key")
 	c.Assert(err, checker.IsNil, check.Commentf("unable to load client certificate and key"))
 	tlsConfig.Certificates = append(tlsConfig.Certificates, cert)
 
-	conn, err := tls.Dial("tcp", "127.0.0.1:4443", tlsConfig)
-	c.Assert(err, checker.IsNil, check.Commentf("failed to connect to server"))
-
-	conn.Close()
+	_, err = client.Do(req)
+	c.Assert(err, checker.IsNil)
 
 	// Connect with client signed by ca2
 	tlsConfig = &tls.Config{
@@ -370,10 +378,13 @@ func (s *HTTPSSuite) TestWithClientCertificateAuthenticationMultipeCAs(c *check.
 	c.Assert(err, checker.IsNil, check.Commentf("unable to load client certificate and key"))
 	tlsConfig.Certificates = append(tlsConfig.Certificates, cert)
 
-	conn, err = tls.Dial("tcp", "127.0.0.1:4443", tlsConfig)
-	c.Assert(err, checker.IsNil, check.Commentf("failed to connect to server"))
+	client = http.Client{
+		Transport: &http.Transport{TLSClientConfig: tlsConfig},
+		Timeout:   1 * time.Second,
+	}
 
-	conn.Close()
+	_, err = client.Do(req)
+	c.Assert(err, checker.IsNil)
 
 	// Connect with client signed by ca3 should fail
 	tlsConfig = &tls.Config{
@@ -385,8 +396,13 @@ func (s *HTTPSSuite) TestWithClientCertificateAuthenticationMultipeCAs(c *check.
 	c.Assert(err, checker.IsNil, check.Commentf("unable to load client certificate and key"))
 	tlsConfig.Certificates = append(tlsConfig.Certificates, cert)
 
-	_, err = tls.Dial("tcp", "127.0.0.1:4443", tlsConfig)
-	c.Assert(err, checker.NotNil, check.Commentf("should not be allowed to connect to server"))
+	client = http.Client{
+		Transport: &http.Transport{TLSClientConfig: tlsConfig},
+		Timeout:   1 * time.Second,
+	}
+
+	_, err = client.Do(req)
+	c.Assert(err, checker.NotNil)
 }
 
 // TestWithClientCertificateAuthentication
@@ -402,24 +418,32 @@ func (s *HTTPSSuite) TestWithClientCertificateAuthenticationMultipeCAsMultipleFi
 	err = try.GetRequest("http://127.0.0.1:8080/api/providers", 1000*time.Millisecond, try.BodyContains("Host:snitest.org"))
 	c.Assert(err, checker.IsNil)
 
+	req, err := http.NewRequest(http.MethodGet, "https://127.0.0.1:4443", nil)
+	c.Assert(err, checker.IsNil)
+	req.Host = "snitest.com"
+
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: true,
 		ServerName:         "snitest.com",
 		Certificates:       []tls.Certificate{},
 	}
+
+	client := http.Client{
+		Transport: &http.Transport{TLSClientConfig: tlsConfig},
+		Timeout:   1 * time.Second,
+	}
+
 	// Connection without client certificate should fail
-	_, err = tls.Dial("tcp", "127.0.0.1:4443", tlsConfig)
-	c.Assert(err, checker.NotNil, check.Commentf("should not be allowed to connect to server"))
+	_, err = client.Do(req)
+	c.Assert(err, checker.NotNil)
 
 	// Connect with client signed by ca1
 	cert, err := tls.LoadX509KeyPair("fixtures/https/clientca/client1.crt", "fixtures/https/clientca/client1.key")
 	c.Assert(err, checker.IsNil, check.Commentf("unable to load client certificate and key"))
 	tlsConfig.Certificates = append(tlsConfig.Certificates, cert)
 
-	conn, err := tls.Dial("tcp", "127.0.0.1:4443", tlsConfig)
-	c.Assert(err, checker.IsNil, check.Commentf("failed to connect to server"))
-
-	conn.Close()
+	_, err = client.Do(req)
+	c.Assert(err, checker.IsNil)
 
 	// Connect with client signed by ca2
 	tlsConfig = &tls.Config{
@@ -431,9 +455,13 @@ func (s *HTTPSSuite) TestWithClientCertificateAuthenticationMultipeCAsMultipleFi
 	c.Assert(err, checker.IsNil, check.Commentf("unable to load client certificate and key"))
 	tlsConfig.Certificates = append(tlsConfig.Certificates, cert)
 
-	conn, err = tls.Dial("tcp", "127.0.0.1:4443", tlsConfig)
-	c.Assert(err, checker.IsNil, check.Commentf("failed to connect to server"))
-	conn.Close()
+	client = http.Client{
+		Transport: &http.Transport{TLSClientConfig: tlsConfig},
+		Timeout:   1 * time.Second,
+	}
+
+	_, err = client.Do(req)
+	c.Assert(err, checker.IsNil)
 
 	// Connect with client signed by ca3 should fail
 	tlsConfig = &tls.Config{
@@ -445,8 +473,13 @@ func (s *HTTPSSuite) TestWithClientCertificateAuthenticationMultipeCAsMultipleFi
 	c.Assert(err, checker.IsNil, check.Commentf("unable to load client certificate and key"))
 	tlsConfig.Certificates = append(tlsConfig.Certificates, cert)
 
-	_, err = tls.Dial("tcp", "127.0.0.1:4443", tlsConfig)
-	c.Assert(err, checker.NotNil, check.Commentf("should not be allowed to connect to server"))
+	client = http.Client{
+		Transport: &http.Transport{TLSClientConfig: tlsConfig},
+		Timeout:   1 * time.Second,
+	}
+
+	_, err = client.Do(req)
+	c.Assert(err, checker.NotNil)
 }
 
 func (s *HTTPSSuite) TestWithRootCAsContentForHTTPSOnBackend(c *check.C) {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -25,11 +25,6 @@ var host = flag.Bool("host", false, "run host integration tests")
 var showLog = flag.Bool("tlog", false, "always show Traefik logs")
 
 func Test(t *testing.T) {
-	check.TestingT(t)
-}
-
-func init() {
-	flag.Parse()
 	if !*integration {
 		log.Info("Integration tests disabled.")
 		return
@@ -70,6 +65,8 @@ func init() {
 		check.Suite(&ProxyProtocolSuite{})
 		check.Suite(&Etcd3Suite{})
 	}
+
+	check.TestingT(t)
 }
 
 var traefikBinary = "../dist/traefik"


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This backports fixes from traefik 2 to 1.7 in order to make it possible
to build traefik 1.7 and run integration tests with a Go 1.13 runtime.

### Motivation

<!-- What inspired you to submit this pull request? -->
Fix #5140

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
