### PR TITLE
Do not stop to listen on tcp listeners on temporary errors 

### DIFF
--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -135,6 +135,10 @@ func (e *TCPEntryPoint) startTCP(ctx context.Context) {
 		conn, err := e.listener.Accept()
 		if err != nil {
 			logger.Error(err)
+			if netErr, ok := err.(net.Error); ok && netErr.Temporary() {
+				continue
+			}
+
 			return
 		}
 

--- a/pkg/tls/certificate.go
+++ b/pkg/tls/certificate.go
@@ -80,7 +80,8 @@ func (f FileOrContent) IsPath() bool {
 
 func (f FileOrContent) Read() ([]byte, error) {
 	var content []byte
-	if _, err := os.Stat(f.String()); err == nil {
+	if f.IsPath() {
+		var err error
 		content, err = ioutil.ReadFile(f.String())
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
### What does this PR do?

This PR prevents the tcp entrypoints listeners to crash when encountering a temporary error on `Accept` calls.


### Motivation

Under heavy load, Traefik could open too many files, reaching the limit and causing `Accept` to fail with the temporary error `too many open files`. Since we returned in the case, this silently broke the accept loop, crashing the entrypoint and preventing it to server further requests.

Fixes #3933

### More

- [ ] ~Added/updated tests~
- [ ] ~Added/updated documentation~

### Additional Notes

Took the opportunity of opening this PR to actually make use of the `IsPath` method of `FileOrContent` :slightly_smiling_face: 
