### PR TITLE
fix: PassClientTLSCert middleware separators and formatting

### DIFF
--- a/docs/content/middlewares/passtlsclientcert.md
+++ b/docs/content/middlewares/passtlsclientcert.md
@@ -416,7 +416,7 @@ The data are taken from the following certificate part:
 The escape `notAfter` info part will be like:
 
 ```text
-NA=1607166616
+NA="1607166616"
 ```
 
 #### `info.notBefore`
@@ -433,7 +433,7 @@ Validity
 The escape `notBefore` info part will be like:
 
 ```text
-NB=1544094616
+NB="1544094616"
 ```
 
 #### `info.sans`

--- a/docs/content/middlewares/passtlsclientcert.md
+++ b/docs/content/middlewares/passtlsclientcert.md
@@ -380,7 +380,7 @@ In the example, it is the part between `-----BEGIN CERTIFICATE-----` and `-----E
 !!! info "Extracted data"
     
     The delimiters and `\n` will be removed.  
-    If there are more than one certificate, they are separated by a "`;`".
+    If there are more than one certificate, they are separated by a "`,`".
 
 !!! warning "`X-Forwarded-Tls-Client-Cert` value could exceed the web server header size limit"
 
@@ -395,12 +395,12 @@ The value of the header will be an escaped concatenation of all the selected cer
 The following example shows an unescaped result that uses all the available fields: 
 
 ```text
-Subject="DC=org,DC=cheese,C=FR,C=US,ST=Cheese org state,ST=Cheese com state,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=*.cheese.com",Issuer="DC=org,DC=cheese,C=FR,C=US,ST=Signing State,ST=Signing State 2,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=Simple Signing CA 2",NB=1544094616,NA=1607166616,SAN=*.cheese.org,*.cheese.net,*.cheese.com,test@cheese.org,test@cheese.net,10.0.1.0,10.0.1.2
+Subject="DC=org,DC=cheese,C=FR,C=US,ST=Cheese org state,ST=Cheese com state,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=*.cheese.com";Issuer="DC=org,DC=cheese,C=FR,C=US,ST=Signing State,ST=Signing State 2,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=Simple Signing CA 2";NB=1544094616;NA=1607166616;SAN="*.cheese.org,*.cheese.net,*.cheese.com,test@cheese.org,test@cheese.net,10.0.1.0,10.0.1.2"
 ```
 
 !!! info "Multiple certificates"
 
-    If there are more than one certificate, they are separated by a `;`.
+    If there are more than one certificate, they are separated by a `,`.
 
 #### `info.notAfter`
 
@@ -450,7 +450,7 @@ The data are taken from the following certificate part:
 The escape SANs info part will be like:
 
 ```text
-SAN=*.cheese.org,*.cheese.net,*.cheese.com,test@cheese.org,test@cheese.net,10.0.1.0,10.0.1.2
+SAN="*.cheese.org,*.cheese.net,*.cheese.com,test@cheese.org,test@cheese.net,10.0.1.0,10.0.1.2"
 ```
 
 !!! info "multiple values"

--- a/docs/content/middlewares/passtlsclientcert.md
+++ b/docs/content/middlewares/passtlsclientcert.md
@@ -395,7 +395,7 @@ The value of the header will be an escaped concatenation of all the selected cer
 The following example shows an unescaped result that uses all the available fields: 
 
 ```text
-Subject="DC=org,DC=cheese,C=FR,C=US,ST=Cheese org state,ST=Cheese com state,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=*.cheese.com";Issuer="DC=org,DC=cheese,C=FR,C=US,ST=Signing State,ST=Signing State 2,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=Simple Signing CA 2";NB=1544094616;NA=1607166616;SAN="*.cheese.org,*.cheese.net,*.cheese.com,test@cheese.org,test@cheese.net,10.0.1.0,10.0.1.2"
+Subject="DC=org,DC=cheese,C=FR,C=US,ST=Cheese org state,ST=Cheese com state,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=*.cheese.com";Issuer="DC=org,DC=cheese,C=FR,C=US,ST=Signing State,ST=Signing State 2,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=Simple Signing CA 2";NB="1544094616";NA="1607166616";SAN="*.cheese.org,*.cheese.net,*.cheese.com,test@cheese.org,test@cheese.net,10.0.1.0,10.0.1.2"
 ```
 
 !!! info "Multiple certificates"

--- a/pkg/middlewares/passtlsclientcert/pass_tls_client_cert.go
+++ b/pkg/middlewares/passtlsclientcert/pass_tls_client_cert.go
@@ -137,7 +137,7 @@ func (p *passTLSClientCert) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 // - the `,` is used to separate certificates
 // - the `;` is used to separate root fields
 // - the value of root fields is always wrapped by double quote
-// - if a field is empty, the field is removed
+// - if a field is empty, the field is ignored
 func (p *passTLSClientCert) getXForwardedTLSClientCertInfo(ctx context.Context, certs []*x509.Certificate) string {
 	var headerValues []string
 

--- a/pkg/middlewares/passtlsclientcert/pass_tls_client_cert.go
+++ b/pkg/middlewares/passtlsclientcert/pass_tls_client_cert.go
@@ -127,7 +127,7 @@ func (p *passTLSClientCert) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 }
 
 // getXForwardedTLSClientCertInfo Build a string with the wanted client certificates information
-// like Subject="C=%s,ST=%s,L=%s,O=%s,CN=%s",NB=%d,NA=%d,SAN=%s;
+// like Subject="C=%s,ST=%s,L=%s,O=%s,CN=%s";NB=%d;NA=%d;SAN=%s;
 func (p *passTLSClientCert) getXForwardedTLSClientCertInfo(ctx context.Context, certs []*x509.Certificate) string {
 	var headerValues []string
 

--- a/pkg/middlewares/passtlsclientcert/pass_tls_client_cert.go
+++ b/pkg/middlewares/passtlsclientcert/pass_tls_client_cert.go
@@ -133,7 +133,6 @@ func (p *passTLSClientCert) getXForwardedTLSClientCertInfo(ctx context.Context, 
 
 	for _, peerCert := range certs {
 		var values []string
-		var sans string
 		var nb string
 		var na string
 
@@ -161,16 +160,19 @@ func (p *passTLSClientCert) getXForwardedTLSClientCertInfo(ctx context.Context, 
 			}
 
 			if ci.sans {
-				sans = fmt.Sprintf("SAN=%s", strings.Join(getSANs(peerCert), ","))
-				values = append(values, sans)
+				ss := getSANs(peerCert)
+				if len(ss) > 0 {
+					sans := fmt.Sprintf(`SAN="%s"`, strings.Join(ss, ","))
+					values = append(values, sans)
+				}
 			}
 		}
 
-		value := strings.Join(values, ",")
+		value := strings.Join(values, ";")
 		headerValues = append(headerValues, value)
 	}
 
-	return strings.Join(headerValues, ";")
+	return strings.Join(headerValues, ",")
 }
 
 func getDNInfo(ctx context.Context, prefix string, options *DistinguishedNameOptions, cs *pkix.Name) string {

--- a/pkg/middlewares/passtlsclientcert/pass_tls_client_cert_test.go
+++ b/pkg/middlewares/passtlsclientcert/pass_tls_client_cert_test.go
@@ -479,8 +479,8 @@ func TestGetSans(t *testing.T) {
 }
 
 func TestTLSClientHeadersWithCertInfo(t *testing.T) {
-	minimalCheeseCertAllInfo := `Subject="C=FR,ST=Some-State,O=Cheese";Issuer="DC=org,DC=cheese,C=FR,C=US,ST=Signing State,ST=Signing State 2,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=Simple Signing CA 2";NB=1544094636;NA=1632568236`
-	completeCertAllInfo := `Subject="DC=org,DC=cheese,C=FR,C=US,ST=Cheese org state,ST=Cheese com state,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=*.cheese.com";Issuer="DC=org,DC=cheese,C=FR,C=US,ST=Signing State,ST=Signing State 2,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=Simple Signing CA 2";NB=1544094616;NA=1607166616;SAN="*.cheese.org,*.cheese.net,*.cheese.com,test@cheese.org,test@cheese.net,10.0.1.0,10.0.1.2"`
+	minimalCheeseCertAllInfo := `Subject="C=FR,ST=Some-State,O=Cheese";Issuer="DC=org,DC=cheese,C=FR,C=US,ST=Signing State,ST=Signing State 2,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=Simple Signing CA 2";NB="1544094636";NA="1632568236"`
+	completeCertAllInfo := `Subject="DC=org,DC=cheese,C=FR,C=US,ST=Cheese org state,ST=Cheese com state,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=*.cheese.com";Issuer="DC=org,DC=cheese,C=FR,C=US,ST=Signing State,ST=Signing State 2,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=Simple Signing CA 2";NB="1544094616";NA="1607166616";SAN="*.cheese.org,*.cheese.net,*.cheese.com,test@cheese.org,test@cheese.net,10.0.1.0,10.0.1.2"`
 
 	testCases := []struct {
 		desc           string
@@ -564,7 +564,7 @@ func TestTLSClientHeadersWithCertInfo(t *testing.T) {
 					},
 				},
 			},
-			expectedHeader: `Subject="O=Cheese";Issuer="C=FR,C=US";NA=1632568236`,
+			expectedHeader: `Subject="O=Cheese";Issuer="C=FR,C=US";NA="1632568236"`,
 		},
 		{
 			desc:         "TLS with complete certificate, with all info",

--- a/pkg/middlewares/passtlsclientcert/pass_tls_client_cert_test.go
+++ b/pkg/middlewares/passtlsclientcert/pass_tls_client_cert_test.go
@@ -547,7 +547,7 @@ func TestTLSClientHeadersWithCertInfo(t *testing.T) {
 					},
 				},
 			},
-			expectedHeader: url.QueryEscape(minimalCheeseCertAllInfo),
+			expectedHeader: minimalCheeseCertAllInfo,
 		},
 		{
 			desc:         "TLS with simple certificate, with some info",
@@ -564,7 +564,7 @@ func TestTLSClientHeadersWithCertInfo(t *testing.T) {
 					},
 				},
 			},
-			expectedHeader: url.QueryEscape(`Subject="O=Cheese";Issuer="C=FR,C=US";NA=1632568236`),
+			expectedHeader: `Subject="O=Cheese";Issuer="C=FR,C=US";NA=1632568236`,
 		},
 		{
 			desc:         "TLS with complete certificate, with all info",
@@ -594,7 +594,7 @@ func TestTLSClientHeadersWithCertInfo(t *testing.T) {
 					},
 				},
 			},
-			expectedHeader: url.QueryEscape(completeCertAllInfo),
+			expectedHeader: completeCertAllInfo,
 		},
 		{
 			desc:         "TLS with 2 certificates, with all info",
@@ -624,7 +624,7 @@ func TestTLSClientHeadersWithCertInfo(t *testing.T) {
 					},
 				},
 			},
-			expectedHeader: url.QueryEscape(strings.Join([]string{minimalCheeseCertAllInfo, completeCertAllInfo}, ",")),
+			expectedHeader: strings.Join([]string{minimalCheeseCertAllInfo, completeCertAllInfo}, ","),
 		},
 	}
 
@@ -649,7 +649,9 @@ func TestTLSClientHeadersWithCertInfo(t *testing.T) {
 			require.Equal(t, "bar", res.Body.String(), "Should be the expected body")
 
 			if test.expectedHeader != "" {
-				require.Equal(t, test.expectedHeader, req.Header.Get(xForwardedTLSClientCertInfo), "The request header should contain the cleaned certificate")
+				unescape, err := url.QueryUnescape(req.Header.Get(xForwardedTLSClientCertInfo))
+				require.NoError(t, err)
+				require.Equal(t, test.expectedHeader, unescape, "The request header should contain the cleaned certificate")
 			} else {
 				require.Empty(t, req.Header.Get(xForwardedTLSClientCertInfo))
 			}

--- a/pkg/middlewares/passtlsclientcert/pass_tls_client_cert_test.go
+++ b/pkg/middlewares/passtlsclientcert/pass_tls_client_cert_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/containous/traefik/v2/pkg/config/dynamic"
 	"github.com/containous/traefik/v2/pkg/testhelpers"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -113,6 +114,7 @@ Cg+XKmHzexmTnKaKac2w9ZECpRsQ9IBdQq9OghIwPtOnERTOUJEEgNcqA+9xELjb
 pQ==
 -----END CERTIFICATE-----
 `
+
 	minimalCheeseCrt = `-----BEGIN CERTIFICATE-----
 MIIEQDCCAygCFFRY0OBk/L5Se0IZRj3CMljawL2UMA0GCSqGSIb3DQEBCwUAMIIB
 hDETMBEGCgmSJomT8ixkARkWA29yZzEWMBQGCgmSJomT8ixkARkWBmNoZWVzZTEP
@@ -262,47 +264,6 @@ jECvgAY7Nfd9mZ1KtyNaW31is+kag7NsvjxU/kM=
 -----END CERTIFICATE-----`
 )
 
-func getCleanCertContents(certContents []string) string {
-	var re = regexp.MustCompile("-----BEGIN CERTIFICATE-----(?s)(.*)")
-
-	var cleanedCertContent []string
-	for _, certContent := range certContents {
-		cert := re.FindString(certContent)
-		cleanedCertContent = append(cleanedCertContent, sanitize([]byte(cert)))
-	}
-
-	return strings.Join(cleanedCertContent, ",")
-}
-
-func getCertificate(certContent string) *x509.Certificate {
-	roots := x509.NewCertPool()
-	ok := roots.AppendCertsFromPEM([]byte(signingCA))
-	if !ok {
-		panic("failed to parse root certificate")
-	}
-
-	block, _ := pem.Decode([]byte(certContent))
-	if block == nil {
-		panic("failed to parse certificate PEM")
-	}
-	cert, err := x509.ParseCertificate(block.Bytes)
-	if err != nil {
-		panic("failed to parse certificate: " + err.Error())
-	}
-
-	return cert
-}
-
-func buildTLSWith(certContents []string) *tls.ConnectionState {
-	var peerCertificates []*x509.Certificate
-
-	for _, certContent := range certContents {
-		peerCertificates = append(peerCertificates, getCertificate(certContent))
-	}
-
-	return &tls.ConnectionState{PeerCertificates: peerCertificates}
-}
-
 var next = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 	_, err := w.Write([]byte("bar"))
 	if err != nil {
@@ -310,59 +271,7 @@ var next = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 	}
 })
 
-func getExpectedSanitized(s string) string {
-	return url.QueryEscape(strings.Replace(s, "\n", "", -1))
-}
-
-func TestSanitize(t *testing.T) {
-	testCases := []struct {
-		desc       string
-		toSanitize []byte
-		expected   string
-	}{
-		{
-			desc: "Empty",
-		},
-		{
-			desc:       "With a minimal cert",
-			toSanitize: []byte(minimalCheeseCrt),
-			expected: getExpectedSanitized(`MIIEQDCCAygCFFRY0OBk/L5Se0IZRj3CMljawL2UMA0GCSqGSIb3DQEBCwUAMIIB
-hDETMBEGCgmSJomT8ixkARkWA29yZzEWMBQGCgmSJomT8ixkARkWBmNoZWVzZTEP
-MA0GA1UECgwGQ2hlZXNlMREwDwYDVQQKDAhDaGVlc2UgMjEfMB0GA1UECwwWU2lt
-cGxlIFNpZ25pbmcgU2VjdGlvbjEhMB8GA1UECwwYU2ltcGxlIFNpZ25pbmcgU2Vj
-dGlvbiAyMRowGAYDVQQDDBFTaW1wbGUgU2lnbmluZyBDQTEcMBoGA1UEAwwTU2lt
-cGxlIFNpZ25pbmcgQ0EgMjELMAkGA1UEBhMCRlIxCzAJBgNVBAYTAlVTMREwDwYD
-VQQHDAhUT1VMT1VTRTENMAsGA1UEBwwETFlPTjEWMBQGA1UECAwNU2lnbmluZyBT
-dGF0ZTEYMBYGA1UECAwPU2lnbmluZyBTdGF0ZSAyMSEwHwYJKoZIhvcNAQkBFhJz
-aW1wbGVAc2lnbmluZy5jb20xIjAgBgkqhkiG9w0BCQEWE3NpbXBsZTJAc2lnbmlu
-Zy5jb20wHhcNMTgxMjA2MTExMDM2WhcNMjEwOTI1MTExMDM2WjAzMQswCQYDVQQG
-EwJGUjETMBEGA1UECAwKU29tZS1TdGF0ZTEPMA0GA1UECgwGQ2hlZXNlMIIBIjAN
-BgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAskX/bUtwFo1gF2BTPNaNcTUMaRFu
-FMZozK8IgLjccZ4kZ0R9oFO6Yp8Zl/IvPaf7tE26PI7XP7eHriUdhnQzX7iioDd0
-RZa68waIhAGc+xPzRFrP3b3yj3S2a9Rve3c0K+SCV+EtKAwsxMqQDhoo9PcBfo5B
-RHfht07uD5MncUcGirwN+/pxHV5xzAGPcc7On0/5L7bq/G+63nhu78zw9XyuLaHC
-PM5VbOUvpyIESJHbMMzTdFGL8ob9VKO+Kr1kVGdEA9i8FLGl3xz/GBKuW/JD0xyW
-DrU29mri5vYWHmkuv7ZWHGXnpXjTtPHwveE9/0/ArnmpMyR9JtqFr1oEvQIDAQAB
-MA0GCSqGSIb3DQEBCwUAA4IBAQBHta+NWXI08UHeOkGzOTGRiWXsOH2dqdX6gTe9
-xF1AIjyoQ0gvpoGVvlnChSzmlUj+vnx/nOYGIt1poE3hZA3ZHZD/awsvGyp3GwWD
-IfXrEViSCIyF+8tNNKYyUcEO3xdAsAUGgfUwwF/mZ6MBV5+A/ZEEILlTq8zFt9dV
-vdKzIt7fZYxYBBHFSarl1x8pDgWXlf3hAufevGJXip9xGYmznF0T5cq1RbWJ4be3
-/9K7yuWhuBYC3sbTbCneHBa91M82za+PIISc1ygCYtWSBoZKSAqLk0rkZpHaekDP
-WqeUSNGYV//RunTeuRDAf5OxehERb1srzBXhRZ3cZdzXbgR/`),
-		},
-	}
-
-	for _, test := range testCases {
-		test := test
-		t.Run(test.desc, func(t *testing.T) {
-			t.Parallel()
-
-			require.Equal(t, test.expected, sanitize(test.toSanitize), "The sanitized certificates should be equal")
-		})
-	}
-}
-
-func TestTLSClientHeadersWithPEM(t *testing.T) {
+func TestPassTLSClientCert_PEM(t *testing.T) {
 	testCases := []struct {
 		desc           string
 		certContents   []string // set the request TLS attribute if defined
@@ -417,70 +326,36 @@ func TestTLSClientHeadersWithPEM(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			require.Equal(t, http.StatusOK, res.Code, "Http Status should be OK")
-			require.Equal(t, "bar", res.Body.String(), "Should be the expected body")
+			assert.Equal(t, http.StatusOK, res.Code, "Http Status should be OK")
+			assert.Equal(t, "bar", res.Body.String(), "Should be the expected body")
 
 			if test.expectedHeader != "" {
-				require.Equal(t, getCleanCertContents(test.certContents), req.Header.Get(xForwardedTLSClientCert), "The request header should contain the cleaned certificate")
+				expected := getCleanCertContents(test.certContents)
+				assert.Equal(t, expected, req.Header.Get(xForwardedTLSClientCert), "The request header should contain the cleaned certificate")
 			} else {
-				require.Empty(t, req.Header.Get(xForwardedTLSClientCert))
+				assert.Empty(t, req.Header.Get(xForwardedTLSClientCert))
 			}
-			require.Empty(t, res.Header().Get(xForwardedTLSClientCert), "The response header should be always empty")
+
+			assert.Empty(t, res.Header().Get(xForwardedTLSClientCert), "The response header should be always empty")
 		})
 	}
 }
 
-func TestGetSans(t *testing.T) {
-	urlFoo, err := url.Parse("my.foo.com")
-	require.NoError(t, err)
-	urlBar, err := url.Parse("my.bar.com")
-	require.NoError(t, err)
+func TestPassTLSClientCert_certInfo(t *testing.T) {
+	minimalCheeseCertAllInfo := strings.Join([]string{
+		`Subject="C=FR,ST=Some-State,O=Cheese"`,
+		`Issuer="DC=org,DC=cheese,C=FR,C=US,ST=Signing State,ST=Signing State 2,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=Simple Signing CA 2"`,
+		`NB="1544094636"`,
+		`NA="1632568236"`,
+	}, fieldSeparator)
 
-	testCases := []struct {
-		desc     string
-		cert     *x509.Certificate // set the request TLS attribute if defined
-		expected []string
-	}{
-		{
-			desc: "With nil",
-		},
-		{
-			desc: "Certificate without Sans",
-			cert: &x509.Certificate{},
-		},
-		{
-			desc: "Certificate with all Sans",
-			cert: &x509.Certificate{
-				DNSNames:       []string{"foo", "bar"},
-				EmailAddresses: []string{"test@test.com", "test2@test.com"},
-				IPAddresses:    []net.IP{net.IPv4(10, 0, 0, 1), net.IPv4(10, 0, 0, 2)},
-				URIs:           []*url.URL{urlFoo, urlBar},
-			},
-			expected: []string{"foo", "bar", "test@test.com", "test2@test.com", "10.0.0.1", "10.0.0.2", urlFoo.String(), urlBar.String()},
-		},
-	}
-
-	for _, test := range testCases {
-		sans := getSANs(test.cert)
-
-		test := test
-		t.Run(test.desc, func(t *testing.T) {
-			t.Parallel()
-
-			if len(test.expected) > 0 {
-				for i, expected := range test.expected {
-					require.Equal(t, expected, sans[i])
-				}
-			} else {
-				require.Empty(t, sans)
-			}
-		})
-	}
-}
-
-func TestTLSClientHeadersWithCertInfo(t *testing.T) {
-	minimalCheeseCertAllInfo := `Subject="C=FR,ST=Some-State,O=Cheese";Issuer="DC=org,DC=cheese,C=FR,C=US,ST=Signing State,ST=Signing State 2,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=Simple Signing CA 2";NB="1544094636";NA="1632568236"`
-	completeCertAllInfo := `Subject="DC=org,DC=cheese,C=FR,C=US,ST=Cheese org state,ST=Cheese com state,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=*.cheese.com";Issuer="DC=org,DC=cheese,C=FR,C=US,ST=Signing State,ST=Signing State 2,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=Simple Signing CA 2";NB="1544094616";NA="1607166616";SAN="*.cheese.org,*.cheese.net,*.cheese.com,test@cheese.org,test@cheese.net,10.0.1.0,10.0.1.2"`
+	completeCertAllInfo := strings.Join([]string{
+		`Subject="DC=org,DC=cheese,C=FR,C=US,ST=Cheese org state,ST=Cheese com state,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=*.cheese.com"`,
+		`Issuer="DC=org,DC=cheese,C=FR,C=US,ST=Signing State,ST=Signing State 2,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=Simple Signing CA 2"`,
+		`NB="1544094616"`,
+		`NA="1607166616"`,
+		`SAN="*.cheese.org,*.cheese.net,*.cheese.com,test@cheese.org,test@cheese.net,10.0.1.0,10.0.1.2"`,
+	}, fieldSeparator)
 
 	testCases := []struct {
 		desc           string
@@ -624,7 +499,7 @@ func TestTLSClientHeadersWithCertInfo(t *testing.T) {
 					},
 				},
 			},
-			expectedHeader: strings.Join([]string{minimalCheeseCertAllInfo, completeCertAllInfo}, ","),
+			expectedHeader: strings.Join([]string{minimalCheeseCertAllInfo, completeCertAllInfo}, certSeparator),
 		},
 	}
 
@@ -645,17 +520,157 @@ func TestTLSClientHeadersWithCertInfo(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			require.Equal(t, http.StatusOK, res.Code, "Http Status should be OK")
-			require.Equal(t, "bar", res.Body.String(), "Should be the expected body")
+			assert.Equal(t, http.StatusOK, res.Code, "Http Status should be OK")
+			assert.Equal(t, "bar", res.Body.String(), "Should be the expected body")
 
 			if test.expectedHeader != "" {
 				unescape, err := url.QueryUnescape(req.Header.Get(xForwardedTLSClientCertInfo))
 				require.NoError(t, err)
-				require.Equal(t, test.expectedHeader, unescape, "The request header should contain the cleaned certificate")
+				assert.Equal(t, test.expectedHeader, unescape, "The request header should contain the cleaned certificate")
 			} else {
-				require.Empty(t, req.Header.Get(xForwardedTLSClientCertInfo))
+				assert.Empty(t, req.Header.Get(xForwardedTLSClientCertInfo))
 			}
-			require.Empty(t, res.Header().Get(xForwardedTLSClientCertInfo), "The response header should be always empty")
+
+			assert.Empty(t, res.Header().Get(xForwardedTLSClientCertInfo), "The response header should be always empty")
 		})
 	}
+}
+
+func Test_sanitize(t *testing.T) {
+	testCases := []struct {
+		desc       string
+		toSanitize []byte
+		expected   string
+	}{
+		{
+			desc: "Empty",
+		},
+		{
+			desc:       "With a minimal cert",
+			toSanitize: []byte(minimalCheeseCrt),
+			expected: `MIIEQDCCAygCFFRY0OBk/L5Se0IZRj3CMljawL2UMA0GCSqGSIb3DQEBCwUAMIIB
+hDETMBEGCgmSJomT8ixkARkWA29yZzEWMBQGCgmSJomT8ixkARkWBmNoZWVzZTEP
+MA0GA1UECgwGQ2hlZXNlMREwDwYDVQQKDAhDaGVlc2UgMjEfMB0GA1UECwwWU2lt
+cGxlIFNpZ25pbmcgU2VjdGlvbjEhMB8GA1UECwwYU2ltcGxlIFNpZ25pbmcgU2Vj
+dGlvbiAyMRowGAYDVQQDDBFTaW1wbGUgU2lnbmluZyBDQTEcMBoGA1UEAwwTU2lt
+cGxlIFNpZ25pbmcgQ0EgMjELMAkGA1UEBhMCRlIxCzAJBgNVBAYTAlVTMREwDwYD
+VQQHDAhUT1VMT1VTRTENMAsGA1UEBwwETFlPTjEWMBQGA1UECAwNU2lnbmluZyBT
+dGF0ZTEYMBYGA1UECAwPU2lnbmluZyBTdGF0ZSAyMSEwHwYJKoZIhvcNAQkBFhJz
+aW1wbGVAc2lnbmluZy5jb20xIjAgBgkqhkiG9w0BCQEWE3NpbXBsZTJAc2lnbmlu
+Zy5jb20wHhcNMTgxMjA2MTExMDM2WhcNMjEwOTI1MTExMDM2WjAzMQswCQYDVQQG
+EwJGUjETMBEGA1UECAwKU29tZS1TdGF0ZTEPMA0GA1UECgwGQ2hlZXNlMIIBIjAN
+BgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAskX/bUtwFo1gF2BTPNaNcTUMaRFu
+FMZozK8IgLjccZ4kZ0R9oFO6Yp8Zl/IvPaf7tE26PI7XP7eHriUdhnQzX7iioDd0
+RZa68waIhAGc+xPzRFrP3b3yj3S2a9Rve3c0K+SCV+EtKAwsxMqQDhoo9PcBfo5B
+RHfht07uD5MncUcGirwN+/pxHV5xzAGPcc7On0/5L7bq/G+63nhu78zw9XyuLaHC
+PM5VbOUvpyIESJHbMMzTdFGL8ob9VKO+Kr1kVGdEA9i8FLGl3xz/GBKuW/JD0xyW
+DrU29mri5vYWHmkuv7ZWHGXnpXjTtPHwveE9/0/ArnmpMyR9JtqFr1oEvQIDAQAB
+MA0GCSqGSIb3DQEBCwUAA4IBAQBHta+NWXI08UHeOkGzOTGRiWXsOH2dqdX6gTe9
+xF1AIjyoQ0gvpoGVvlnChSzmlUj+vnx/nOYGIt1poE3hZA3ZHZD/awsvGyp3GwWD
+IfXrEViSCIyF+8tNNKYyUcEO3xdAsAUGgfUwwF/mZ6MBV5+A/ZEEILlTq8zFt9dV
+vdKzIt7fZYxYBBHFSarl1x8pDgWXlf3hAufevGJXip9xGYmznF0T5cq1RbWJ4be3
+/9K7yuWhuBYC3sbTbCneHBa91M82za+PIISc1ygCYtWSBoZKSAqLk0rkZpHaekDP
+WqeUSNGYV//RunTeuRDAf5OxehERb1srzBXhRZ3cZdzXbgR/`,
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			content := sanitize(test.toSanitize)
+
+			expected := url.QueryEscape(strings.Replace(test.expected, "\n", "", -1))
+			assert.Equal(t, expected, content, "The sanitized certificates should be equal")
+		})
+	}
+}
+
+func Test_getSANs(t *testing.T) {
+	urlFoo := testhelpers.MustParseURL("my.foo.com")
+	urlBar := testhelpers.MustParseURL("my.bar.com")
+
+	testCases := []struct {
+		desc     string
+		cert     *x509.Certificate // set the request TLS attribute if defined
+		expected []string
+	}{
+		{
+			desc: "With nil",
+		},
+		{
+			desc: "Certificate without Sans",
+			cert: &x509.Certificate{},
+		},
+		{
+			desc: "Certificate with all Sans",
+			cert: &x509.Certificate{
+				DNSNames:       []string{"foo", "bar"},
+				EmailAddresses: []string{"test@test.com", "test2@test.com"},
+				IPAddresses:    []net.IP{net.IPv4(10, 0, 0, 1), net.IPv4(10, 0, 0, 2)},
+				URIs:           []*url.URL{urlFoo, urlBar},
+			},
+			expected: []string{"foo", "bar", "test@test.com", "test2@test.com", "10.0.0.1", "10.0.0.2", urlFoo.String(), urlBar.String()},
+		},
+	}
+
+	for _, test := range testCases {
+		sans := getSANs(test.cert)
+
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			if len(test.expected) > 0 {
+				for i, expected := range test.expected {
+					assert.Equal(t, expected, sans[i])
+				}
+			} else {
+				assert.Empty(t, sans)
+			}
+		})
+	}
+}
+
+func getCleanCertContents(certContents []string) string {
+	exp := regexp.MustCompile("-----BEGIN CERTIFICATE-----(?s)(.*)")
+
+	var cleanedCertContent []string
+	for _, certContent := range certContents {
+		cert := sanitize([]byte(exp.FindString(certContent)))
+		cleanedCertContent = append(cleanedCertContent, cert)
+	}
+
+	return strings.Join(cleanedCertContent, certSeparator)
+}
+
+func buildTLSWith(certContents []string) *tls.ConnectionState {
+	var peerCertificates []*x509.Certificate
+
+	for _, certContent := range certContents {
+		peerCertificates = append(peerCertificates, getCertificate(certContent))
+	}
+
+	return &tls.ConnectionState{PeerCertificates: peerCertificates}
+}
+
+func getCertificate(certContent string) *x509.Certificate {
+	roots := x509.NewCertPool()
+	ok := roots.AppendCertsFromPEM([]byte(signingCA))
+	if !ok {
+		panic("failed to parse root certificate")
+	}
+
+	block, _ := pem.Decode([]byte(certContent))
+	if block == nil {
+		panic("failed to parse certificate PEM")
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		panic("failed to parse certificate: " + err.Error())
+	}
+
+	return cert
 }

--- a/pkg/middlewares/passtlsclientcert/pass_tls_client_cert_test.go
+++ b/pkg/middlewares/passtlsclientcert/pass_tls_client_cert_test.go
@@ -479,8 +479,8 @@ func TestGetSans(t *testing.T) {
 }
 
 func TestTLSClientHeadersWithCertInfo(t *testing.T) {
-	minimalCheeseCertAllInfo := `Subject="C=FR,ST=Some-State,O=Cheese",Issuer="DC=org,DC=cheese,C=FR,C=US,ST=Signing State,ST=Signing State 2,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=Simple Signing CA 2",NB=1544094636,NA=1632568236,SAN=`
-	completeCertAllInfo := `Subject="DC=org,DC=cheese,C=FR,C=US,ST=Cheese org state,ST=Cheese com state,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=*.cheese.com",Issuer="DC=org,DC=cheese,C=FR,C=US,ST=Signing State,ST=Signing State 2,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=Simple Signing CA 2",NB=1544094616,NA=1607166616,SAN=*.cheese.org,*.cheese.net,*.cheese.com,test@cheese.org,test@cheese.net,10.0.1.0,10.0.1.2`
+	minimalCheeseCertAllInfo := `Subject="C=FR,ST=Some-State,O=Cheese";Issuer="DC=org,DC=cheese,C=FR,C=US,ST=Signing State,ST=Signing State 2,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=Simple Signing CA 2";NB=1544094636;NA=1632568236`
+	completeCertAllInfo := `Subject="DC=org,DC=cheese,C=FR,C=US,ST=Cheese org state,ST=Cheese com state,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=*.cheese.com";Issuer="DC=org,DC=cheese,C=FR,C=US,ST=Signing State,ST=Signing State 2,L=TOULOUSE,L=LYON,O=Cheese,O=Cheese 2,CN=Simple Signing CA 2";NB=1544094616;NA=1607166616;SAN="*.cheese.org,*.cheese.net,*.cheese.com,test@cheese.org,test@cheese.net,10.0.1.0,10.0.1.2"`
 
 	testCases := []struct {
 		desc           string
@@ -564,7 +564,7 @@ func TestTLSClientHeadersWithCertInfo(t *testing.T) {
 					},
 				},
 			},
-			expectedHeader: url.QueryEscape(`Subject="O=Cheese",Issuer="C=FR,C=US",NA=1632568236,SAN=`),
+			expectedHeader: url.QueryEscape(`Subject="O=Cheese";Issuer="C=FR,C=US";NA=1632568236`),
 		},
 		{
 			desc:         "TLS with complete certificate, with all info",
@@ -624,7 +624,7 @@ func TestTLSClientHeadersWithCertInfo(t *testing.T) {
 					},
 				},
 			},
-			expectedHeader: url.QueryEscape(strings.Join([]string{minimalCheeseCertAllInfo, completeCertAllInfo}, ";")),
+			expectedHeader: url.QueryEscape(strings.Join([]string{minimalCheeseCertAllInfo, completeCertAllInfo}, ",")),
 		},
 	}
 


### PR DESCRIPTION
### What does this PR do?

Use `,` as separator for certificates in the header `X-Forwarded-Tls-Client-Cert-Info` as for the header `X-Forwarded-Tls-Client-Cert`

### Motivation

Be homogeneous. 

### More

- [x] Added/updated tests
~~- [ ] Added/updated documentation~~

### Additional Notes
Closes #5919