### PR TITLE
Fix Docker example in "Strip and Rewrite Path Prefixes" in migration guide

### DIFF
--- a/docs/content/migration/v1-to-v2.md
+++ b/docs/content/migration/v1-to-v2.md
@@ -560,8 +560,8 @@ with the path `/admin` stripped, e.g. to `http://<IP>:<port>/`. In this case, yo
     ```yaml tab="Docker"
     labels:
       - "traefik.http.routers.admin.rule=Host(`company.org`) && PathPrefix(`/admin`)"
+      - "traefik.http.routers.admin.middlewares=admin-stripprefix"
       - "traefik.http.middlewares.admin-stripprefix.stripprefix.prefixes=/admin"
-      - "traefik.http.routers.admin.middlewares=admin-stripprefix@docker"
     ```
 
     ```yaml tab="Kubernetes IngressRoute"

--- a/docs/content/migration/v1-to-v2.md
+++ b/docs/content/migration/v1-to-v2.md
@@ -561,7 +561,7 @@ with the path `/admin` stripped, e.g. to `http://<IP>:<port>/`. In this case, yo
     labels:
       - "traefik.http.routers.admin.rule=Host(`company.org`) && PathPrefix(`/admin`)"
       - "traefik.http.middlewares.admin-stripprefix.stripprefix.prefixes=/admin"
-      - "traefik.http.routers.web.middlewares=admin-stripprefix@docker"
+      - "traefik.http.routers.admin.middlewares=admin-stripprefix@docker"
     ```
 
     ```yaml tab="Kubernetes IngressRoute"


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.0

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.0

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes incorrect router name in Docker example from "Strip and Rewrite Path Prefixes" part of migration guide - router created in this example is named "admin", but `stripprefix` middleware is set for router "web"

### Motivation

I've spotted this inconsistency when trying to migrate my docker-compose configuration to traefik 2.06

### More

- [ ] Added/updated tests
- [X] Added/updated documentation