### PR TITLE
Web UI: Fix displayed tcp service details

### DIFF
--- a/webui/src/components/_commons/PanelServiceDetails.vue
+++ b/webui/src/components/_commons/PanelServiceDetails.vue
@@ -45,11 +45,24 @@
           </div>
         </div>
       </q-card-section>
-      <q-card-section v-if="data.loadBalancer">
+      <q-card-section v-if="data.loadBalancer && $route.meta.protocol !== 'tcp'">
         <div class="row items-start no-wrap">
           <div class="col">
             <div class="text-subtitle2">Pass Host Header</div>
             <boolean-state :value="data.loadBalancer.passHostHeader"/>
+          </div>
+        </div>
+      </q-card-section>
+
+      <q-card-section v-if="data.loadBalancer.terminationDelay">
+        <div class="row items-start no-wrap">
+          <div class="col">
+            <div class="text-subtitle2">Termination Delay</div>
+            <q-chip
+              dense
+              class="app-chip app-chip-name">
+              {{ data.loadBalancer.terminationDelay }} ms
+            </q-chip>
           </div>
         </div>
       </q-card-section>


### PR DESCRIPTION
### What does this PR do?

Fix the details displayed for tcp services

### Motivation

For tcp services:
- passHostHeader was wrongly displayed
- terminationDelay was missing

### Additional Notes

https://community.containo.us/t/pass-host-header-for-tcp/3018
