### PR TITLE
detect CloseNotify capability in accesslog and metrics

### DIFF
--- a/pkg/middlewares/accesslog/field_middleware.go
+++ b/pkg/middlewares/accesslog/field_middleware.go
@@ -49,7 +49,7 @@ func AddServiceFields(rw http.ResponseWriter, req *http.Request, next http.Handl
 
 // AddOriginFields add origin fields
 func AddOriginFields(rw http.ResponseWriter, req *http.Request, next http.Handler, data *LogData) {
-	crw := &captureResponseWriter{rw: rw}
+	crw := newCaptureResponseWriter(rw)
 	start := time.Now().UTC()
 
 	next.ServeHTTP(crw, req)

--- a/pkg/middlewares/accesslog/logger.go
+++ b/pkg/middlewares/accesslog/logger.go
@@ -200,7 +200,7 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request, next http
 		core[ClientHost] = forwardedFor
 	}
 
-	crw := &captureResponseWriter{rw: rw}
+	crw := newCaptureResponseWriter(rw)
 
 	next.ServeHTTP(crw, reqWithDataTable)
 

--- a/pkg/middlewares/metrics/metrics.go
+++ b/pkg/middlewares/metrics/metrics.go
@@ -89,10 +89,10 @@ func (m *metricsMiddleware) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 	}(labels)
 
 	start := time.Now()
-	recorder := &responseRecorder{rw, http.StatusOK}
+	recorder := newResponseRecorder(rw)
 	m.next.ServeHTTP(recorder, req)
 
-	labels = append(labels, "code", strconv.Itoa(recorder.statusCode))
+	labels = append(labels, "code", strconv.Itoa(recorder.getCode()))
 	m.reqsCounter.With(labels...).Add(1)
 	m.reqDurationHistogram.With(labels...).Observe(time.Since(start).Seconds())
 }

--- a/pkg/middlewares/metrics/recorder.go
+++ b/pkg/middlewares/metrics/recorder.go
@@ -6,11 +6,42 @@ import (
 	"net/http"
 )
 
+type recorder interface {
+	http.ResponseWriter
+	http.Flusher
+	getCode() int
+}
+
+func newResponseRecorder(rw http.ResponseWriter) recorder {
+	rec := &responseRecorder{
+		ResponseWriter: rw,
+		statusCode:     http.StatusOK,
+	}
+	if _, ok := rw.(http.CloseNotifier); !ok {
+		return rec
+	}
+	return responseRecorderWithCloseNotify{rec}
+}
+
 // responseRecorder captures information from the response and preserves it for
 // later analysis.
 type responseRecorder struct {
 	http.ResponseWriter
 	statusCode int
+}
+
+type responseRecorderWithCloseNotify struct {
+	*responseRecorder
+}
+
+// CloseNotify returns a channel that receives at most a
+// single value (true) when the client connection has gone away.
+func (r *responseRecorderWithCloseNotify) CloseNotify() <-chan bool {
+	return r.ResponseWriter.(http.CloseNotifier).CloseNotify()
+}
+
+func (r *responseRecorder) getCode() int {
+	return r.statusCode
 }
 
 // WriteHeader captures the status code for later retrieval.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.0

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.0

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR makes sure that the ResponseWriters in accesslog and metrics only implement CloseNotify if their underlying ResponseWriter does so.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

Fixes https://github.com/containous/traefik/issues/5953#issuecomment-563933225
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
