### PR TITLE
Fix error in link description for priority

### DIFF
--- a/docs/content/routing/providers/docker.md
+++ b/docs/content/routing/providers/docker.md
@@ -226,7 +226,7 @@ For example, to change the rule, you could add the label ```traefik.http.routers
 
 ??? info "`traefik.http.routers.<router_name>.priority`"
 
-    See [options](../routers/index.md#priority) for more information.
+    See [priority](../routers/index.md#priority) for more information.
 
     ```yaml
     - "traefik.http.routers.myrouter.priority=42"

--- a/docs/content/routing/providers/marathon.md
+++ b/docs/content/routing/providers/marathon.md
@@ -128,7 +128,7 @@ For example, to change the routing rule, you could add the label ```"traefik.htt
 
 ??? info "`traefik.http.routers.<router_name>.priority`"
     
-    See [options](../routers/index.md#priority) for more information.
+    See [priority](../routers/index.md#priority) for more information.
     
     ```json
     "traefik.http.routers.myrouter.priority": "42"

--- a/docs/content/routing/providers/rancher.md
+++ b/docs/content/routing/providers/rancher.md
@@ -133,7 +133,7 @@ For example, to change the rule, you could add the label ```traefik.http.routers
 
 ??? info "`traefik.http.routers.<router_name>.priority`"
     
-    See [options](../routers/index.md#priority) for more information.
+    See [priority](../routers/index.md#priority) for more information.
     
     ```yaml
     - "traefik.http.routers.myrouter.priority=42"


### PR DESCRIPTION
### What does this PR do?
This renames the description of the Link to ../routers/index.md#priority from options to priority. The old description was probably an copy and paste error.

### Motivation

I read the documentation and noticed this small error. 


### More

- [ ] Added/updated tests
- [x] Added/updated documentation
