### PR TITLE
Fix integration tests on MacOS

### DIFF
--- a/integration/proxy_protocol_test.go
+++ b/integration/proxy_protocol_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"net/http"
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/containous/traefik/v2/integration/try"
@@ -18,6 +19,10 @@ func (s *ProxyProtocolSuite) SetUpSuite(c *check.C) {
 }
 
 func (s *ProxyProtocolSuite) TestProxyProtocolTrusted(c *check.C) {
+	if runtime.GOOS == "darwin" {
+		c.Skip("This test can't be ran on MacOS because there docker bridge networking does not work")
+	}
+
 	gatewayIP := s.composeProject.Container(c, "haproxy").NetworkSettings.Gateway
 	haproxyIP := s.composeProject.Container(c, "haproxy").NetworkSettings.IPAddress
 	whoamiIP := s.composeProject.Container(c, "whoami").NetworkSettings.IPAddress
@@ -41,6 +46,10 @@ func (s *ProxyProtocolSuite) TestProxyProtocolTrusted(c *check.C) {
 }
 
 func (s *ProxyProtocolSuite) TestProxyProtocolV2Trusted(c *check.C) {
+	if runtime.GOOS == "darwin" {
+		c.Skip("This test can't be ran on MacOS because there docker bridge networking does not work")
+	}
+
 	gatewayIP := s.composeProject.Container(c, "haproxy").NetworkSettings.Gateway
 	haproxyIP := s.composeProject.Container(c, "haproxy").NetworkSettings.IPAddress
 	whoamiIP := s.composeProject.Container(c, "whoami").NetworkSettings.IPAddress
@@ -64,6 +73,10 @@ func (s *ProxyProtocolSuite) TestProxyProtocolV2Trusted(c *check.C) {
 }
 
 func (s *ProxyProtocolSuite) TestProxyProtocolNotTrusted(c *check.C) {
+	if runtime.GOOS == "darwin" {
+		c.Skip("This test can't be ran on MacOS because there docker bridge networking does not work")
+	}
+
 	haproxyIP := s.composeProject.Container(c, "haproxy").NetworkSettings.IPAddress
 	whoamiIP := s.composeProject.Container(c, "whoami").NetworkSettings.IPAddress
 
@@ -86,6 +99,10 @@ func (s *ProxyProtocolSuite) TestProxyProtocolNotTrusted(c *check.C) {
 }
 
 func (s *ProxyProtocolSuite) TestProxyProtocolV2NotTrusted(c *check.C) {
+	if runtime.GOOS == "darwin" {
+		c.Skip("This test can't be ran on MacOS because there docker bridge networking does not work")
+	}
+
 	haproxyIP := s.composeProject.Container(c, "haproxy").NetworkSettings.IPAddress
 	whoamiIP := s.composeProject.Container(c, "whoami").NetworkSettings.IPAddress
 

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -3,6 +3,7 @@ package static
 import (
 	"fmt"
 	stdlog "log"
+	"runtime"
 	"strings"
 	"time"
 
@@ -169,7 +170,12 @@ type Providers struct {
 // It also takes care of maintaining backwards compatibility.
 func (c *Configuration) SetEffectiveConfiguration() {
 	if len(c.EntryPoints) == 0 {
-		ep := &EntryPoint{Address: ":80"}
+		var ep *EntryPoint
+		if runtime.GOOS == "darwin" {
+			ep = &EntryPoint{Address: "localhost:80"}
+		} else {
+			ep = &EntryPoint{Address: ":80"}
+		}
 		ep.SetDefaults()
 		c.EntryPoints = EntryPoints{
 			"http": ep,
@@ -181,7 +187,12 @@ func (c *Configuration) SetEffectiveConfiguration() {
 		(c.Metrics != nil && c.Metrics.Prometheus != nil && !c.Metrics.Prometheus.ManualRouting && c.Metrics.Prometheus.EntryPoint == DefaultInternalEntryPointName) ||
 		(c.Providers != nil && c.Providers.Rest != nil && c.Providers.Rest.Insecure) {
 		if _, ok := c.EntryPoints[DefaultInternalEntryPointName]; !ok {
-			ep := &EntryPoint{Address: ":8080"}
+			var ep *EntryPoint
+			if runtime.GOOS == "darwin" {
+				ep = &EntryPoint{Address: "localhost:8080"}
+			} else {
+				ep = &EntryPoint{Address: ":8080"}
+			}
 			ep.SetDefaults()
 			c.EntryPoints[DefaultInternalEntryPointName] = ep
 		}


### PR DESCRIPTION
### What does this PR do?

This PR improves the ability to run integration tests on MacOS.

To do so, we make the defaults traefik entryPoints listen on `localhost:<port>` instead of `:<port>` so that macos does not complain an unsigned application is trying to receive incoming connection.

Also fix all test fixture configs to use `localhost:<port>`.

### Motivation

I'm trying to run integrations test on my dev machine to validate my work.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
