### PR TITLE
Fix traefik behavior when network_mode is host

### DIFF
--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -118,7 +118,9 @@ Ports detection works as follows:
 
 ### Host networking
 
-When exposing containers configured with [host networking](https://docs.docker.com/network/host/), you need to provide the IP adress of the bridge interface (docker0 by default) to the Traefik container using `extra_hosts`: `--add-host=host.docker.internal:172.17.0.1`
+When exposing containers are configured with [host networking](https://docs.docker.com/network/host/), we will try to resolve the DNS entry `host.docker.internal` and if it does not resolve, we will fall back to` 127.0.0.1`.
+On Docker Desktop for Windows and for Mac, this DNS entry is automatically configured with the IP address of the bridge interface.
+On other platform, you should provide the IP address of the bridge interface (docker0 by default) to the Traefik container using `extra_hosts`: `--add-host=host.docker.internal:172.17.0.1`.
 
 ### Docker API Access
 

--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -118,8 +118,17 @@ Ports detection works as follows:
 
 ### Host networking
 
-When exposing containers that are configured with [host networking](https://docs.docker.com/network/host/), we will try to resolve the DNS entry `host.docker.internal` and if it does not resolve, we will fall back to `127.0.0.1`.
-With current versions of Docker, you should manually provide the IP address of the bridge interface (docker0 by default) to the Traefik container using `extra_hosts`: `--add-host=host.docker.internal:172.17.0.1`.
+When exposing containers that are configured with [host networking](https://docs.docker.com/network/host/),
+the IP address of the host is resolved as follows:
+
+<!-- - if in swarm mode, check whether the Node.IPAddress field of the container is provided by the API -->
+- try a lookup of `host.docker.internal`
+- otherwise fall back to `127.0.0.1`
+
+On Linux, (and until [github.com/moby/moby/pull/40007](https://github.com/moby/moby/pull/40007) is included in a release),
+for `host.docker.internal` to be defined, it should be provided as an `extra_host` to the Traefik container,
+using the `--add-host` flag. For example, to set it to the IP address of the bridge interface (docker0 by default):
+`--add-host=host.docker.internal:172.17.0.1`
 
 ### Docker API Access
 

--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -118,9 +118,8 @@ Ports detection works as follows:
 
 ### Host networking
 
-When exposing containers are configured with [host networking](https://docs.docker.com/network/host/), we will try to resolve the DNS entry `host.docker.internal` and if it does not resolve, we will fall back to` 127.0.0.1`.
-On Docker Desktop for Windows and for Mac, this DNS entry is automatically configured with the IP address of the bridge interface.
-On other platform, you should provide the IP address of the bridge interface (docker0 by default) to the Traefik container using `extra_hosts`: `--add-host=host.docker.internal:172.17.0.1`.
+When exposing containers that are configured with [host networking](https://docs.docker.com/network/host/), we will try to resolve the DNS entry `host.docker.internal` and if it does not resolve, we will fall back to `127.0.0.1`.
+With current versions of Docker, you should manually provide the IP address of the bridge interface (docker0 by default) to the Traefik container using `extra_hosts`: `--add-host=host.docker.internal:172.17.0.1`.
 
 ### Docker API Access
 

--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -116,6 +116,11 @@ Ports detection works as follows:
   by using the label `traefik.http.services.<service_name>.loadbalancer.server.port`
   (Read more on this label in the dedicated section in [routing](../routing/providers/docker.md#port)).
 
+### Host networking
+
+When exposing containers configured with [host networking](https://docs.docker.com/network/host/), you need to
+provide the IP adress of the bridge interface to the Traefik container using `extra_hosts`: `--add-host=host.docker.internal:host-gateway`
+
 ### Docker API Access
 
 Traefik requires access to the docker socket to get its dynamic configuration.

--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -118,8 +118,7 @@ Ports detection works as follows:
 
 ### Host networking
 
-When exposing containers configured with [host networking](https://docs.docker.com/network/host/), you need to
-provide the IP adress of the bridge interface to the Traefik container using `extra_hosts`: `--add-host=host.docker.internal:host-gateway`
+When exposing containers configured with [host networking](https://docs.docker.com/network/host/), you need to provide the IP adress of the bridge interface to the Traefik container using `extra_hosts`: `--add-host=host.docker.internal:host-gateway`
 
 ### Docker API Access
 

--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -121,7 +121,7 @@ Ports detection works as follows:
 When exposing containers that are configured with [host networking](https://docs.docker.com/network/host/),
 the IP address of the host is resolved as follows:
 
-<!-- - if in swarm mode, check whether the Node.IPAddress field of the container is provided by the API -->
+<!-- TODO: verify and document the swarm mode case with container.Node.IPAddress coming from the API -->
 - try a lookup of `host.docker.internal`
 - otherwise fall back to `127.0.0.1`
 

--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -118,7 +118,7 @@ Ports detection works as follows:
 
 ### Host networking
 
-When exposing containers configured with [host networking](https://docs.docker.com/network/host/), you need to provide the IP adress of the bridge interface to the Traefik container using `extra_hosts`: `--add-host=host.docker.internal:host-gateway`
+When exposing containers configured with [host networking](https://docs.docker.com/network/host/), you need to provide the IP adress of the bridge interface (docker0 by default) to the Traefik container using `extra_hosts`: `--add-host=host.docker.internal:172.17.0.1`
 
 ### Docker API Access
 

--- a/pkg/provider/docker/config.go
+++ b/pkg/provider/docker/config.go
@@ -259,7 +259,7 @@ func (p Provider) getIPAddress(ctx context.Context, container dockerData) string
 		if container.Node != nil && container.Node.IPAddress != "" {
 			return container.Node.IPAddress
 		}
-		if host, err := net.LookupHost("host.docker.internal"); err == nil  {
+		if host, err := net.LookupHost("host.docker.internal"); err == nil {
 			return host[0]
 		}
 		return "127.0.0.1"

--- a/pkg/provider/docker/config.go
+++ b/pkg/provider/docker/config.go
@@ -259,6 +259,9 @@ func (p Provider) getIPAddress(ctx context.Context, container dockerData) string
 		if container.Node != nil && container.Node.IPAddress != "" {
 			return container.Node.IPAddress
 		}
+		if host, err := net.LookupHost("host.docker.internal"); err == nil  {
+			return host[0]
+		}
 		return "127.0.0.1"
 	}
 


### PR DESCRIPTION
### What does this PR do?

When traefik cannot identify the ip address of the container, it returns 127.0.0.1 no matter what. This behavior is not desirable in many situations (i.e. exposed container running in network_mode = host while traefik doesn't, docker desktop, ...)


### Motivation

It solves https://github.com/containous/traefik/issues/5559 and https://github.com/containous/traefik/issues/5535 and maybe a few other I didn't catch


### Additional Notes

For this to work in linux, https://github.com/moby/moby/pull/40007 needs to be merged. In the meantime you need to define "host.docker.internal" using extra_hosts if you want to take advantage of it.

In any case, this won't alter the current behavior. If you are running traefik in network_mode host or on a platform/version that does not provide the dns record its behavior won't change.
