### PR TITLE
Adding support for HTTPs backends with Kubernetes ExternalName services

### DIFF
--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -209,13 +209,13 @@ func loadServers(client Client, namespace string, svc v1alpha1.Service) ([]dynam
 
 	var servers []dynamic.Server
 	if service.Spec.Type == corev1.ServiceTypeExternalName {
-		var ENproto string
-		ENproto = "http"
+		protocol := "http"
 		if portSpec.Port == 443 || strings.HasPrefix(portSpec.Name, "https") {
-			ENproto = "https"
+			protocol = "https"
 		}
+
 		servers = append(servers, dynamic.Server{
-			URL: fmt.Sprintf("%s://%s:%d", ENproto, service.Spec.ExternalName, portSpec.Port),
+			URL: fmt.Sprintf("%s://%s:%d", protocol, service.Spec.ExternalName, portSpec.Port),
 		})
 	} else {
 		endpoints, endpointsExists, endpointsErr := client.GetEndpoints(namespace, svc.Name)

--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -209,8 +209,13 @@ func loadServers(client Client, namespace string, svc v1alpha1.Service) ([]dynam
 
 	var servers []dynamic.Server
 	if service.Spec.Type == corev1.ServiceTypeExternalName {
+		var ENproto string
+		ENproto = "http"
+		if portSpec.Port == 443 || strings.HasPrefix(portSpec.Name, "https") {
+			ENproto = "https"
+		}
 		servers = append(servers, dynamic.Server{
-			URL: fmt.Sprintf("http://%s:%d", service.Spec.ExternalName, portSpec.Port),
+			URL: fmt.Sprintf("%s://%s:%d", ENproto, service.Spec.ExternalName, portSpec.Port),
 		})
 	} else {
 		endpoints, endpointsExists, endpointsErr := client.GetEndpoints(namespace, svc.Name)

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -203,13 +203,13 @@ func loadService(client Client, namespace string, backend v1beta1.IngressBackend
 	}
 
 	if service.Spec.Type == corev1.ServiceTypeExternalName {
-		var ENproto string
-		ENproto = "http"
+		protocol := "http"
 		if portSpec.Port == 443 || strings.HasPrefix(portSpec.Name, "https") {
-			ENproto = "https"
+			protocol = "https"
 		}
+
 		servers = append(servers, dynamic.Server{
-			URL: fmt.Sprintf("%s://%s:%d", ENproto, service.Spec.ExternalName, portSpec.Port),
+			URL: fmt.Sprintf("%s://%s:%d", protocol, service.Spec.ExternalName, portSpec.Port),
 		})
 	} else {
 		endpoints, endpointsExists, endpointsErr := client.GetEndpoints(namespace, backend.ServiceName)

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -203,8 +203,13 @@ func loadService(client Client, namespace string, backend v1beta1.IngressBackend
 	}
 
 	if service.Spec.Type == corev1.ServiceTypeExternalName {
+		var ENproto string
+		ENproto = "http"
+		if portSpec.Port == 443 || strings.HasPrefix(portSpec.Name, "https") {
+			ENproto = "https"
+		}
 		servers = append(servers, dynamic.Server{
-			URL: fmt.Sprintf("http://%s:%d", service.Spec.ExternalName, portSpec.Port),
+			URL: fmt.Sprintf("%s://%s:%d", ENproto, service.Spec.ExternalName, portSpec.Port),
 		})
 	} else {
 		endpoints, endpointsExists, endpointsErr := client.GetEndpoints(namespace, backend.ServiceName)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.0

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.0

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adds support for HTTPS with Kubernetes ExternalName, for both CRD and Ingress Class.

### Motivation

Trying to configure a backend with HTTPS, traefik hardcodded "http://" in front of the URL


### Additional Notes

I've already tested it with docker image kpeiruza/traefik:2.0 and is working. Dunno why the build has failed with travis-ci, it said something about documentation!!!!