### PR TITLE
Cherry pick v1.7 into v2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,12 @@
 - Add the router priority documentation ([#5481](https://github.com/containous/traefik/pull/5481) by [jbdoumenjou](https://github.com/jbdoumenjou))
 - Improve the Migration Guide ([#5391](https://github.com/containous/traefik/pull/5391) by [jbdoumenjou](https://github.com/jbdoumenjou))
 
+## [v1.7.18](https://github.com/containous/traefik/tree/v1.7.18) (2019-09-23)
+[All Commits](https://github.com/containous/traefik/compare/v1.7.17...v1.7.18)
+
+**Bug fixes:**
+- **[go,security]** This version is compiled with [Go 1.12.10](https://groups.google.com/d/msg/golang-announce/cszieYyuL9Q/g4Z7pKaqAgAJ), which fixes a vulnerability in previous versions. See the [CVE](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16276) about it for more details.
+
 ## [v1.7.17](https://github.com/containous/traefik/tree/v1.7.17) (2019-09-23)
 [All Commits](https://github.com/containous/traefik/compare/v1.7.16...v1.7.17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -414,6 +414,23 @@
 - fix a service with one server .yaml example ([#5373](https://github.com/containous/traefik/pull/5373) by [zaverden](https://github.com/zaverden))
 - fix: services configuration documentation. ([#5359](https://github.com/containous/traefik/pull/5359) by [ldez](https://github.com/ldez))
 
+## [v1.7.15](https://github.com/containous/traefik/tree/v1.7.15) (2019-09-12)
+[All Commits](https://github.com/containous/traefik/compare/v1.7.14...v1.7.15)
+
+**Bug fixes:**
+- **[authentication,k8s/ingress]** Kubernetes support for Auth.HeaderField ([#5235](https://github.com/containous/traefik/pull/5235) by [ErikWegner](https://github.com/ErikWegner))
+- **[k8s,k8s/ingress]** Finish kubernetes throttling refactoring ([#5269](https://github.com/containous/traefik/pull/5269) by [mpl](https://github.com/mpl))
+- **[k8s]** Throttle Kubernetes config refresh ([#4716](https://github.com/containous/traefik/pull/4716) by [benweissmann](https://github.com/benweissmann))
+- **[k8s]** Fix wrong handling of insecure tls auth forward ingress annotation ([#5319](https://github.com/containous/traefik/pull/5319) by [majkrzak](https://github.com/majkrzak))
+- **[middleware]** error pages: do not buffer response when it&#39;s not an error ([#5285](https://github.com/containous/traefik/pull/5285) by [mpl](https://github.com/mpl))
+- **[tls]** Consider default cert domain in certificate store ([#5353](https://github.com/containous/traefik/pull/5353) by [nrwiersma](https://github.com/nrwiersma))
+- **[tls]** Add TLS minversion constraint ([#5356](https://github.com/containous/traefik/pull/5356) by [dtomcej](https://github.com/dtomcej))
+
+**Documentation:**
+- **[acme]** Update Acme doc - Vultr Wildcard &amp; Root ([#5320](https://github.com/containous/traefik/pull/5320) by [ddymko](https://github.com/ddymko))
+- **[consulcatalog]** Typo in basic auth usersFile label consul-catalog ([#5230](https://github.com/containous/traefik/pull/5230) by [pitan](https://github.com/pitan))
+- **[logs]** Improve Access Logs Documentation page ([#5238](https://github.com/containous/traefik/pull/5238) by [dduportal](https://github.com/dduportal))
+
 ## [v2.0.0-rc3](https://github.com/containous/traefik/tree/v2.0.0-rc3) (2019-09-10)
 [All Commits](https://github.com/containous/traefik/compare/v2.0.0-rc2...v2.0.0-rc3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -414,6 +414,12 @@
 - fix a service with one server .yaml example ([#5373](https://github.com/containous/traefik/pull/5373) by [zaverden](https://github.com/zaverden))
 - fix: services configuration documentation. ([#5359](https://github.com/containous/traefik/pull/5359) by [ldez](https://github.com/ldez))
 
+## [v1.7.16](https://github.com/containous/traefik/tree/v1.7.16) (2019-09-13)
+[All Commits](https://github.com/containous/traefik/compare/v1.7.15...v1.7.16)
+
+**Bug fixes:**
+- **[middleware,websocket]** implement Flusher and Hijacker for codeCatcher ([#5376](https://github.com/containous/traefik/pull/5376) by [mpl](https://github.com/mpl))
+
 ## [v1.7.15](https://github.com/containous/traefik/tree/v1.7.15) (2019-09-12)
 [All Commits](https://github.com/containous/traefik/compare/v1.7.14...v1.7.15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,18 @@
 - Add the router priority documentation ([#5481](https://github.com/containous/traefik/pull/5481) by [jbdoumenjou](https://github.com/jbdoumenjou))
 - Improve the Migration Guide ([#5391](https://github.com/containous/traefik/pull/5391) by [jbdoumenjou](https://github.com/jbdoumenjou))
 
+## [v1.7.17](https://github.com/containous/traefik/tree/v1.7.17) (2019-09-23)
+[All Commits](https://github.com/containous/traefik/compare/v1.7.16...v1.7.17)
+
+**Bug fixes:**
+- **[logs,middleware]** Avoid closing stdout when the accesslog handler is closed ([#5459](https://github.com/containous/traefik/pull/5459) by [nrwiersma](https://github.com/nrwiersma))
+- **[middleware]** Actually send header and code during WriteHeader, if needed ([#5404](https://github.com/containous/traefik/pull/5404) by [mpl](https://github.com/mpl))
+
+**Documentation:**
+- **[k8s]** Add note clarifying client certificate header ([#5362](https://github.com/containous/traefik/pull/5362) by [bradjones1](https://github.com/bradjones1))
+- **[webui]** Update docs links. ([#5412](https://github.com/containous/traefik/pull/5412) by [ldez](https://github.com/ldez))
+- Update Traefik image version. ([#5399](https://github.com/containous/traefik/pull/5399) by [ldez](https://github.com/ldez))
+
 ## [v2.0.0](https://github.com/containous/traefik/tree/v2.0.0) (2019-09-16)
 [All Commits](https://github.com/containous/traefik/compare/v2.0.0-alpha1...v2.0.0)
 

--- a/docs/content/middlewares/passtlsclientcert.md
+++ b/docs/content/middlewares/passtlsclientcert.md
@@ -219,7 +219,10 @@ PassTLSClientCert can add two headers to the request:
 - `X-Forwarded-Tls-Client-Cert-Info` that contains all the selected certificate information in an escaped string.
 
 !!! info
-    The headers are filled with escaped string so it can be safely placed inside a URL query.
+
+    * The headers are filled with escaped string so it can be safely placed inside a URL query.
+    * These options only work accordingly to the [MutualTLS configuration](../https/tls.md#client-authentication-mtls).
+    That is to say, only the certificates that match the `clientAuth.clientAuthType` policy are passed.
 
 In the following example, you can see a complete certificate. We will use each part of it to explain the middleware options.
 

--- a/pkg/tls/generate/generate.go
+++ b/pkg/tls/generate/generate.go
@@ -86,6 +86,7 @@ func derCert(privKey *rsa.PrivateKey, expiration time.Time, domain string) ([]by
 		NotAfter:  expiration,
 
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageKeyAgreement | x509.KeyUsageDataEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
 		DNSNames:              []string{domain},
 	}


### PR DESCRIPTION
### What does this PR do?

Cherry pick v1.7 into v2.0:

* [x] 772c9ca4d - Allow Default Certificate to work on macOS 10.15
* [x] 74ad83f0 - Prepare release v1.7.18
* [x] d707c8ba - Prepare release v1.7.17
* [x] 640eb62c - Avoid closing stdout when the accesslog handler is closed
* [x] 226f20b6 - Add note clarifying client certificate header
* [x] 254dc38c - Prepare release v1.7.16
* [x] df5f5300 - Prepare release v1.7.15
* [x] 753d1739 - error pages: do not buffer response when it's not an error 

Skip:

* [x] 208d0fa4 - Update DaemonSet apiVersion
* [x] 9f72b6d1 - Add functions to support precise float compute of weight (#5663)
* [x] 29ef0079 - Backport Go 1.13 integration test fixes
* [x] 590a0d67 - Fix Location response header http to https when SSL
* [x] 21671086 - Actually send header and code during WriteHeader, if needed
* [x] 151be83b - Update docs links.
* [x] d1a8c7fa - Update Traefik image version.
* [x] 24d084d7 - implement Flusher and Hijacker for codeCatcher
* [x] ffd1f122 - Add TLS minversion constraint
* [x] f98b57fd - Fix wrong handling of insecure tls auth forward ingress annotation
* [x] 2d37f088 - Improve Access Logs Documentation page
* [x] a7dbcc28 - Consider default cert domain in certificate store

### Motivation

To keep v2.0 in sync with changes in v1.7.

### More

- ~~[ ] Added/updated tests~~
- ~~[ ] Added/updated documentation~~
