### PR TITLE
fix: default router name for k8s ingress.

### DIFF
--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -294,7 +294,7 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 					continue
 				}
 
-				conf.HTTP.Routers["/"] = &dynamic.Router{
+				conf.HTTP.Routers["default-router"] = &dynamic.Router{
 					Rule:     "PathPrefix(`/`)",
 					Priority: math.MinInt32,
 					Service:  "default-backend",

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -422,7 +422,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"/": {
+						"default-router": {
 							Rule:     "PathPrefix(`/`)",
 							Service:  "default-backend",
 							Priority: math.MinInt32,
@@ -819,7 +819,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"/": {
+						"default-router": {
 							Rule:     "PathPrefix(`/`)",
 							Service:  "default-backend",
 							Priority: math.MinInt32,


### PR DESCRIPTION
### What does this PR do?

fix: default router name for k8s ingress.

### Motivation

be able to use api and dashboard with the default router.

Fixes #5611

### More

- [x] Added/updated tests
- [ ] ~~Added/updated documentation~~
