### PR TITLE
doc: fix the accessControlAllowMethods guide in kubernetes

### DIFF
--- a/docs/content/middlewares/headers.md
+++ b/docs/content/middlewares/headers.md
@@ -209,10 +209,7 @@ metadata:
   name: testHeader
 spec:
   headers:
-    accessControlAllowMethods:
-      - "GET"
-      - "OPTIONS"
-      - "PUT"
+    accessControlAllowMethods: "GET,OPTIONS,PUT"
     accessControlAllowOrigin: "origin-list-or-null"
     accessControlMaxAge: 100
     addVaryHeader: "true"


### PR DESCRIPTION
### What does this PR do?
- fix the accessControlAllowMethods guide in kubernetes


### Motivation
- the current guide is not working
