### PR TITLE
Fix: use the total number of items given by the overview API in the main table pagination

### DIFF
--- a/webui/src/pages/http/Middlewares.vue
+++ b/webui/src/pages/http/Middlewares.vue
@@ -48,6 +48,7 @@ export default {
     ...mapGetters('http', { allMiddlewares: 'allMiddlewares' })
   },
   methods: {
+    ...mapActions('core', { getOverview: 'getOverview' }),
     ...mapActions('http', { getAllMiddlewares: 'getAllMiddlewares' }),
     refreshAll () {
       if (this.allMiddlewares.loading) {
@@ -70,8 +71,6 @@ export default {
           }
           this.loading = false
           console.log('Success -> http/middlewares', body)
-          // update rowsNumber with appropriate value
-          this.pagination.rowsNumber = body.total
           // update local pagination object
           this.pagination.page = page
           this.pagination.rowsPerPage = rowsPerPage
@@ -92,7 +91,15 @@ export default {
     }
   },
   created () {
-
+    // Get overview to initialize the number of http middlewares available
+    this.getOverview()
+      .then(body => {
+        console.log('Success -> http/middlewares/overview', body)
+        this.pagination.rowsNumber = (body && body['http'] && body['http']['middlewares'] && body['http']['middlewares']['total']) || 0
+      })
+      .catch(error => {
+        console.log('Error -> http/middlewares/overview', error)
+      })
   },
   mounted () {
     this.refreshAll()

--- a/webui/src/pages/http/Routers.vue
+++ b/webui/src/pages/http/Routers.vue
@@ -48,6 +48,7 @@ export default {
     ...mapGetters('http', { allRouters: 'allRouters' })
   },
   methods: {
+    ...mapActions('core', { getOverview: 'getOverview' }),
     ...mapActions('http', { getAllRouters: 'getAllRouters' }),
     refreshAll () {
       if (this.allRouters.loading) {
@@ -61,7 +62,6 @@ export default {
     },
     onGetAll (props) {
       let { page, rowsPerPage, sortBy, descending } = props.pagination
-
       this.getAllRouters({ query: props.filter, status: this.status, page, limit: rowsPerPage, sortBy, descending })
         .then(body => {
           if (!body) {
@@ -70,8 +70,6 @@ export default {
           }
           this.loading = false
           console.log('Success -> http/routers', body)
-          // update rowsNumber with appropriate value
-          this.pagination.rowsNumber = body.total
           // update local pagination object
           this.pagination.page = page
           this.pagination.rowsPerPage = rowsPerPage
@@ -92,7 +90,15 @@ export default {
     }
   },
   created () {
-
+    // Get overview to initialize the number of http routers available
+    this.getOverview()
+      .then(body => {
+        console.log('Success -> http/routers/overview', body)
+        this.pagination.rowsNumber = (body && body['http'] && body['http']['routers'] && body['http']['routers']['total']) || 0
+      })
+      .catch(error => {
+        console.log('Error -> http/routers/overview', error)
+      })
   },
   mounted () {
     this.refreshAll()

--- a/webui/src/pages/http/Services.vue
+++ b/webui/src/pages/http/Services.vue
@@ -48,6 +48,7 @@ export default {
     ...mapGetters('http', { allServices: 'allServices' })
   },
   methods: {
+    ...mapActions('core', { getOverview: 'getOverview' }),
     ...mapActions('http', { getAllServices: 'getAllServices' }),
     refreshAll () {
       if (this.allServices.loading) {
@@ -70,8 +71,6 @@ export default {
           }
           this.loading = false
           console.log('Success -> http/services', body)
-          // update rowsNumber with appropriate value
-          this.pagination.rowsNumber = body.total
           // update local pagination object
           this.pagination.page = page
           this.pagination.rowsPerPage = rowsPerPage
@@ -92,7 +91,15 @@ export default {
     }
   },
   created () {
-
+    // Get overview to initialize the number of http services available
+    this.getOverview()
+      .then(body => {
+        console.log('Success -> http/services/overview', body)
+        this.pagination.rowsNumber = (body && body['http'] && body['http']['services'] && body['http']['services']['total']) || 0
+      })
+      .catch(error => {
+        console.log('Error -> http/services/overview', error)
+      })
   },
   mounted () {
     this.refreshAll()

--- a/webui/src/pages/tcp/Routers.vue
+++ b/webui/src/pages/tcp/Routers.vue
@@ -48,6 +48,7 @@ export default {
     ...mapGetters('tcp', { allRouters: 'allRouters' })
   },
   methods: {
+    ...mapActions('core', { getOverview: 'getOverview' }),
     ...mapActions('tcp', { getAllRouters: 'getAllRouters' }),
     refreshAll () {
       if (this.allRouters.loading) {
@@ -70,8 +71,6 @@ export default {
           }
           this.loading = false
           console.log('Success -> tcp/routers', body)
-          // update rowsNumber with appropriate value
-          this.pagination.rowsNumber = body.total
           // update local pagination object
           this.pagination.page = page
           this.pagination.rowsPerPage = rowsPerPage
@@ -92,7 +91,15 @@ export default {
     }
   },
   created () {
-
+  // Get overview to initialize the number of tcp routers available
+    this.getOverview()
+      .then(body => {
+        console.log('Success -> tcp/routers/overview', body)
+        this.pagination.rowsNumber = (body && body['tcp'] && body['tcp']['routers'] && body['tcp']['routers']['total']) || 0
+      })
+      .catch(error => {
+        console.log('Error -> tcp/routers/overview', error)
+      })
   },
   mounted () {
     this.refreshAll()

--- a/webui/src/pages/tcp/Services.vue
+++ b/webui/src/pages/tcp/Services.vue
@@ -48,6 +48,7 @@ export default {
     ...mapGetters('tcp', { allServices: 'allServices' })
   },
   methods: {
+    ...mapActions('core', { getOverview: 'getOverview' }),
     ...mapActions('tcp', { getAllServices: 'getAllServices' }),
     refreshAll () {
       if (this.allServices.loading) {
@@ -70,8 +71,6 @@ export default {
           }
           this.loading = false
           console.log('Success -> tcp/services', body)
-          // update rowsNumber with appropriate value
-          this.pagination.rowsNumber = body.total
           // update local pagination object
           this.pagination.page = page
           this.pagination.rowsPerPage = rowsPerPage
@@ -92,7 +91,15 @@ export default {
     }
   },
   created () {
-
+    // Get overview to initialize the number of tcp services available
+    this.getOverview()
+      .then(body => {
+        console.log('Success -> tcp/services/overview', body)
+        this.pagination.rowsNumber = (body && body['tcp'] && body['tcp']['services'] && body['tcp']['services']['total']) || 0
+      })
+      .catch(error => {
+        console.log('Error -> tcp/services/overview', error)
+      })
   },
   mounted () {
     this.refreshAll()


### PR DESCRIPTION

### What does this PR do?

Use the total number of items given by the overview API in the main table pagination.

### Motivation

Fixes #5959 

### More

- [ ] ~Added/updated tests~
- [ ] ~Added/updated documentation~
