### PR TITLE
Don't throw away valid configuration updates

### DIFF
--- a/pkg/server/configurationwatcher.go
+++ b/pkg/server/configurationwatcher.go
@@ -130,7 +130,7 @@ func (c *ConfigurationWatcher) loadMessage(configMsg dynamic.Message) {
 	currentConfigurations := c.currentConfigurations.Get().(dynamic.Configurations)
 
 	if reflect.DeepEqual(currentConfigurations[configMsg.ProviderName], configMsg.Configuration) {
-                logger := log.WithoutContext().WithField(log.ProviderName, configMsg.ProviderName)
+		logger := log.WithoutContext().WithField(log.ProviderName, configMsg.ProviderName)
 		logger.Infof("Skipping same configuration for provider %s", configMsg.ProviderName)
 		return
 	}

--- a/pkg/server/configurationwatcher_test.go
+++ b/pkg/server/configurationwatcher_test.go
@@ -195,13 +195,13 @@ func TestListenProvidersDoesNotSkipFlappingConfiguration(t *testing.T) {
 	pvd := &mockProvider{
 		wait: 5 * time.Millisecond, // The last message needs to be received before the second has been fully processed
 		messages: []dynamic.Message{
-                        {ProviderName: "mock", Configuration: configuration},
-                        {ProviderName: "mock", Configuration: transientConfiguration},
-                        {ProviderName: "mock", Configuration: configuration},
+			{ProviderName: "mock", Configuration: configuration},
+			{ProviderName: "mock", Configuration: transientConfiguration},
+			{ProviderName: "mock", Configuration: configuration},
 		},
 	}
 
-	watcher := NewConfigurationWatcher(routinesPool, pvd, 15 * time.Millisecond)
+	watcher := NewConfigurationWatcher(routinesPool, pvd, 15*time.Millisecond)
 
 	var lastConfig dynamic.Configuration
 	watcher.AddListener(func(conf dynamic.Configuration) {

--- a/pkg/server/configurationwatcher_test.go
+++ b/pkg/server/configurationwatcher_test.go
@@ -175,6 +175,66 @@ func TestListenProvidersSkipsSameConfigurationForProvider(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 }
 
+func TestListenProvidersDoesNotSkipFlappingConfiguration(t *testing.T) {
+	routinesPool := safe.NewPool(context.Background())
+
+	configuration := &dynamic.Configuration{
+		HTTP: th.BuildConfiguration(
+			th.WithRouters(th.WithRouter("foo")),
+			th.WithLoadBalancerServices(th.WithService("bar")),
+		),
+	}
+
+	transientConfiguration := &dynamic.Configuration{
+		HTTP: th.BuildConfiguration(
+			th.WithRouters(th.WithRouter("bad")),
+			th.WithLoadBalancerServices(th.WithService("bad")),
+		),
+	}
+
+	pvd := &mockProvider{
+		wait: 5 * time.Millisecond, // The last message needs to be received before the second has been fully processed
+		messages: []dynamic.Message{
+                        {ProviderName: "mock", Configuration: configuration},
+                        {ProviderName: "mock", Configuration: transientConfiguration},
+                        {ProviderName: "mock", Configuration: configuration},
+		},
+	}
+
+	watcher := NewConfigurationWatcher(routinesPool, pvd, 15 * time.Millisecond)
+
+	var lastConfig dynamic.Configuration
+	watcher.AddListener(func(conf dynamic.Configuration) {
+		lastConfig = conf
+	})
+
+	watcher.Start()
+	defer watcher.Stop()
+
+	// give some time so that the configuration can be processed
+	time.Sleep(40 * time.Millisecond)
+
+	expected := dynamic.Configuration{
+		HTTP: th.BuildConfiguration(
+			th.WithRouters(th.WithRouter("foo@mock")),
+			th.WithLoadBalancerServices(th.WithService("bar@mock")),
+			th.WithMiddlewares(),
+		),
+		TCP: &dynamic.TCPConfiguration{
+			Routers:  map[string]*dynamic.TCPRouter{},
+			Services: map[string]*dynamic.TCPService{},
+		},
+		TLS: &dynamic.TLSConfiguration{
+			Options: map[string]tls.Options{
+				"default": {},
+			},
+			Stores: map[string]tls.Store{},
+		},
+	}
+
+	assert.Equal(t, expected, lastConfig)
+}
+
 func TestListenProvidersPublishesConfigForEachProvider(t *testing.T) {
 	routinesPool := safe.NewPool(context.Background())
 


### PR DESCRIPTION
### What does this PR do?

The configuration reloading code takes various actions in order to limit the number of reloads that have to be performed.
One of those actions is to check if the new configuration is the same as the current configuration. 
If the new configuration is the same, then there is no need to apply it and it can be safely ignored.

However, the check was performed at the wrong location.
The location assumed that the `c.currentConfiguration`s variable is up to date.
This assumption does not hold given the throttling and asynchronous handling of configuration updates.
The effect of this incorrect assumption is that a configuration update can be thrown away and leave a prior configuration in place.

This resolves the problem by moving the check to the `loadMessage` method.
This is the point where the `c.currentConfigurations` variable is modified and so there is no chance that the new configuration will be compared against an incorrect version.

<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.0

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.0

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->



<!-- A brief description of the change being made with this pull request. -->


### Motivation

Fixes #5901 
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

