### PR TITLE
Add serial number certificate to forward headers

### DIFF
--- a/docs/content/middlewares/passtlsclientcert.md
+++ b/docs/content/middlewares/passtlsclientcert.md
@@ -70,6 +70,7 @@ http:
       - "traefik.http.middlewares.test-passtlsclientcert.passtlsclientcert.info.notafter=true"
       - "traefik.http.middlewares.test-passtlsclientcert.passtlsclientcert.info.notbefore=true"
       - "traefik.http.middlewares.test-passtlsclientcert.passtlsclientcert.info.sans=true"
+      - "traefik.http.middlewares.test-passtlsclientcert.passtlsclientcert.info.serialnumber=true"
       - "traefik.http.middlewares.test-passtlsclientcert.passtlsclientcert.info.subject.commonname=true"
       - "traefik.http.middlewares.test-passtlsclientcert.passtlsclientcert.info.subject.country=true"
       - "traefik.http.middlewares.test-passtlsclientcert.passtlsclientcert.info.subject.domaincomponent=true"
@@ -482,7 +483,7 @@ SAN="*.cheese.org,*.cheese.net,*.cheese.com,test@cheese.org,test@cheese.net,10.0
 !!! info "multiple values"
 
     All the SANs data are separated by a `,`.
-    
+
 #### `info.subject`
 
 The `info.subject` select the specific client certificate subject details you want to add to the `X-Forwarded-Tls-Client-Cert-Info` header.

--- a/docs/content/reference/dynamic-configuration/file.toml
+++ b/docs/content/reference/dynamic-configuration/file.toml
@@ -196,6 +196,7 @@
           notAfter = true
           notBefore = true
           sans = true
+          serialNumber = true
           [http.middlewares.Middleware12.passTLSClientCert.info.subject]
             country = true
             province = true

--- a/docs/content/reference/dynamic-configuration/file.yaml
+++ b/docs/content/reference/dynamic-configuration/file.yaml
@@ -239,6 +239,7 @@ http:
             commonName: true
             serialNumber: true
             domainComponent: true
+          serialNumber: true
     Middleware13:
       rateLimit:
         average: 42

--- a/docs/content/reference/dynamic-configuration/kv-ref.md
+++ b/docs/content/reference/dynamic-configuration/kv-ref.md
@@ -92,6 +92,7 @@
 | `traefik/http/middlewares/Middleware12/passTLSClientCert/info/notAfter` | `true` |
 | `traefik/http/middlewares/Middleware12/passTLSClientCert/info/notBefore` | `true` |
 | `traefik/http/middlewares/Middleware12/passTLSClientCert/info/sans` | `true` |
+| `traefik/http/middlewares/Middleware12/passTLSClientCert/info/serialNumber` | `true` |
 | `traefik/http/middlewares/Middleware12/passTLSClientCert/info/subject/commonName` | `true` |
 | `traefik/http/middlewares/Middleware12/passTLSClientCert/info/subject/country` | `true` |
 | `traefik/http/middlewares/Middleware12/passTLSClientCert/info/subject/domainComponent` | `true` |

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -377,11 +377,12 @@ type StripPrefixRegex struct {
 
 // TLSClientCertificateInfo holds the client TLS certificate info configuration.
 type TLSClientCertificateInfo struct {
-	NotAfter  bool                        `json:"notAfter,omitempty" toml:"notAfter,omitempty" yaml:"notAfter,omitempty"`
-	NotBefore bool                        `json:"notBefore,omitempty" toml:"notBefore,omitempty" yaml:"notBefore,omitempty"`
-	Sans      bool                        `json:"sans,omitempty" toml:"sans,omitempty" yaml:"sans,omitempty"`
-	Subject   *TLSCLientCertificateDNInfo `json:"subject,omitempty" toml:"subject,omitempty" yaml:"subject,omitempty"`
-	Issuer    *TLSCLientCertificateDNInfo `json:"issuer,omitempty" toml:"issuer,omitempty" yaml:"issuer,omitempty"`
+	NotAfter     bool                        `json:"notAfter,omitempty" toml:"notAfter,omitempty" yaml:"notAfter,omitempty"`
+	NotBefore    bool                        `json:"notBefore,omitempty" toml:"notBefore,omitempty" yaml:"notBefore,omitempty"`
+	Sans         bool                        `json:"sans,omitempty" toml:"sans,omitempty" yaml:"sans,omitempty"`
+	Subject      *TLSCLientCertificateDNInfo `json:"subject,omitempty" toml:"subject,omitempty" yaml:"subject,omitempty"`
+	Issuer       *TLSCLientCertificateDNInfo `json:"issuer,omitempty" toml:"issuer,omitempty" yaml:"issuer,omitempty"`
+	SerialNumber bool                        `json:"serialNumber,omitempty" toml:"serialNumber,omitempty" yaml:"serialNumber,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/config/label/label_test.go
+++ b/pkg/config/label/label_test.go
@@ -84,6 +84,7 @@ func TestDecodeConfiguration(t *testing.T) {
 		"traefik.http.middlewares.Middleware11.passtlsclientcert.info.notafter":                    "true",
 		"traefik.http.middlewares.Middleware11.passtlsclientcert.info.notbefore":                   "true",
 		"traefik.http.middlewares.Middleware11.passtlsclientcert.info.sans":                        "true",
+		"traefik.http.middlewares.Middleware11.passTLSClientCert.info.serialNumber":                "true",
 		"traefik.http.middlewares.Middleware11.passtlsclientcert.info.subject.commonname":          "true",
 		"traefik.http.middlewares.Middleware11.passtlsclientcert.info.subject.country":             "true",
 		"traefik.http.middlewares.Middleware11.passtlsclientcert.info.subject.domaincomponent":     "true",
@@ -294,8 +295,9 @@ func TestDecodeConfiguration(t *testing.T) {
 					PassTLSClientCert: &dynamic.PassTLSClientCert{
 						PEM: true,
 						Info: &dynamic.TLSClientCertificateInfo{
-							NotAfter:  true,
-							NotBefore: true,
+							NotAfter:     true,
+							NotBefore:    true,
+							SerialNumber: true,
 							Subject: &dynamic.TLSCLientCertificateDNInfo{
 								Country:         true,
 								Province:        true,
@@ -699,8 +701,9 @@ func TestEncodeConfiguration(t *testing.T) {
 					PassTLSClientCert: &dynamic.PassTLSClientCert{
 						PEM: true,
 						Info: &dynamic.TLSClientCertificateInfo{
-							NotAfter:  true,
-							NotBefore: true,
+							NotAfter:     true,
+							NotBefore:    true,
+							SerialNumber: true,
 							Subject: &dynamic.TLSCLientCertificateDNInfo{
 								Country:         true,
 								Province:        true,
@@ -1061,6 +1064,7 @@ func TestEncodeConfiguration(t *testing.T) {
 		"traefik.HTTP.Middlewares.Middleware11.PassTLSClientCert.Info.NotAfter":                    "true",
 		"traefik.HTTP.Middlewares.Middleware11.PassTLSClientCert.Info.NotBefore":                   "true",
 		"traefik.HTTP.Middlewares.Middleware11.PassTLSClientCert.Info.Sans":                        "true",
+		"traefik.HTTP.Middlewares.Middleware11.PassTLSClientCert.Info.SerialNumber":                "true",
 		"traefik.HTTP.Middlewares.Middleware11.PassTLSClientCert.Info.Subject.Country":             "true",
 		"traefik.HTTP.Middlewares.Middleware11.PassTLSClientCert.Info.Subject.Province":            "true",
 		"traefik.HTTP.Middlewares.Middleware11.PassTLSClientCert.Info.Subject.Locality":            "true",

--- a/pkg/middlewares/passtlsclientcert/pass_tls_client_cert_test.go
+++ b/pkg/middlewares/passtlsclientcert/pass_tls_client_cert_test.go
@@ -345,6 +345,7 @@ func TestPassTLSClientCert_certInfo(t *testing.T) {
 	minimalCheeseCertAllInfo := strings.Join([]string{
 		`Subject="C=FR,ST=Some-State,O=Cheese"`,
 		`Issuer="DC=org,DC=cheese,C=FR,C=US,ST=Signing State,ST=Signing State 2,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=Simple Signing CA 2"`,
+		`SerialNumber="481535886039632329873080491016862977516759989652"`,
 		`NB="1544094636"`,
 		`NA="1632568236"`,
 	}, fieldSeparator)
@@ -352,6 +353,7 @@ func TestPassTLSClientCert_certInfo(t *testing.T) {
 	completeCertAllInfo := strings.Join([]string{
 		`Subject="DC=org,DC=cheese,C=FR,C=US,ST=Cheese org state,ST=Cheese com state,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=*.cheese.com"`,
 		`Issuer="DC=org,DC=cheese,C=FR,C=US,ST=Signing State,ST=Signing State 2,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=Simple Signing CA 2"`,
+		`SerialNumber="1"`,
 		`NB="1544094616"`,
 		`NA="1607166616"`,
 		`SAN="*.cheese.org,*.cheese.net,*.cheese.com,test@cheese.org,test@cheese.net,10.0.1.0,10.0.1.2"`,
@@ -399,9 +401,10 @@ func TestPassTLSClientCert_certInfo(t *testing.T) {
 			certContents: []string{minimalCheeseCrt},
 			config: dynamic.PassTLSClientCert{
 				Info: &dynamic.TLSClientCertificateInfo{
-					NotAfter:  true,
-					NotBefore: true,
-					Sans:      true,
+					NotAfter:     true,
+					NotBefore:    true,
+					Sans:         true,
+					SerialNumber: true,
 					Subject: &dynamic.TLSCLientCertificateDNInfo{
 						CommonName:      true,
 						Country:         true,
@@ -446,9 +449,10 @@ func TestPassTLSClientCert_certInfo(t *testing.T) {
 			certContents: []string{completeCheeseCrt},
 			config: dynamic.PassTLSClientCert{
 				Info: &dynamic.TLSClientCertificateInfo{
-					NotAfter:  true,
-					NotBefore: true,
-					Sans:      true,
+					NotAfter:     true,
+					NotBefore:    true,
+					Sans:         true,
+					SerialNumber: true,
 					Subject: &dynamic.TLSCLientCertificateDNInfo{
 						Country:         true,
 						Province:        true,
@@ -476,9 +480,10 @@ func TestPassTLSClientCert_certInfo(t *testing.T) {
 			certContents: []string{minimalCheeseCrt, completeCheeseCrt},
 			config: dynamic.PassTLSClientCert{
 				Info: &dynamic.TLSClientCertificateInfo{
-					NotAfter:  true,
-					NotBefore: true,
-					Sans:      true,
+					NotAfter:     true,
+					NotBefore:    true,
+					Sans:         true,
+					SerialNumber: true,
 					Subject: &dynamic.TLSCLientCertificateDNInfo{
 						Country:         true,
 						Province:        true,


### PR DESCRIPTION
### What does this PR do?

The SerialNumber field for a client certificate was not forwarded as a header in the PassTLSClientCert middleware. This PR fixes that issue.


### Motivation

Fixes #5881 

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

I was unable to completely build the entire project. The fix was tested by running the unit tests.
