### PR TITLE
Truncate key for identification in log

### DIFF
--- a/acme/account.go
+++ b/acme/account.go
@@ -112,11 +112,11 @@ func (a *Account) GetPrivateKey() crypto.PrivateKey {
 	}
 
 	keySnippet := ""
-	if a.PrivateKey != nil && len(a.PrivateKey) >= 16 {
+	if len(a.PrivateKey) >= 16 {
 		keySnippet = string(a.PrivateKey[:16])
 	}
 
-	log.Errorf("Cannot unmarshall private key beginning with %+v", keySnippet)
+	log.Errorf("Cannot unmarshall private key beginning with %s", keySnippet)
 	return nil
 }
 

--- a/acme/account.go
+++ b/acme/account.go
@@ -111,7 +111,12 @@ func (a *Account) GetPrivateKey() crypto.PrivateKey {
 		return privateKey
 	}
 
-	log.Errorf("Cannot unmarshall private key %+v", a.PrivateKey)
+	keySnippet := ""
+	if a.PrivateKey != nil && len(a.PrivateKey) >= 16 {
+		keySnippet = string(a.PrivateKey[:16])
+	}
+
+	log.Errorf("Cannot unmarshall private key beginning with %+v", keySnippet)
 	return nil
 }
 

--- a/provider/acme/account.go
+++ b/provider/acme/account.go
@@ -57,7 +57,12 @@ func (a *Account) GetPrivateKey() crypto.PrivateKey {
 		return privateKey
 	}
 
-	log.Errorf("Cannot unmarshal private key %+v", a.PrivateKey)
+	keySnippet := ""
+	if len(a.PrivateKey) >= 16 {
+		keySnippet = string(a.PrivateKey[:16])
+	}
+
+	log.Errorf("Cannot unmarshall private key beginning with %s", keySnippet)
 	return nil
 }
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.0

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.0

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR truncates the private key to 16 characters for use for identification in the log.

The entire key should not be provided in the log.

### Motivation

Fixes #5284 
