### PR TITLE
Web UI: Avoid some router properties to overflow their container

### DIFF
--- a/webui/src/components/_commons/PanelRouterDetails.vue
+++ b/webui/src/components/_commons/PanelRouterDetails.vue
@@ -27,7 +27,7 @@
             <div class="text-subtitle2">RULE</div>
             <q-chip
               dense
-              class="app-chip app-chip-rule">
+              class="app-chip app-chip-wrap app-chip-rule">
               {{ data.rule }}
             </q-chip>
           </div>
@@ -39,7 +39,7 @@
             <div class="text-subtitle2">NAME</div>
             <q-chip
               dense
-              class="app-chip app-chip-name">
+              class="app-chip app-chip-wrap app-chip-name">
               {{ data.name }}
             </q-chip>
           </div>
@@ -66,7 +66,7 @@
               dense
               clickable
               @click.native="$router.push({ path: `/${protocol}/services/${getServiceId()}`})"
-              class="app-chip app-chip-service">
+              class="app-chip app-chip-wrap app-chip-service">
               {{ data.service }}
             </q-chip>
           </div>


### PR DESCRIPTION
### What does this PR do?

Set some web ui router properties as wrappable.


### Motivation

Avoid some web ui router properties to overflow their container.

<img width="1065" alt="Capture d’écran 2019-11-20 à 11 58 41" src="https://user-images.githubusercontent.com/1550192/69233605-776abe80-0b8d-11ea-90d3-f7106884698c.png">
