### PR TITLE
fix: release timeout.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ generate-crd:
 ## Create packages for the release
 release-packages: generate-webui build-dev-image
 	rm -rf dist
-	$(DOCKER_RUN_TRAEFIK_NOTTY) goreleaser release --skip-publish
+	$(DOCKER_RUN_TRAEFIK_NOTTY) goreleaser release --skip-publish --timeout="60m"
 	$(DOCKER_RUN_TRAEFIK_NOTTY) tar cfz dist/traefik-${VERSION}.src.tar.gz \
 		--exclude-vcs \
 		--exclude .idea \


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.0

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.0

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

Increase the release timeout from 30m to 60m.

### Motivation

The v2.0.3 release is blocked by:
```
⨯ release failed after 1800.00s error=context deadline exceeded
```

### More

- [ ] ~~Added/updated tests~~
- [ ] ~~Added/updated documentation~~
