### PR TITLE
Remove mirroring impact in accesslog

### DIFF
--- a/pkg/server/service/loadbalancer/mirror/mirror.go
+++ b/pkg/server/service/loadbalancer/mirror/mirror.go
@@ -72,7 +72,6 @@ func (m *Mirroring) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 				// server. Especially since it would result in unguarded concurrent reads/writes on
 				// the datatable. Therefore, we reset any potential datatable key in the new
 				// context that we pass around.
-				// want to change the serviceName in the accesslog and in addition, it fixes some
 				// concurrent map write issues.
 				ctx := context.WithValue(req.Context(), accesslog.DataTableKey, nil)
 

--- a/pkg/server/service/loadbalancer/mirror/mirror.go
+++ b/pkg/server/service/loadbalancer/mirror/mirror.go
@@ -72,7 +72,6 @@ func (m *Mirroring) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 				// server. Especially since it would result in unguarded concurrent reads/writes on
 				// the datatable. Therefore, we reset any potential datatable key in the new
 				// context that we pass around.
-				// concurrent map write issues.
 				ctx := context.WithValue(req.Context(), accesslog.DataTableKey, nil)
 
 				// When a request served by m.handler is successful, req.Context will be canceled,

--- a/pkg/server/service/loadbalancer/mirror/mirror.go
+++ b/pkg/server/service/loadbalancer/mirror/mirror.go
@@ -65,7 +65,13 @@ func (m *Mirroring) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 				handler.count++
 				handler.lock.Unlock()
 
-				// We remove the accesslog's datatable in the context because we don't
+				// In ServeHTTP, we rely on the presence of the accesslog datatable found in the
+				// request's context to know whether we should mutate said datatable (and
+				// contribute some fields to the log). In this instance, we do not want the mirrors
+				// mutating (i.e. changing the service name in) the logs related to the mirrored
+				// server. Especially since it would result in unguarded concurrent reads/writes on
+				// the datatable. Therefore, we reset any potential datatable key in the new
+				// context that we pass around.
 				// want to change the serviceName in the accesslog and in addition, it fixes some
 				// concurrent map write issues.
 				ctx := context.WithValue(req.Context(), accesslog.DataTableKey, nil)


### PR DESCRIPTION
### What does this PR do?
This PR removes impact on accesslogs when we use the mirroring.

### Motivation
Fixes #5953 
And fix that sometimes, when using mirroring, in the access log, the `serviceName` field was incorrect because mirroring replaced the main `serviceName`.
