### PR TITLE
Don't set user-agent to Go-http-client/1.1

### DIFF
--- a/pkg/server/service/proxy.go
+++ b/pkg/server/service/proxy.go
@@ -52,6 +52,10 @@ func buildProxy(passHostHeader *bool, responseForwarding *dynamic.ResponseForwar
 			outReq.ProtoMajor = 1
 			outReq.ProtoMinor = 1
 
+			if _, ok := outReq.Header["User-Agent"]; !ok {
+				outReq.Header.Set("User-Agent", "")
+			}
+
 			// Do not pass client Host header unless optsetter PassHostHeader is set.
 			if passHostHeader != nil && !*passHostHeader {
 				outReq.Host = outReq.URL.Host


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?
Force `User-Agent` header to `""` if it's not set to avoid it being replaced with `Go-http-client/1.1"`.
<!-- A brief description of the change being made with this pull request. -->

https://github.com/golang/go/blob/7d30af8e17d62932f8a458ad96f483b9afec6171/src/net/http/request.go#L614-L619

### Motivation
Fixes #5621, but only for v2.1.
<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes
Probably we should add a backport for this to v1.7, since the issue was reported to occur on that version. If the backport is needed, I can create it.
<!-- Anything else we should know when reviewing? -->
