### PR TITLE
Fix acme storage file docker mounting example

### DIFF
--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -382,7 +382,7 @@ ACME certificates can be stored in a JSON file that needs to have a `600` file m
 In Docker you can mount either the JSON file, or the folder containing it:
 
 ```bash
-docker run -v "/my/host/acme.json:acme.json" traefik
+docker run -v "/my/host/acme.json:/acme.json" traefik
 ```
 
 ```bash


### PR DESCRIPTION
It is not possible to mount a relative file. A mount path has to be be absolute.

```
docker: Error response from daemon: invalid volume specification: '/my/host/acme.json:acme.json': invalid mount config for type "bind": invalid mount path: 'acme.json' mount path must be absolute.
See 'docker run --help'.
```

### More

- [ ] Added/updated tests
- [X] Updated documentation

