### PR TITLE
fix: remove double call to server Close.

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -69,10 +69,10 @@ Complete documentation is available at https://traefik.io`,
 	err = cli.Execute(cmdTraefik)
 	if err != nil {
 		stdlog.Println(err)
-		os.Exit(1)
+		logrus.Exit(1)
 	}
 
-	os.Exit(0)
+	logrus.Exit(0)
 }
 
 func runCmd(staticConfiguration *static.Configuration) error {
@@ -156,7 +156,6 @@ func runCmd(staticConfiguration *static.Configuration) error {
 
 	svr.Wait()
 	log.WithoutContext().Info("Shutting down")
-	logrus.Exit(0)
 	return nil
 }
 

--- a/pkg/server/configurationwatcher.go
+++ b/pkg/server/configurationwatcher.go
@@ -49,8 +49,8 @@ func NewConfigurationWatcher(routinesPool *safe.Pool, pvd provider.Provider, pro
 
 // Start the configuration watcher.
 func (c *ConfigurationWatcher) Start() {
-	c.routinesPool.Go(func(stop chan bool) { c.listenProviders(stop) })
-	c.routinesPool.Go(func(stop chan bool) { c.listenConfigurations(stop) })
+	c.routinesPool.Go(c.listenProviders)
+	c.routinesPool.Go(c.listenConfigurations)
 	c.startProvider()
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -48,7 +48,6 @@ func NewServer(routinesPool *safe.Pool, entryPoints TCPEntryPoints, watcher *Con
 // Start starts the server and Stop/Close it when context is Done
 func (s *Server) Start(ctx context.Context) {
 	go func() {
-		defer s.Close()
 		<-ctx.Done()
 		logger := log.FromContext(ctx)
 		logger.Info("I have to go...")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -59,9 +59,7 @@ func (s *Server) Start(ctx context.Context) {
 	s.tcpEntryPoints.Start()
 	s.watcher.Start()
 
-	s.routinesPool.Go(func(stop chan bool) {
-		s.listenSignals(stop)
-	})
+	s.routinesPool.Go(s.listenSignals)
 }
 
 // Wait blocks until the server shutdown.


### PR DESCRIPTION
### What does this PR do?

- Removes double call to server `Close`.
- Removes `logrus.Exit(0)` in `runCmd` because it kill Traefik before the end of the server `Close` called in the defer of  `runCmd`.

### Motivation

Have a clean stop of Traefik

### More

- ~~[ ] Added/updated tests~~
- ~~[ ] Added/updated documentation~~
