### PR TITLE
X-Forwarded-Proto must not skip the redirection.

### DIFF
--- a/pkg/middlewares/redirect/redirect.go
+++ b/pkg/middlewares/redirect/redirect.go
@@ -132,17 +132,11 @@ func rawURL(req *http.Request) string {
 		uri = match[4]
 	}
 
-	if req.TLS != nil || isXForwardedHTTPS(req) {
+	if req.TLS != nil {
 		scheme = "https"
 	}
 
 	return strings.Join([]string{scheme, "://", host, port, uri}, "")
-}
-
-func isXForwardedHTTPS(request *http.Request) bool {
-	xForwardedProto := request.Header.Get("X-Forwarded-Proto")
-
-	return len(xForwardedProto) > 0 && xForwardedProto == "https"
 }
 
 func applyString(in string, out io.Writer, req *http.Request) error {


### PR DESCRIPTION
### What does this PR do?

Before the PR, if the request contains the header `X-Forwarded-Proto: https` the HTTPS redirect is skipped.

### Motivation

To be able to create a HTTPS redirection even if the header `X-Forwarded-Proto: https` is set.

### More

- [x] Added/updated tests
- ~~[ ] Added/updated documentation~~
