### PR TITLE
Fix finding proper provided certificate when ACME is enabled

### DIFF
--- a/tls/certificate.go
+++ b/tls/certificate.go
@@ -120,6 +120,7 @@ func (c *Certificates) CreateTLSConfig(entryPointName string) (*tls.Config, erro
 			}
 		}
 	}
+	config.BuildNameToCertificate()
 	return config, nil
 }
 

--- a/tls/certificate_test.go
+++ b/tls/certificate_test.go
@@ -1,0 +1,103 @@
+package tls
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCertificates_CreateTLSConfig(t *testing.T) {
+	var cert Certificates
+	certificate1, err := generateCertificate("test1.traefik.com")
+	require.NoError(t, err)
+	require.NotNil(t, certificate1)
+
+	cert = append(cert, *certificate1)
+
+	certificate2, err := generateCertificate("test2.traefik.com")
+	require.NoError(t, err)
+	require.NotNil(t, certificate2)
+
+	cert = append(cert, *certificate2)
+
+	config, err := cert.CreateTLSConfig("http")
+	require.NoError(t, err)
+
+	require.Len(t, config.NameToCertificate, 2)
+	require.Contains(t, config.NameToCertificate, "test1.traefik.com")
+	require.Contains(t, config.NameToCertificate, "test2.traefik.com")
+
+}
+
+func generateCertificate(domain string) (*Certificate, error) {
+	certPEM, keyPEM, err := keyPair(domain, time.Time{})
+	if err != nil {
+		return nil, err
+	}
+
+	return &Certificate{
+		CertFile: FileOrContent(certPEM),
+		KeyFile:  FileOrContent(keyPEM),
+	}, nil
+
+}
+
+// keyPair generates cert and key files
+func keyPair(domain string, expiration time.Time) ([]byte, []byte, error) {
+	rsaPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(rsaPrivKey)})
+
+	certPEM, err := PemCert(rsaPrivKey, domain, expiration)
+	if err != nil {
+		return nil, nil, err
+	}
+	return certPEM, keyPEM, nil
+}
+
+// PemCert generates PEM cert file
+func PemCert(privKey *rsa.PrivateKey, domain string, expiration time.Time) ([]byte, error) {
+	derBytes, err := derCert(privKey, expiration, domain)
+	if err != nil {
+		return nil, err
+	}
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes}), nil
+}
+
+func derCert(privKey *rsa.PrivateKey, expiration time.Time, domain string) ([]byte, error) {
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, err
+	}
+
+	if expiration.IsZero() {
+		expiration = time.Now().Add(365 * (24 * time.Hour))
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName: domain,
+		},
+		NotBefore: time.Now(),
+		NotAfter:  expiration,
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageKeyAgreement | x509.KeyUsageDataEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{domain},
+	}
+
+	return x509.CreateCertificate(rand.Reader, &template, &template, &privKey.PublicKey, privKey)
+}

--- a/tls/certificate_test.go
+++ b/tls/certificate_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,10 +31,9 @@ func TestCertificates_CreateTLSConfig(t *testing.T) {
 	config, err := cert.CreateTLSConfig("http")
 	require.NoError(t, err)
 
-	require.Len(t, config.NameToCertificate, 2)
-	require.Contains(t, config.NameToCertificate, "test1.traefik.com")
-	require.Contains(t, config.NameToCertificate, "test2.traefik.com")
-
+	assert.Len(t, config.NameToCertificate, 2)
+	assert.Contains(t, config.NameToCertificate, "test1.traefik.com")
+	assert.Contains(t, config.NameToCertificate, "test2.traefik.com")
 }
 
 func generateCertificate(domain string) (*Certificate, error) {
@@ -46,7 +46,6 @@ func generateCertificate(domain string) (*Certificate, error) {
 		CertFile: FileOrContent(certPEM),
 		KeyFile:  FileOrContent(keyPEM),
 	}, nil
-
 }
 
 // keyPair generates cert and key files


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.0

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.0

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

Fixes domain to certificate matching when ACME is enabled and non-acme certificates are provided via configuration.

Currently the domain to certificate matching algorithm [here](https://github.com/containous/traefik/blob/f68b6294693b01fd18fcd1f1dd5818be6d0c2c85/acme/acme.go#L611) fails and the default certificate is served. The result is that if two or more non-ACME certificates are provided, only the first one is used.
HTTPS requests to domains not covered by the default certificate fail.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

I am not aware of the project's architecture, or whether the place where I added the call to `BuildNameToCertificate` is the best place for it.