### PR TITLE
Removed the TLS_RSA_WITH_AES_256_GCM_SHA384 cipher

### DIFF
--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -394,8 +394,11 @@ It refers to a [TLS Options](../../https/tls.md#tls-options) and will be applied
       [tls.options.foo]
         minVersion = "VersionTLS12"
         cipherSuites = [
-          "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-          "TLS_RSA_WITH_AES_256_GCM_SHA384"
+          "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+          "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+          "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+          "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+          "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
         ]
     ```
     
@@ -415,8 +418,11 @@ It refers to a [TLS Options](../../https/tls.md#tls-options) and will be applied
         foo:
           minVersion: VersionTLS12
           cipherSuites:
+            - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+            - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+            - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+            - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
             - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-            - TLS_RSA_WITH_AES_256_GCM_SHA384
     ```
 
 !!! important "Conflicting TLS Options"
@@ -766,8 +772,11 @@ It refers to a [TLS Options](../../https/tls.md#tls-options) and will be applied
       [tls.options.foo]
         minVersion = "VersionTLS12"
         cipherSuites = [
-          "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-          "TLS_RSA_WITH_AES_256_GCM_SHA384"
+          "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+          "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+          "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+          "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+          "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
         ]
     ```
 
@@ -787,8 +796,11 @@ It refers to a [TLS Options](../../https/tls.md#tls-options) and will be applied
         foo:
           minVersion: VersionTLS12
           cipherSuites:
+            - "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+            - "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305"
+            - "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
+            - "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
             - "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-            - "TLS_RSA_WITH_AES_256_GCM_SHA384"
     ```
 
 #### `certResolver`


### PR DESCRIPTION
Removed the TLS_RSA_WITH_AES_256_GCM_SHA384 cipher that causes the B rating from https://www.ssllabs.com/ssltest/ 

This cipher is considered weak and including it will result in a B rating by default.
Adding the ciphers that are not considered weak will result in an A rating out of the box.

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Removes the TLS_RSA_WITH_AES_256_GCM_SHA384 cipher that is considered weak.

### Motivation

<!-- What inspired you to submit this pull request? -->
After the removal of this cipher the site security rating raises from a **B** to an **A**. 

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
It'd be useful, in the future, to provide a configuration that gives an **A+** rating out of the box.
