### PR TITLE
Uses, if it exists, the ping entry point provided in the static configuration

### DIFF
--- a/cmd/healthcheck/healthcheck.go
+++ b/cmd/healthcheck/healthcheck.go
@@ -51,9 +51,14 @@ func Do(staticConfiguration static.Configuration) (*http.Response, error) {
 		return nil, errors.New("please enable `ping` to use health check")
 	}
 
-	pingEntryPoint, ok := staticConfiguration.EntryPoints["traefik"]
+	ep := staticConfiguration.Ping.EntryPoint
+	if ep == "" {
+		ep = "traefik"
+	}
+
+	pingEntryPoint, ok := staticConfiguration.EntryPoints[ep]
 	if !ok {
-		return nil, errors.New("missing `ping` entrypoint")
+		return nil, fmt.Errorf("ping: missing %s entry point", ep)
 	}
 
 	client := &http.Client{Timeout: 5 * time.Second}


### PR DESCRIPTION

### What does this PR do?

Uses the entry point of ping if it is provided, otherwise uses the `traefik` entrypoint.

### Motivation

Fixes #5856 

### More

- [ ] ~~Added/updated tests~~
- [ ] ~~Added/updated documentation~~

### Additional Notes

Co-authored-by: Ludovic Fernandez <ldez@users.noreply.github.com>