### PR TITLE
Fix rate limiting and SSE

### DIFF
--- a/pkg/middlewares/ratelimiter/rate_limiter.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter.go
@@ -55,7 +55,7 @@ func New(ctx context.Context, next http.Handler, config dynamic.RateLimit, name 
 		return nil, err
 	}
 
-	buckets, err := ttlmap.NewMap(maxSources)
+	buckets, err := ttlmap.NewConcurrent(maxSources)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/middlewares/ratelimiter/rate_limiter.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/containous/traefik/v2/pkg/config/dynamic"
@@ -35,8 +34,7 @@ type rateLimiter struct {
 	sourceMatcher utils.SourceExtractor
 	next          http.Handler
 
-	bucketsMu sync.Mutex
-	buckets   *ttlmap.TtlMap // actual buckets, keyed by source.
+	buckets *ttlmap.TtlMap // actual buckets, keyed by source.
 }
 
 // New returns a rate limiter middleware.
@@ -104,8 +102,6 @@ func (rl *rateLimiter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		logger.Infof("ignoring token bucket amount > 1: %d", amount)
 	}
 
-	rl.bucketsMu.Lock()
-
 	var bucket *rate.Limiter
 	if rlSource, exists := rl.buckets.Get(source); exists {
 		bucket = rlSource.(*rate.Limiter)
@@ -117,8 +113,6 @@ func (rl *rateLimiter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-
-	rl.bucketsMu.Unlock()
 
 	res := bucket.Reserve()
 	if !res.OK() {

--- a/pkg/middlewares/ratelimiter/rate_limiter.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter.go
@@ -105,7 +105,6 @@ func (rl *rateLimiter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rl.bucketsMu.Lock()
-	defer rl.bucketsMu.Unlock()
 
 	var bucket *rate.Limiter
 	if rlSource, exists := rl.buckets.Get(source); exists {
@@ -118,6 +117,8 @@ func (rl *rateLimiter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+
+	rl.bucketsMu.Unlock()
 
 	res := bucket.Reserve()
 	if !res.OK() {


### PR DESCRIPTION
### Motivation

While using long lasting SSE connections the mutex is not released
until the connection is closed. This caused rate limiter to throttle
any SSE endpoint to 1 service connection.

### What does this PR do?

Replacing the defer call that releases the mutex by a direct call
at the appropriate location removes the contention.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
