### PR TITLE
fix: flaky Travis builds due to 'not get uid/gid'

### DIFF
--- a/docs/check.Dockerfile
+++ b/docs/check.Dockerfile
@@ -15,8 +15,12 @@ RUN gem install html-proofer --version 3.13.0 --no-document -- --use-system-libr
 RUN apk --no-cache --no-progress add \
     git \
     nodejs \
-    npm \
-  && npm install --global \
+    npm
+
+# To handle 'not get uid/gid'
+RUN npm config set unsafe-perm true
+
+RUN npm install --global \
     markdownlint@0.17.2 \
     markdownlint-cli@0.19.0
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.0

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.0

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

Fixes flaky Travis builds due to 'not get uid/gid'

### Motivation

To have a stable CI.

```
Step 4/10 : RUN apk --no-cache --no-progress add     git     nodejs     npm   && npm install --global     markdownlint@0.17.2     markdownlint-cli@0.19.0
 ---> Running in f06d17604331
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/community/x86_64/APKINDEX.tar.gz
(1/10) Installing expat (2.2.8-r0)
(2/10) Installing pcre2 (10.33-r0)
(3/10) Installing git (2.22.0-r0)
(4/10) Installing c-ares (1.15.0-r0)
(5/10) Installing libgcc (8.3.0-r0)
(6/10) Installing http-parser (2.9.2-r0)
(7/10) Installing libstdc++ (8.3.0-r0)
(8/10) Installing libuv (1.29.1-r0)
(9/10) Installing nodejs (10.16.3-r0)
(10/10) Installing npm (10.16.3-r0)
Executing busybox-1.30.1-r2.trigger
OK: 99 MiB in 46 packages
Error: could not get uid/gid
[ 'nobody', 0 ]
    at /usr/lib/node_modules/npm/node_modules/uid-number/uid-number.js:37:16
    at ChildProcess.exithandler (child_process.js:301:5)
    at ChildProcess.emit (events.js:198:13)
    at maybeClose (internal/child_process.js:982:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)
TypeError: Cannot read property 'loaded' of undefined
    at exit (/usr/lib/node_modules/npm/lib/utils/error-handler.js:98:27)
    at errorHandler (/usr/lib/node_modules/npm/lib/utils/error-handler.js:216:3)
    at /usr/lib/node_modules/npm/bin/npm-cli.js:77:20
    at cb (/usr/lib/node_modules/npm/lib/npm.js:225:22)
    at /usr/lib/node_modules/npm/lib/npm.js:263:24
    at /usr/lib/node_modules/npm/lib/config/core.js:83:7
    at Array.forEach (<anonymous>)
    at /usr/lib/node_modules/npm/lib/config/core.js:82:13
    at f (/usr/lib/node_modules/npm/node_modules/once/once.js:25:25)
    at afterExtras (/usr/lib/node_modules/npm/lib/config/core.js:173:20)
/usr/lib/node_modules/npm/lib/utils/error-handler.js:98
  var doExit = npm.config.loaded ? npm.config.get('_exit') : true
                          ^
TypeError: Cannot read property 'loaded' of undefined
    at exit (/usr/lib/node_modules/npm/lib/utils/error-handler.js:98:27)
    at process.errorHandler (/usr/lib/node_modules/npm/lib/utils/error-handler.js:216:3)
    at process.emit (events.js:198:13)
    at process._fatalException (internal/bootstrap/node.js:496:27)
The command '/bin/sh -c apk --no-cache --no-progress add     git     nodejs     npm   && npm install --global     markdownlint@0.17.2     markdownlint-cli@0.19.0' returned a non-zero code: 7
make[1]: *** [docs-lint] Error 7
make[1]: Leaving directory `/home/travis/build/containous/traefik/docs'
make: *** [docs] Error 2
The command "if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then make docs; fi" exited with 2.
```

### More

- ~~[ ] Added/updated tests~~
- ~~[ ] Added/updated documentation~~

### Additional Notes


- https://geedew.com/What-does-unsafe-perm-in-npm-actually-do/
- https://stackoverflow.com/a/52196681/8228109