### PR TITLE
Add back the security section from v1

### DIFF
--- a/docs/content/contributing/submitting-security-issues.md
+++ b/docs/content/contributing/submitting-security-issues.md
@@ -1,0 +1,15 @@
+# Security
+
+## Security Advisories
+
+We strongly advise you to join our mailing list to be aware of the latest announcements from our security team. You can subscribe sending a mail to security+subscribe@traefik.io or on [the online viewer](https://groups.google.com/a/traefik.io/forum/#!forum/security).
+
+## CVE
+
+Reported vulnerabilities can be found on 
+[cve.mitre.org](https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=traefik).
+
+## Report a Vulnerability
+
+We want to keep Traefik safe for everyone.
+If you've discovered a security vulnerability in Traefik, we appreciate your help in disclosing it to us in a responsible manner, using [this form](https://security.traefik.io).

--- a/docs/content/contributing/submitting-security-issues.md
+++ b/docs/content/contributing/submitting-security-issues.md
@@ -2,7 +2,8 @@
 
 ## Security Advisories
 
-We strongly advise you to join our mailing list to be aware of the latest announcements from our security team. You can subscribe sending a mail to security+subscribe@traefik.io or on [the online viewer](https://groups.google.com/a/traefik.io/forum/#!forum/security).
+We strongly advise you to join our mailing list to be aware of the latest announcements from our security team.
+You can subscribe sending a mail to security+subscribe@traefik.io or on [the online viewer](https://groups.google.com/a/traefik.io/forum/#!forum/security).
 
 ## CVE
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -157,6 +157,7 @@ nav:
       - 'Thank You!': 'contributing/thank-you.md'
       - 'Submitting Issues': 'contributing/submitting-issues.md'
       - 'Submitting PRs': 'contributing/submitting-pull-requests.md'
+      - 'Security': 'contributing/submitting-security-issues.md'
       - 'Building and Testing': 'contributing/building-testing.md'
       - 'Documentation': 'contributing/documentation.md'
       - 'Data Collection': 'contributing/data-collection.md'


### PR DESCRIPTION
### Documentation fixes or enhancements:
- Docs fixes

### What does this PR do?

Docs: Add back the security section that was on the homepage from v1.7 docs


### Motivation

This docs was delete by accident when we merge from v1.7 to v2.0

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

That's my first PR over here :)
