### PR TITLE
fix misspelling on documentation landing page

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -20,4 +20,4 @@ Developing Traefik, our main goal is to make it simple to use, and we're sure yo
 
 !!! info
 
-    If you're a businness running critical services behind Traefik, know that [Containous](https://containo.us), the company that sponsors Traefik's development, can provide [commercial support](https://containo.us/services/#commercial-support) and develops an [Enterprise Edition](https://containo.us/traefikee/) of Traefik. 
+    If you're a business running critical services behind Traefik, know that [Containous](https://containo.us), the company that sponsors Traefik's development, can provide [commercial support](https://containo.us/services/#commercial-support) and develops an [Enterprise Edition](https://containo.us/traefikee/) of Traefik. 


### PR DESCRIPTION
### What does this PR do?

Updates a misspelled word on the documentation page. ("businness" misspelled. Should be: "business") 

### Motivation 

Saw the misspelled word while browsing the docs and I thought I would just help out by fixing it. 

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
