### PR TITLE
Update apiVersion in documentation descriptor

### DIFF
--- a/docs/content/user-guides/crd-acme/03-deployments.yml
+++ b/docs/content/user-guides/crd-acme/03-deployments.yml
@@ -6,7 +6,7 @@ metadata:
 
 ---
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   namespace: default
   name: traefik
@@ -49,7 +49,7 @@ spec:
 
 ---
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   namespace: default
   name: whoami


### PR DESCRIPTION
### What does this PR do?

Update apiVersion in documentation descriptor


### Motivation

The old extensions/v1beta1 Deployment API is [deprecated](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/). 


### More

- [X] Updated documentation
