### PR TITLE
Fix typo in docker routing documentation

### DIFF
--- a/docs/content/routing/providers/docker.md
+++ b/docs/content/routing/providers/docker.md
@@ -178,7 +178,7 @@ For example, to change the rule, you could add the label ```traefik.http.routers
 
 ??? info "`traefik.http.routers.<router_name>.service`"
 
-    See [rule](../routers/index.md#service) for more information.
+    See [service](../routers/index.md#service) for more information.
 
     ```yaml
     - "traefik.http.routers.myrouter.service=myservice"


### PR DESCRIPTION
### What does this PR do?

Fixes a link to `service` named `rule` in the routing documentation.
