### PR TITLE
Fix command for use websecure via CLI

### DIFF
--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -58,7 +58,7 @@ They define the port which will receive the requests (whether HTTP or TCP).
     ```bash tab="CLI"
     ## Static configuration
     --entryPoints.web.address=:80
-    --entryPoints.web-secure.address=:443
+    --entryPoints.websecure.address=:443
     ```
 
     - Two entrypoints are defined: one called `web`, and the other called `web-secure`.

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -41,7 +41,7 @@ They define the port which will receive the requests (whether HTTP or TCP).
       [entryPoints.web]
         address = ":80"
     
-      [entryPoints.web-secure]
+      [entryPoints.websecure]
         address = ":443"
     ```
     
@@ -51,7 +51,7 @@ They define the port which will receive the requests (whether HTTP or TCP).
       web:
         address: ":80"
      
-      web-secure:
+      websecure:
         address: ":443"
     ```
     
@@ -61,8 +61,8 @@ They define the port which will receive the requests (whether HTTP or TCP).
     --entryPoints.websecure.address=:443
     ```
 
-    - Two entrypoints are defined: one called `web`, and the other called `web-secure`.
-    - `web` listens on port `80`, and `web-secure` on port `443`. 
+    - Two entrypoints are defined: one called `web`, and the other called `websecure`.
+    - `web` listens on port `80`, and `websecure` on port `443`. 
 
 ## Configuration
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Fix the command for use websecure mode via CLI.


### Motivation

I using with Docker and detect this error [following this doc](https://docs.traefik.io/user-guides/docker-compose/acme-http/). See `websecure` in `command` property.

## Works

```
traefik:
   command:
      - "--entrypoints.websecure.address=:443"
```

## Error

```
traefik:
   command:
      - "--entrypoints.web-secure.address=:443"
```

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Using `web-secure` rather than `websecure` the API not response in previous endpoint.
