### PR TITLE
fix: typo in healthCheck examples

### DIFF
--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -232,7 +232,7 @@ Below are the available options for the health check mechanism:
     ```toml tab="TOML"
     ## Dynamic configuration
     [http.services]
-      [http.servicess.Service-1]
+      [http.services.Service-1]
         [http.services.Service-1.loadBalancer.healthCheck]
           path = "/health"
           interval = "10s"
@@ -242,7 +242,7 @@ Below are the available options for the health check mechanism:
     ```yaml tab="YAML"
     ## Dynamic configuration
     http:
-      servicess:
+      services:
         Service-1:
           loadBalancer:
             healthCheck:


### PR DESCRIPTION
### What does this PR do?

Fixes typo in routing/services/#health-check
services is misspelled as servicess
