### PR TITLE
Add Migration Guide for Traefik v2.1

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -1,33 +1,29 @@
 # Migration: Steps needed between the versions
 
-## 2.0 to 2.1
-In Version 2.1, we added a new CRD called ``TraefikService``. When you're updating your installation to 2.1,
-you therefore need to apply that CRD before as well as enhance your ClusterRole to allow Traefik
-to use that CRD.
+## v2.0 to v2.1
 
-To add that CRD, you need to apply the following definition:
+In v2.1, we added a new CRD called `TraefikService`. When you're updating your installation to v2.1,
+you therefore need to apply that CRD before as well as enhance your `ClusterRole` to allow Traefik to use that CRD.
 
-```yaml tab="Kubernetes TraefikService
----
-  apiVersion: apiextensions.k8s.io/v1beta1
-  kind: CustomResourceDefinition
-  metadata:
-    name: traefikservices.traefik.containo.us
-  
-  spec:
-    group: traefik.containo.us
-    version: v1alpha1
-    names:
-      kind: TraefikService
-      plural: traefikservices
-      singular: traefikservice
-    scope: Namespaced
+To add that CRD, you need to apply the following definition, and you need to extend your permissions to that:
+
+```yaml tab="TraefikService"
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: traefikservices.traefik.containo.us
+
+spec:
+  group: traefik.containo.us
+  version: v1alpha1
+  names:
+    kind: TraefikService
+    plural: traefikservices
+    singular: traefikservice
+  scope: Namespaced
 ```
 
-Also, you need to extend your permissions to that:
-
 ```yaml tab="ClusterRole"
----
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -2,12 +2,12 @@
 
 ## 2.0 to 2.1
 In Version 2.1, we added a new CRD called ``TraefikService``. When you're updating your installation to 2.1,
-you therefore need to apply that CRD Definition before as well as enhance your ClusterRole to allow Traefik
+you therefore need to apply that CRD before as well as enhance your ClusterRole to allow Traefik
 to use that CRD.
 
 To add that CRD, you need to apply the following definition:
 
-```yaml
+```yaml tab="Kubernetes TraefikService
 ---
   apiVersion: apiextensions.k8s.io/v1beta1
   kind: CustomResourceDefinition
@@ -22,11 +22,11 @@ To add that CRD, you need to apply the following definition:
       plural: traefikservices
       singular: traefikservice
     scope: Namespaced
- ```
+```
 
 Also, you need to extend your permissions to that:
 
-```yaml
+```yaml tab="ClusterRole"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -1,0 +1,103 @@
+# Migration: Steps needed between the versions
+
+## 2.0 to 2.1
+In Version 2.1, we added a new CRD called ``TraefikService``. When you're updating your installation to 2.1,
+you therefore need to apply that CRD Definition before as well as enhance your ClusterRole to allow Traefik
+to use that CRD.
+
+To add that CRD, you need to apply the following definition:
+
+```yaml
+---
+  apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: traefikservices.traefik.containo.us
+  
+  spec:
+    group: traefik.containo.us
+    version: v1alpha1
+    names:
+      kind: TraefikService
+      plural: traefikservices
+      singular: traefikservice
+    scope: Namespaced
+ ```
+
+Also, you need to extend your permissions to that:
+
+```yaml
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: traefik-ingress-controller
+
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+  - apiGroups:
+      - traefik.containo.us
+    resources:
+      - middlewares
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.containo.us
+    resources:
+      - ingressroutes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.containo.us
+    resources:
+      - ingressroutetcps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.containo.us
+    resources:
+      - tlsoptions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.containo.us
+    resources:
+      - traefikservices
+    verbs:
+      - get
+      - list
+      - watch
+```
+
+After having both resources applied, Traefik will work properly.

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -2,10 +2,10 @@
 
 ## v2.0 to v2.1
 
-In v2.1, we added a new CRD called `TraefikService`. When you're updating your installation to v2.1,
-you therefore need to apply that CRD before as well as enhance your `ClusterRole` to allow Traefik to use that CRD.
+In v2.1, a new CRD called `TraefikService` was added. While updating an installation to v2.1,
+it is required to apply that CRD before as well as enhance the existing `ClusterRole` definition to allow Traefik to use that CRD.
 
-To add that CRD, you need to apply the following definition, and you need to extend your permissions to that:
+To add that CRD and enhance the permissions, following definitions need to be applied to the cluster.
 
 ```yaml tab="TraefikService"
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -154,6 +154,7 @@ nav:
           - 'HTTP Challenge': 'user-guides/docker-compose/acme-http/index.md'
           - 'DNS Challenge': 'user-guides/docker-compose/acme-dns/index.md'
   - 'Migration':
+      - 'Traefik v2 minor migrations': 'migration/v2.md'
       - 'Traefik v1 to v2': 'migration/v1-to-v2.md'
   - 'Contributing':
       - 'Thank You!': 'contributing/thank-you.md'


### PR DESCRIPTION
### What does this PR do?

Adds a guide on how to migrate Traefik v2.x minor versions.


### Motivation

Have our users do the right things ;-)

### More

- [ ] Added/updated tests
- [x] Added/updated documentation
