### PR TITLE
k8s Ingress: fix crash on rules with nil http

### DIFF
--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-host-only_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-host-only_ingress.yml
@@ -1,0 +1,9 @@
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: ""
+  namespace: testing
+
+spec:
+  rules:
+  - host: testing.example.com

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -319,6 +319,10 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 				continue
 			}
 
+			if rule.HTTP == nil {
+				continue
+			}
+
 			for _, p := range rule.HTTP.Paths {
 				service, err := loadService(client, ingress.Namespace, p.Backend)
 				if err != nil {

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -313,57 +313,57 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 				conf.HTTP.Services["default-backend"] = service
 			}
 		}
+
 		for _, rule := range ingress.Spec.Rules {
 			if err := checkStringQuoteValidity(rule.Host); err != nil {
 				log.FromContext(ctx).Errorf("Invalid syntax for host: %s", rule.Host)
 				continue
 			}
 
-			if rule.HTTP == nil {
-				continue
-			}
+			if rule.HTTP != nil {
+				for _, p := range rule.HTTP.Paths {
+					service, err := loadService(client, ingress.Namespace, p.Backend)
+					if err != nil {
+						log.FromContext(ctx).
+							WithField("serviceName", p.Backend.ServiceName).
+							WithField("servicePort", p.Backend.ServicePort.String()).
+							Errorf("Cannot create service: %v", err)
+						continue
+					}
 
-			for _, p := range rule.HTTP.Paths {
-				service, err := loadService(client, ingress.Namespace, p.Backend)
-				if err != nil {
-					log.FromContext(ctx).
-						WithField("serviceName", p.Backend.ServiceName).
-						WithField("servicePort", p.Backend.ServicePort.String()).
-						Errorf("Cannot create service: %v", err)
-					continue
-				}
+					if err = checkStringQuoteValidity(p.Path); err != nil {
+						log.FromContext(ctx).Errorf("Invalid syntax for path: %s", p.Path)
+						continue
+					}
 
-				if err = checkStringQuoteValidity(p.Path); err != nil {
-					log.FromContext(ctx).Errorf("Invalid syntax for path: %s", p.Path)
-					continue
-				}
+					serviceName := provider.Normalize(ingress.Namespace + "-" + p.Backend.ServiceName + "-" + p.Backend.ServicePort.String())
+					var rules []string
+					if len(rule.Host) > 0 {
+						rules = []string{"Host(`" + rule.Host + "`)"}
+					}
 
-				serviceName := provider.Normalize(ingress.Namespace + "-" + p.Backend.ServiceName + "-" + p.Backend.ServicePort.String())
-				var rules []string
-				if len(rule.Host) > 0 {
-					rules = []string{"Host(`" + rule.Host + "`)"}
-				}
+					if len(p.Path) > 0 {
+						rules = append(rules, "PathPrefix(`"+p.Path+"`)")
+					}
 
-				if len(p.Path) > 0 {
-					rules = append(rules, "PathPrefix(`"+p.Path+"`)")
-				}
-
-				routerKey := strings.TrimPrefix(provider.Normalize(rule.Host+p.Path), "-")
-				conf.HTTP.Routers[routerKey] = &dynamic.Router{
-					Rule:    strings.Join(rules, " && "),
-					Service: serviceName,
-				}
-
-				if len(ingress.Spec.TLS) > 0 {
-					// TLS enabled for this ingress, add TLS router
-					conf.HTTP.Routers[routerKey+"-tls"] = &dynamic.Router{
+					routerKey := strings.TrimPrefix(provider.Normalize(rule.Host+p.Path), "-")
+					conf.HTTP.Routers[routerKey] = &dynamic.Router{
 						Rule:    strings.Join(rules, " && "),
 						Service: serviceName,
-						TLS:     &dynamic.RouterTLSConfig{},
 					}
+
+					if len(ingress.Spec.TLS) > 0 {
+						// TLS enabled for this ingress, add TLS router
+						conf.HTTP.Routers[routerKey+"-tls"] = &dynamic.Router{
+							Rule:    strings.Join(rules, " && "),
+							Service: serviceName,
+							TLS:     &dynamic.RouterTLSConfig{},
+						}
+					}
+					conf.HTTP.Services[serviceName] = service
 				}
-				conf.HTTP.Services[serviceName] = service
 			}
+
 			err := p.updateIngressStatus(ingress, client)
 			if err != nil {
 				log.FromContext(ctx).Errorf("Error while updating ingress status: %v", err)

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -39,6 +39,17 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 			},
 		},
 		{
+			desc: "Ingress one rule host only",
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:     map[string]*dynamic.Router{},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services:    map[string]*dynamic.Service{},
+				},
+			},
+		},
+		{
 			desc: "Ingress with a basic rule on one path",
 			expected: &dynamic.Configuration{
 				TCP: &dynamic.TCPConfiguration{},


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

Fixes a crash when using the KubernetesIngress Provider if an Ingress has a rule without a `nil` `http` element.

This is a common case if you're using Let's Encrypt `http01` verification to create a certificate for a non-HTTP based service.  Or in my case, the ingress just uses an annotation to HTTP redirect with ingress-nginx (which i'm migrating away from).

<!-- A brief description of the change being made with this pull request. -->

Basically, just adds a `nil` check.  Without this `nil` check a single ingress rule that has a `nil` `http` element will make the entire provider not work.

I also added a unit test to verify the change and to avoid it from happening again in the future.

### Motivation

I'm trying to migrate to traefik from ingress-nginx and after hours of searching for why my secrets weren't being found, I finally dug into the nil pointer deference I was also seeing and it turned out that it was the culprit all along.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

This is targeting the master branch as during my testing it appeared that 028683666 may have had some impact on the secret resolution, but ultimately I don't think that really matters
