### PR TITLE
fix: add filename in the file provider logs.

### DIFF
--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -539,7 +539,7 @@ The `address` option (IP:Port) point to a specific instance.
         my-service:
           loadBalancer:
             servers:
-              address: "xx.xx.xx.xx:xx"
+              - address: "xx.xx.xx.xx:xx"
     ```
 
 #### Termination Delay


### PR DESCRIPTION
### What does this PR do?

Add filename in the file provider logs.


### Motivation

Adding the file name makes it easier to understand an error.

### More

- [ ] ~~Added/updated tests~~
- [x] Added/updated documentation
