### PR TITLE
Support Brotli compression format

### DIFF
--- a/docs/content/middlewares/compress.md
+++ b/docs/content/middlewares/compress.md
@@ -5,18 +5,18 @@ Compressing the Response before Sending it to the Client
 
 ![Compress](../assets/img/middleware/compress.png)
 
-The Compress middleware enables the gzip compression. 
+The Compress middleware enables the Brotli or gzip compression. 
 
 ## Configuration Examples
 
 ```yaml tab="Docker"
-# Enable gzip compression
+# Enable compression
 labels:
   - "traefik.http.middlewares.test-compress.compress=true"
 ```
 
 ```yaml tab="Kubernetes"
-# Enable gzip compression
+# Enable compression
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
@@ -26,7 +26,7 @@ spec:
 ```
 
 ```yaml tab="Consul Catalog"
-# Enable gzip compression
+# Enable compression
 - "traefik.http.middlewares.test-compress.compress=true"
 ```
 
@@ -37,19 +37,19 @@ spec:
 ```
 
 ```yaml tab="Rancher"
-# Enable gzip compression
+# Enable compression
 labels:
   - "traefik.http.middlewares.test-compress.compress=true"
 ```
 
 ```toml tab="File (TOML)"
-# Enable gzip compression
+# Enable compression
 [http.middlewares]
   [http.middlewares.test-compress.compress]
 ```
 
 ```yaml tab="File (YAML)"
-# Enable gzip compression
+# Enable compression
 http:
   middlewares:
     test-compress:
@@ -61,8 +61,8 @@ http:
     Responses are compressed when:
     
     * The response body is larger than `1400` bytes.
-    * The `Accept-Encoding` request header contains `gzip`.
-    * The response is not already compressed, i.e. the `Content-Encoding` response header is not already set.
+    * The `Accept-Encoding` request header contains `gzip` or `br`.
+    * The response is not already compressed, i.e. the `Content-Encoding` response header is not already set to `gzip`, `br` or `deflate`.
 
 ## Configuration Options
 

--- a/dynamic.toml
+++ b/dynamic.toml
@@ -1,0 +1,16 @@
+[http]
+  [http.routers]
+    [http.routers.router0]
+      entryPoints = ["web"]
+      middlewares = ["my-compression"]
+      service = "service-foo"
+      rule = "Path(`/`)"
+
+[http.middlewares]
+  [http.middlewares.my-compression.compress]
+
+[http.services]
+  [http.services.service-foo]
+    [http.services.service-foo.loadBalancer]
+      [[http.services.service-foo.loadBalancer.servers]]
+        url = "http://127.0.0.1:4000/"

--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/prometheus/client_golang v1.1.0
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4
 	github.com/rancher/go-rancher-metadata v0.0.0-00010101000000-000000000000
+	github.com/sh7dm/brotlihandler v0.0.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
 	github.com/stvp/go-udp-testing v0.0.0-20171104055251-c4434f09ec13

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/VividCortex/gohistogram v1.0.0 // indirect
 	github.com/abbot/go-http-auth v0.0.0-00010101000000-000000000000
 	github.com/abronan/valkeyrie v0.0.0-20190822142731-f2e1850dc905
+	github.com/andybalholm/brotli v1.0.0
 	github.com/c0va23/go-proxyprotocol v0.9.1
 	github.com/cenkalti/backoff/v3 v3.0.0
 	github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc // indirect
@@ -75,7 +76,6 @@ require (
 	github.com/prometheus/client_golang v1.1.0
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4
 	github.com/rancher/go-rancher-metadata v0.0.0-00010101000000-000000000000
-	github.com/sh7dm/brotlihandler v0.0.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
 	github.com/stvp/go-udp-testing v0.0.0-20171104055251-c4434f09ec13

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190808125512-07798873deee h1:NYqDBPkhVYt68W3yoGoRRi32i3MLx2ey7SFkJ1v/UI0=
 github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190808125512-07798873deee/go.mod h1:myCDvQSzCW+wB1WAlocEru4wMGJxy+vlxHdhegi1CDQ=
 github.com/aliyun/aliyun-oss-go-sdk v0.0.0-20190307165228-86c17b95fcd5/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
+github.com/andybalholm/brotli v1.0.0 h1:7UCwP93aiSfvWpapti8g88vVVGp2qqtGyePsSuDafo4=
+github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/apache/thrift v0.12.0 h1:pODnxUFNcjP9UTLZGTdeh+j16A8lJbRvD3rOtrk/7bs=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
@@ -541,6 +543,8 @@ github.com/santhosh-tekuri/jsonschema v1.2.4/go.mod h1:TEAUOeZSmIxTTuHatJzrvARHi
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/sh7dm/brotlihandler v0.0.1 h1:Z03e/T3zvAE5xdYrcnGKqtcH8Qv+NWKcPZqmyGQyZBg=
+github.com/sh7dm/brotlihandler v0.0.1/go.mod h1:SlI4IqBvHLUChGcMTRS89G2SBGXifdXuL80EsZvPdnA=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=

--- a/go.sum
+++ b/go.sum
@@ -543,8 +543,6 @@ github.com/santhosh-tekuri/jsonschema v1.2.4/go.mod h1:TEAUOeZSmIxTTuHatJzrvARHi
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
-github.com/sh7dm/brotlihandler v0.0.1 h1:Z03e/T3zvAE5xdYrcnGKqtcH8Qv+NWKcPZqmyGQyZBg=
-github.com/sh7dm/brotlihandler v0.0.1/go.mod h1:SlI4IqBvHLUChGcMTRS89G2SBGXifdXuL80EsZvPdnA=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=

--- a/pkg/brotlihandler/brotli.go
+++ b/pkg/brotlihandler/brotli.go
@@ -1,0 +1,166 @@
+// Copyright 2013 The Gorilla Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package brotlihandler // import "github.com/containous/traefik/v2/pkg/brotlihandler"
+
+import (
+	"compress/gzip"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/andybalholm/brotli"
+)
+
+const (
+	brEncoding      = "br"
+	gzipEncoding    = "gzip"
+	deflateEncoding = "deflate"
+)
+
+type compressResponseWriter struct {
+	Writer io.WriteCloser
+	http.ResponseWriter
+	http.Hijacker
+	http.Flusher
+	http.CloseNotifier
+	encoding string
+	level    int
+	code     int
+}
+
+func (w *compressResponseWriter) WriteHeader(c int) {
+	w.ResponseWriter.Header().Del("Content-Length")
+	if w.code == 0 {
+		w.code = c
+	}
+}
+
+func (w *compressResponseWriter) Header() http.Header {
+	return w.ResponseWriter.Header()
+}
+
+func (w *compressResponseWriter) writeHeader() {
+	if w.code != 0 {
+		w.ResponseWriter.WriteHeader(w.code)
+		w.code = 0
+	}
+}
+
+func (w *compressResponseWriter) Write(b []byte) (int, error) {
+	h := w.ResponseWriter.Header()
+	if h.Get("Content-Type") == "" {
+		h.Set("Content-Type", http.DetectContentType(b))
+	}
+	h.Del("Content-Length")
+
+	e := h.Get("Content-Encoding")
+	// Don't compress short pieces of data since it won't improve performance. Ignore compressed data too
+	if len(b) < 1400 || e == brEncoding || e == gzipEncoding || e == deflateEncoding {
+		w.writeHeader()
+		return w.ResponseWriter.Write(b)
+	}
+
+	h.Set("Content-Encoding", w.encoding)
+	w.writeHeader()
+
+	if w.encoding == brEncoding {
+		if w.level < brotli.BestSpeed || w.level > brotli.BestCompression {
+			w.level = brotli.DefaultCompression
+		}
+
+		w.Writer = brotli.NewWriterLevel(w, w.level)
+	} else {
+		if w.level < gzip.HuffmanOnly || w.level > gzip.BestCompression {
+			w.level = gzip.DefaultCompression
+		}
+
+		w.Writer, _ = gzip.NewWriterLevel(w, w.level)
+	}
+	defer w.Writer.Close()
+
+	return w.Writer.Write(b)
+}
+
+type flusher interface {
+	Flush() error
+}
+
+func (w *compressResponseWriter) Flush() {
+	// Flush compressed data if compressor supports it.
+	f, ok := w.Writer.(flusher)
+	if !ok {
+		return
+	}
+	f.Flush()
+	// Flush HTTP response.
+	if w.Flusher != nil {
+		w.Flusher.Flush()
+	}
+}
+
+// CompressHandler gzip/brotli compresses HTTP responses for clients that support it
+// via the 'Accept-Encoding' header.
+//
+// Compressing TLS traffic may leak the page contents to an attacker if the
+// page contains user input: http://security.stackexchange.com/a/102015/12208
+func CompressHandler(h http.Handler) http.Handler {
+	return CompressHandlerLevel(h, 6)
+}
+
+// CompressHandlerLevel gzip/brotli compresses HTTP responses with specified compression level
+// for clients that support it via the 'Accept-Encoding' header.
+//
+// The compression level should be valid for encodings you use
+func CompressHandlerLevel(h http.Handler, level int) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// detect what encoding to use
+		var encoding string
+		for _, curEnc := range strings.Split(r.Header.Get("Accept-Encoding"), ",") {
+			curEnc = strings.TrimSpace(curEnc)
+			if curEnc == brEncoding || curEnc == gzipEncoding {
+				encoding = curEnc
+				if curEnc == brEncoding {
+					break
+				}
+			}
+		}
+
+		// if we weren't able to identify an encoding we're familiar with, pass on the
+		// request to the handler and return
+		if encoding == "" {
+			h.ServeHTTP(w, r)
+			return
+		}
+
+		r.Header.Del("Accept-Encoding")
+		w.Header().Add("Vary", "Accept-Encoding")
+
+		hijacker, ok := w.(http.Hijacker)
+		if !ok { /* w is not Hijacker... oh well... */
+			hijacker = nil
+		}
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			flusher = nil
+		}
+
+		closeNotifier, ok := w.(http.CloseNotifier)
+		if !ok {
+			closeNotifier = nil
+		}
+
+		w = &compressResponseWriter{
+			ResponseWriter: w,
+			Hijacker:       hijacker,
+			Flusher:        flusher,
+			CloseNotifier:  closeNotifier,
+			encoding:       encoding,
+			level:          level,
+		}
+
+		h.ServeHTTP(w, r)
+	})
+}

--- a/pkg/brotlihandler/brotli_test.go
+++ b/pkg/brotlihandler/brotli_test.go
@@ -1,0 +1,218 @@
+package brotlihandler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	gzipLength   = 306 // Lenght of 1400-byte response compressed with gzip
+	brotliLength = 269 // Lenght of 1400-byte response compressed with Brotli
+)
+
+func TestShouldCompressWhenNoContentEncoding(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://localhost", nil)
+	assert.Nil(t, err, "Request error")
+	req.Header.Add("Accept-Encoding", gzipEncoding)
+
+	baseBody := generateBytes(1400)
+
+	next := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		_, err := rw.Write(baseBody)
+		assert.NoError(t, err)
+	})
+	handler := CompressHandler(next)
+
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, req)
+
+	assert.Equal(t, gzipEncoding, rw.Header().Get("Content-Encoding"))
+	assert.Equal(t, "Accept-Encoding", rw.Header().Get("Vary"))
+	assert.Equal(t, gzipLength, len(rw.Body.Bytes()))
+
+	if assert.ObjectsAreEqualValues(rw.Body.Bytes(), baseBody) {
+		assert.Fail(t, "expected a compressed body", "got %v", rw.Body.Bytes())
+	}
+}
+
+func TestShouldCompressBrotliWhenNoContentEncoding(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://localhost", nil)
+	assert.Nil(t, err, "Request error")
+	req.Header.Add("Accept-Encoding", brEncoding)
+
+	baseBody := generateBytes(1400)
+
+	next := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		_, err := rw.Write(baseBody)
+		assert.NoError(t, err)
+	})
+	handler := CompressHandler(next)
+
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, req)
+
+	assert.Equal(t, brEncoding, rw.Header().Get("Content-Encoding"))
+	assert.Equal(t, "Accept-Encoding", rw.Header().Get("Vary"))
+	assert.Equal(t, brotliLength, len(rw.Body.Bytes()))
+
+	if assert.ObjectsAreEqualValues(rw.Body.Bytes(), baseBody) {
+		assert.Fail(t, "expected a compressed body", "got %v", rw.Body.Bytes())
+	}
+}
+
+func TestShouldCompressBrotliWhenAcceptBrotliAndGzip(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://localhost", nil)
+	assert.Nil(t, err, "Request error")
+	req.Header.Add("Accept-Encoding", "gzip,br")
+
+	baseBody := generateBytes(1400)
+
+	next := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		_, err := rw.Write(baseBody)
+		assert.NoError(t, err)
+	})
+	handler := CompressHandler(next)
+
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, req)
+
+	assert.Equal(t, brEncoding, rw.Header().Get("Content-Encoding"))
+	assert.Equal(t, "Accept-Encoding", rw.Header().Get("Vary"))
+	assert.Equal(t, brotliLength, len(rw.Body.Bytes()))
+
+	if assert.ObjectsAreEqualValues(rw.Body.Bytes(), baseBody) {
+		assert.Fail(t, "expected a compressed body", "got %v", rw.Body.Bytes())
+	}
+}
+
+func TestShouldNotCompressCompressed(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://localhost", nil)
+	assert.Nil(t, err, "Request error")
+	req.Header.Add("Accept-Encoding", deflateEncoding)
+
+	fakeCompressedBody := generateBytes(1400)
+	handler := CompressHandler(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.Header().Add("Content-Encoding", deflateEncoding)
+		rw.Header().Add("Vary", "Accept-Encoding")
+		_, err := rw.Write(fakeCompressedBody)
+		if err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+		}
+	}))
+
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, req)
+
+	assert.Equal(t, deflateEncoding, rw.Header().Get("Content-Encoding"))
+	assert.Equal(t, "Accept-Encoding", rw.Header().Get("Vary"))
+
+	assert.EqualValues(t, rw.Body.Bytes(), fakeCompressedBody)
+}
+
+func TestShouldNotCompressWhenNotAccepted(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://localhost", nil)
+	assert.Nil(t, err, "Request error")
+	req.Header.Add("Accept-Encoding", "deflate")
+
+	fakeBody := generateBytes(1400)
+	next := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		_, err := rw.Write(fakeBody)
+		if err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+		}
+	})
+	handler := CompressHandler(next)
+
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, req)
+
+	assert.Empty(t, rw.Header().Get("Content-Encoding"))
+	assert.EqualValues(t, rw.Body.Bytes(), fakeBody)
+}
+
+func TestShouldNotCompressWhenShort(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://localhost", nil)
+	assert.Nil(t, err, "Request error")
+
+	fakeBody := generateBytes(1000)
+	next := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		_, err := rw.Write(fakeBody)
+		if err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+		}
+	})
+	handler := CompressHandler(next)
+
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, req)
+
+	assert.Empty(t, rw.Header().Get("Content-Encoding"))
+	assert.EqualValues(t, rw.Body.Bytes(), fakeBody)
+}
+
+func TestShouldWriteHeader(t *testing.T) {
+	next := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.Header().Add("Content-Encoding", gzipEncoding)
+		rw.Header().Add("Vary", "Accept-Encoding")
+		rw.WriteHeader(http.StatusUnauthorized)
+		_, err := rw.Write([]byte("short"))
+		if err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+		}
+	})
+	handler := CompressHandler(next)
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	assert.Nil(t, err, "Request error")
+	req.Header.Add("Accept-Encoding", gzipEncoding)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	assert.Equal(t, gzipEncoding, resp.Header.Get("Content-Encoding"))
+	assert.Equal(t, "Accept-Encoding", resp.Header.Get("Vary"))
+}
+
+func TestShouldWriteHeaderWhenFlush(t *testing.T) {
+	next := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.Header().Add("Content-Encoding", gzipEncoding)
+		rw.Header().Add("Vary", "Accept-Encoding")
+		rw.WriteHeader(http.StatusUnauthorized)
+		rw.(http.Flusher).Flush()
+		_, err := rw.Write([]byte("short"))
+		if err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+		}
+	})
+	handler := CompressHandler(next)
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	assert.Nil(t, err, "Request error")
+	req.Header.Add("Accept-Encoding", gzipEncoding)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	assert.Equal(t, gzipEncoding, resp.Header.Get("Content-Encoding"))
+	assert.Equal(t, "Accept-Encoding", resp.Header.Get("Vary"))
+}
+
+func generateBytes(len int) []byte {
+	var value []byte
+	for i := 0; i < len; i++ {
+		value = append(value, 0x61+byte(i))
+	}
+	return value
+}

--- a/pkg/brotlihandler/push.go
+++ b/pkg/brotlihandler/push.go
@@ -1,0 +1,62 @@
+// +build go1.8
+
+package brotlihandler
+
+import "net/http"
+
+// Push initiates an HTTP/2 server push. This constructs a synthetic
+// request using the given target and options, serializes that request
+// into a PUSH_PROMISE frame, then dispatches that request using the
+// server's request handler. If opts is nil, default options are used.
+//
+// The target must either be an absolute path (like "/path") or an absolute
+// URL that contains a valid host and the same scheme as the parent request.
+// If the target is a path, it will inherit the scheme and host of the
+// parent request.
+//
+// The HTTP/2 spec disallows recursive pushes and cross-authority pushes.
+// Push may or may not detect these invalid pushes; however, invalid
+// pushes will be detected and canceled by conforming clients.
+//
+// Handlers that wish to push URL X should call Push before sending any
+// data that may trigger a request for URL X. This avoids a race where the
+// client issues requests for X before receiving the PUSH_PROMISE for X.
+//
+// Push will run in a separate goroutine making the order of arrival
+// non-deterministic. Any required synchronization needs to be implemented
+// by the caller.
+//
+// Push returns ErrNotSupported if the client has disabled push or if push
+// is not supported on the underlying connection.
+func (w *compressResponseWriter) Push(target string, opts *http.PushOptions) error {
+	pusher, ok := w.ResponseWriter.(http.Pusher)
+	if ok && pusher != nil {
+		return pusher.Push(target, setAcceptEncodingForPushOptions(opts))
+	}
+	return http.ErrNotSupported
+}
+
+func setAcceptEncodingForPushOptions(opts *http.PushOptions) *http.PushOptions {
+	if opts == nil {
+		opts = &http.PushOptions{
+			Header: http.Header{
+				"Accept-Encoding": []string{"br", "gzip"},
+			},
+		}
+		return opts
+	}
+
+	if opts.Header == nil {
+		opts.Header = http.Header{
+			"Accept-Encoding": []string{"br", "gzip"},
+		}
+		return opts
+	}
+
+	if encoding := opts.Header.Get("Accept-Encoding"); encoding == "" {
+		opts.Header.Add("Accept-Encoding", "br,gzip")
+		return opts
+	}
+
+	return opts
+}

--- a/pkg/brotlihandler/push_test.go
+++ b/pkg/brotlihandler/push_test.go
@@ -1,0 +1,70 @@
+package brotlihandler
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetAcceptEncodingForPushOptionsWithoutHeaders(t *testing.T) {
+	var opts *http.PushOptions
+	opts = setAcceptEncodingForPushOptions(opts)
+
+	assert.NotNil(t, opts)
+	assert.NotNil(t, opts.Header)
+
+	for k, v := range opts.Header {
+		assert.Equal(t, "Accept-Encoding", k)
+		assert.Len(t, v, 2)
+		assert.Equal(t, "br", v[0])
+		assert.Equal(t, "gzip", v[1])
+	}
+
+	opts = &http.PushOptions{}
+	opts = setAcceptEncodingForPushOptions(opts)
+
+	assert.NotNil(t, opts)
+	assert.NotNil(t, opts.Header)
+
+	for k, v := range opts.Header {
+		assert.Equal(t, "Accept-Encoding", k)
+		assert.Len(t, v, 2)
+		assert.Equal(t, "br", v[0])
+		assert.Equal(t, "gzip", v[1])
+	}
+}
+
+func TestSetAcceptEncodingForPushOptionsWithHeaders(t *testing.T) {
+	opts := &http.PushOptions{
+		Header: http.Header{
+			"User-Agent": []string{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.98 Safari/537.36"},
+		},
+	}
+	opts = setAcceptEncodingForPushOptions(opts)
+
+	assert.NotNil(t, opts)
+	assert.NotNil(t, opts.Header)
+
+	assert.Equal(t, "br,gzip", opts.Header.Get("Accept-Encoding"))
+	assert.Equal(t, "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.98 Safari/537.36", opts.Header.Get("User-Agent"))
+
+	opts = &http.PushOptions{
+		Header: http.Header{
+			"User-Agent":      []string{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.98 Safari/537.36"},
+			"Accept-Encoding": []string{"deflate"},
+		},
+	}
+	opts = setAcceptEncodingForPushOptions(opts)
+
+	assert.NotNil(t, opts)
+	assert.NotNil(t, opts.Header)
+
+	e, found := opts.Header["Accept-Encoding"]
+	if !found {
+		assert.Fail(t, "Missing Accept-Encoding header value")
+	}
+	assert.Len(t, e, 1)
+	assert.Equal(t, "deflate", e[0])
+	assert.Equal(t, "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.98 Safari/537.36", opts.Header.Get("User-Agent"))
+}

--- a/pkg/middlewares/compress/compress.go
+++ b/pkg/middlewares/compress/compress.go
@@ -10,7 +10,7 @@ import (
 	"github.com/containous/traefik/v2/pkg/middlewares"
 	"github.com/containous/traefik/v2/pkg/tracing"
 	"github.com/opentracing/opentracing-go/ext"
-	"github.com/sh7dm/brotlihandler"
+	"github.com/containous/traefik/v2/pkg/brotlihandler"
 )
 
 const (

--- a/pkg/middlewares/compress/compress_test.go
+++ b/pkg/middlewares/compress/compress_test.go
@@ -20,7 +20,9 @@ const (
 	contentTypeHeader     = "Content-Type"
 	varyHeader            = "Vary"
 	gzipValue             = "gzip"
+	gzipLength            = 306
 	brotliValue           = "br"
+	brotliLength          = 269
 )
 
 func TestShouldCompressWhenNoContentEncodingHeader(t *testing.T) {
@@ -40,6 +42,7 @@ func TestShouldCompressWhenNoContentEncodingHeader(t *testing.T) {
 
 	assert.Equal(t, gzipValue, rw.Header().Get(contentEncodingHeader))
 	assert.Equal(t, acceptEncodingHeader, rw.Header().Get(varyHeader))
+	assert.Equal(t, gzipLength, len(rw.Body.Bytes()))
 
 	if assert.ObjectsAreEqualValues(rw.Body.Bytes(), baseBody) {
 		assert.Fail(t, "expected a compressed body", "got %v", rw.Body.Bytes())
@@ -63,6 +66,7 @@ func TestShouldCompressBrWhenNoContentEncodingHeader(t *testing.T) {
 
 	assert.Equal(t, brotliValue, rw.Header().Get(contentEncodingHeader))
 	assert.Equal(t, acceptEncodingHeader, rw.Header().Get(varyHeader))
+	assert.Equal(t, brotliLength, len(rw.Body.Bytes()))
 
 	if assert.ObjectsAreEqualValues(rw.Body.Bytes(), baseBody) {
 		assert.Fail(t, "expected a compressed body", "got %v", rw.Body.Bytes())


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?
Add support of modern Brotli compression format to Compress middleware.
<!-- A brief description of the change being made with this pull request. -->


### Motivation
Fixes #4202
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes
The package used in this update is a drop-in replacement for gzip middleware which supports Brotli.
<!-- Anything else we should know when reviewing? -->
