### PR TITLE
fix: invalid label/flag parsing.

### DIFF
--- a/pkg/config/parser/labels_decode.go
+++ b/pkg/config/parser/labels_decode.go
@@ -21,6 +21,10 @@ func DecodeToNode(labels map[string]string, rootName string, filters ...string) 
 
 		var parts []string
 		for _, v := range split {
+			if v == "" {
+				return nil, fmt.Errorf("invalid element: %s", key)
+			}
+
 			if v[0] == '[' {
 				return nil, fmt.Errorf("invalid leading character '[' in field name (bracket is a slice delimiter): %s", v)
 			}

--- a/pkg/config/parser/labels_decode_test.go
+++ b/pkg/config/parser/labels_decode_test.go
@@ -27,6 +27,15 @@ func TestDecodeToNode(t *testing.T) {
 			expected: expected{node: nil},
 		},
 		{
+			desc: "invalid label, ending by a dot",
+			in: map[string]string{
+				"traefik.http.": "bar",
+			},
+			expected: expected{
+				error: true,
+			},
+		},
+		{
 			desc: "level 1",
 			in: map[string]string{
 				"traefik.foo": "bar",


### PR DESCRIPTION
### What does this PR do?

Throw an error instead of panic when a label/flag name ends with a dot.

### Motivation

Fixes #6024

```
Stack: goroutine 62 [running]:
runtime/debug.Stack(0xc00010c000, 0x2550df9, 0x17)
	/usr/local/go/src/runtime/debug/stack.go:24 +0x9d
github.com/containous/traefik/v2/pkg/safe.defaultRecoverGoroutine(0x235a380, 0xc0007e5420)
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:160 +0xb1
github.com/containous/traefik/v2/pkg/safe.OperationWithRecover.func1.1(0xc000705d78)
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:168 +0x56
panic(0x235a380, 0xc0007e5420)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/containous/traefik/v2/pkg/config/parser.DecodeToNode(0xc0007a7e30, 0x252f8bb, 0x7, 0xc0007053a0, 0x2, 0x2, 0x10, 0x21fd9e0, 0x29f5b01)
	/go/src/github.com/containous/traefik/pkg/config/parser/labels_decode.go:24 +0x6ec
github.com/containous/traefik/v2/pkg/config/parser.Decode(0xc0007a7e30, 0x21158e0, 0xc00095db40, 0x252f8bb, 0x7, 0xc0007053a0, 0x2, 0x2, 0x75ffba, 0x241de40)
	/go/src/github.com/containous/traefik/pkg/config/parser/parser.go:11 +0x6d
github.com/containous/traefik/v2/pkg/config/label.DecodeConfiguration(0xc0007a7e30, 0xc000290510, 0x29f5b60, 0xc0003e2a80)
	/go/src/github.com/containous/traefik/pkg/config/label/label.go:16 +0xfb
github.com/containous/traefik/v2/pkg/provider/docker.(*Provider).buildConfiguration(0xc000318c40, 0x29ac080, 0xc0001f6c30, 0xc000a5a000, 0x6, 0x8, 0x6)
	/go/src/github.com/containous/traefik/pkg/provider/docker/config.go:31 +0x326
github.com/containous/traefik/v2/pkg/provider/docker.(*Provider).Provide.func1.1(0x0, 0x0)
	/go/src/github.com/containous/traefik/pkg/provider/docker/docker.go:193 +0x657
github.com/containous/traefik/v2/pkg/safe.OperationWithRecover.func1(0x0, 0x0)
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:172 +0x6c
github.com/cenkalti/backoff/v3.RetryNotify(0xc0002ba840, 0x296a180, 0xc0000c9000, 0xc000705ef0, 0x0, 0x0)
	/go/pkg/mod/github.com/cenkalti/backoff/v3@v3.0.0/retry.go:37 +0xb8
github.com/containous/traefik/v2/pkg/provider/docker.(*Provider).Provide.func1(0x29abfc0, 0xc00012c680)
	/go/src/github.com/containous/traefik/pkg/provider/docker/docker.go:293 +0x2d6
github.com/containous/traefik/v2/pkg/safe.(*Pool).GoCtx.func1()
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:63 +0x84
github.com/containous/traefik/v2/pkg/safe.GoWithRecover.func1(0x262c6e0, 0xc0000c8fe0)
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:153 +0x57
created by github.com/containous/traefik/v2/pkg/safe.GoWithRecover
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:147 +0x49
```

### More

- [x] Added/updated tests
- ~~[ ] Added/updated documentation~~
