### PR TITLE
Add Swarm section to the Docker Provider Documentation

### DIFF
--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -16,13 +16,13 @@ and [Docker Swarm Mode](https://docs.docker.com/engine/swarm/).
 ## Routing Configuration
 
 When using Docker as a [provider](https://docs.traefik.io/providers/overview/),
-Trafik uses [containers labels](https://docs.docker.com/engine/reference/commandline/run/#set-metadata-on-container--l---label---label-file) to retrieve its routing configuration.
+Trafik uses [container labels](https://docs.docker.com/engine/reference/commandline/run/#set-metadata-on-container--l---label---label-file) to retrieve its routing configuration.
 
-See the list of labels in the dedicated section in [routing](../routing/providers/docker.md).
+See the list of labels in the dedicated [routing](../routing/providers/docker.md) section.
 
 ### Routing Configuration with Labels
 
-By default, Traefik watches for [container level's labels](https://docs.docker.com/config/labels-custom-metadata/) on a standalone Docker Engine.
+By default, Traefik watches for [container level labels](https://docs.docker.com/config/labels-custom-metadata/) on a standalone Docker Engine.
 
 When using Docker Compose, labels are specified by the directive
 [`labels`](https://docs.docker.com/compose/compose-file/#labels) from the
@@ -39,10 +39,10 @@ Traefik retrieves the private IP and port of containers from the Docker API.
 
 Ports detection works as follow:
 
-- If a container only [exposes](https://docs.docker.com/engine/reference/builder/#expose) one port,
+- If a container [exposes](https://docs.docker.com/engine/reference/builder/#expose) only one port,
   then Traefik uses this port for private communication.
 - If a container [exposes](https://docs.docker.com/engine/reference/builder/#expose) multiple ports,
-  or does not expose any port, then you must specify to Traefik which port to use for communication 
+  or does not expose any ports, then you must manually specify which port Traefik should use for communication 
   by using the label `traefik.http.services.<service_name>.loadbalancer.server.port`
   (Read more on this label in the dedicated section in [routing](../routing/providers/docker.md#port)).
 

--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -13,6 +13,76 @@ and [Docker Swarm Mode](https://docs.docker.com/engine/swarm/).
 !!! tip "The Quick Start Uses Docker"
     If you haven't already, maybe you'd like to go through the [quick start](../getting-started/quick-start.md) that uses the docker provider!
 
+## Configuration Examples
+
+??? example "Configuring Docker & Deploying / Exposing Services"
+
+    Enabling the docker provider
+    
+    ```toml tab="File (TOML)"
+    [providers.docker]
+    ```
+    
+    ```yaml tab="File (YAML)"
+    providers:
+      docker: {}
+    ```
+    
+    ```bash tab="CLI"
+    --providers.docker=true
+    ```
+
+    Attaching labels to containers (in your docker compose file)
+
+    ```yaml
+    version: "3"
+    services:
+      my-container:
+        # ...
+        labels:
+          - traefik.http.routers.my-container.rule=Host(`mydomain.com`)
+    ```
+
+??? example "Configuring Docker Swarm & Deploying / Exposing Services"
+
+    Enabling the docker provider (Swarm Mode)
+
+    ```toml tab="File (TOML)"
+    [providers.docker]
+      # swarm classic (1.12-)
+      # endpoint = "tcp://127.0.0.1:2375"
+      # docker swarm mode (1.12+)
+      endpoint = "tcp://127.0.0.1:2377"
+      swarmMode = true
+    ```
+    
+    ```yaml tab="File (YAML)"
+    providers:
+      docker:
+        # swarm classic (1.12-)
+        # endpoint = "tcp://127.0.0.1:2375"
+        # docker swarm mode (1.12+)
+        endpoint: "tcp://127.0.0.1:2375"
+        swarmMode: true
+    ```
+    
+    ```bash tab="CLI"
+    --providers.docker.endpoint=tcp://127.0.0.1:2375
+    --providers.docker.swarmMode=true
+    ```
+
+    Attach labels to services (not to containers) while in Swarm mode (in your docker compose file)
+
+    ```yaml
+    version: "3"
+    services:
+      my-container:
+        deploy:
+          labels:
+            - traefik.http.routers.my-container.rule=Host(`mydomain.com`)
+            - traefik.http.services.my-container-service.loadbalancer.server.port=8080
+    ```
+
 ## Routing Configuration
 
 When using Docker as a [provider](https://docs.traefik.io/providers/overview/),
@@ -143,76 +213,6 @@ services:
     Please consider the security implications by reading the [Security Note](#security-note).
     
     A good example can be found on [Bret Fisher's repository](https://github.com/BretFisher/dogvscat/blob/master/stack-proxy-global.yml#L124).
-    
-## Configuration Examples
-
-??? example "Configuring Docker & Deploying / Exposing Services"
-
-    Enabling the docker provider
-    
-    ```toml tab="File (TOML)"
-    [providers.docker]
-    ```
-    
-    ```yaml tab="File (YAML)"
-    providers:
-      docker: {}
-    ```
-    
-    ```bash tab="CLI"
-    --providers.docker=true
-    ```
-
-    Attaching labels to containers (in your docker compose file)
-
-    ```yaml
-    version: "3"
-    services:
-      my-container:
-        # ...
-        labels:
-          - traefik.http.routers.my-container.rule=Host(`mydomain.com`)
-    ```
-
-??? example "Configuring Docker Swarm & Deploying / Exposing Services"
-
-    Enabling the docker provider (Swarm Mode)
-
-    ```toml tab="File (TOML)"
-    [providers.docker]
-      # swarm classic (1.12-)
-      # endpoint = "tcp://127.0.0.1:2375"
-      # docker swarm mode (1.12+)
-      endpoint = "tcp://127.0.0.1:2377"
-      swarmMode = true
-    ```
-    
-    ```yaml tab="File (YAML)"
-    providers:
-      docker:
-        # swarm classic (1.12-)
-        # endpoint = "tcp://127.0.0.1:2375"
-        # docker swarm mode (1.12+)
-        endpoint: "tcp://127.0.0.1:2375"
-        swarmMode: true
-    ```
-    
-    ```bash tab="CLI"
-    --providers.docker.endpoint=tcp://127.0.0.1:2375
-    --providers.docker.swarmMode=true
-    ```
-
-    Attach labels to services (not to containers) while in Swarm mode (in your docker compose file)
-
-    ```yaml
-    version: "3"
-    services:
-      my-container:
-        deploy:
-          labels:
-            - traefik.http.routers.my-container.rule=Host(`mydomain.com`)
-            - traefik.http.services.my-container-service.loadbalancer.server.port=8080
-    ```
 
 ## Provider Configuration
 

--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -30,19 +30,19 @@ When using Docker Compose, labels are specified by the directive
 
 !!! tip "Not Only Docker"
     Please note that any tool like Nomad, Terraform, Ansible, etc.
-    is able to define Docker container with label can work
+    that is able to define a Docker container with labels can work
     with Traefik & the Docker provider.
 
 ### Port Detection
 
 Traefik retrieves the private IP and port of containers from the Docker API.
 
-Ports detection works as follow:
+Ports detection works as follows:
 
 - If a container [exposes](https://docs.docker.com/engine/reference/builder/#expose) only one port,
   then Traefik uses this port for private communication.
 - If a container [exposes](https://docs.docker.com/engine/reference/builder/#expose) multiple ports,
-  or does not expose any ports, then you must manually specify which port Traefik should use for communication 
+  or does not expose any port, then you must manually specify which port Traefik should use for communication 
   by using the label `traefik.http.services.<service_name>.loadbalancer.server.port`
   (Read more on this label in the dedicated section in [routing](../routing/providers/docker.md#port)).
 
@@ -235,7 +235,7 @@ providers:
 --providers.docker.endpoint=unix:///var/run/docker.sock
 ```
 
-See the sections [Docker API Access](#docker-api-access) and [Docker Swarm API Access](#docker-api-access_1) for more informations.
+See the sections [Docker API Access](#docker-api-access) and [Docker Swarm API Access](#docker-api-access_1) for more information.
 
 ??? example "Using the docker.sock"
 

--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -100,11 +100,11 @@ While in Swarm Mode, Traefik uses labels found on services, not on individual co
 Therefore, if you use a compose file with Swarm Mode, labels should be defined in the
 [`deploy`](https://docs.docker.com/compose/compose-file/#labels-1) part of your service.
 
-This behavior is only enabled for docker-compose version 3+ ([Compose file reference](https://docs.docker.com/compose/compose-file/#labels-1)).
+This behavior is only enabled for docker-compose version 3+ ([Compose file reference](https://docs.docker.com/compose/compose-file)).
 
 ### Port Detection
 
-Docker Swarm does not provide any [port exposition](port-detection) information to Traefik.
+Docker Swarm does not provide any [port detection](#port-detection) information to Traefik.
 
 Therefore you **must** specify the port to use for communication by using the label `traefik.http.services.<service_name>.loadbalancer.server.port`
 (Check the reference for this label in the [routing section for Docker](../routing/providers/docker.md#port)).
@@ -113,7 +113,7 @@ Therefore you **must** specify the port to use for communication by using the la
 
 Docker Swarm Mode follows the same rules as Docker [API Access](#docker-api-access).
 
-As the Swarm API is only exposed on the [manager nodes](it is mandatory to schedule Traefik on the Swarm manager nodes), you should schedule Traefik on the Swarm manager nodes by default,
+As the Swarm API is only exposed on the [manager nodes](https://docs.docker.com/engine/swarm/how-swarm-mode-works/nodes/#manager-nodes), you should schedule Traefik on the Swarm manager nodes by default,
 by deploying Traefik with a [constraint](https://success.docker.com/article/using-contraints-and-labels-to-control-the-placement-of-containers) on the node's "role":
 
 ```shell tab="With Docker CLI"
@@ -235,7 +235,7 @@ providers:
 --providers.docker.endpoint=unix:///var/run/docker.sock
 ```
 
-See the sections [Docker API Access](#docker-api-access) and [Docker Swarm API Access](#docker-api-access-1) for more informations.
+See the sections [Docker API Access](#docker-api-access) and [Docker Swarm API Access](#docker-api-access_1) for more informations.
 
 ??? example "Using the docker.sock"
 

--- a/docs/content/routing/providers/docker.md
+++ b/docs/content/routing/providers/docker.md
@@ -243,11 +243,12 @@ you'd add the label `traefik.http.services.<name-of-your-choice>.loadbalancer.pa
 !!! warning "The character `@` is not authorized in the service name `<service_name>`."
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.server.port`"
-
+    
     Registers a port.
     Useful when the container exposes multiples ports.
 
-    Mandatory for Docker Swarm.
+    Mandatory for Docker Swarm (see the section ["Port Detection with Docker Swarm"](../../providers/docker.md#port-detection_1)).
+    {: #port }
 
     ```yaml
     - "traefik.http.services.myservice.loadbalancer.server.port=8080"


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.0

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.0

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR aims at adding a Swarm section in the Docker provider documentation,
introducing the following changes:

- [Docker provider documentation] Elaborate that Swarm Mode is supported + elaborate and moving upfront the "Routing Configuration" for Docker standalone
- [Docker provider documentation] Add a section "Routing Configuration with Labels" for Docker standalone to elaborate the concept (as the quickstart is not really explicit about the "label" magic), and mention other tools that could be used if Docker is used in background
- [Docker provider documentation] Add a section "Port Detection" for Docker standalone to explain the port detection mechanism
- [Docker provider documentation] Add a section "Docker API Access" for Docker standalone with the content around security moved here (and adapted to recent publications as it was for Traefik v1)
- [Docker provider documentation] Add a full section "Docker Swarm Mode", mirroring the 3 sub sections added to standalone (labels, port and api access) to elaborate on the swarm mode specifics.
- [Docker provider & Docker routing documentations] Minor adaptations to adapt to the new sections introduction (moving configuration examples, adding internal links, etc.)

### Motivation

- We want Docker Swarm users to be able to learn how to use Traefik in a single location.
- We want Docker users to fully understand how Traefik interacts with Docker and/or Swarm.
- We want to leverage the amount of community issues on these topics by improving the documentation based on the raising voices from community of users.
- Follows up #5795
- Closes #5735 
- Related to https://community.containo.us/t/dashboard-gives-me-an-error-bad-gateway/1883/2 and https://community.containo.us/tags/docker-swarm


### More

- ~[ ] Added/updated tests~
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
