### PR TITLE
chore(node/webui): update node to 12.11 version

### DIFF
--- a/exp.Dockerfile
+++ b/exp.Dockerfile
@@ -1,5 +1,5 @@
 # WEBUI
-FROM node:8.15.0 as webui
+FROM node:12.11 as webui
 
 ENV WEBUI_DIR /src/webui
 RUN mkdir -p $WEBUI_DIR
@@ -7,7 +7,7 @@ RUN mkdir -p $WEBUI_DIR
 COPY ./webui/ $WEBUI_DIR/
 
 WORKDIR $WEBUI_DIR
-RUN yarn install
+RUN npm install
 
 RUN npm run build
 

--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.15.0
+FROM node:12.11
 
 ENV WEBUI_DIR /src/webui
 RUN mkdir -p $WEBUI_DIR

--- a/webui/readme.md
+++ b/webui/readme.md
@@ -20,7 +20,7 @@ make generate-webui  # Generate static contents in `traefik/static/` folder.
 
 ## How to build (only for frontend developer)
 
-- prerequisite: [Node 6+](https://nodejs.org) [Npm](https://www.npmjs.com/)
+- prerequisite: [Node 12.11+](https://nodejs.org) [Npm](https://www.npmjs.com/)
 
 - Go to the directory `webui`
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.0

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.0

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- Update Node to a up to date version
- Update readme of the webui

### Motivation

<!-- What inspired you to submit this pull request? -->
Keep træfik up to date ❤️ 

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
- The webui is not concerned by the breaking changes of NodeJS between 8 and 12.
- This will normally boost the build time for the webui
- *Node version 8 will be a dead version by the end of the year https://github.com/nodejs/Release*
