### PR TITLE
Fix panic in accesslog middleware

### DIFF
--- a/pkg/middlewares/accesslog/logger.go
+++ b/pkg/middlewares/accesslog/logger.go
@@ -171,7 +171,7 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request, next http
 
 	var crr *captureRequestReader
 	if req.Body != nil {
-		crr = &captureRequestReader{source: req.Body, count: 0}
+		crr = &captureRequestReader{req: req, count: 0}
 		reqWithDataTable.Body = crr
 	}
 


### PR DESCRIPTION
### What does this PR do?

This patch fixes an invalid memory address or nil pointer dereference panic which route cause is still unknown.

My guess is that it occurs when a connection is closed before the accesslog middleware had the chance to do what it's supposed to do after the request has came back from the other middlewares.

With this patch the `captureRequestReader` will now first check that the connection has not been closed before trying to read its body.

### Motivation

Fix #5922

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
