### PR TITLE
fix: sub command help

### DIFF
--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -61,10 +61,12 @@ func execute(cmd *Command, args []string, root bool) error {
 
 	// Calls command by its name.
 	if len(args) >= 2 && cmd.Name == args[1] {
-		if err := run(cmd, args[2:]); err != nil {
-			return fmt.Errorf("command %s error: %v", cmd.Name, err)
+		if len(args) < 3 || !contains(cmd.subCommands, args[2]) {
+			if err := run(cmd, args[2:]); err != nil {
+				return fmt.Errorf("command %s error: %v", cmd.Name, err)
+			}
+			return nil
 		}
-		return nil
 	}
 
 	// No sub-command, calls the current command.
@@ -78,6 +80,9 @@ func execute(cmd *Command, args []string, root bool) error {
 	// Trying to find the sub-command.
 	for _, subCmd := range cmd.subCommands {
 		if len(args) >= 2 && subCmd.Name == args[1] {
+			return execute(subCmd, args, false)
+		}
+		if len(args) >= 3 && subCmd.Name == args[2] {
 			return execute(subCmd, args[1:], false)
 		}
 	}

--- a/pkg/cli/commands_test.go
+++ b/pkg/cli/commands_test.go
@@ -559,6 +559,88 @@ func Test_execute(t *testing.T) {
 			},
 			expected: expected{result: "root---foo=bar--fii=bir"},
 		},
+		{
+			desc: "sub command help",
+			args: []string{"", "test", "subtest", "--help"},
+			command: func() *Command {
+				rootCmd := &Command{
+					Name:      "test",
+					Resources: []ResourceLoader{&FlagLoader{}},
+				}
+
+				subCmd := &Command{
+					Name:      "subtest",
+					Resources: []ResourceLoader{&FlagLoader{}},
+				}
+
+				err := rootCmd.AddCommand(subCmd)
+				require.NoError(t, err)
+
+				subSubCmd := &Command{
+					Name:      "subsubtest",
+					Resources: []ResourceLoader{&FlagLoader{}},
+				}
+
+				err = subCmd.AddCommand(subSubCmd)
+				require.NoError(t, err)
+
+				subSubSubCmd := &Command{
+					Name:      "subsubsubtest",
+					Resources: []ResourceLoader{&FlagLoader{}},
+					Run: func([]string) error {
+						called = "subsubsubtest"
+						return nil
+					},
+				}
+
+				err = subSubCmd.AddCommand(subSubSubCmd)
+				require.NoError(t, err)
+
+				return rootCmd
+			},
+			expected: expected{},
+		},
+		{
+			desc: "sub sub command help",
+			args: []string{"", "test", "subtest", "subsubtest", "--help"},
+			command: func() *Command {
+				rootCmd := &Command{
+					Name:      "test",
+					Resources: []ResourceLoader{&FlagLoader{}},
+				}
+
+				subCmd := &Command{
+					Name:      "subtest",
+					Resources: []ResourceLoader{&FlagLoader{}},
+				}
+
+				err := rootCmd.AddCommand(subCmd)
+				require.NoError(t, err)
+
+				subSubCmd := &Command{
+					Name:      "subsubtest",
+					Resources: []ResourceLoader{&FlagLoader{}},
+				}
+
+				err = subCmd.AddCommand(subSubCmd)
+				require.NoError(t, err)
+
+				subSubSubCmd := &Command{
+					Name:      "subsubsubtest",
+					Resources: []ResourceLoader{&FlagLoader{}},
+					Run: func([]string) error {
+						called = "subsubsubtest"
+						return nil
+					},
+				}
+
+				err = subSubCmd.AddCommand(subSubSubCmd)
+				require.NoError(t, err)
+
+				return rootCmd
+			},
+			expected: expected{},
+		},
 	}
 
 	for _, test := range testCases {
@@ -755,4 +837,44 @@ Flags:
     --yu.fuu  (Default: "")
 
 `, string(out))
+}
+
+func TestName(t *testing.T) {
+	rootCmd := &Command{
+		Name:      "test",
+		Resources: []ResourceLoader{&FlagLoader{}},
+	}
+
+	subCmd := &Command{
+		Name:      "subtest",
+		Resources: []ResourceLoader{&FlagLoader{}},
+	}
+
+	err := rootCmd.AddCommand(subCmd)
+	require.NoError(t, err)
+
+	subSubCmd := &Command{
+		Name:      "subsubtest",
+		Resources: []ResourceLoader{&FlagLoader{}},
+		Run: func([]string) error {
+			return nil
+		},
+	}
+
+	err = subCmd.AddCommand(subSubCmd)
+	require.NoError(t, err)
+
+	subSubSubCmd := &Command{
+		Name:      "subsubsubtest",
+		Resources: []ResourceLoader{&FlagLoader{}},
+		Run: func([]string) error {
+			return nil
+		},
+	}
+
+	err = subSubCmd.AddCommand(subSubSubCmd)
+	require.NoError(t, err)
+
+	err = execute(rootCmd, []string{"", "test", "subtest", "subsubtest", "subsubsubtest", "--help"}, true)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
### What does this PR do?

sub command help

### Motivation

before:
```console
$ ./cmd test subtest subsubtest --help
command test error: command not found: subtest
```
after:
```console
$ ./cmd test subtest subsubtest --help
subsubtest    

Usage: subsubtest [command] [flags] [arguments]

Use "subsubtest [command] --help" for help on any command.

Commands:
    subsubsubtest    

```

### More

- [x] Added/updated tests
- [ ] Added/updated documentation
