### PR TITLE
fix statsd scale for duration based metrics

### DIFF
--- a/pkg/metrics/datadog.go
+++ b/pkg/metrics/datadog.go
@@ -50,14 +50,14 @@ func RegisterDatadog(ctx context.Context, config *types.Datadog) Registry {
 	if config.AddEntryPointsLabels {
 		registry.epEnabled = config.AddEntryPointsLabels
 		registry.entryPointReqsCounter = datadogClient.NewCounter(ddEntryPointReqsName, 1.0)
-		registry.entryPointReqDurationHistogram = NewHistogramWithScale(datadogClient.NewHistogram(ddEntryPointReqDurationName, 1.0), time.Second)
+		registry.entryPointReqDurationHistogram, _ = NewHistogramWithScale(datadogClient.NewHistogram(ddEntryPointReqDurationName, 1.0), time.Second)
 		registry.entryPointOpenConnsGauge = datadogClient.NewGauge(ddEntryPointOpenConnsName)
 	}
 
 	if config.AddServicesLabels {
 		registry.svcEnabled = config.AddServicesLabels
 		registry.serviceReqsCounter = datadogClient.NewCounter(ddMetricsServiceReqsName, 1.0)
-		registry.serviceReqDurationHistogram = NewHistogramWithScale(datadogClient.NewHistogram(ddMetricsServiceLatencyName, 1.0), time.Second)
+		registry.serviceReqDurationHistogram, _ = NewHistogramWithScale(datadogClient.NewHistogram(ddMetricsServiceLatencyName, 1.0), time.Second)
 		registry.serviceRetriesCounter = datadogClient.NewCounter(ddRetriesTotalName, 1.0)
 		registry.serviceOpenConnsGauge = datadogClient.NewGauge(ddOpenConnsName)
 		registry.serviceServerUpGauge = datadogClient.NewGauge(ddServerUpName)

--- a/pkg/metrics/datadog.go
+++ b/pkg/metrics/datadog.go
@@ -50,14 +50,14 @@ func RegisterDatadog(ctx context.Context, config *types.Datadog) Registry {
 	if config.AddEntryPointsLabels {
 		registry.epEnabled = config.AddEntryPointsLabels
 		registry.entryPointReqsCounter = datadogClient.NewCounter(ddEntryPointReqsName, 1.0)
-		registry.entryPointReqDurationHistogram = datadogClient.NewHistogram(ddEntryPointReqDurationName, 1.0)
+		registry.entryPointReqDurationHistogram = NewHistogramWithScale(datadogClient.NewHistogram(ddEntryPointReqDurationName, 1.0), time.Second)
 		registry.entryPointOpenConnsGauge = datadogClient.NewGauge(ddEntryPointOpenConnsName)
 	}
 
 	if config.AddServicesLabels {
 		registry.svcEnabled = config.AddServicesLabels
 		registry.serviceReqsCounter = datadogClient.NewCounter(ddMetricsServiceReqsName, 1.0)
-		registry.serviceReqDurationHistogram = datadogClient.NewHistogram(ddMetricsServiceLatencyName, 1.0)
+		registry.serviceReqDurationHistogram = NewHistogramWithScale(datadogClient.NewHistogram(ddMetricsServiceLatencyName, 1.0), time.Second)
 		registry.serviceRetriesCounter = datadogClient.NewCounter(ddRetriesTotalName, 1.0)
 		registry.serviceOpenConnsGauge = datadogClient.NewGauge(ddOpenConnsName)
 		registry.serviceServerUpGauge = datadogClient.NewGauge(ddServerUpName)

--- a/pkg/metrics/influxdb.go
+++ b/pkg/metrics/influxdb.go
@@ -64,14 +64,14 @@ func RegisterInfluxDB(ctx context.Context, config *types.InfluxDB) Registry {
 	if config.AddEntryPointsLabels {
 		registry.epEnabled = config.AddEntryPointsLabels
 		registry.entryPointReqsCounter = influxDBClient.NewCounter(influxDBEntryPointReqsName)
-		registry.entryPointReqDurationHistogram = NewHistogramWithScale(influxDBClient.NewHistogram(influxDBEntryPointReqDurationName), time.Second)
+		registry.entryPointReqDurationHistogram, _ = NewHistogramWithScale(influxDBClient.NewHistogram(influxDBEntryPointReqDurationName), time.Second)
 		registry.entryPointOpenConnsGauge = influxDBClient.NewGauge(influxDBEntryPointOpenConnsName)
 	}
 
 	if config.AddServicesLabels {
 		registry.svcEnabled = config.AddServicesLabels
 		registry.serviceReqsCounter = influxDBClient.NewCounter(influxDBMetricsServiceReqsName)
-		registry.serviceReqDurationHistogram = NewHistogramWithScale(influxDBClient.NewHistogram(influxDBMetricsServiceLatencyName), time.Second)
+		registry.serviceReqDurationHistogram, _ = NewHistogramWithScale(influxDBClient.NewHistogram(influxDBMetricsServiceLatencyName), time.Second)
 		registry.serviceRetriesCounter = influxDBClient.NewCounter(influxDBRetriesTotalName)
 		registry.serviceOpenConnsGauge = influxDBClient.NewGauge(influxDBOpenConnsName)
 		registry.serviceServerUpGauge = influxDBClient.NewGauge(influxDBServerUpName)

--- a/pkg/metrics/influxdb.go
+++ b/pkg/metrics/influxdb.go
@@ -64,14 +64,14 @@ func RegisterInfluxDB(ctx context.Context, config *types.InfluxDB) Registry {
 	if config.AddEntryPointsLabels {
 		registry.epEnabled = config.AddEntryPointsLabels
 		registry.entryPointReqsCounter = influxDBClient.NewCounter(influxDBEntryPointReqsName)
-		registry.entryPointReqDurationHistogram = influxDBClient.NewHistogram(influxDBEntryPointReqDurationName)
+		registry.entryPointReqDurationHistogram = NewHistogramWithScale(influxDBClient.NewHistogram(influxDBEntryPointReqDurationName), time.Second)
 		registry.entryPointOpenConnsGauge = influxDBClient.NewGauge(influxDBEntryPointOpenConnsName)
 	}
 
 	if config.AddServicesLabels {
 		registry.svcEnabled = config.AddServicesLabels
 		registry.serviceReqsCounter = influxDBClient.NewCounter(influxDBMetricsServiceReqsName)
-		registry.serviceReqDurationHistogram = influxDBClient.NewHistogram(influxDBMetricsServiceLatencyName)
+		registry.serviceReqDurationHistogram = NewHistogramWithScale(influxDBClient.NewHistogram(influxDBMetricsServiceLatencyName), time.Second)
 		registry.serviceRetriesCounter = influxDBClient.NewCounter(influxDBRetriesTotalName)
 		registry.serviceOpenConnsGauge = influxDBClient.NewGauge(influxDBOpenConnsName)
 		registry.serviceServerUpGauge = influxDBClient.NewGauge(influxDBServerUpName)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"errors"
 	"time"
 
 	"github.com/go-kit/kit/metrics"
@@ -231,12 +232,15 @@ func (s *HistogramWithScale) Observe(v float64) {
 	s.histogram.Observe(v)
 }
 
-// NewHistogramWithScale returns a ScalableHistogram
-func NewHistogramWithScale(histogram metrics.Histogram, unit time.Duration) ScalableHistogram {
+// NewHistogramWithScale returns a ScalableHistogram. It returns an error if the given unit is <= 0.
+func NewHistogramWithScale(histogram metrics.Histogram, unit time.Duration) (ScalableHistogram, error) {
+	if unit <= 0 {
+		return nil, errors.New("invalid time unit")
+	}
 	return &HistogramWithScale{
 		histogram: histogram,
 		unit:      unit,
-	}
+	}, nil
 }
 
 // MultiHistogram collects multiple individual histograms and treats them as a unit.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -187,8 +187,8 @@ func (r *standardRegistry) ServiceServerUpGauge() metrics.Gauge {
 	return r.serviceServerUpGauge
 }
 
-// ScalableHistogram is a Histogram with a predefined time unit, used when
-// producing observations without explicitly setting the observed value.
+// ScalableHistogram is a Histogram with a predefined time unit,
+// used when producing observations without explicitly setting the observed value.
 type ScalableHistogram interface {
 	With(labelValues ...string) ScalableHistogram
 	StartAt(t time.Time)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -232,10 +232,10 @@ func (s *HistogramWithScale) Observe(v float64) {
 }
 
 // NewHistogramWithScale returns a ScalableHistogram
-func NewHistogramWithScale(h metrics.Histogram, u time.Duration) ScalableHistogram {
+func NewHistogramWithScale(histogram metrics.Histogram, unit time.Duration) ScalableHistogram {
 	return &HistogramWithScale{
-		histogram: h,
-		unit:      u,
+		histogram: histogram,
+		unit:      unit,
 	}
 }
 

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -97,6 +97,8 @@ func (c *histogramMock) With(labelValues ...string) ScalableHistogram {
 
 func (c *histogramMock) Start() {}
 
+func (c *histogramMock) StartAt(t time.Time) {}
+
 func (c *histogramMock) ObserveDuration() {}
 
 func (c *histogramMock) Observe(v float64) {

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -17,7 +17,7 @@ func TestScalableHistogram(t *testing.T) {
 
 	ticker := time.NewTicker(500 * time.Millisecond)
 	<-ticker.C
-	sh.Start()
+	sh.StartAt(time.Now())
 	<-ticker.C
 	sh.ObserveDuration()
 

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,18 +1,42 @@
 package metrics
 
 import (
+	"bytes"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-kit/kit/metrics"
+	"github.com/go-kit/kit/metrics/generic"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestScalableHistogram(t *testing.T) {
+	h := generic.NewHistogram("test", 1)
+	sh := NewHistogramWithScale(h, time.Millisecond)
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	<-ticker.C
+	sh.Start()
+	<-ticker.C
+	sh.ObserveDuration()
+
+	var b bytes.Buffer
+	h.Print(&b)
+
+	extractedDurationString := strings.Split(strings.Split(b.String(), "\n")[1], " ")
+	measuredDuration, err := time.ParseDuration(extractedDurationString[0] + "ms")
+	assert.NoError(t, err)
+
+	assert.InDelta(t, 500*time.Millisecond, measuredDuration, float64(1*time.Millisecond))
+}
 
 func TestNewMultiRegistry(t *testing.T) {
 	registries := []Registry{newCollectingRetryMetrics(), newCollectingRetryMetrics()}
 	registry := NewMultiRegistry(registries)
 
 	registry.ServiceReqsCounter().With("key", "requests").Add(1)
-	registry.ServiceReqDurationHistogram().With("key", "durations").Observe(2)
+	registry.ServiceReqDurationHistogram().With("key", "durations").Observe(float64(2))
 	registry.ServiceRetriesCounter().With("key", "retries").Add(3)
 
 	for _, collectingRegistry := range registries {
@@ -66,11 +90,15 @@ type histogramMock struct {
 	lastLabelValues    []string
 }
 
-func (c *histogramMock) With(labelValues ...string) metrics.Histogram {
+func (c *histogramMock) With(labelValues ...string) ScalableHistogram {
 	c.lastLabelValues = labelValues
 	return c
 }
 
-func (c *histogramMock) Observe(value float64) {
-	c.lastHistogramValue = value
+func (c *histogramMock) Start() {}
+
+func (c *histogramMock) ObserveDuration() {}
+
+func (c *histogramMock) Observe(v float64) {
+	c.lastHistogramValue = v
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -9,11 +9,13 @@ import (
 	"github.com/go-kit/kit/metrics"
 	"github.com/go-kit/kit/metrics/generic"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestScalableHistogram(t *testing.T) {
 	h := generic.NewHistogram("test", 1)
-	sh := NewHistogramWithScale(h, time.Millisecond)
+	sh, err := NewHistogramWithScale(h, time.Millisecond)
+	require.NoError(t, err)
 
 	ticker := time.NewTicker(500 * time.Millisecond)
 	<-ticker.C

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -153,7 +153,7 @@ func initStandardRegistry(config *types.Prometheus) Registry {
 			entryPointOpenConns.gv.Describe,
 		}...)
 		reg.entryPointReqsCounter = entryPointReqs
-		reg.entryPointReqDurationHistogram = NewHistogramWithScale(entryPointReqDurations, time.Second)
+		reg.entryPointReqDurationHistogram, _ = NewHistogramWithScale(entryPointReqDurations, time.Second)
 		reg.entryPointOpenConnsGauge = entryPointOpenConns
 	}
 	if config.AddServicesLabels {
@@ -188,7 +188,7 @@ func initStandardRegistry(config *types.Prometheus) Registry {
 		}...)
 
 		reg.serviceReqsCounter = serviceReqs
-		reg.serviceReqDurationHistogram = NewHistogramWithScale(serviceReqDurations, time.Second)
+		reg.serviceReqDurationHistogram, _ = NewHistogramWithScale(serviceReqDurations, time.Second)
 		reg.serviceOpenConnsGauge = serviceOpenConns
 		reg.serviceRetriesCounter = serviceRetries
 		reg.serviceServerUpGauge = serviceServerUp

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/containous/traefik/v2/pkg/config/dynamic"
 	"github.com/containous/traefik/v2/pkg/log"
@@ -152,7 +153,7 @@ func initStandardRegistry(config *types.Prometheus) Registry {
 			entryPointOpenConns.gv.Describe,
 		}...)
 		reg.entryPointReqsCounter = entryPointReqs
-		reg.entryPointReqDurationHistogram = entryPointReqDurations
+		reg.entryPointReqDurationHistogram = NewHistogramWithScale(entryPointReqDurations, time.Second)
 		reg.entryPointOpenConnsGauge = entryPointOpenConns
 	}
 	if config.AddServicesLabels {
@@ -187,7 +188,7 @@ func initStandardRegistry(config *types.Prometheus) Registry {
 		}...)
 
 		reg.serviceReqsCounter = serviceReqs
-		reg.serviceReqDurationHistogram = serviceReqDurations
+		reg.serviceReqDurationHistogram = NewHistogramWithScale(serviceReqDurations, time.Second)
 		reg.serviceOpenConnsGauge = serviceOpenConns
 		reg.serviceRetriesCounter = serviceRetries
 		reg.serviceServerUpGauge = serviceServerUp

--- a/pkg/metrics/statsd.go
+++ b/pkg/metrics/statsd.go
@@ -55,14 +55,14 @@ func RegisterStatsd(ctx context.Context, config *types.Statsd) Registry {
 	if config.AddEntryPointsLabels {
 		registry.epEnabled = config.AddEntryPointsLabels
 		registry.entryPointReqsCounter = statsdClient.NewCounter(statsdEntryPointReqsName, 1.0)
-		registry.entryPointReqDurationHistogram = NewHistogramWithScale(statsdClient.NewTiming(statsdEntryPointReqDurationName, 1.0), time.Millisecond)
+		registry.entryPointReqDurationHistogram, _ = NewHistogramWithScale(statsdClient.NewTiming(statsdEntryPointReqDurationName, 1.0), time.Millisecond)
 		registry.entryPointOpenConnsGauge = statsdClient.NewGauge(statsdEntryPointOpenConnsName)
 	}
 
 	if config.AddServicesLabels {
 		registry.svcEnabled = config.AddServicesLabels
 		registry.serviceReqsCounter = statsdClient.NewCounter(statsdMetricsServiceReqsName, 1.0)
-		registry.serviceReqDurationHistogram = NewHistogramWithScale(statsdClient.NewTiming(statsdMetricsServiceLatencyName, 1.0), time.Millisecond)
+		registry.serviceReqDurationHistogram, _ = NewHistogramWithScale(statsdClient.NewTiming(statsdMetricsServiceLatencyName, 1.0), time.Millisecond)
 		registry.serviceRetriesCounter = statsdClient.NewCounter(statsdRetriesTotalName, 1.0)
 		registry.serviceOpenConnsGauge = statsdClient.NewGauge(statsdOpenConnsName)
 		registry.serviceServerUpGauge = statsdClient.NewGauge(statsdServerUpName)

--- a/pkg/metrics/statsd.go
+++ b/pkg/metrics/statsd.go
@@ -55,14 +55,14 @@ func RegisterStatsd(ctx context.Context, config *types.Statsd) Registry {
 	if config.AddEntryPointsLabels {
 		registry.epEnabled = config.AddEntryPointsLabels
 		registry.entryPointReqsCounter = statsdClient.NewCounter(statsdEntryPointReqsName, 1.0)
-		registry.entryPointReqDurationHistogram = statsdClient.NewTiming(statsdEntryPointReqDurationName, 1.0)
+		registry.entryPointReqDurationHistogram = NewHistogramWithScale(statsdClient.NewTiming(statsdEntryPointReqDurationName, 1.0), time.Millisecond)
 		registry.entryPointOpenConnsGauge = statsdClient.NewGauge(statsdEntryPointOpenConnsName)
 	}
 
 	if config.AddServicesLabels {
 		registry.svcEnabled = config.AddServicesLabels
 		registry.serviceReqsCounter = statsdClient.NewCounter(statsdMetricsServiceReqsName, 1.0)
-		registry.serviceReqDurationHistogram = statsdClient.NewTiming(statsdMetricsServiceLatencyName, 1.0)
+		registry.serviceReqDurationHistogram = NewHistogramWithScale(statsdClient.NewTiming(statsdMetricsServiceLatencyName, 1.0), time.Millisecond)
 		registry.serviceRetriesCounter = statsdClient.NewCounter(statsdRetriesTotalName, 1.0)
 		registry.serviceOpenConnsGauge = statsdClient.NewGauge(statsdOpenConnsName)
 		registry.serviceServerUpGauge = statsdClient.NewGauge(statsdServerUpName)

--- a/pkg/middlewares/metrics/metrics.go
+++ b/pkg/middlewares/metrics/metrics.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
+	"time"
 	"unicode/utf8"
 
 	"github.com/containous/alice"
@@ -88,7 +89,7 @@ func (m *metricsMiddleware) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 	}(labels)
 
 	histograms := m.reqDurationHistogram.With(labels...)
-	histograms.Start()
+	histograms.StartAt(time.Now())
 
 	recorder := newResponseRecorder(rw)
 	m.next.ServeHTTP(recorder, req)

--- a/pkg/middlewares/metrics/metrics.go
+++ b/pkg/middlewares/metrics/metrics.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
-	"time"
 	"unicode/utf8"
 
 	"github.com/containous/alice"
@@ -32,7 +31,7 @@ type metricsMiddleware struct {
 	openConns            int64
 	next                 http.Handler
 	reqsCounter          gokitmetrics.Counter
-	reqDurationHistogram gokitmetrics.Histogram
+	reqDurationHistogram metrics.ScalableHistogram
 	openConnsGauge       gokitmetrics.Gauge
 	baseLabels           []string
 }
@@ -88,13 +87,16 @@ func (m *metricsMiddleware) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 		m.openConnsGauge.With(labelValues...).Set(float64(openConns))
 	}(labels)
 
-	start := time.Now()
+	histograms := m.reqDurationHistogram.With(labels...)
+	histograms.Start()
+
 	recorder := newResponseRecorder(rw)
 	m.next.ServeHTTP(recorder, req)
 
 	labels = append(labels, "code", strconv.Itoa(recorder.getCode()))
 	m.reqsCounter.With(labels...).Add(1)
-	m.reqDurationHistogram.With(labels...).Observe(time.Since(start).Seconds())
+
+	histograms.ObserveDuration()
 }
 
 func getRequestProtocol(req *http.Request) string {

--- a/pkg/middlewares/metrics/metrics.go
+++ b/pkg/middlewares/metrics/metrics.go
@@ -89,12 +89,14 @@ func (m *metricsMiddleware) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 	}(labels)
 
 	recorder := newResponseRecorder(rw)
+	start := time.Now()
+
+	m.next.ServeHTTP(recorder, req)
+
 	labels = append(labels, "code", strconv.Itoa(recorder.getCode()))
 
 	histograms := m.reqDurationHistogram.With(labels...)
-	histograms.StartAt(time.Now())
-
-	m.next.ServeHTTP(recorder, req)
+	histograms.StartAt(start)
 
 	m.reqsCounter.With(labels...).Add(1)
 


### PR DESCRIPTION
### What does this PR do?

Fixes #5944  

### Motivation

StatsD assumes that duration based metric values are in Milliseconds.

Currently Traefik always calls the `Observe` function converting the `time.Duration` to seconds. With this change we can set the scale in the metric provider implementation, on statsD case Milliseconds, while keeping the current value as the default for those that don't specify it.

### More

- [X] Added/updated tests
- [ ] ~~Added/updated documentation~~

### Additional Notes

