### PR TITLE
fix: dashboard redirect loop

### DIFF
--- a/integration/testdata/rawdata-ingress.json
+++ b/integration/testdata/rawdata-ingress.json
@@ -60,7 +60,7 @@
 	"middlewares": {
 		"dashboard_redirect@internal": {
 			"redirectRegex": {
-				"regex": "^(http:\\/\\/[^:]+(:\\d+)?)/$",
+				"regex": "^(http:\\/\\/[^:\\/]+(:\\d+)?)\\/$",
 				"replacement": "${1}/dashboard/",
 				"permanent": true
 			},

--- a/pkg/provider/traefik/fixtures/api_insecure_with_dashboard.json
+++ b/pkg/provider/traefik/fixtures/api_insecure_with_dashboard.json
@@ -25,7 +25,7 @@
     "middlewares": {
       "dashboard_redirect": {
         "redirectRegex": {
-          "regex": "^(http:\\/\\/[^:]+(:\\d+)?)/$",
+          "regex": "^(http:\\/\\/[^:\\/]+(:\\d+)?)\\/$",
           "replacement": "${1}/dashboard/",
           "permanent": true
         }

--- a/pkg/provider/traefik/fixtures/full_configuration.json
+++ b/pkg/provider/traefik/fixtures/full_configuration.json
@@ -57,7 +57,7 @@
     "middlewares": {
       "dashboard_redirect": {
         "redirectRegex": {
-          "regex": "^(http:\\/\\/[^:]+(:\\d+)?)/$",
+          "regex": "^(http:\\/\\/[^:\\/]+(:\\d+)?)\\/$",
           "replacement": "${1}/dashboard/",
           "permanent": true
         }

--- a/pkg/provider/traefik/internal.go
+++ b/pkg/provider/traefik/internal.go
@@ -86,7 +86,7 @@ func (i *Provider) apiConfiguration(cfg *dynamic.Configuration) {
 
 			cfg.HTTP.Middlewares["dashboard_redirect"] = &dynamic.Middleware{
 				RedirectRegex: &dynamic.RedirectRegex{
-					Regex:       `^(http:\/\/[^:]+(:\d+)?)/$`,
+					Regex:       `^(http:\/\/[^:\/]+(:\d+)?)\/$`,
 					Replacement: "${1}/dashboard/",
 					Permanent:   true,
 				},


### PR DESCRIPTION
### What does this PR do?

fix dashboard redirect loop

### Motivation

Fix #6073, #6041

### More

- ~~[ ] Added/updated tests~~
- ~~[ ] Added/updated documentation~~

### Additional Notes

The recommended way to create routing for the dashboard/api is to use `api@internal` and `api.insecure=false`.

https://community.containo.us/t/serving-traefiks-internal-dashboard-behind-traefik-itself/3457/7?u=ldez