### PR TITLE
Fix panic in accesslog with recover()

### DIFF
--- a/pkg/middlewares/accesslog/capture_request_reader.go
+++ b/pkg/middlewares/accesslog/capture_request_reader.go
@@ -1,18 +1,72 @@
 package accesslog
 
-import "io"
+import (
+	"errors"
+	"net/http"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
 
 type captureRequestReader struct {
-	source io.ReadCloser
+	req    *http.Request
 	count  int64
+	mu     sync.Mutex
+	logger *logrus.Logger
 }
 
-func (r *captureRequestReader) Read(p []byte) (int, error) {
-	n, err := r.source.Read(p)
+func (r *captureRequestReader) GetCount() int64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.count
+}
+
+func (r *captureRequestReader) Read(p []byte) (n int, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Access to req.Body is unsafe so we add recovery management
+	defer func() {
+		if rec := recover(); rec != nil {
+			r.logger.Errorf("error while reading req.Body: %#v", rec)
+			n = 0
+			switch x := rec.(type) {
+			case error:
+				err = x
+			case string:
+				err = errors.New(x)
+			default:
+				// Fallback err (per specs, error strings should be lowercase w/o punctuation
+				err = errors.New("error while reading req.Body: unknown panic")
+			}
+		}
+	}()
+
+	n, err = r.req.Body.Read(p)
 	r.count += int64(n)
 	return n, err
 }
 
-func (r *captureRequestReader) Close() error {
-	return r.source.Close()
+func (r *captureRequestReader) Close() (err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Access to req.Body is unsafe so we add recovery management
+	defer func() {
+		if rec := recover(); rec != nil {
+			r.logger.Errorf("error while closing req.Body: %#v", rec)
+			switch x := rec.(type) {
+			case error:
+				err = x
+			case string:
+				err = errors.New(x)
+			default:
+				// Fallback err (per specs, error strings should be lowercase w/o punctuation
+				err = errors.New("error while closing req.Body: unknown panic")
+			}
+		}
+	}()
+
+	return r.req.Body.Close()
 }

--- a/pkg/middlewares/accesslog/logger.go
+++ b/pkg/middlewares/accesslog/logger.go
@@ -171,7 +171,7 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request, next http
 
 	var crr *captureRequestReader
 	if req.Body != nil {
-		crr = &captureRequestReader{source: req.Body, count: 0}
+		crr = &captureRequestReader{req: req, logger: h.logger}
 		reqWithDataTable.Body = crr
 	}
 
@@ -214,7 +214,7 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request, next http
 		size:    crw.Size(),
 	}
 	if crr != nil {
-		logDataTable.Request.count = crr.count
+		logDataTable.Request.count = crr.GetCount()
 	}
 
 	if h.config.BufferingSize > 0 {


### PR DESCRIPTION
### What does this PR do?

To the best of my current knowledge there is no way to not be racing for `Request.Body` with `net/http.(*conn)`.

So the only way to not panic if you happen to try to read a request body after the client connection has been closed (rogue client) is to use `recover()`.

The addition of the mutex is to fix another potential data race I discovered with running traefik built with `-race`.

### Motivation

Fix https://github.com/containous/traefik/issues/5922

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
