### PR TITLE
Clarify unit of duration field in access log

### DIFF
--- a/docs/content/observability/access-logs.md
+++ b/docs/content/observability/access-logs.md
@@ -180,7 +180,7 @@ accessLog:
     |-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
     | `StartUTC`              | The time at which request processing started.                                                                                                                       |
     | `StartLocal`            | The local time at which request processing started.                                                                                                                 |
-    | `Duration`              | The total time taken (in nanoseconds) by processing the response, including the origin server's time but not the log writing time.                                                   |
+    | `Duration`              | The total time taken (in nanoseconds) by processing the response, including the origin server's time but not the log writing time.                                  |
     | `FrontendName`          | The name of the Traefik frontend.                                                                                                                                   |
     | `BackendName`           | The name of the Traefik backend.                                                                                                                                    |
     | `BackendURL`            | The URL of the Traefik backend.                                                                                                                                     |

--- a/docs/content/observability/access-logs.md
+++ b/docs/content/observability/access-logs.md
@@ -180,7 +180,7 @@ accessLog:
     |-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
     | `StartUTC`              | The time at which request processing started.                                                                                                                       |
     | `StartLocal`            | The local time at which request processing started.                                                                                                                 |
-    | `Duration`              | The total time taken by processing the response, including the origin server's time but not the log writing time.                                                   |
+    | `Duration`              | The total time taken (in nanoseconds) by processing the response, including the origin server's time but not the log writing time.                                                   |
     | `FrontendName`          | The name of the Traefik frontend.                                                                                                                                   |
     | `BackendName`           | The name of the Traefik backend.                                                                                                                                    |
     | `BackendURL`            | The URL of the Traefik backend.                                                                                                                                     |


### PR DESCRIPTION
### What does this PR do?

Clarifies the unit of duration field in access logs.

Fixes #3493.

See https://github.com/containous/traefik/issues/3493#issuecomment-523503228

### Motivation

I too needed clarification and did not find it in the docs.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

No.
