### PR TITLE
Update tooling used for documentation

### DIFF
--- a/docs/.markdownlint.json
+++ b/docs/.markdownlint.json
@@ -7,5 +7,6 @@
     "MD026": false,
     "MD033": false,
     "MD034": false,
-    "MD036": false
+    "MD036": false,
+    "MD046": false
 }

--- a/docs/check.Dockerfile
+++ b/docs/check.Dockerfile
@@ -1,9 +1,6 @@
 
-FROM alpine:3.9 as alpine
+FROM alpine:3.10 as alpine
 
-# The "build-dependencies" virtual package provides build tools for html-proofer installation.
-# It compile ruby-nokogiri, because alpine native version is always out of date
-# This virtual package is cleaned at the end.
 RUN apk --no-cache --no-progress add \
     libcurl \
     ruby \
@@ -11,14 +8,8 @@ RUN apk --no-cache --no-progress add \
     ruby-etc \
     ruby-ffi \
     ruby-json \
-  && apk add --no-cache --virtual build-dependencies \
-    build-base \
-    libcurl \
-    libxml2-dev \
-    libxslt-dev \
-    ruby-dev \
-  && gem install --no-document html-proofer -v 3.10.2 \
-  && apk del build-dependencies
+    ruby-nokogiri
+RUN NOKOGIRI_USE_SYSTEM_LIBRARIES=true gem install --no-document html-proofer -v 3.13.0
 
 # After Ruby, some NodeJS YAY!
 RUN apk --no-cache --no-progress add \

--- a/docs/check.Dockerfile
+++ b/docs/check.Dockerfile
@@ -16,7 +16,9 @@ RUN apk --no-cache --no-progress add \
     git \
     nodejs \
     npm \
-  && npm install markdownlint@0.12.0 markdownlint-cli@0.13.0 --global
+  && npm install --global \
+    markdownlint@0.17.2 \
+    markdownlint-cli@0.19.0
 
 # Finally the shell tools we need for later
 # tini helps to terminate properly all the parallelized tasks when sending CTRL-C

--- a/docs/check.Dockerfile
+++ b/docs/check.Dockerfile
@@ -9,7 +9,7 @@ RUN apk --no-cache --no-progress add \
     ruby-ffi \
     ruby-json \
     ruby-nokogiri
-RUN NOKOGIRI_USE_SYSTEM_LIBRARIES=true gem install --no-document html-proofer -v 3.13.0
+RUN gem install html-proofer --version 3.13.0 --no-document -- --use-system-libraries
 
 # After Ruby, some NodeJS YAY!
 RUN apk --no-cache --no-progress add \

--- a/docs/docs.Dockerfile
+++ b/docs/docs.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.10
 
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.local/bin
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 mkdocs==1.0.4
-pymdown-extensions==6.0
+pymdown-extensions==6.1
 mkdocs-bootswatch==1.0
-mkdocs-material==4.0.2
+mkdocs-material==4.4.3
 markdown-include==0.5.1
 mkdocs-exclude==1.0.2


### PR DESCRIPTION
### What does this PR do?

- Update docker base image of documentation tooling to Alpine 3.10 
- Install `html-proofer` using the native nokogiri Ruby gem thanks to Alpine 3.10 and its package `ruby-nokogiri`
- Bump `markdownlint` (and the CLI) versions
- Ignoring markdown rule MD046
- Bump mkdocs's dependencies updates

### Motivation

- Keep tooling clean and up to date
- Improve contributors "first experience", as switching to native nokogiri made the first image documentation build from ~45s to ~10s.

### More

- ~[ ] Added/updated tests~
- [x] Added/updated documentation

