### PR TITLE
Don't nest middleware spans

### DIFF
--- a/pkg/middlewares/tracing/wrapper.go
+++ b/pkg/middlewares/tracing/wrapper.go
@@ -34,14 +34,14 @@ func Wrap(ctx context.Context, constructor alice.Constructor) alice.Constructor 
 		if tracableHandler, ok := handler.(Tracable); ok {
 			name, spanKind := tracableHandler.GetTracingInformation()
 			log.FromContext(ctx).WithField(log.MiddlewareName, name).Debug("Adding tracing to middleware")
-			return NewTraceStarted(handler, name, spanKind, tracingFinisher), nil
+			return NewTraceStarter(handler, name, spanKind, tracingFinisher), nil
 		}
 		return handler, nil
 	}
 }
 
-// NewTraceStarted returns a *TracingStarted struct
-func NewTraceStarted(middleware http.Handler, name string, spanKind ext.SpanKindEnum, finisher *TraceFinisher) *TraceStarter {
+// NewTraceStarter returns a *TracingStarted struct
+func NewTraceStarter(middleware http.Handler, name string, spanKind ext.SpanKindEnum, finisher *TraceFinisher) *TraceStarter {
 	return &TraceStarter{
 		middleware: middleware,
 		name:       name,


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

Converts this
![before](https://user-images.githubusercontent.com/4923699/70716956-0a62c880-1cf6-11ea-8b56-cfb3b8fabb03.png)
to this
![after](https://user-images.githubusercontent.com/4923699/70716967-0e8ee600-1cf6-11ea-8ebc-566ca267a74c.png)

In other words, my PR makes middleware span to display only time when middleware is processing, not all nested middleware and forward spans.

### Motivation

To display correct span times in tracing UI

### More

- [ ] Added/updated tests
- [ ] ~Added/updated documentation~ (not needed)

