### PR TITLE
Use debug for log about skipping addition of cert

### DIFF
--- a/tls/certificate.go
+++ b/tls/certificate.go
@@ -192,7 +192,7 @@ func (c *Certificate) AppendCertificate(certs map[string]map[string]*tls.Certifi
 		}
 	}
 	if certExists {
-		log.Warnf("Skipping addition of certificate for domain(s) %q, to EntryPoint %s, as it already exists for this Entrypoint.", certKey, ep)
+		log.Debugf("Skipping addition of certificate for domain(s) %q, to EntryPoint %s, as it already exists for this Entrypoint.", certKey, ep)
 	} else {
 		log.Debugf("Adding certificate for domain(s) %s", certKey)
 		certs[ep][certKey] = &tlsCert


### PR DESCRIPTION
### What does this PR do?

This entry can flood the logs if a cert is duplicated like wildcard certs can be.

### Motivation

Backport https://github.com/containous/traefik/pull/5641 in v1.7 tree.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
