### PR TITLE
fix(dns): /etc/hosts was ignored by traefik

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,6 @@ COPY script/ca-certificates.crt /etc/ssl/certs/
 COPY dist/traefik /
 EXPOSE 80
 VOLUME ["/tmp"]
+## Fix nssswitch not looking at host file (See https://stackoverflow.com/questions/49476452/traefik-forwarding-to-a-host-and-overriding-ip?answertab=oldest#tab-top)
+RUN echo "hosts: files dns" > /etc/nsswitch.conf
 ENTRYPOINT ["/traefik"]


### PR DESCRIPTION
Fix #6001

### What does this PR do?

It create the missing `/etc/nsswitch.conf`.

### Motivation

During proxying, traefik is performing a DNS resolution. This DNS resolution is skipping `/etc/hosts` file. This can cause unwanted DNS resolution, especially when using hostname as fqdn in marathon.

If you use `/etc/hosts` file for some resolution, this will fix it. If you use a real fqdn in marathon on a private network, you will still have to properly configure DNS serveur in traefik host.
