### PR TITLE
Fix panic with get body

### DIFF
--- a/pkg/middlewares/accesslog/capture_request_reader.go
+++ b/pkg/middlewares/accesslog/capture_request_reader.go
@@ -9,6 +9,10 @@ type captureRequestReader struct {
 
 func (r *captureRequestReader) Read(p []byte) (int, error) {
 	n, err := r.source.Read(p)
+	if err != nil {
+		return 0, err
+	}
+
 	r.count += int64(n)
 	return n, err
 }

--- a/pkg/middlewares/accesslog/logger.go
+++ b/pkg/middlewares/accesslog/logger.go
@@ -171,8 +171,11 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request, next http
 
 	var crr *captureRequestReader
 	if req.Body != nil {
-		crr = &captureRequestReader{source: req.Body, count: 0}
-		reqWithDataTable.Body = crr
+		body, err := req.GetBody()
+		if err == nil {
+			crr = &captureRequestReader{source: body, count: 0}
+			reqWithDataTable.Body = crr
+		}
 	}
 
 	core[RequestCount] = nextRequestCount()

--- a/pkg/middlewares/accesslog/logger.go
+++ b/pkg/middlewares/accesslog/logger.go
@@ -170,7 +170,7 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request, next http
 	reqWithDataTable := req.WithContext(context.WithValue(req.Context(), DataTableKey, logDataTable))
 
 	var crr *captureRequestReader
-	if req.Body != nil {
+	if req.Body != nil && req.GetBody != nil {
 		body, err := req.GetBody()
 		if err == nil {
 			crr = &captureRequestReader{source: body, count: 0}


### PR DESCRIPTION
### What does this PR do?

Try using `req.GetBody()` instead of `req.Body` in the accesslog middleware.

### Motivation
Fixes #5922

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
