### PR TITLE
k8s: make sure to return an error when no healthy endpoints

### DIFF
--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -356,6 +356,10 @@ func (c configBuilder) loadServers(fallbackNamespace string, svc v1alpha1.LoadBa
 		}
 	}
 
+	if len(servers) == 0 {
+		return nil, fmt.Errorf("no healthy endpoints found for %s/%s", namespace, sanitizedName)
+	}
+
 	return servers, nil
 }
 

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -255,6 +255,10 @@ func loadService(client Client, namespace string, backend v1beta1.IngressBackend
 		}
 	}
 
+	if len(servers) == 0 {
+		return nil, errors.New("no healthy endpoints found")
+	}
+
 	return &dynamic.Service{
 		LoadBalancer: &dynamic.ServersLoadBalancer{
 			Servers:        servers,


### PR DESCRIPTION
### What does this PR do?

This PR makes sure kubernetes endpoints discovery does not return en empty list of servers but rather an error.

### Motivation

In the case that all pods referenced by a k8s service are unhealthy `kubernetes endpoints discovery` will return an empty list of service which will ultimately end up by a `Service Unavailable` for the client.

By returning an error here I hope that traefik will continue matching the request against other routes so that we can do a fallback.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
