### PR TITLE
Fix Security Headers Doc

### DIFF
--- a/docs/content/middlewares/headers.md
+++ b/docs/content/middlewares/headers.md
@@ -162,8 +162,8 @@ labels:
 ```toml tab="File (TOML)"    
 [http.middlewares]
   [http.middlewares.testHeader.headers]
-    FrameDeny = true
-    SSLRedirect = true
+    framedeny = true
+    sslredirect = true
 ```
 
 ```yaml tab="File (YAML)"  
@@ -171,8 +171,8 @@ http:
   middlewares:
     testHeader:
       headers:
-        FrameDeny: true
-        SSLRedirect: true
+        framedeny: true
+        sslredirect: true
 ```
 
 ### CORS Headers

--- a/docs/content/middlewares/headers.md
+++ b/docs/content/middlewares/headers.md
@@ -162,8 +162,8 @@ labels:
 ```toml tab="File (TOML)"    
 [http.middlewares]
   [http.middlewares.testHeader.headers]
-    framedeny = true
-    sslredirect = true
+    frameDeny = true
+    sslRedirect = true
 ```
 
 ```yaml tab="File (YAML)"  
@@ -171,8 +171,8 @@ http:
   middlewares:
     testHeader:
       headers:
-        framedeny: true
-        sslredirect: true
+        frameDeny: true
+        sslRedirect: true
 ```
 
 ### CORS Headers


### PR DESCRIPTION
Headers configuration not valid with `SSLRedirect` or `FrameDeny`  should be lowercase.