### PR TITLE
fix: skip ECS container when information are missing instead of panic.

### DIFF
--- a/provider/ecs/ecs.go
+++ b/provider/ecs/ecs.go
@@ -309,6 +309,11 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 						state:     aws.StringValue(task.LastStatus),
 					}
 				} else {
+					if containerInstance == nil {
+						log.Errorf("Unable to find container instance information for %s", aws.StringValue(container.Name))
+						continue
+					}
+
 					var ports []portMapping
 					for _, mapping := range container.NetworkBindings {
 						if mapping != nil {


### PR DESCRIPTION
### What does this PR do?

Skip ECS container when information are missing instead of panic.

### Motivation

```
Stack: goroutine 70 [running]:
runtime/debug.Stack(0x26cb820, 0x17, 0xc0012ee0f0)
	/usr/local/go/src/runtime/debug/stack.go:24 +0xa7
github.com/containous/traefik/safe.defaultRecoverGoroutine(0x2246600, 0x4603250)
	/go/src/github.com/containous/traefik/safe/routine.go:148 +0x89
github.com/containous/traefik/safe.OperationWithRecover.func1.1(0xc00101be18)
	/go/src/github.com/containous/traefik/safe/routine.go:156 +0x56
panic(0x2246600, 0x4603250)
	/usr/local/go/src/runtime/panic.go:513 +0x1b9
github.com/containous/traefik/provider/ecs.(*Provider).listInstances(0xc0004432b0, 0x29eaee0, 0xc000087400, 0xc000423330, 0x0, 0x0, 0x0, 0x0, 0x0)
	/go/src/github.com/containous/traefik/provider/ecs/ecs.go:322 +0xe62
github.com/containous/traefik/provider/ecs.(*Provider).loadECSConfig(0xc0004432b0, 0x29eaee0, 0xc000087400, 0xc000423330, 0x2030e80, 0x203000, 0x203000)
	/go/src/github.com/containous/traefik/provider/ecs/ecs.go:426 +0x4d
github.com/containous/traefik/provider/ecs.(*Provider).Provide.func2.2(0x0, 0x0)
	/go/src/github.com/containous/traefik/provider/ecs/ecs.go:144 +0xb7
github.com/containous/traefik/safe.OperationWithRecover.func1(0x0, 0x0)
	/go/src/github.com/containous/traefik/safe/routine.go:160 +0x62
github.com/containous/traefik/vendor/github.com/cenk/backoff.RetryNotify(0xc0004231d0, 0x29c9760, 0xc0004231f0, 0x2783850, 0xc0004231c0, 0xc0008b9980)
	/go/src/github.com/containous/traefik/vendor/github.com/cenk/backoff/retry.go:37 +0xa2
github.com/containous/traefik/provider/ecs.(*Provider).Provide.func2(0xc0000884d0)
	/go/src/github.com/containous/traefik/provider/ecs/ecs.go:181 +0x1c0
github.com/containous/traefik/safe.(*Pool).Go.func1()
	/go/src/github.com/containous/traefik/safe/routine.go:78 +0x37
github.com/containous/traefik/safe.GoWithRecover.func1(0x2783a68, 0xc000036660)
	/go/src/github.com/containous/traefik/safe/routine.go:142 +0x4d
created by github.com/containous/traefik/safe.GoWithRecover
	/go/src/github.com/containous/traefik/safe/routine.go:136 +0x49
```

Related to #6066

### More

- ~~[ ] Added/updated tests~~
- ~~[ ] Added/updated documentation~~

### Additional Notes

<!-- Anything else we should know when reviewing? -->
