### PR TITLE
readme: Fix link to file backend/provider documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ _(But if you'd rather configure some of your routes manually, Traefik supports t
 - [Kubernetes](https://docs.traefik.io/providers/kubernetes-crd/)
 - [Marathon](https://docs.traefik.io/providers/marathon/)
 - [Rancher](https://docs.traefik.io/providers/rancher/) (Metadata)
-- [File](https://docs.traefik.io/configuration/backends/file)
+- [File](https://docs.traefik.io/providers/file/)
 
 ## Quickstart
 


### PR DESCRIPTION
### What does this PR do?

Fix a broken link


### Motivation

A broken link that wastes user Googling time


### Additional Notes

I ran into this broken link on `master` (and suppose other people will run into it there) and hence I'm targetting `master`. Should it target branch `v2.1` instead?