### PR TITLE
Update consul-catalog documentation

### DIFF
--- a/docs/content/routing/providers/consul-catalog.md
+++ b/docs/content/routing/providers/consul-catalog.md
@@ -1,6 +1,6 @@
 # Traefik & Consul Catalog
 
-A Story of Labels, Services & Containers
+A Story of Labels, Services & Instances
 {: .subtitle }
 
 ![Rancher](../../assets/img/providers/consul.png)
@@ -10,226 +10,235 @@ Attach labels to your services and let Traefik do the rest!
 ## Routing Configuration
 
 !!! info "Labels"
-    
+
+    - Labels are defined by Consul Catalog service tags starting with the `traefik` prefix.
+    - The prefix can be customized with the `prefix` option of the provider
     - Labels are case insensitive.
-    - The complete list of labels can be found [the reference page](../../reference/dynamic-configuration/consul-catalog.md)
+    - Labels always consist of a key/value pair
+    - The complete list of labels can be found on [the reference page](../../reference/dynamic-configuration/consul-catalog.md)
+
+    ```toml
+    # Label examples
+    traefik.my_custom_label=value
+    traefik.enable=true
+    ```
 
 ### General
 
 Traefik creates, for each consul Catalog service, a corresponding [service](../services/index.md) and [router](../routers/index.md).
 
-The Service automatically gets a server per container in this consul Catalog service, and the router gets a default rule attached to it, based on the service name.
+The Service automatically gets a server per instance in this consul Catalog service, and the router gets a default rule attached to it, based on the service name.
 
 ### Routers
 
-To update the configuration of the Router automatically attached to the container, add labels starting with `traefik.routers.{name-of-your-choice}.` and followed by the option you want to change.
+To update the configuration of the Router automatically attached to the service, add labels starting with `traefik.routers.{name-of-your-choice}.` and followed by the option you want to change.
 
-For example, to change the rule, you could add the label ```traefik.http.routers.my-container.rule=Host(`mydomain.com`)```.
+For example, to change the rule, you could add the label ```traefik.http.routers.my-service.rule=Host(`mydomain.com`)```.
 
 ??? info "`traefik.http.routers.<router_name>.rule`"
-    
-    See [rule](../routers/index.md#rule) for more information. 
-    
+
+    See [rule](../routers/index.md#rule) for more information.
+
     ```yaml
     - "traefik.http.routers.myrouter.rule=Host(`mydomain.com`)"
     ```
 
 ??? info "`traefik.http.routers.<router_name>.entrypoints`"
-    
-    See [entry points](../routers/index.md#entrypoints) for more information. 
-    
+
+    See [entry points](../routers/index.md#entrypoints) for more information.
+
     ```yaml
     - "traefik.http.routers.myrouter.entrypoints=web,websecure"
     ```
 
 ??? info "`traefik.http.routers.<router_name>.middlewares`"
-    
-    See [middlewares](../routers/index.md#middlewares) and [middlewares overview](../../middlewares/overview.md) for more information. 
-    
+
+    See [middlewares](../routers/index.md#middlewares) and [middlewares overview](../../middlewares/overview.md) for more information.
+
     ```yaml
     - "traefik.http.routers.myrouter.middlewares=auth,prefix,cb"
     ```
 
 ??? info "`traefik.http.routers.<router_name>.service`"
-    
-    See [rule](../routers/index.md#service) for more information. 
-    
+
+    See [rule](../routers/index.md#service) for more information.
+
     ```yaml
     - "traefik.http.routers.myrouter.service=myservice"
     ```
 
 ??? info "`traefik.http.routers.<router_name>.tls`"
-    
+
     See [tls](../routers/index.md#tls) for more information.
-    
+
     ```yaml
     - "traefik.http.routers.myrouter>.tls=true"
     ```
 
 ??? info "`traefik.http.routers.<router_name>.tls.certresolver`"
-    
+
     See [certResolver](../routers/index.md#certresolver) for more information.
-    
+
     ```yaml
     - "traefik.http.routers.myrouter.tls.certresolver=myresolver"
     ```
 
 ??? info "`traefik.http.routers.<router_name>.tls.domains[n].main`"
-    
+
     See [domains](../routers/index.md#domains) for more information.
-    
+
     ```yaml
     - "traefik.http.routers.myrouter.tls.domains[0].main=foobar.com"
     ```
 
 ??? info "`traefik.http.routers.<router_name>.tls.domains[n].sans`"
-    
+
     See [domains](../routers/index.md#domains) for more information.
-    
+
     ```yaml
     - "traefik.http.routers.myrouter.tls.domains[0].sans=test.foobar.com,dev.foobar.com"
     ```
 
 ??? info "`traefik.http.routers.<router_name>.tls.options`"
-    
+
     See [options](../routers/index.md#options) for more information.
-    
+
     ```yaml
     - "traefik.http.routers.myrouter.tls.options=foobar"
     ```
 
 ??? info "`traefik.http.routers.<router_name>.priority`"
     <!-- TODO doc priority in routers page -->
-    
+
     ```yaml
     - "traefik.http.routers.myrouter.priority=42"
     ```
 
 ### Services
 
-To update the configuration of the Service automatically attached to the container,
+To update the configuration of the Service automatically attached to the service,
 add labels starting with `traefik.http.services.{name-of-your-choice}.`, followed by the option you want to change.
 
 For example, to change the `passHostHeader` behavior,
 you'd add the label `traefik.http.services.{name-of-your-choice}.loadbalancer.passhostheader=false`.
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.server.port`"
-    
+
     Registers a port.
-    Useful when the container exposes multiples ports.
-    
+    Useful when the service exposes multiples ports.
+
     ```yaml
     - "traefik.http.services.myservice.loadbalancer.server.port=8080"
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.server.scheme`"
-    
+
     Overrides the default scheme.
-    
+
     ```yaml
     - "traefik.http.services.myservice.loadbalancer.server.scheme=http"
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.passhostheader`"
     <!-- TODO doc passHostHeader in services page -->
-    
+
     ```yaml
     - "traefik.http.services.myservice.loadbalancer.passhostheader=true"
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.healthcheck.headers.<header_name>`"
-    
+
     See [health check](../services/index.md#health-check) for more information.
-    
+
     ```yaml
     - "traefik.http.services.myservice.loadbalancer.healthcheck.headers.X-Foo=foobar"
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.healthcheck.hostname`"
-    
+
     See [health check](../services/index.md#health-check) for more information.
-    
+
     ```yaml
     - "traefik.http.services.myservice.loadbalancer.healthcheck.hostname=foobar.com"
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.healthcheck.interval`"
-    
+
     See [health check](../services/index.md#health-check) for more information.
-    
+
     ```yaml
     - "traefik.http.services.myservice.loadbalancer.healthcheck.interval=10"
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.healthcheck.path`"
-    
+
     See [health check](../services/index.md#health-check) for more information.
-    
+
     ```yaml
     - "traefik.http.services.myservice.loadbalancer.healthcheck.path=/foo"
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.healthcheck.port`"
-    
+
     See [health check](../services/index.md#health-check) for more information.
-    
+
     ```yaml
     - "traefik.http.services.myservice.loadbalancer.healthcheck.port=42"
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.healthcheck.scheme`"
-    
+
     See [health check](../services/index.md#health-check) for more information.
-    
+
     ```yaml
     - "traefik.http.services.myservice.loadbalancer.healthcheck.scheme=http"
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.healthcheck.timeout`"
-    
+
     See [health check](../services/index.md#health-check) for more information.
-    
+
     ```yaml
     - "traefik.http.services.myservice.loadbalancer.healthcheck.timeout=10"
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.sticky`"
-    
+
     See [sticky sessions](../services/index.md#sticky-sessions) for more information.
-    
+
     ```yaml
     - "traefik.http.services.myservice.loadbalancer.sticky=true"
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.sticky.cookie.httponly`"
-    
+
     See [sticky sessions](../services/index.md#sticky-sessions) for more information.
-    
+
     ```yaml
     - "traefik.http.services.myservice.loadbalancer.sticky.cookie.httponly=true"
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.sticky.cookie.name`"
-    
+
     See [sticky sessions](../services/index.md#sticky-sessions) for more information.
-    
+
     ```yaml
     - "traefik.http.services.myservice.loadbalancer.sticky.cookie.name=foobar"
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.sticky.cookie.secure`"
-    
+
     See [sticky sessions](../services/index.md#sticky-sessions) for more information.
-    
+
     ```yaml
     - "traefik.http.services.myservice.loadbalancer.sticky.cookie.secure=true"
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.responseforwarding.flushinterval`"
     <!-- TODO doc responseforwarding in services page -->
-    
+
     FlushInterval specifies the flush interval to flush to the client while copying the response body.
-    
+
     ```yaml
     - "traefik.http.services.myservice.loadbalancer.responseforwarding.flushinterval=10"
     ```
@@ -243,14 +252,14 @@ For example, to declare a middleware [`redirectscheme`](../../middlewares/redire
 More information about available middlewares in the dedicated [middlewares section](../../middlewares/overview.md).
 
 ??? example "Declaring and Referencing a Middleware"
-    
+
     ```yaml
     # ...
     labels:
       # Declaring a middleware
       - traefik.http.middlewares.my-redirect.redirectscheme.scheme=https
       # Referencing a middleware
-      - traefik.http.routers.my-container.middlewares=my-redirect
+      - traefik.http.routers.my-service.middlewares=my-redirect
     ```
 
 !!! warning "Conflicts in Declaration"
@@ -265,7 +274,7 @@ You can declare TCP Routers and/or Services using labels.
 
     ```yaml
        services:
-         my-container:
+         my-service:
            # ...
            labels:
              - "traefik.tcp.routers.my-router.rule=HostSNI(`my-host.com`)"
@@ -276,78 +285,78 @@ You can declare TCP Routers and/or Services using labels.
 !!! warning "TCP and HTTP"
 
     If you declare a TCP Router/Service, it will prevent Traefik from automatically creating an HTTP Router/Service (like it does by default if no TCP Router/Service is defined).
-    You can declare both a TCP Router/Service and an HTTP Router/Service for the same container (but you have to do so manually).
+    You can declare both a TCP Router/Service and an HTTP Router/Service for the same consul service (but you have to do so manually).
 
 #### TCP Routers
 
 ??? info "`traefik.tcp.routers.<router_name>.entrypoints`"
-    
+
     See [entry points](../routers/index.md#entrypoints_1) for more information.
-    
+
     ```yaml
     - "traefik.tcp.routers.mytcprouter.entrypoints=ep1,ep2"
     ```
 
 ??? info "`traefik.tcp.routers.<router_name>.rule`"
-    
+
     See [rule](../routers/index.md#rule_1) for more information.
-    
+
     ```yaml
     - "traefik.tcp.routers.mytcprouter.rule=HostSNI(`myhost.com`)"
     ```
 
 ??? info "`traefik.tcp.routers.<router_name>.service`"
-    
+
     See [service](../routers/index.md#services) for more information.
-    
+
     ```yaml
     - "traefik.tcp.routers.mytcprouter.service=myservice"
     ```
 
 ??? info "`traefik.tcp.routers.<router_name>.tls`"
-    
+
     See [TLS](../routers/index.md#tls_1) for more information.
-    
+
     ```yaml
     - "traefik.tcp.routers.mytcprouter.tls=true"
     ```
 
 ??? info "`traefik.tcp.routers.<router_name>.tls.certresolver`"
-    
+
     See [certResolver](../routers/index.md#certresolver_1) for more information.
-    
+
     ```yaml
     - "traefik.tcp.routers.mytcprouter.tls.certresolver=myresolver"
     ```
 
 ??? info "`traefik.tcp.routers.<router_name>.tls.domains[n].main`"
-    
+
     See [domains](../routers/index.md#domains_1) for more information.
-    
+
     ```yaml
     - "traefik.tcp.routers.mytcprouter.tls.domains[0].main=foobar.com"
     ```
 
 ??? info "`traefik.tcp.routers.<router_name>.tls.domains[n].sans`"
-    
+
     See [domains](../routers/index.md#domains_1) for more information.
-    
+
     ```yaml
     - "traefik.tcp.routers.mytcprouter.tls.domains[0].sans=test.foobar.com,dev.foobar.com"
     ```
 
 ??? info "`traefik.tcp.routers.<router_name>.tls.options`"
-    
+
     See [options](../routers/index.md#options_1) for more information.
-    
+
     ```yaml
     - "traefik.tcp.routers.mytcprouter.tls.options=mysoptions"
     ```
 
 ??? info "`traefik.tcp.routers.<router_name>.tls.passthrough`"
-    
+
     See [TLS](../routers/index.md#tls_1) for more information.
-    
+
     ```yaml
     - "traefik.tcp.routers.mytcprouter.tls.passthrough=true"
     ```
@@ -355,17 +364,17 @@ You can declare TCP Routers and/or Services using labels.
 #### TCP Services
 
 ??? info "`traefik.tcp.services.<service_name>.loadbalancer.server.port`"
-    
+
     Registers a port of the application.
-    
+
     ```yaml
     - "traefik.tcp.services.mytcpservice.loadbalancer.server.port=423"
     ```
 
 ??? info "`traefik.tcp.services.<service_name>.loadbalancer.terminationdelay`"
-        
+
     See [termination delay](../services/index.md#termination-delay) for more information.
-    
+
     ```yaml
     - "traefik.tcp.services.mytcpservice.loadbalancer.terminationdelay=100"
     ```
@@ -378,7 +387,7 @@ You can declare TCP Routers and/or Services using labels.
 - "traefik.enable=true"
 ```
 
-You can tell Traefik to consider (or not) the container by setting `traefik.enable` to true or false.
+You can tell Traefik to consider (or not) the service by setting `traefik.enable` to true or false.
 
 This option overrides the value of `exposedByDefault`.
 


### PR DESCRIPTION
The Consul Catalog documentation was not using the proper Consul terms and wasn't clear on how to define labels used for constraints. This made me lose quite some time switching from v1.7 to v2.1.

In the end I had to dive in to the code to see how I needed to configure the tags/labels in Consul to get the constraints working. With this PR I hope to correct en clarify the documentation so others don't have to do the same.

During my effort I also noticed that the documentation for the `prefix` option was not correct, and this has also been fixed.

- Explain the relation between Consul tags and Traefik labels
- Remove container references (consul is not limited to containers)
- Make it clear that constraints need to include the prefix value
- Fix the prefix documentation