### PR TITLE
fix: debug endpoint when insecure API.

### DIFF
--- a/pkg/provider/traefik/fixtures/full_configuration.json
+++ b/pkg/provider/traefik/fixtures/full_configuration.json
@@ -21,6 +21,14 @@
         "rule": "PathPrefix(`/`)",
         "priority": 2147483645
       },
+      "debug": {
+        "entryPoints": [
+          "traefik"
+        ],
+        "service": "api@internal",
+        "rule": "PathPrefix(`/debug`)",
+        "priority": 2147483646
+      },
       "ping": {
         "entryPoints": [
           "test"

--- a/pkg/provider/traefik/internal.go
+++ b/pkg/provider/traefik/internal.go
@@ -95,6 +95,15 @@ func (i *Provider) apiConfiguration(cfg *dynamic.Configuration) {
 				StripPrefix: &dynamic.StripPrefix{Prefixes: []string{"/dashboard/", "/dashboard"}},
 			}
 		}
+
+		if i.staticCfg.API.Debug {
+			cfg.HTTP.Routers["debug"] = &dynamic.Router{
+				EntryPoints: []string{"traefik"},
+				Service:     "api@internal",
+				Priority:    math.MaxInt32 - 1,
+				Rule:        "PathPrefix(`/debug`)",
+			}
+		}
 	}
 
 	cfg.HTTP.Services["api"] = &dynamic.Service{}

--- a/pkg/provider/traefik/internal_test.go
+++ b/pkg/provider/traefik/internal_test.go
@@ -28,6 +28,7 @@ func Test_createConfiguration(t *testing.T) {
 				API: &static.API{
 					Insecure:  true,
 					Dashboard: true,
+					Debug:     true,
 				},
 				Ping: &ping.Handler{
 					EntryPoint:    "test",


### PR DESCRIPTION
### What does this PR do?

Add a router for the debug endpoint when the API use the insecure mode.

### Motivation

Be able to use pprof.


### More

- [x] Added/updated tests
-  ~~[ ] Added/updated documentation~~

### Additional Notes

Related to https://github.com/containous/traefik/issues/5904#issuecomment-561507210
