### PR TITLE
Add missing "-" in traefik configuration example file

### DIFF
--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -25,7 +25,7 @@
   [entryPoints.web]
     address = ":80"
 
-  [entryPoints.websecure]
+  [entryPoints.web-secure]
     address = ":443"
 
 ################################################################


### PR DESCRIPTION
### What does this PR do?

A "-" was missing to match with the configuration example at https://docs.traefik.io/routing/entrypoints/

### Motivation

When you follow the tutorial on the website, the entrypoint "web-secure" is used, in this file, the entrypoint is "websecure", which does not match with website examples.
