### PR TITLE
Remove Request Headers CORS Preflight Requirement

### DIFF
--- a/pkg/middlewares/headers/headers.go
+++ b/pkg/middlewares/headers/headers.go
@@ -221,13 +221,11 @@ func (s *Header) processCorsHeaders(rw http.ResponseWriter, req *http.Request) b
 	}
 
 	reqAcMethod := req.Header.Get("Access-Control-Request-Method")
-	reqAcHeaders := req.Header.Get("Access-Control-Request-Headers")
 	originHeader := req.Header.Get("Origin")
 
-	if reqAcMethod != "" && reqAcHeaders != "" && originHeader != "" && req.Method == http.MethodOptions {
+	if reqAcMethod != "" && originHeader != "" && req.Method == http.MethodOptions {
 		// If the request is an OPTIONS request with an Access-Control-Request-Method header,
-		// and Access-Control-Request-Headers headers, and Origin headers,
-		// then it is a CORS preflight request,
+		// and Origin headers, then it is a CORS preflight request,
 		// and we need to build a custom response: https://www.w3.org/TR/cors/#preflight-request
 		if s.headers.AccessControlAllowCredentials {
 			rw.Header().Set("Access-Control-Allow-Credentials", "true")

--- a/pkg/middlewares/headers/headers_test.go
+++ b/pkg/middlewares/headers/headers_test.go
@@ -275,6 +275,25 @@ func TestCORSPreflights(t *testing.T) {
 				"Access-Control-Allow-Headers": {"origin,X-Forwarded-For"},
 			},
 		},
+		{
+			desc: "No Request Headers Preflight",
+			header: NewHeader(emptyHandler, dynamic.Headers{
+				AccessControlAllowMethods: []string{"GET", "OPTIONS", "PUT"},
+				AccessControlAllowOrigin:  "*",
+				AccessControlAllowHeaders: []string{"origin", "X-Forwarded-For"},
+				AccessControlMaxAge:       600,
+			}),
+			requestHeaders: map[string][]string{
+				"Access-Control-Request-Method": {"GET", "OPTIONS"},
+				"Origin":                        {"https://foo.bar.org"},
+			},
+			expected: map[string][]string{
+				"Access-Control-Allow-Origin":  {"*"},
+				"Access-Control-Max-Age":       {"600"},
+				"Access-Control-Allow-Methods": {"GET,OPTIONS,PUT"},
+				"Access-Control-Allow-Headers": {"origin,X-Forwarded-For"},
+			},
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.0

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.0

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR Removes the `Access-Control-Request-Headers` requirement for determining if the request is a Preflight or not.

### Motivation

Fixes #5896 

### More

- [x] Added/updated tests
- [x] Added/updated documentation - None needed, bugfix

### Additional Notes

The W3 cors documentation leaves much to be desired:
https://www.w3.org/TR/cors/#cross-origin-request-with-preflight-0
