### PR TITLE
Log the ignored namespace only when needed

### DIFF
--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -400,19 +400,17 @@ func splitSvcNameProvider(name string) (string, string) {
 }
 
 func fullServiceName(ctx context.Context, namespace string, service v1alpha1.LoadBalancerSpec, port int32) string {
-	ns := namespaceOrFallback(service, namespace)
-
 	if port != 0 {
-		return provider.Normalize(fmt.Sprintf("%s-%s-%d", ns, service.Name, port))
+		return provider.Normalize(fmt.Sprintf("%s-%s-%d", namespace, service.Name, port))
 	}
 
 	if !strings.Contains(service.Name, providerNamespaceSeparator) {
-		return provider.Normalize(fmt.Sprintf("%s-%s", ns, service.Name))
+		return provider.Normalize(fmt.Sprintf("%s-%s", namespace, service.Name))
 	}
 
 	name, pName := splitSvcNameProvider(service.Name)
 	if pName == providerName {
-		return provider.Normalize(fmt.Sprintf("%s-%s", ns, name))
+		return provider.Normalize(fmt.Sprintf("%s-%s", namespace, name))
 	}
 
 	if service.Namespace != "" {


### PR DESCRIPTION
### What does this PR do?

In the Kubernetes CRD provider, log the ignored namespace only when a service namespace is explicitly defined with a cross provider reference.

### Motivation

Fixes #6033

### More

- [ ] ~Added/updated tests~
- [ ] ~Added/updated documentation~
