### PR TITLE
Let instana/go-sensor handle default agent host

### DIFF
--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -529,7 +529,7 @@ Specifies the header name that will be used to store the trace ID.
 Settings for Instana. (Default: ```false```)
 
 `--tracing.instana.localagenthost`:  
-Set instana-agent's host that the reporter will used. (Default: ```localhost```)
+Set instana-agent's host that the reporter will used.
 
 `--tracing.instana.localagentport`:  
 Set instana-agent's port that the reporter will used. (Default: ```42699```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -529,7 +529,7 @@ Specifies the header name that will be used to store the trace ID.
 Settings for Instana. (Default: ```false```)
 
 `TRAEFIK_TRACING_INSTANA_LOCALAGENTHOST`:  
-Set instana-agent's host that the reporter will used. (Default: ```localhost```)
+Set instana-agent's host that the reporter will used.
 
 `TRAEFIK_TRACING_INSTANA_LOCALAGENTPORT`:  
 Set instana-agent's port that the reporter will used. (Default: ```42699```)

--- a/pkg/tracing/instana/instana.go
+++ b/pkg/tracing/instana/instana.go
@@ -20,7 +20,7 @@ type Config struct {
 
 // SetDefaults sets the default values.
 func (c *Config) SetDefaults() {
-	c.LocalAgentHost = "localhost"
+	c.LocalAgentHost = ""
 	c.LocalAgentPort = 42699
 	c.LogLevel = "info"
 }

--- a/pkg/tracing/instana/instana.go
+++ b/pkg/tracing/instana/instana.go
@@ -20,7 +20,6 @@ type Config struct {
 
 // SetDefaults sets the default values.
 func (c *Config) SetDefaults() {
-	c.LocalAgentHost = ""
 	c.LocalAgentPort = 42699
 	c.LogLevel = "info"
 }


### PR DESCRIPTION
### What does this PR do?

Passing an empty string as default host allows instana/go-sensor to look up INSTANA_HOST_AGENT env var.

See https://github.com/instana/go-sensor/blob/master/fsm.go#L82-L92

### Motivation

In a kubernetes env it enables the possibility to give to traefik the ip of the host which should have a local instana agent.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
