### PR TITLE
Fix target branch for Traefik v2

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,11 +3,11 @@ PLEASE READ THIS MESSAGE.
 
 Documentation fixes or enhancements:
 - for Traefik v1: use branch v1.7
-- for Traefik v2: use branch v2.0
+- for Traefik v2: use branch v2.1
 
 Bug fixes:
 - for Traefik v1: use branch v1.7
-- for Traefik v2: use branch v2.0
+- for Traefik v2: use branch v2.1
 
 Enhancements:
 - for Traefik v1: we only accept bug fixes


### PR DESCRIPTION
### What does this PR do?

Update the pull request template to ask people to target branch `v2.1` for Traefik v2 changes, instead of `v2.0`.


### Motivation

I was presented the template mentioning `v2.0` and it seemed out of date and I found it confusing and worth a bump (or adding more text to say why not `v2.1` should be targeted). Happy to adjust as needed.