### PR TITLE
Added ExternalName https support for Kubernetes CRD, as done in v2.0

### DIFF
--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -307,8 +307,13 @@ func (c configBuilder) loadServers(fallbackNamespace string, svc v1alpha1.LoadBa
 
 	var servers []dynamic.Server
 	if service.Spec.Type == corev1.ServiceTypeExternalName {
+                protocol := "http"
+                if portSpec.Port == 443 || strings.HasPrefix(portSpec.Name, "https") {
+                        protocol = "https"
+                }
+
 		return append(servers, dynamic.Server{
-			URL: fmt.Sprintf("http://%s:%d", service.Spec.ExternalName, portSpec.Port),
+                        URL: fmt.Sprintf("%s://%s:%d", protocol, service.Spec.ExternalName, portSpec.Port),
 		}), nil
 	}
 

--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -307,13 +307,13 @@ func (c configBuilder) loadServers(fallbackNamespace string, svc v1alpha1.LoadBa
 
 	var servers []dynamic.Server
 	if service.Spec.Type == corev1.ServiceTypeExternalName {
-                protocol := "http"
-                if portSpec.Port == 443 || strings.HasPrefix(portSpec.Name, "https") {
-                        protocol = "https"
-                }
+		protocol := "http"
+		if portSpec.Port == 443 || strings.HasPrefix(portSpec.Name, "https") {
+			protocol = "https"
+		}
 
 		return append(servers, dynamic.Server{
-                        URL: fmt.Sprintf("%s://%s:%d", protocol, service.Spec.ExternalName, portSpec.Port),
+			URL: fmt.Sprintf("%s://%s:%d", protocol, service.Spec.ExternalName, portSpec.Port),
 		}), nil
 	}
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

Kubernetes CRD was missing support for ExternalName https backends. It's already added into v2.0 and Kubernetes Ingress in v2.1 has it already included, so, I simply add this into CRDs. 
<!-- A brief description of the change being made with this pull request. -->


### Motivation
I need Sticky sessions with Kubernetes CRDs and ExternalName on https backends in an ongoing project, and this feature is going to be implemented anyway.
<!-- What inspired you to submit this pull request? -->

I made the former pull request to support https backends in ExternalNames for v2.0, as they were hardcoded as "http" backends in the code. 

### More


- [ ] Added/updated tests
- [ ] Added/updated documentation


### Additional Notes

Related to #5660
Regression from #5711