### PR TITLE
Add tracing headers to forwardAuth middleware requests

### DIFF
--- a/pkg/middlewares/auth/forward.go
+++ b/pkg/middlewares/auth/forward.go
@@ -88,6 +88,14 @@ func (fa *forwardAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	tr, err := tracing.FromContext(req.Context())
+	if err == nil {
+		opParts := []string{fa.name}
+		_, forwardReqWithCtx, finish := tr.StartSpanfWithContext(forwardReq, req.Context(), ext.SpanKindRPCClientEnum, "forward-auth", opParts, "/")
+		forwardReq = forwardReqWithCtx
+		defer finish()
+	}
+
 	writeHeader(req, forwardReq, fa.trustForwardHeader)
 
 	tracing.InjectRequestHeaders(forwardReq)

--- a/pkg/middlewares/auth/forward.go
+++ b/pkg/middlewares/auth/forward.go
@@ -91,7 +91,7 @@ func (fa *forwardAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	tr, err := tracing.FromContext(req.Context())
 	if err == nil {
 		opParts := []string{fa.name}
-		_, forwardReqWithCtx, finish := tr.StartSpanfWithContext(forwardReq, req.Context(), ext.SpanKindRPCClientEnum, "forward-auth", opParts, "/")
+		_, forwardReqWithCtx, finish := tr.StartSpanfWithContext(req.Context(), forwardReq, ext.SpanKindRPCClientEnum, "forward-auth", opParts, "/")
 		forwardReq = forwardReqWithCtx
 		defer finish()
 	}

--- a/pkg/middlewares/tracing/wrapper.go
+++ b/pkg/middlewares/tracing/wrapper.go
@@ -59,7 +59,7 @@ func (w *Wrapper) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	var finish func()
-	_, req, finish = tracing.StartSpan(req, w.name, w.spanKind)
+	_, req, finish = tracing.StartSpan(req, req.Context(), w.name, w.spanKind)
 	defer finish()
 
 	if w.next != nil {

--- a/pkg/middlewares/tracing/wrapper.go
+++ b/pkg/middlewares/tracing/wrapper.go
@@ -59,7 +59,7 @@ func (w *Wrapper) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	var finish func()
-	_, req, finish = tracing.StartSpan(req, req.Context(), w.name, w.spanKind)
+	_, req, finish = tracing.StartSpan(req.Context(), req, w.name, w.spanKind)
 	defer finish()
 
 	if w.next != nil {

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -155,7 +155,7 @@ func LogEventf(r *http.Request, format string, args ...interface{}) {
 	}
 }
 
-// StartSpan starts a new span from the span in provided context
+// StartSpan starts a new span from the one in provided context and adds tracing information to provided request
 func StartSpan(providedCtx context.Context, r *http.Request, operationName string, spanKind ext.SpanKindEnum, opts ...opentracing.StartSpanOption) (opentracing.Span, *http.Request, func()) {
 	span, ctx := opentracing.StartSpanFromContext(providedCtx, operationName, opts...)
 

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -76,14 +76,14 @@ func (t *Tracing) StartSpan(operationName string, opts ...opentracing.StartSpanO
 func (t *Tracing) StartSpanf(r *http.Request, spanKind ext.SpanKindEnum, opPrefix string, opParts []string, separator string, opts ...opentracing.StartSpanOption) (opentracing.Span, *http.Request, func()) {
 	operationName := generateOperationName(opPrefix, opParts, separator, t.SpanNameLimit)
 
-	return StartSpan(r, r.Context(), operationName, spanKind, opts...)
+	return StartSpan(r.Context(), r, operationName, spanKind, opts...)
 }
 
 // StartSpanfWithContext delegates to StartSpan.
-func (t *Tracing) StartSpanfWithContext(r *http.Request, ctx context.Context, spanKind ext.SpanKindEnum, opPrefix string, opParts []string, separator string, opts ...opentracing.StartSpanOption) (opentracing.Span, *http.Request, func()) {
+func (t *Tracing) StartSpanfWithContext(ctx context.Context, r *http.Request, spanKind ext.SpanKindEnum, opPrefix string, opParts []string, separator string, opts ...opentracing.StartSpanOption) (opentracing.Span, *http.Request, func()) {
 	operationName := generateOperationName(opPrefix, opParts, separator, t.SpanNameLimit)
 
-	return StartSpan(r, ctx, operationName, spanKind, opts...)
+	return StartSpan(ctx, r, operationName, spanKind, opts...)
 }
 
 // Inject delegates to opentracing.Tracer.
@@ -156,7 +156,7 @@ func LogEventf(r *http.Request, format string, args ...interface{}) {
 }
 
 // StartSpan starts a new span from the span in provided context
-func StartSpan(r *http.Request, providedCtx context.Context, operationName string, spanKind ext.SpanKindEnum, opts ...opentracing.StartSpanOption) (opentracing.Span, *http.Request, func()) {
+func StartSpan(providedCtx context.Context, r *http.Request, operationName string, spanKind ext.SpanKindEnum, opts ...opentracing.StartSpanOption) (opentracing.Span, *http.Request, func()) {
 	span, ctx := opentracing.StartSpanFromContext(providedCtx, operationName, opts...)
 
 	switch spanKind {


### PR DESCRIPTION
### What does this PR do?

Added tracing headers to forwardAuth middleware requests
Fixes #5774

### Motivation

Motivation is to see traces and logs from authorization service in full request trace

### More

- [ ] Added/updated tests
- [ ] ~Added/updated documentation~ (not needed)

### Additional Notes

It looks like a bug. The line `tracing.InjectRequestHeaders(forwardReq)` already present in `middlewares/auth/forward.go`, but `InjectRequestHeaders` injects headers for context that present in provided request. But in case of forwardAuth request is new and have no context. 

I tried to save context, provided in `tracing.FromContext`, in `tracing.Tracing` struct and use it in `StartSpanf`. But if I correctly understands scope of use of `tracing.Tracing`, it uses as middleware in `server.NewServer`, it independent of request, uses to "enrich" requests with tracing data and should not contain any request-dependent state. 

So I added new method (`StartSpanfWithContext`) that allows to start new span for request using  context provided from other request as parent span. 
Maybe this is not the best solution, but it is working. If you know how to improve it - write about it.