### PR TITLE
Change service name in rancher provider to make webui service details view work

### DIFF
--- a/pkg/provider/rancher/rancher.go
+++ b/pkg/provider/rancher/rancher.go
@@ -193,7 +193,7 @@ func (p *Provider) parseMetadataSourcedRancherData(ctx context.Context, stacks [
 			}
 
 			service := rancherData{
-				Name:       service.Name + "/" + stack.Name,
+				Name:       service.Name + "_" + stack.Name,
 				State:      service.State,
 				Labels:     service.Labels,
 				Port:       servicePort,


### PR DESCRIPTION
### What does this PR do?

Changes the internal Service Name for the services discovered through the rancher provider.

### Motivation

Make the WebUI work with Rancher Services

