### PR TITLE
Rename the non-exposed field "count" to "size"

### DIFF
--- a/pkg/middlewares/accesslog/capture_request_reader.go
+++ b/pkg/middlewares/accesslog/capture_request_reader.go
@@ -3,16 +3,15 @@ package accesslog
 import "io"
 
 type captureRequestReader struct {
-	// ReadCloser from where the request body is read
+	// source ReadCloser from where the request body is read.
 	source io.ReadCloser
-	// Size of the request body incremented each time
-	// captureRequestReader.Read is called
-	size int64
+	// count Counts the number of bytes read (when captureRequestReader.Read is called).
+	count int64
 }
 
 func (r *captureRequestReader) Read(p []byte) (int, error) {
 	n, err := r.source.Read(p)
-	r.size += int64(n)
+	r.count += int64(n)
 	return n, err
 }
 

--- a/pkg/middlewares/accesslog/capture_request_reader.go
+++ b/pkg/middlewares/accesslog/capture_request_reader.go
@@ -3,13 +3,16 @@ package accesslog
 import "io"
 
 type captureRequestReader struct {
+	// ReadCloser from where the request body is read
 	source io.ReadCloser
-	count  int64
+	// Size of the request body incremented each time
+	// captureRequestReader.Read is called
+	size int64
 }
 
 func (r *captureRequestReader) Read(p []byte) (int, error) {
 	n, err := r.source.Read(p)
-	r.count += int64(n)
+	r.size += int64(n)
 	return n, err
 }
 

--- a/pkg/middlewares/accesslog/logdata.go
+++ b/pkg/middlewares/accesslog/logdata.go
@@ -129,5 +129,6 @@ type downstreamResponse struct {
 
 type request struct {
 	headers http.Header
-	count   int64
+	// Request body size
+	size int64
 }

--- a/pkg/middlewares/accesslog/logger.go
+++ b/pkg/middlewares/accesslog/logger.go
@@ -171,7 +171,7 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request, next http
 
 	var crr *captureRequestReader
 	if req.Body != nil {
-		crr = &captureRequestReader{source: req.Body, size: 0}
+		crr = &captureRequestReader{source: req.Body, count: 0}
 		reqWithDataTable.Body = crr
 	}
 
@@ -214,7 +214,7 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request, next http
 		size:    crw.Size(),
 	}
 	if crr != nil {
-		logDataTable.Request.size = crr.size
+		logDataTable.Request.size = crr.count
 	}
 
 	if h.config.BufferingSize > 0 {

--- a/pkg/middlewares/accesslog/logger.go
+++ b/pkg/middlewares/accesslog/logger.go
@@ -171,7 +171,7 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request, next http
 
 	var crr *captureRequestReader
 	if req.Body != nil {
-		crr = &captureRequestReader{source: req.Body, count: 0}
+		crr = &captureRequestReader{source: req.Body, size: 0}
 		reqWithDataTable.Body = crr
 	}
 
@@ -214,7 +214,7 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request, next http
 		size:    crw.Size(),
 	}
 	if crr != nil {
-		logDataTable.Request.count = crr.count
+		logDataTable.Request.size = crr.size
 	}
 
 	if h.config.BufferingSize > 0 {
@@ -280,7 +280,7 @@ func (h *Handler) logTheRoundTrip(logDataTable *LogData) {
 		retryAttempts = 0
 	}
 	core[RetryAttempts] = retryAttempts
-	core[RequestContentSize] = logDataTable.Request.count
+	core[RequestContentSize] = logDataTable.Request.size
 
 	status := logDataTable.DownstreamResponse.status
 	core[DownstreamStatus] = status


### PR DESCRIPTION
### What does this PR do?

This PR renames a variable which name led to believe it contains a count whereas it contains a size.

### Motivation

I've lost quite a bit of time while debuging thinking that `crr.count` was wrongly incremented. 

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
