### PR TITLE
Make trailing slash more prominent for the "secure dashboard setup" too

### DIFF
--- a/docs/content/operations/dashboard.md
+++ b/docs/content/operations/dashboard.md
@@ -85,21 +85,23 @@ We recommend to use a "Host Based rule" as ```Host(`traefik.domain.com`)``` to m
 or to make sure that the defined rule captures both prefixes:
 
 ```bash tab="Host Rule"
-# Matches http://traefik.domain.com/api or http://traefik.domain.com/dashboard
+# Matches http://traefik.domain.com/api/ or http://traefik.domain.com/dashboard/
 rule = "Host(`traefik.domain.com`)"
 ```
 
 ```bash tab="Path Prefix Rule"
-# Matches http://traefik.domain.com/api , http://domain.com/api or http://traefik.domain.com/dashboard
+# Matches http://traefik.domain.com/api/ , http://domain.com/api/ or http://traefik.domain.com/dashboard/
 # but does not match http://traefik.domain.com/hello
 rule = "PathPrefix(`/api`) || PathPrefix(`/dashboard`)"
 ```
 
 ```bash tab="Combination of Rules"
-# Matches http://traefik.domain.com/api or http://traefik.domain.com/dashboard
+# Matches http://traefik.domain.com/api/ or http://traefik.domain.com/dashboard/
 # but does not match http://traefik.domain.com/hello
 rule = "Host(`traefik.domain.com`) && (PathPrefix(`/api`) || PathPrefix(`/dashboard`))"
 ```
+
+You can now access the dashboard using the URL: `http://<traefik.domain.com>:<endpointport>/dashboard/` (trailing slash is mandatory).
 
 ## Insecure Mode
 

--- a/docs/content/operations/dashboard.md
+++ b/docs/content/operations/dashboard.md
@@ -85,23 +85,19 @@ We recommend to use a "Host Based rule" as ```Host(`traefik.domain.com`)``` to m
 or to make sure that the defined rule captures both prefixes:
 
 ```bash tab="Host Rule"
-# Matches http://traefik.domain.com/api/ or http://traefik.domain.com/dashboard/
+# The dashboard can be accessed on http://traefik.domain.com/dashboard/
 rule = "Host(`traefik.domain.com`)"
 ```
 
 ```bash tab="Path Prefix Rule"
-# Matches http://traefik.domain.com/api/ , http://domain.com/api/ or http://traefik.domain.com/dashboard/
-# but does not match http://traefik.domain.com/hello
+# The dashboard can be accessed on http://domain.com/dashboard/ or http://traefik.domain.com/dashboard/
 rule = "PathPrefix(`/api`) || PathPrefix(`/dashboard`)"
 ```
 
 ```bash tab="Combination of Rules"
-# Matches http://traefik.domain.com/api/ or http://traefik.domain.com/dashboard/
-# but does not match http://traefik.domain.com/hello
+# The dashboard can be accessed on http://traefik.domain.com/dashboard/
 rule = "Host(`traefik.domain.com`) && (PathPrefix(`/api`) || PathPrefix(`/dashboard`))"
 ```
-
-You can now access the dashboard using the URL: `http://<traefik.domain.com>:<endpointport>/dashboard/` (trailing slash is mandatory).
 
 ## Insecure Mode
 


### PR DESCRIPTION
Right now it makes it harder for people not using the `insecure` mode to recognize that the dashboard can only be reached using the trailing slash only since it is at the bottom of the page to the "insecure" chapter ( which those people will most probably skip ) -

I assume the trailing slash is somewhat surprising, it might be helpful to make the fact more prominent

### More

- [x] Added/updated documentation

### Additional Notes
-
