### PR TITLE
CloseNotifier: return pointer instead of value

### DIFF
--- a/pkg/middlewares/accesslog/capture_response_writer.go
+++ b/pkg/middlewares/accesslog/capture_response_writer.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	_ middlewares.Stateful = &captureResponseWriter{}
+	_ middlewares.Stateful = &captureResponseWriterWithCloseNotify{}
 )
 
 type capturer interface {
@@ -24,7 +24,7 @@ func newCaptureResponseWriter(rw http.ResponseWriter) capturer {
 	if _, ok := rw.(http.CloseNotifier); !ok {
 		return capt
 	}
-	return captureResponseWriterWithCloseNotify{capt}
+	return &captureResponseWriterWithCloseNotify{capt}
 }
 
 // captureResponseWriter is a wrapper of type http.ResponseWriter
@@ -74,13 +74,6 @@ func (crw *captureResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) 
 		return h.Hijack()
 	}
 	return nil, nil, fmt.Errorf("not a hijacker: %T", crw.rw)
-}
-
-func (crw *captureResponseWriter) CloseNotify() <-chan bool {
-	if c, ok := crw.rw.(http.CloseNotifier); ok {
-		return c.CloseNotify()
-	}
-	return nil
 }
 
 func (crw *captureResponseWriter) Status() int {

--- a/pkg/middlewares/accesslog/capture_response_writer_test.go
+++ b/pkg/middlewares/accesslog/capture_response_writer_test.go
@@ -1,0 +1,50 @@
+package accesslog
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type rwWithCloseNotify struct {
+	*httptest.ResponseRecorder
+}
+
+func (r *rwWithCloseNotify) CloseNotify() <-chan bool {
+	panic("implement me")
+}
+
+func TestCloseNotifier(t *testing.T) {
+	testCases := []struct {
+		rw                      http.ResponseWriter
+		desc                    string
+		implementsCloseNotifier bool
+	}{
+		{
+			rw:                      httptest.NewRecorder(),
+			desc:                    "does not implement CloseNotifier",
+			implementsCloseNotifier: false,
+		},
+		{
+			rw:                      &rwWithCloseNotify{httptest.NewRecorder()},
+			desc:                    "implements CloseNotifier",
+			implementsCloseNotifier: true,
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			_, ok := test.rw.(http.CloseNotifier)
+			assert.Equal(t, test.implementsCloseNotifier, ok)
+
+			rw := newCaptureResponseWriter(test.rw)
+			_, impl := rw.(http.CloseNotifier)
+			assert.Equal(t, test.implementsCloseNotifier, impl)
+		})
+	}
+}

--- a/pkg/middlewares/metrics/recorder.go
+++ b/pkg/middlewares/metrics/recorder.go
@@ -20,7 +20,7 @@ func newResponseRecorder(rw http.ResponseWriter) recorder {
 	if _, ok := rw.(http.CloseNotifier); !ok {
 		return rec
 	}
-	return responseRecorderWithCloseNotify{rec}
+	return &responseRecorderWithCloseNotify{rec}
 }
 
 // responseRecorder captures information from the response and preserves it for
@@ -53,13 +53,6 @@ func (r *responseRecorder) WriteHeader(status int) {
 // Hijack hijacks the connection
 func (r *responseRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return r.ResponseWriter.(http.Hijacker).Hijack()
-}
-
-// CloseNotify returns a channel that receives at most a
-// single value (true) when the client connection has gone
-// away.
-func (r *responseRecorder) CloseNotify() <-chan bool {
-	return r.ResponseWriter.(http.CloseNotifier).CloseNotify()
 }
 
 // Flush sends any buffered data to the client.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

In #5985, we added `CloseNotify` specific versions of the `responseWriter` wrappers in
accesslog and metrics.
But the implementer is the pointer, not the value, and we messed up because we returned the value instead of the pointer in the "constructor".

Also, we had forgotten to remove the `CloseNotify` method for the type that is not supposed to implement it.

Therefore this PR fixes the above.

### Motivation

<!-- What inspired you to submit this pull request? -->

Fixes #6008 

### More

- [x] Added/updated tests
- ~[ ] Added/updated documentation~
