### PR TITLE
Quick fix on services documentation page

### DIFF
--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -539,7 +539,7 @@ The `address` option (IP:Port) point to a specific instance.
         my-service:
           loadBalancer:
             servers:
-              address: "xx.xx.xx.xx:xx"
+              - address: "xx.xx.xx.xx:xx"
     ```
 
 #### Termination Delay


### PR DESCRIPTION
Signed-off-by: dduportal <1522731+dduportal@users.noreply.github.com>

### What does this PR do?

This PR fix a typo in a code snippet of the documentation page for services.

### Motivation

Avoid reproducing #5634.

### More

- ~[ ] Added/updated tests~
- [x] Added/updated documentation

