### PR TITLE
Duration order consistency when multiplying number by time unit

### DIFF
--- a/integration/grpc_test.go
+++ b/integration/grpc_test.go
@@ -349,7 +349,7 @@ func (s *GRPCSuite) TestGRPCBuffer(c *check.C) {
 		received <- true
 	}()
 
-	err = try.Do(time.Second*10, func() error {
+	err = try.Do(10*time.Second, func() error {
 		select {
 		case <-received:
 			return nil

--- a/integration/simple_test.go
+++ b/integration/simple_test.go
@@ -705,7 +705,7 @@ func (s *SimpleSuite) TestMirrorCanceled(c *check.C) {
 
 	main := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		atomic.AddInt32(&count, 1)
-		time.Sleep(time.Second * 2)
+		time.Sleep(2 * time.Second)
 	}))
 
 	mirror1 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {

--- a/pkg/provider/file/file_test.go
+++ b/pkg/provider/file/file_test.go
@@ -139,7 +139,7 @@ func TestProvideWithWatch(t *testing.T) {
 				}
 			}
 
-			timeout = time.After(time.Second * 1)
+			timeout = time.After(1 * time.Second)
 			var numUpdates, numServices, numRouters, numTLSConfs int
 			for {
 				select {

--- a/pkg/provider/rancher/rancher.go
+++ b/pkg/provider/rancher/rancher.go
@@ -151,7 +151,7 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 }
 
 func (p *Provider) intervalPoll(ctx context.Context, client rancher.Client, updateConfiguration func(string)) {
-	ticker := time.NewTicker(time.Second * time.Duration(p.RefreshSeconds))
+	ticker := time.NewTicker(time.Duration(p.RefreshSeconds) * time.Second)
 	defer ticker.Stop()
 
 	var version string

--- a/pkg/server/service/tcp/service.go
+++ b/pkg/server/service/tcp/service.go
@@ -51,7 +51,7 @@ func (m *Manager) BuildTCP(rootCtx context.Context, serviceName string) (tcp.Han
 			defaultTerminationDelay := 100
 			conf.LoadBalancer.TerminationDelay = &defaultTerminationDelay
 		}
-		duration := time.Millisecond * time.Duration(*conf.LoadBalancer.TerminationDelay)
+		duration := time.Duration(*conf.LoadBalancer.TerminationDelay) * time.Millisecond
 
 		for name, server := range conf.LoadBalancer.Servers {
 			if _, _, err := net.SplitHostPort(server.Address); err != nil {

--- a/pkg/tcp/proxy_test.go
+++ b/pkg/tcp/proxy_test.go
@@ -24,7 +24,7 @@ func fakeRedis(t *testing.T, listener net.Listener) {
 			}
 
 			if string(buf[:4]) == "ping" {
-				time.Sleep(time.Millisecond * 1)
+				time.Sleep(1 * time.Millisecond)
 				if _, err := conn.Write([]byte("PONG")); err != nil {
 					conn.Close()
 					return


### PR DESCRIPTION
### What does this PR do?
Fix duration order consistency when multiplying number by time unit

### Motivation

I saw some inconsistency in the code and wanna fix it :)

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation
