### PR TITLE
Web UI: Sync toolbar table state with url query params

### DIFF
--- a/webui/src/components/_commons/ToolBarTable.vue
+++ b/webui/src/components/_commons/ToolBarTable.vue
@@ -26,6 +26,8 @@
 </template>
 
 <script>
+import Helps from '../../_helpers/Helps'
+
 export default {
   name: 'ToolBarTable',
   props: ['status', 'filter'],
@@ -36,6 +38,9 @@ export default {
     return {
     }
   },
+  mounted () {
+    this.routeToState(this.$route)
+  },
   computed: {
     getStatus: {
       get () {
@@ -43,6 +48,7 @@ export default {
       },
       set (newValue) {
         this.$emit('update:status', newValue)
+        this.stateToRoute(this.$route, { status: newValue })
       }
     },
     getFilter: {
@@ -51,11 +57,30 @@ export default {
       },
       set (newValue) {
         this.$emit('update:filter', newValue)
+        this.stateToRoute(this.$route, { filter: newValue })
       }
     }
   },
+  watch: {
+    $route (to, from) {
+      this.routeToState(to)
+    }
+  },
   methods: {
-
+    routeToState (route) {
+      for (const query in route.query) {
+        this.$emit(`update:${query}`, route.query[query])
+      }
+    },
+    stateToRoute (route, values) {
+      this.$router.push({
+        path: route.path,
+        query: Helps.removeEmptyObjects({
+          ...route.query,
+          ...values
+        })
+      })
+    }
   },
   created () {
 


### PR DESCRIPTION
### What does this PR do?

Sync the web ui ToolbarTable component state with the url query parameters.

### Motivation

Changing status and searching in a table state wasn't saved in the navigation. So state was lost going to an other route then going back to the previous one.