### PR TITLE
doc: remove double quotes on CLI flags.

### DIFF
--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -47,11 +47,11 @@ You can configure Traefik to use an ACME provider (like Let's Encrypt) for autom
     ```
     
     ```bash tab="CLI"
-    --entryPoints.web.address=":80"
-    --entryPoints.websecure.address=":443"
+    --entryPoints.web.address=:80
+    --entryPoints.websecure.address=:443
     # ...
-    --certificatesResolvers.sample.acme.email="your-email@your-domain.org"
-    --certificatesResolvers.sample.acme.storage="acme.json"
+    --certificatesResolvers.sample.acme.email=your-email@your-domain.org
+    --certificatesResolvers.sample.acme.storage=acme.json
     # used during the challenge
     --certificatesResolvers.sample.acme.httpChallenge.entryPoint=web
     ```
@@ -156,8 +156,8 @@ when using the `HTTP-01` challenge, `certificatesResolvers.sample.acme.httpChall
     ```
     
     ```bash tab="CLI"
-    --entryPoints.web.address=":80"
-    --entryPoints.websecure.address=":443"
+    --entryPoints.web.address=:80
+    --entryPoints.websecure.address=:443
     # ...
     --certificatesResolvers.sample.acme.httpChallenge.entryPoint=web
     ```
@@ -312,7 +312,7 @@ certificatesResolvers:
 
 ```bash tab="CLI"
 # ...
---certificatesResolvers.sample.acme.dnsChallenge.resolvers:="1.1.1.1:53,8.8.8.8:53"
+--certificatesResolvers.sample.acme.dnsChallenge.resolvers:=1.1.1.1:53,8.8.8.8:53
 ```
 
 #### Wildcard Domains
@@ -342,7 +342,7 @@ As described in [Let's Encrypt's post](https://community.letsencrypt.org/t/stagi
 
     ```bash tab="CLI"
     # ...
-    --certificatesResolvers.sample.acme.caServer="https://acme-staging-v02.api.letsencrypt.org/directory"
+    --certificatesResolvers.sample.acme.caServer=https://acme-staging-v02.api.letsencrypt.org/directory
     # ...
     ```
 

--- a/docs/content/https/ref-acme.txt
+++ b/docs/content/https/ref-acme.txt
@@ -4,13 +4,13 @@
 #
 # Required
 #
---certificatesResolvers.sample.acme.email="test@traefik.io"
+--certificatesResolvers.sample.acme.email=test@traefik.io
 
 # File or key used for certificates storage.
 #
 # Required
 #
---certificatesResolvers.sample.acme.storage="acme.json"
+--certificatesResolvers.sample.acme.storage=acme.json
 
 # CA server to use.
 # Uncomment the line to use Let's Encrypt's staging server,
@@ -19,7 +19,7 @@
 # Optional
 # Default: "https://acme-v02.api.letsencrypt.org/directory"
 #
---certificatesResolvers.sample.acme.caServer="https://acme-staging-v02.api.letsencrypt.org/directory"
+--certificatesResolvers.sample.acme.caServer=https://acme-staging-v02.api.letsencrypt.org/directory
 
 # KeyType to use.
 #
@@ -75,7 +75,7 @@
 # Optional
 # Default: empty
 #
---certificatesResolvers.sample.acme.dnsChallenge.resolvers="1.1.1.1:53,8.8.8.8:53"
+--certificatesResolvers.sample.acme.dnsChallenge.resolvers=1.1.1.1:53,8.8.8.8:53
 
 # Disable the DNS propagation checks before notifying ACME that the DNS challenge is ready.
 #

--- a/docs/content/migration/v1-to-v2.md
+++ b/docs/content/migration/v1-to-v2.md
@@ -718,8 +718,8 @@ with the path `/admin` stripped, e.g. to `http://<IP>:<port>/`. In this case, yo
     ```
 
     ```bash tab="CLI"
-    --entryPoints.web.address=":80"
-    --entryPoints.websecure.address=":443"
+    --entryPoints.web.address=:80
+    --entryPoints.websecure.address=:443
     --certificatesResolvers.sample.acme.email: your-email@your-domain.org
     --certificatesResolvers.sample.acme.storage: acme.json
     --certificatesResolvers.sample.acme.httpChallenge.entryPoint: web
@@ -744,9 +744,9 @@ There is no more log configuration at the root level.
     ```
 
     ```bash tab="CLI"
-    --logLevel="DEBUG"
-    --traefikLog.filePath="/path/to/traefik.log"
-    --traefikLog.format="json"
+    --logLevel=DEBUG
+    --traefikLog.filePath=/path/to/traefik.log
+    --traefikLog.format=json
     ```
 
     !!! info "v2"
@@ -768,9 +768,9 @@ There is no more log configuration at the root level.
     ```
 
     ```bash tab="CLI"
-    --log.level="DEBUG"
-    --log.filePath="/path/to/traefik.log"
-    --log.format="json"
+    --log.level=DEBUG
+    --log.filePath=/path/to/traefik.log
+    --log.format=json
     ```
 
 ## Tracing
@@ -794,12 +794,12 @@ Traefik v2 retains OpenTracing support. The `backend` root option from the v1 is
     ```
 
     ```bash tab="CLI"
-    --tracing.backend="jaeger"
-    --tracing.servicename="tracing"
-    --tracing.jaeger.localagenthostport="12.0.0.1:6831"
-    --tracing.jaeger.samplingparam="1.0"
-    --tracing.jaeger.samplingserverurl="http://12.0.0.1:5778/sampling"
-    --tracing.jaeger.samplingtype="const"
+    --tracing.backend=jaeger
+    --tracing.servicename=tracing
+    --tracing.jaeger.localagenthostport=12.0.0.1:6831
+    --tracing.jaeger.samplingparam=1.0
+    --tracing.jaeger.samplingserverurl=http://12.0.0.1:5778/sampling
+    --tracing.jaeger.samplingtype=const
     ```
 
     !!! info "v2"
@@ -827,11 +827,11 @@ Traefik v2 retains OpenTracing support. The `backend` root option from the v1 is
     ```
 
     ```bash tab="CLI"
-    --tracing.servicename="tracing"
-    --tracing.jaeger.localagenthostport="12.0.0.1:6831"
-    --tracing.jaeger.samplingparam="1.0"
-    --tracing.jaeger.samplingserverurl="http://12.0.0.1:5778/sampling"
-    --tracing.jaeger.samplingtype="const"
+    --tracing.servicename=tracing
+    --tracing.jaeger.localagenthostport=12.0.0.1:6831
+    --tracing.jaeger.samplingparam=1.0
+    --tracing.jaeger.samplingserverurl=http://12.0.0.1:5778/sampling
+    --tracing.jaeger.samplingtype=const
     ```
 
 ## Metrics
@@ -852,7 +852,7 @@ For a basic configuration, the [metrics configuration](../observability/metrics/
 
     ```bash tab="CLI"
     --metrics.prometheus.buckets=[0.1,0.3,1.2,5.0]
-    --metrics.prometheus.entrypoint="traefik"
+    --metrics.prometheus.entrypoint=traefik
     ```
 
     !!! info "v2"
@@ -878,7 +878,7 @@ For a basic configuration, the [metrics configuration](../observability/metrics/
 
     ```bash tab="CLI"
     --metrics.prometheus.buckets=[0.1,0.3,1.2,5.0]
-    --metrics.prometheus.entrypoint="metrics"
+    --metrics.prometheus.entrypoint=metrics
     ```
 
 ## No More Root Level Key/Values
@@ -908,14 +908,14 @@ Each root item has been moved to a related section or removed.
     ```bash tab="CLI"
     --checknewversion=false
     --sendanonymoususage=true
-    --loglevel="DEBUG"
+    --loglevel=DEBUG
     --insecureskipverify=true
-    --rootcas="/mycert.cert"
+    --rootcas=/mycert.cert
     --maxidleconnsperhost=200
-    --providersthrottleduration="2s"
+    --providersthrottleduration=2s
     --allowminweightzero=true
     --debug=true
-    --defaultentrypoints="web","web-secure"
+    --defaultentrypoints=web,web-secure
     --keeptrailingslash=true
     ```
 
@@ -961,9 +961,9 @@ Each root item has been moved to a related section or removed.
     ```bash tab="CLI"
     --global.checknewversion=true
     --global.sendanonymoususage=true
-    --log.level="DEBUG"
+    --log.level=DEBUG
     --serverstransport.insecureskipverify=true
-    --serverstransport.rootcas="/mycert.cert"
+    --serverstransport.rootcas=/mycert.cert
     --serverstransport.maxidleconnsperhost=42
     --providers.providersthrottleduration=42
     ```

--- a/docs/content/migration/v1-to-v2.md
+++ b/docs/content/migration/v1-to-v2.md
@@ -720,9 +720,9 @@ with the path `/admin` stripped, e.g. to `http://<IP>:<port>/`. In this case, yo
     ```bash tab="CLI"
     --entryPoints.web.address=:80
     --entryPoints.websecure.address=:443
-    --certificatesResolvers.sample.acme.email: your-email@your-domain.org
-    --certificatesResolvers.sample.acme.storage: acme.json
-    --certificatesResolvers.sample.acme.httpChallenge.entryPoint: web
+    --certificatesResolvers.sample.acme.email=your-email@your-domain.org
+    --certificatesResolvers.sample.acme.storage=acme.json
+    --certificatesResolvers.sample.acme.httpChallenge.entryPoint=web
     ```
 
 ## Traefik Logs
@@ -1029,7 +1029,7 @@ As the dashboard access is now secured by default you can either:
     [api]
     
     [providers.file]
-        filename = "/dynamic-conf.toml"
+      filename = "/dynamic-conf.toml"
     
     ##---------------------##
     

--- a/docs/content/observability/access-logs.md
+++ b/docs/content/observability/access-logs.md
@@ -61,7 +61,7 @@ accessLog:
 ```bash tab="CLI"
 # Configuring a buffer of 100 lines
 --accesslog=true
---accesslog.filepath="/path/to/access.log"
+--accesslog.filepath=/path/to/access.log
 --accesslog.bufferingsize=100
 ```
 
@@ -104,11 +104,11 @@ accessLog:
 ```bash tab="CLI"
 # Configuring Multiple Filters
 --accesslog=true
---accesslog.filepath="/path/to/access.log"
---accesslog.format="json"
---accesslog.filters.statuscodes="200, 300-302"
+--accesslog.filepath=/path/to/access.log
+--accesslog.format=json
+--accesslog.filters.statuscodes=200,300-302
 --accesslog.filters.retryattempts
---accesslog.filters.minduration="10ms"
+--accesslog.filters.minduration=10ms
 ```
 
 ### Limiting the Fields
@@ -164,14 +164,14 @@ accessLog:
 ```bash tab="CLI"
 # Limiting the Logs to Specific Fields
 --accesslog=true
---accesslog.filepath="/path/to/access.log"
---accesslog.format="json"
---accesslog.fields.defaultmode="keep"
---accesslog.fields.names.ClientUsername="drop"
---accesslog.fields.headers.defaultmode="keep"
---accesslog.fields.headers.names.User-Agent="redact"
---accesslog.fields.headers.names.Authorization="drop"
---accesslog.fields.headers.names.Content-Type="keep"
+--accesslog.filepath=/path/to/access.log
+--accesslog.format=json
+--accesslog.fields.defaultmode=keep
+--accesslog.fields.names.ClientUsername=drop
+--accesslog.fields.headers.defaultmode=keep
+--accesslog.fields.headers.names.User-Agent=redact
+--accesslog.fields.headers.names.Authorization=drop
+--accesslog.fields.headers.names.Content-Type=keep
 ```
 
 ??? info "Available Fields"

--- a/docs/content/observability/logs.md
+++ b/docs/content/observability/logs.md
@@ -30,7 +30,7 @@ log:
 
 ```bash tab="CLI"
 # Writing Logs to a File
---log.filePath="/path/to/traefik.log"
+--log.filePath=/path/to/traefik.log
 ```
 
 #### `format`
@@ -53,8 +53,8 @@ log:
 
 ```bash tab="CLI"
 # Writing Logs to a File, in JSON
---log.filePath="/path/to/traefik.log"
---log.format="json"
+--log.filePath=/path/to/traefik.log
+--log.format=json
 ```
 
 #### `level`
@@ -72,7 +72,7 @@ log:
 ```
 
 ```bash tab="CLI"
---log.level="DEBUG"
+--log.level=DEBUG
 ```
 
 ## Log Rotation

--- a/docs/content/observability/metrics/datadog.md
+++ b/docs/content/observability/metrics/datadog.md
@@ -35,7 +35,7 @@ metrics:
 ```
 
 ```bash tab="CLI"
---metrics.datadog.address="127.0.0.1:8125"
+--metrics.datadog.address=127.0.0.1:8125
 ```
 
 #### `addEntryPointsLabels`

--- a/docs/content/observability/metrics/influxdb.md
+++ b/docs/content/observability/metrics/influxdb.md
@@ -35,7 +35,7 @@ metrics:
 ```
 
 ```bash tab="CLI"
---metrics.influxdb.address="localhost:8089"
+--metrics.influxdb.address=localhost:8089
 ```
 
 #### `protocol`
@@ -57,7 +57,7 @@ metrics:
 ```
 
 ```bash tab="CLI"
---metrics.influxdb.protocol="udp"
+--metrics.influxdb.protocol=udp
 ```
 
 #### `database`
@@ -69,17 +69,17 @@ InfluxDB database used when protocol is http.
 ```toml tab="File (TOML)"
 [metrics]
   [metrics.influxDB]
-    database = ""
+    database = "db"
 ```
 
 ```yaml tab="File (YAML)"
 metrics:
   influxDB:
-    database: ""
+    database: "db"
 ```
 
 ```bash tab="CLI"
---metrics.influxdb.database=""
+--metrics.influxdb.database=db
 ```
 
 #### `retentionPolicy`
@@ -91,17 +91,17 @@ InfluxDB retention policy used when protocol is http.
 ```toml tab="File (TOML)"
 [metrics]
   [metrics.influxDB]
-    retentionPolicy = ""
+    retentionPolicy = "two_hours"
 ```
 
 ```yaml tab="File (YAML)"
 metrics:
   influxDB:
-    retentionPolicy: ""
+    retentionPolicy: "two_hours"
 ```
 
 ```bash tab="CLI"
---metrics.influxdb.retentionPolicy=""
+--metrics.influxdb.retentionPolicy=two_hours
 ```
 
 #### `username`
@@ -113,17 +113,17 @@ InfluxDB username (only with http).
 ```toml tab="File (TOML)"
 [metrics]
   [metrics.influxDB]
-    username = ""
+    username = "john"
 ```
 
 ```yaml tab="File (YAML)"
 metrics:
   influxDB:
-    username: ""
+    username: "john"
 ```
 
 ```bash tab="CLI"
---metrics.influxdb.username=""
+--metrics.influxdb.username=john
 ```
 
 #### `password`
@@ -135,17 +135,17 @@ InfluxDB password (only with http).
 ```toml tab="File (TOML)"
 [metrics]
   [metrics.influxDB]
-    password = ""
+    password = "secret"
 ```
 
 ```yaml tab="File (YAML)"
 metrics:
   influxDB:
-    password: ""
+    password: "secret"
 ```
 
 ```bash tab="CLI"
---metrics.influxdb.password=""
+--metrics.influxdb.password=secret
 ```
 
 #### `addEntryPointsLabels`

--- a/docs/content/observability/metrics/prometheus.md
+++ b/docs/content/observability/metrics/prometheus.md
@@ -113,6 +113,6 @@ metrics:
 ```
 
 ```bash tab="CLI"
---entryPoints.metrics.address=":8082"
---metrics.prometheus.entryPoint="metrics"
+--entryPoints.metrics.address=:8082
+--metrics.prometheus.entryPoint=metrics
 ```

--- a/docs/content/observability/metrics/statsd.md
+++ b/docs/content/observability/metrics/statsd.md
@@ -35,7 +35,7 @@ metrics:
 ```
 
 ```bash tab="CLI"
---metrics.statsd.address="localhost:8125"
+--metrics.statsd.address=localhost:8125
 ```
 
 #### `addEntryPointsLabels`

--- a/docs/content/observability/tracing/datadog.md
+++ b/docs/content/observability/tracing/datadog.md
@@ -35,7 +35,7 @@ tracing:
 ```
 
 ```bash tab="CLI"
---tracing.datadog.localAgentHostPort="127.0.0.1:8126"
+--tracing.datadog.localAgentHostPort=127.0.0.1:8126
 ```
 
 #### `debug`
@@ -79,7 +79,7 @@ tracing:
 ```
 
 ```bash tab="CLI"
---tracing.datadog.globalTag="sample"
+--tracing.datadog.globalTag=sample
 ```
 
 #### `prioritySampling`

--- a/docs/content/observability/tracing/haystack.md
+++ b/docs/content/observability/tracing/haystack.md
@@ -35,7 +35,7 @@ tracing:
 ```
 
 ```bash tab="CLI"
---tracing.haystack.localAgentHost="127.0.0.1"
+--tracing.haystack.localAgentHost=127.0.0.1
 ```
 
 #### `localAgentPort`
@@ -79,7 +79,7 @@ tracing:
 ```
 
 ```bash tab="CLI"
---tracing.haystack.globalTag="sample:test"
+--tracing.haystack.globalTag=sample:test
 ```
 
 #### `traceIDHeaderName`
@@ -101,7 +101,7 @@ tracing:
 ```
 
 ```bash tab="CLI"
---tracing.haystack.traceIDHeaderName="sample"
+--tracing.haystack.traceIDHeaderName=sample
 ```
 
 #### `parentIDHeaderName`
@@ -123,7 +123,7 @@ tracing:
 ```
 
 ```bash tab="CLI"
---tracing.haystack.parentIDHeaderName="sample"
+--tracing.haystack.parentIDHeaderName=sample
 ```
 
 #### `spanIDHeaderName`
@@ -168,5 +168,5 @@ tracing:
 
 
 ```bash tab="CLI"
---tracing.haystack.baggagePrefixHeaderName="sample"
+--tracing.haystack.baggagePrefixHeaderName=sample
 ```

--- a/docs/content/observability/tracing/instana.md
+++ b/docs/content/observability/tracing/instana.md
@@ -35,7 +35,7 @@ tracing:
 ```
 
 ```bash tab="CLI"
---tracing.instana.localAgentHost="127.0.0.1"
+--tracing.instana.localAgentHost=127.0.0.1
 ```
 
 #### `localAgentPort`
@@ -86,5 +86,5 @@ tracing:
 ```
 
 ```bash tab="CLI"
---tracing.instana.logLevel="info"
+--tracing.instana.logLevel=info
 ```

--- a/docs/content/observability/tracing/jaeger.md
+++ b/docs/content/observability/tracing/jaeger.md
@@ -39,7 +39,7 @@ tracing:
 ```
 
 ```bash tab="CLI"
---tracing.jaeger.samplingServerURL="http://localhost:5778/sampling"
+--tracing.jaeger.samplingServerURL=http://localhost:5778/sampling
 ```
 
 #### `samplingType`
@@ -61,7 +61,7 @@ tracing:
 ```
 
 ```bash tab="CLI"
---tracing.jaeger.samplingType="const"
+--tracing.jaeger.samplingType=const
 ```
 
 #### `samplingParam`
@@ -89,7 +89,7 @@ tracing:
 ```
 
 ```bash tab="CLI"
---tracing.jaeger.samplingParam="1.0"
+--tracing.jaeger.samplingParam=1.0
 ```
 
 #### `localAgentHostPort`
@@ -111,7 +111,7 @@ tracing:
 ```
 
 ```bash tab="CLI"
---tracing.jaeger.localAgentHostPort="127.0.0.1:6831"
+--tracing.jaeger.localAgentHostPort=127.0.0.1:6831
 ```
 
 #### `gen128Bit`
@@ -159,7 +159,7 @@ tracing:
 ```
 
 ```bash tab="CLI"
---tracing.jaeger.propagation="jaeger"
+--tracing.jaeger.propagation=jaeger
 ```
 
 #### `traceContextHeaderName`
@@ -182,7 +182,7 @@ tracing:
 ```
 
 ```bash tab="CLI"
---tracing.jaeger.traceContextHeaderName="uber-trace-id"
+--tracing.jaeger.traceContextHeaderName=uber-trace-id
 ```
 
 ### `collector`
@@ -206,7 +206,7 @@ tracing:
 ```
 
 ```bash tab="CLI"
---tracing.jaeger.collector.endpoint="http://127.0.0.1:14268/api/traces?format=jaeger.thrift"
+--tracing.jaeger.collector.endpoint=http://127.0.0.1:14268/api/traces?format=jaeger.thrift
 ```
 
 #### `user`
@@ -229,7 +229,7 @@ tracing:
 ```
 
 ```bash tab="CLI"
---tracing.jaeger.collector.user="my-user"
+--tracing.jaeger.collector.user=my-user
 ```
 
 #### `password`
@@ -252,5 +252,5 @@ tracing:
 ```
 
 ```bash tab="CLI"
---tracing.jaeger.collector.password="my-password"
+--tracing.jaeger.collector.password=my-password
 ```

--- a/docs/content/observability/tracing/overview.md
+++ b/docs/content/observability/tracing/overview.md
@@ -52,7 +52,7 @@ tracing:
 ```
 
 ```bash tab="CLI"
---tracing.serviceName="traefik"
+--tracing.serviceName=traefik
 ```
 
 #### `spanNameLimit`

--- a/docs/content/observability/tracing/zipkin.md
+++ b/docs/content/observability/tracing/zipkin.md
@@ -35,7 +35,7 @@ tracing:
 ```
 
 ```bash tab="CLI"
---tracing.zipkin.httpEndpoint="http://localhost:9411/api/v2/spans"
+--tracing.zipkin.httpEndpoint=http://localhost:9411/api/v2/spans
 ```
 
 #### `sameSpan`
@@ -101,5 +101,5 @@ tracing:
 ```
 
 ```bash tab="CLI"
---tracing.zipkin.sampleRate="0.2"
+--tracing.zipkin.sampleRate=0.2
 ```

--- a/docs/content/operations/ping.md
+++ b/docs/content/operations/ping.md
@@ -55,6 +55,6 @@ ping:
 ```
 
 ```bash tab="CLI"
---entryPoints.ping.address=":8082"
---ping.entryPoint="ping"
+--entryPoints.ping.address=:8082
+--ping.entryPoint=ping
 ```

--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -64,7 +64,7 @@ Attach labels to your containers and let Traefik do the rest!
     ```
     
     ```bash tab="CLI"
-    --providers.docker.endpoint="tcp://127.0.0.1:2375"
+    --providers.docker.endpoint=tcp://127.0.0.1:2375
     --providers.docker.swarmMode=true
     ```
 
@@ -108,7 +108,7 @@ providers:
 ```
 
 ```bash tab="CLI"
---providers.docker.endpoint="unix:///var/run/docker.sock"
+--providers.docker.endpoint=unix:///var/run/docker.sock
 ```
 
 Traefik requires access to the docker socket to get its dynamic configuration.
@@ -186,7 +186,7 @@ Traefik requires access to the docker socket to get its dynamic configuration.
     ```
     
     ```bash tab="CLI"
-    --providers.docker.endpoint="unix:///var/run/docker.sock"
+    --providers.docker.endpoint=unix:///var/run/docker.sock
     # ...
     ```
 
@@ -311,7 +311,7 @@ providers:
 ```
 
 ```bash tab="CLI"
---providers.docker.defaultRule="Host(`{{ .Name }}.{{ index .Labels \"customLabel\"}}`)"
+--providers.docker.defaultRule=Host(`{{ .Name }}.{{ index .Labels \"customLabel\"}}`)
 # ...
 ```
 
@@ -375,19 +375,19 @@ _Optional, Default=""_
 
 ```toml tab="File (TOML)"
 [providers.docker]
-  constraints = "Label(`a.label.name`, `foo`)"
+  constraints = "Label(`a.label.name`,`foo`)"
   # ...
 ```
 
 ```yaml tab="File (YAML)"
 providers:
   docker:
-    constraints: "Label(`a.label.name`, `foo`)"
+    constraints: "Label(`a.label.name`,`foo`)"
     # ...
 ```
 
 ```bash tab="CLI"
---providers.docker.constraints="Label(`a.label.name`, `foo`)"
+--providers.docker.constraints=Label(`a.label.name`,`foo`)
 # ...
 ```
 

--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -32,7 +32,7 @@ providers:
 ```
 
 ```bash tab="CLI"
---providers.kubernetescrd.endpoint="http://localhost:8080"
+--providers.kubernetescrd.endpoint=http://localhost:8080
 ```
 
 The Kubernetes server endpoint as URL.
@@ -66,7 +66,7 @@ providers:
 ```
 
 ```bash tab="CLI"
---providers.kubernetescrd.token="mytoken"
+--providers.kubernetescrd.token=mytoken
 ```
 
 Bearer token used for the Kubernetes client configuration.
@@ -89,7 +89,7 @@ providers:
 ```
 
 ```bash tab="CLI"
---providers.kubernetescrd.certauthfilepath="/my/ca.crt"
+--providers.kubernetescrd.certauthfilepath=/my/ca.crt
 ```
 
 Path to the certificate authority file.
@@ -115,7 +115,7 @@ providers:
 ```
 
 ```bash tab="CLI"
---providers.kubernetescrd.namespaces="default,production"
+--providers.kubernetescrd.namespaces=default,production
 ```
 
 Array of namespaces to watch.
@@ -164,7 +164,7 @@ providers:
 ```
 
 ```bash tab="CLI"
---providers.kubernetescrd.ingressclass="traefik-internal"
+--providers.kubernetescrd.ingressclass=traefik-internal
 ```
 
 Value of `kubernetes.io/ingress.class` annotation that identifies Ingress objects to be processed.
@@ -190,7 +190,7 @@ providers:
 ```
 
 ```bash tab="CLI"
---providers.kubernetescrd.throttleDuration="10s"
+--providers.kubernetescrd.throttleDuration=10s
 ```
 
 ## Further

--- a/docs/content/providers/kubernetes-ingress.md
+++ b/docs/content/providers/kubernetes-ingress.md
@@ -67,7 +67,7 @@ providers:
 ```
 
 ```bash tab="CLI"
---providers.kubernetesingress.endpoint="http://localhost:8080"
+--providers.kubernetesingress.endpoint=http://localhost:8080
 ```
 
 The Kubernetes server endpoint as URL, which is only used when the behavior based on environment variables described below does not apply.
@@ -99,7 +99,7 @@ providers:
 ```
 
 ```bash tab="CLI"
---providers.kubernetesingress.token="mytoken"
+--providers.kubernetesingress.token=mytoken
 ```
 
 Bearer token used for the Kubernetes client configuration.
@@ -122,7 +122,7 @@ providers:
 ```
 
 ```bash tab="CLI"
---providers.kubernetesingress.certauthfilepath="/my/ca.crt"
+--providers.kubernetesingress.certauthfilepath=/my/ca.crt
 ```
 
 Path to the certificate authority file.
@@ -171,7 +171,7 @@ providers:
 ```
 
 ```bash tab="CLI"
---providers.kubernetesingress.namespaces="default,production"
+--providers.kubernetesingress.namespaces=default,production
 ```
 
 Array of namespaces to watch.
@@ -220,7 +220,7 @@ providers:
 ```
 
 ```bash tab="CLI"
---providers.kubernetesingress.ingressclass="traefik-internal"
+--providers.kubernetesingress.ingressclass=traefik-internal
 ```
 
 Value of `kubernetes.io/ingress.class` annotation that identifies Ingress objects to be processed.
@@ -249,7 +249,7 @@ providers:
 ```
 
 ```bash tab="CLI"
---providers.kubernetesingress.ingressendpoint.hostname="foo.com"
+--providers.kubernetesingress.ingressendpoint.hostname=foo.com
 ```
 
 Hostname used for Kubernetes Ingress endpoints.
@@ -273,7 +273,7 @@ providers:
 ```
 
 ```bash tab="CLI"
---providers.kubernetesingress.ingressendpoint.ip="1.2.3.4"
+--providers.kubernetesingress.ingressendpoint.ip=1.2.3.4
 ```
 
 IP used for Kubernetes Ingress endpoints.
@@ -297,7 +297,7 @@ providers:
 ```
 
 ```bash tab="CLI"
---providers.kubernetesingress.ingressendpoint.publishedservice="foo-service"
+--providers.kubernetesingress.ingressendpoint.publishedservice=foo-service
 ```
 
 Published Kubernetes Service to copy status from.
@@ -320,7 +320,7 @@ providers:
 ```
 
 ```bash tab="CLI"
---providers.kubernetesingress.throttleDuration="10s"
+--providers.kubernetesingress.throttleDuration=10s
 ```
 
 ## Further

--- a/docs/content/providers/marathon.md
+++ b/docs/content/providers/marathon.md
@@ -74,8 +74,8 @@ providers:
 ```
 
 ```bash tab="CLI"
---providers.marathon.basic.httpbasicauthuser="foo"
---providers.marathon.basic.httpbasicpassword="bar"
+--providers.marathon.basic.httpbasicauthuser=foo
+--providers.marathon.basic.httpbasicpassword=bar
 ```
 
 Enables Marathon basic authentication.
@@ -98,7 +98,7 @@ providers:
 ```
 
 ```bash tab="CLI"
---providers.marathon.dcosToken="xxxxxx"
+--providers.marathon.dcosToken=xxxxxx
 ```
 
 DCOSToken for DCOS environment.
@@ -123,7 +123,7 @@ providers:
 ```
 
 ```bash tab="CLI"
---providers.marathon.defaultRule="Host(`{{ .Name }}.{{ index .Labels \"customLabel\"}}`)"
+--providers.marathon.defaultRule=Host(`{{ .Name }}.{{ index .Labels \"customLabel\"}}`)
 # ...
 ```
 
@@ -182,7 +182,7 @@ providers:
 ```
 
 ```bash tab="CLI"
---providers.marathon.endpoint="http://10.241.1.71:8080,10.241.1.72:8080,10.241.1.73:8080"
+--providers.marathon.endpoint=http://10.241.1.71:8080,10.241.1.72:8080,10.241.1.73:8080
 ```
 
 Marathon server endpoint.
@@ -223,19 +223,19 @@ _Optional, Default=""_
 
 ```toml tab="File (TOML)"
 [providers.marathon]
-  constraints = "Label(`a.label.name`, `foo`)"
+  constraints = "Label(`a.label.name`,`foo`)"
   # ...
 ```
 
 ```yaml tab="File (YAML)"
 providers:
   marathon:
-    constraints: "Label(`a.label.name`, `foo`)"
+    constraints: "Label(`a.label.name`,`foo`)"
     # ...
 ```
 
 ```bash tab="CLI"
---providers.marathon.constraints="Label(`a.label.name`, `foo`)"
+--providers.marathon.constraints=Label(`a.label.name`,`foo`)
 # ...
 ```
 
@@ -389,7 +389,7 @@ providers:
 ```
 
 ```bash tab="CLI"
---providers.marathon.responseHeaderTimeout="66s"
+--providers.marathon.responseHeaderTimeout=66s
 # ...
 ```
 
@@ -532,7 +532,7 @@ providers:
 ```
 
 ```bash tab="CLI"
---providers.marathon.responseHeaderTimeout="10s"
+--providers.marathon.responseHeaderTimeout=10s
 # ...
 ```
 

--- a/docs/content/providers/rancher.md
+++ b/docs/content/providers/rancher.md
@@ -104,7 +104,7 @@ providers:
 ```
 
 ```bash tab="CLI"
---providers.rancher.defaultRule="Host(`{{ .Name }}.{{ index .Labels \"customLabel\"}}`)"
+--providers.rancher.defaultRule=Host(`{{ .Name }}.{{ index .Labels \"customLabel\"}}`)
 # ...
 ```
 
@@ -209,7 +209,7 @@ providers:
 ```
 
 ```bash tab="CLI"
---providers.rancher.prefix="/test"
+--providers.rancher.prefix=/test
 # ...
 ```
 
@@ -221,19 +221,19 @@ _Optional, Default=""_
 
 ```toml tab="File (TOML)"
 [providers.rancher]
-  constraints = "Label(`a.label.name`, `foo`)"
+  constraints = "Label(`a.label.name`,`foo`)"
   # ...
 ```
 
 ```yaml tab="File (YAML)"
 providers:
   rancher:
-    constraints: "Label(`a.label.name`, `foo`)"
+    constraints: "Label(`a.label.name`,`foo`)"
     # ...
 ```
 
 ```bash tab="CLI"
---providers.rancher.constraints="Label(`a.label.name`, `foo`)"
+--providers.rancher.constraints=Label(`a.label.name`,`foo`)
 # ...
 ```
 

--- a/docs/content/providers/rancher.txt
+++ b/docs/content/providers/rancher.txt
@@ -17,4 +17,4 @@
 --providers.rancher.intervalPoll=false
 
 # Prefix used for accessing the Rancher metadata service
---providers.rancher.prefix="/latest"
+--providers.rancher.prefix=/latest

--- a/docs/content/providers/rancher.yml
+++ b/docs/content/providers/rancher.yml
@@ -18,4 +18,4 @@ providers:
   intervalPoll: false
 
   # Prefix used for accessing the Rancher metadata service
-  prefix: "/latest"
+  prefix: /latest

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -128,9 +128,9 @@ You can define them using a toml file, CLI arguments, or a key-value store.
     --entryPoints.name.transport.respondingTimeouts.writeTimeout=42
     --entryPoints.name.transport.respondingTimeouts.idleTimeout=42
     --entryPoints.name.proxyProtocol.insecure=true
-    --entryPoints.name.proxyProtocol.trustedIPs="127.0.0.1,192.168.0.1"
+    --entryPoints.name.proxyProtocol.trustedIPs=127.0.0.1,192.168.0.1
     --entryPoints.name.forwardedHeaders.insecure=true
-    --entryPoints.name.forwardedHeaders.trustedIPs="127.0.0.1,192.168.0.1"
+    --entryPoints.name.forwardedHeaders.trustedIPs=127.0.0.1,192.168.0.1
     ```
 
 ### Forwarded Header

--- a/docs/content/routing/overview.md
+++ b/docs/content/routing/overview.md
@@ -151,7 +151,7 @@ http:
         
         ```bash tab="CLI"
         # Listen on port 8081 for incoming requests
-        --entryPoints.web.address=":8081"
+        --entryPoints.web.address=:8081
         
         # Enable the file provider to define routers / middlewares / services in a file
         --providers.file.filename=dynamic_conf.toml

--- a/docs/content/routing/providers/docker.md
+++ b/docs/content/routing/providers/docker.md
@@ -82,7 +82,7 @@ Attach labels to your containers and let Traefik do the rest!
     ```
 
     ```bash tab="CLI"
-    --providers.docker.endpoint="tcp://127.0.0.1:2375"
+    --providers.docker.endpoint=tcp://127.0.0.1:2375
     --providers.docker.swarmMode=true
     ```
 

--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -78,8 +78,8 @@ In the process, routers may use pieces of [middleware](../../middlewares/overvie
     
     ```bash tab="CLI"
     ## Static configuration
-    --entryPoints.web.address=":80"
-    --entryPoints.mysql.address=":3306"   
+    --entryPoints.web.address=:80
+    --entryPoints.mysql.address=:3306
     ```
 
 ## Configuring HTTP Routers
@@ -140,9 +140,9 @@ If you want to limit the router scope to a set of entry points, set the `entryPo
     
     ```bash tab="CLI"
     ## Static configuration
-    --entrypoints.web.address=":80"
-    --entrypoints.websecure.address=":443"
-    --entrypoints.other.address=":9090"
+    --entrypoints.web.address=:80
+    --entrypoints.websecure.address=:443
+    --entrypoints.other.address=:9090
     ```
 
 ??? example "Listens to Specific EntryPoints"
@@ -198,9 +198,9 @@ If you want to limit the router scope to a set of entry points, set the `entryPo
     
     ```bash tab="CLI"
     ## Static configuration
-    --entrypoints.web.address=":80"
-    --entrypoints.websecure.address=":443"
-    --entrypoints.other.address=":9090"
+    --entrypoints.web.address=:80
+    --entrypoints.websecure.address=:443
+    --entrypoints.other.address=:9090
     ```
 
 ### Rule
@@ -700,9 +700,9 @@ If you want to limit the router scope to a set of entry points, set the entry po
     
     ```bash tab="CLI"
     ## Static configuration
-    --entrypoints.web.address=":80"
-    --entrypoints.websecure.address=":443"
-    --entrypoints.other.address=":9090"
+    --entrypoints.web.address=:80
+    --entrypoints.websecure.address=:443
+    --entrypoints.other.address=:9090
     ```
 
 ??? example "Listens to Specific Entry Points"
@@ -764,9 +764,9 @@ If you want to limit the router scope to a set of entry points, set the entry po
     
     ```bash tab="CLI"
     ## Static configuration
-    --entrypoints.web.address=":80"
-    --entrypoints.websecure.address=":443"
-    --entrypoints.other.address=":9090"
+    --entrypoints.web.address=:80
+    --entrypoints.websecure.address=:443
+    --entrypoints.other.address=:9090
     ```
 
 ### Rule

--- a/docs/content/user-guides/grpc.md
+++ b/docs/content/user-guides/grpc.md
@@ -32,7 +32,7 @@ api: {}
 ```
 
 ```yaml tab="CLI"
---entryPoints.web.address=":80"
+--entryPoints.web.address=:80
 --providers.file.filename=dynamic_conf.toml
 --api.insecure=true
 ```
@@ -153,7 +153,7 @@ api: {}
 ```
 
 ```yaml tab="CLI"
---entryPoints.websecure.address=":4443"
+--entryPoints.websecure.address=:4443
 # For secure connection on backend.local
 --serversTransport.rootCAs=./backend.cert
 --providers.file.filename=dynamic_conf.toml


### PR DESCRIPTION
### What does this PR do?

doc: remove double quotes on CLI flags.

### Motivation

Have a better documentation.

Related to #5797, #5822

### More

~~- [ ] Added/updated tests~~
- [x] Added/updated documentation

