### PR TITLE
add a documentation example for dashboard and api for kubernetes CRD

### DIFF
--- a/docs/content/operations/include-api-examples.md
+++ b/docs/content/operations/include-api-examples.md
@@ -19,6 +19,28 @@ deploy:
     - "traefik.http.services.dummy-svc.loadbalancer.server.port=9999"
 ```
 
+```yaml tab="Kubernetes CRD"
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: traefik-dashboard
+spec:
+  routes:
+  - match: Host(`traefik.domain.com`)
+    kind: Rule
+    services:
+    - name: api@internal
+      kind: TraefikService
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: auth
+spec:
+  basicAuth:
+    secret: secretName # Kubernetes secret named "secretName"
+```
+
 ```yaml tab="Consul Catalog"
 # Dynamic Configuration
 - "traefik.http.routers.api.rule=Host(`traefik.domain.com`)"


### PR DESCRIPTION
Signed-off-by: dduportal <1522731+dduportal@users.noreply.github.com>

### What does this PR do?

This PR adds a documentation example for dashboard and api for kubernetes CRD.

### Motivation

With the release of Traefik v2.1, Kubernetes CRD `IngressRoute` can now specify the internal service `api@internal` as a type `TraefikService`, which allow a "Secure Dashboard" configuration.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

![gif](https://media.giphy.com/media/U3D5dmP3LRWLWbSKlj/giphy.gif)
