### PR TITLE
Query consul for service health separately

### DIFF
--- a/integration/consul_catalog_test.go
+++ b/integration/consul_catalog_test.go
@@ -61,13 +61,13 @@ func (s *ConsulCatalogSuite) TearDownSuite(c *check.C) {
 	}
 }
 
-func (s *ConsulCatalogSuite) registerService(foo *api.AgentServiceRegistration, onAgent bool) error {
+func (s *ConsulCatalogSuite) registerService(reg *api.AgentServiceRegistration, onAgent bool) error {
 	client := s.consulClient
 	if onAgent {
 		client = s.consulAgentClient
 	}
 
-	return client.Agent().ServiceRegister(foo)
+	return client.Agent().ServiceRegister(reg)
 }
 
 func (s *ConsulCatalogSuite) deregisterService(id string, onAgent bool) error {

--- a/pkg/provider/consulcatalog/consul_catalog.go
+++ b/pkg/provider/consulcatalog/consul_catalog.go
@@ -157,7 +157,7 @@ func (p *Provider) getConsulServicesData(ctx context.Context) ([]itemData, error
 			return nil, err
 		}
 
-		for k, consulService := range consulServices {
+		for i, consulService := range consulServices {
 			address := consulService.ServiceAddress
 			if address == "" {
 				address = consulService.Address
@@ -171,7 +171,7 @@ func (p *Provider) getConsulServicesData(ctx context.Context) ([]itemData, error
 				Port:    strconv.Itoa(consulService.ServicePort),
 				Labels:  tagsToNeutralLabels(consulService.ServiceTags, p.Prefix),
 				Tags:    consulService.ServiceTags,
-				Status:  healthServices[k].Checks.AggregatedStatus(),
+				Status:  healthServices[i].Checks.AggregatedStatus(),
 			}
 
 			extraConf, err := p.getConfiguration(item)
@@ -194,9 +194,13 @@ func (p *Provider) fetchService(ctx context.Context, name string) ([]*api.Catalo
 	}
 
 	opts := &api.QueryOptions{AllowStale: p.Stale, RequireConsistent: p.RequireConsistent, UseCache: p.Cache}
-	consulServices, _, _ := p.client.Catalog().Service(name, tagFilter, opts)
-	healthServices, _, err := p.client.Health().Service(name, tagFilter, false, opts)
 
+	consulServices, _, err := p.client.Catalog().Service(name, tagFilter, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	healthServices, _, err := p.client.Health().Service(name, tagFilter, false, opts)
 	return consulServices, healthServices, err
 }
 

--- a/pkg/provider/consulcatalog/consul_catalog.go
+++ b/pkg/provider/consulcatalog/consul_catalog.go
@@ -152,12 +152,12 @@ func (p *Provider) getConsulServicesData(ctx context.Context) ([]itemData, error
 
 	var data []itemData
 	for name := range consulServiceNames {
-		consulServices, err := p.fetchService(ctx, name)
+		consulServices, healthServices, err := p.fetchService(ctx, name)
 		if err != nil {
 			return nil, err
 		}
 
-		for _, consulService := range consulServices {
+		for k, consulService := range consulServices {
 			address := consulService.ServiceAddress
 			if address == "" {
 				address = consulService.Address
@@ -171,7 +171,7 @@ func (p *Provider) getConsulServicesData(ctx context.Context) ([]itemData, error
 				Port:    strconv.Itoa(consulService.ServicePort),
 				Labels:  tagsToNeutralLabels(consulService.ServiceTags, p.Prefix),
 				Tags:    consulService.ServiceTags,
-				Status:  consulService.Checks.AggregatedStatus(),
+				Status:  healthServices[k].Checks.AggregatedStatus(),
 			}
 
 			extraConf, err := p.getConfiguration(item)
@@ -187,15 +187,17 @@ func (p *Provider) getConsulServicesData(ctx context.Context) ([]itemData, error
 	return data, nil
 }
 
-func (p *Provider) fetchService(ctx context.Context, name string) ([]*api.CatalogService, error) {
+func (p *Provider) fetchService(ctx context.Context, name string) ([]*api.CatalogService, []*api.ServiceEntry, error) {
 	var tagFilter string
 	if !p.ExposedByDefault {
 		tagFilter = p.Prefix + ".enable=true"
 	}
 
 	opts := &api.QueryOptions{AllowStale: p.Stale, RequireConsistent: p.RequireConsistent, UseCache: p.Cache}
-	consulServices, _, err := p.client.Catalog().Service(name, tagFilter, opts)
-	return consulServices, err
+	consulServices, _, _ := p.client.Catalog().Service(name, tagFilter, opts)
+	healthServices, _, err := p.client.Health().Service(name, tagFilter, false, opts)
+
+	return consulServices, healthServices, err
 }
 
 func (p *Provider) fetchServices(ctx context.Context) (map[string][]string, error) {


### PR DESCRIPTION
### What does this PR do?

Fetches additional health data from consul to detect whether a service is healthy or not.


### Motivation

Fix #5905 

### More

- [X] Added/updated tests

### Additional Notes

