### PR TITLE
fix(tracing): makes sure tracing headers are being propagated when using forwardAuth

### DIFF
--- a/pkg/middlewares/auth/forward.go
+++ b/pkg/middlewares/auth/forward.go
@@ -88,9 +88,11 @@ func (fa *forwardAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	writeHeader(req, forwardReq, fa.trustForwardHeader)
+	// Ensure tracing headers are in the request before we copy the headers to the
+	// forwardReq.
+	tracing.InjectRequestHeaders(req)
 
-	tracing.InjectRequestHeaders(forwardReq)
+	writeHeader(req, forwardReq, fa.trustForwardHeader)
 
 	forwardResponse, forwardErr := httpClient.Do(forwardReq)
 	if forwardErr != nil {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR **fixes** the propagation of tracing headers when using `forwardAuth`

### Motivation

fixes #5774 
close #6009

### More

- [x] Added/updated tests

### Additional Notes

This PR fixes the problems described in https://github.com/containous/traefik/pull/6009.

**Important Note:** While working on this I realized that tracing propagation will only work if tracing middleware happens before the forwardauth middleware, is this something we can guarantee?

Ping @ldez @aliksend 