### PR TITLE
Support 'networking.k8s.io/v1beta1' ingress apiVersion

### DIFF
--- a/docs/content/migration/v1-to-v2.md
+++ b/docs/content/migration/v1-to-v2.md
@@ -40,7 +40,7 @@ Then any router can refer to an instance of the wanted middleware.
     ```
 
     ```yaml tab="K8s Ingress"
-    apiVersion: extensions/v1beta1
+    apiVersion: networking.k8s.io/v1beta1
     kind: Ingress
     metadata:
       name: traefik

--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -24,7 +24,7 @@ The Kubernetes Ingress Controller, The Custom Resource Way.
     
     ---
     kind: Deployment
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     metadata:
       name: traefik
       labels:
@@ -97,7 +97,7 @@ The Kubernetes Ingress Controller, The Custom Resource Way.
 
     ```yaml tab="Whoami"
     kind: Deployment
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     metadata:
       name: whoami
       namespace: default

--- a/docs/content/routing/providers/kubernetes-ingress.md
+++ b/docs/content/routing/providers/kubernetes-ingress.md
@@ -11,7 +11,7 @@ which in turn will create the resulting routers, services, handlers, etc.
 
 ```yaml
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: foo
   namespace: production
@@ -40,7 +40,7 @@ spec:
     
     ```yaml tab="Ingress"
     kind: Ingress
-    apiVersion: extensions/v1beta1
+    apiVersion: networking.k8s.io/v1beta1
     metadata:
       name: foo
       namespace: production
@@ -234,7 +234,7 @@ and will connect via TLS automatically.
     
     ```yaml tab="Ingress"
     kind: Ingress
-    apiVersion: extensions/v1beta1
+    apiVersion: networking.k8s.io/v1beta1
     metadata:
       name: foo
       namespace: production
@@ -276,7 +276,7 @@ TLS certificates can be managed in Secrets objects.
 Ingresses can be created that look like the following:
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
  name: cheese

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/go-acme/lego/v3 v3.2.0
 	github.com/go-check/check v0.0.0-00010101000000-000000000000
 	github.com/go-kit/kit v0.9.0
-	github.com/gogo/protobuf v1.3.0 // indirect
+	github.com/gogo/protobuf v1.3.0
 	github.com/golang/protobuf v1.3.2
 	github.com/google/go-github/v28 v28.1.1
 	github.com/googleapis/gnostic v0.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/go-acme/lego/v3 v3.2.0
 	github.com/go-check/check v0.0.0-00010101000000-000000000000
 	github.com/go-kit/kit v0.9.0
-	github.com/gogo/protobuf v1.3.0
+	github.com/gogo/protobuf v1.3.0 // indirect
 	github.com/golang/protobuf v1.3.2
 	github.com/google/go-github/v28 v28.1.1
 	github.com/googleapis/gnostic v0.1.0 // indirect

--- a/integration/fixtures/k8s/02-services.yml
+++ b/integration/fixtures/k8s/02-services.yml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: whoami
   namespace: default
@@ -42,7 +42,7 @@ spec:
 
 ---
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: whoamitcp
   namespace: default

--- a/integration/fixtures/k8s/03-ingress-https.yml
+++ b/integration/fixtures/k8s/03-ingress-https.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: test.ingress.https

--- a/integration/fixtures/k8s/03-ingress.yml
+++ b/integration/fixtures/k8s/03-ingress.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: test.ingress

--- a/pkg/provider/kubernetes/crd/client.go
+++ b/pkg/provider/kubernetes/crd/client.go
@@ -53,11 +53,9 @@ type Client interface {
 	GetTraefikServices() []*v1alpha1.TraefikService
 	GetTLSOptions() []*v1alpha1.TLSOption
 
-	GetIngresses() []*extensionsv1beta1.Ingress
 	GetService(namespace, name string) (*corev1.Service, bool, error)
 	GetSecret(namespace, name string) (*corev1.Secret, bool, error)
 	GetEndpoints(namespace, name string) (*corev1.Endpoints, bool, error)
-	UpdateIngressStatus(namespace, name, ip, hostname string) error
 }
 
 // TODO: add tests for the clientWrapper (and its methods) itself.
@@ -272,7 +270,7 @@ func (c *clientWrapper) GetTraefikServices() []*v1alpha1.TraefikService {
 	return result
 }
 
-// GetTLSOptions
+// GetTLSOptions returns all TLS options.
 func (c *clientWrapper) GetTLSOptions() []*v1alpha1.TLSOption {
 	var result []*v1alpha1.TLSOption
 
@@ -285,48 +283,6 @@ func (c *clientWrapper) GetTLSOptions() []*v1alpha1.TLSOption {
 	}
 
 	return result
-}
-
-// GetIngresses returns all Ingresses for observed namespaces in the cluster.
-func (c *clientWrapper) GetIngresses() []*extensionsv1beta1.Ingress {
-	var result []*extensionsv1beta1.Ingress
-	for ns, factory := range c.factoriesKube {
-		ings, err := factory.Extensions().V1beta1().Ingresses().Lister().List(c.labelSelector)
-		if err != nil {
-			log.Errorf("Failed to list ingresses in namespace %s: %v", ns, err)
-		}
-		result = append(result, ings...)
-	}
-	return result
-}
-
-// UpdateIngressStatus updates an Ingress with a provided status.
-func (c *clientWrapper) UpdateIngressStatus(namespace, name, ip, hostname string) error {
-	if !c.isWatchedNamespace(namespace) {
-		return fmt.Errorf("failed to get ingress %s/%s: namespace is not within watched namespaces", namespace, name)
-	}
-
-	ing, err := c.factoriesKube[c.lookupNamespace(namespace)].Extensions().V1beta1().Ingresses().Lister().Ingresses(namespace).Get(name)
-	if err != nil {
-		return fmt.Errorf("failed to get ingress %s/%s: %v", namespace, name, err)
-	}
-
-	if len(ing.Status.LoadBalancer.Ingress) > 0 {
-		if ing.Status.LoadBalancer.Ingress[0].Hostname == hostname && ing.Status.LoadBalancer.Ingress[0].IP == ip {
-			// If status is already set, skip update
-			log.Debugf("Skipping status update on ingress %s/%s", ing.Namespace, ing.Name)
-			return nil
-		}
-	}
-	ingCopy := ing.DeepCopy()
-	ingCopy.Status = extensionsv1beta1.IngressStatus{LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{{IP: ip, Hostname: hostname}}}}
-
-	_, err = c.csKube.ExtensionsV1beta1().Ingresses(ingCopy.Namespace).UpdateStatus(ingCopy)
-	if err != nil {
-		return fmt.Errorf("failed to update ingress status %s/%s: %v", namespace, name, err)
-	}
-	log.Infof("Updated status on ingress %s/%s", namespace, name)
-	return nil
 }
 
 // GetService returns the named service from the given namespace.

--- a/pkg/provider/kubernetes/crd/client_mock_test.go
+++ b/pkg/provider/kubernetes/crd/client_mock_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/containous/traefik/v2/pkg/provider/kubernetes/crd/traefik/v1alpha1"
 	"github.com/containous/traefik/v2/pkg/provider/kubernetes/k8s"
 	corev1 "k8s.io/api/core/v1"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
-	v1beta12 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
@@ -24,15 +22,13 @@ func init() {
 }
 
 type clientMock struct {
-	ingresses []*extensionsv1beta1.Ingress
 	services  []*corev1.Service
 	secrets   []*corev1.Secret
 	endpoints []*corev1.Endpoints
 
-	apiServiceError       error
-	apiSecretError        error
-	apiEndpointsError     error
-	apiIngressStatusError error
+	apiServiceError   error
+	apiSecretError    error
+	apiEndpointsError error
 
 	ingressRoutes    []*v1alpha1.IngressRoute
 	ingressRouteTCPs []*v1alpha1.IngressRouteTCP
@@ -69,8 +65,6 @@ func newClientMock(paths ...string) clientMock {
 				c.traefikServices = append(c.traefikServices, o)
 			case *v1alpha1.TLSOption:
 				c.tlsOptions = append(c.tlsOptions, o)
-			case *v1beta12.Ingress:
-				c.ingresses = append(c.ingresses, o)
 			case *corev1.Secret:
 				c.secrets = append(c.secrets, o)
 			default:
@@ -122,10 +116,6 @@ func (c clientMock) GetTLSOption(namespace, name string) (*v1alpha1.TLSOption, b
 	return nil, false, nil
 }
 
-func (c clientMock) GetIngresses() []*extensionsv1beta1.Ingress {
-	return c.ingresses
-}
-
 func (c clientMock) GetService(namespace, name string) (*corev1.Service, bool, error) {
 	if c.apiServiceError != nil {
 		return nil, false, c.apiServiceError
@@ -168,8 +158,4 @@ func (c clientMock) GetSecret(namespace, name string) (*corev1.Secret, bool, err
 
 func (c clientMock) WatchAll(namespaces []string, stopCh <-chan struct{}) (<-chan interface{}, error) {
 	return c.watchChan, nil
-}
-
-func (c clientMock) UpdateIngressStatus(namespace, name, ip, hostname string) error {
-	return c.apiIngressStatusError
 }

--- a/pkg/provider/kubernetes/ingress/builder_ingress_test.go
+++ b/pkg/provider/kubernetes/ingress/builder_ingress_test.go
@@ -1,11 +1,11 @@
 package ingress
 
 import (
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 )
 
-func buildIngress(opts ...func(*extensionsv1beta1.Ingress)) *extensionsv1beta1.Ingress {
-	i := &extensionsv1beta1.Ingress{}
+func buildIngress(opts ...func(*v1beta1.Ingress)) *v1beta1.Ingress {
+	i := &v1beta1.Ingress{}
 	i.Kind = "Ingress"
 	for _, opt := range opts {
 		opt(i)
@@ -13,15 +13,15 @@ func buildIngress(opts ...func(*extensionsv1beta1.Ingress)) *extensionsv1beta1.I
 	return i
 }
 
-func iNamespace(value string) func(*extensionsv1beta1.Ingress) {
-	return func(i *extensionsv1beta1.Ingress) {
+func iNamespace(value string) func(*v1beta1.Ingress) {
+	return func(i *v1beta1.Ingress) {
 		i.Namespace = value
 	}
 }
 
-func iRules(opts ...func(*extensionsv1beta1.IngressSpec)) func(*extensionsv1beta1.Ingress) {
-	return func(i *extensionsv1beta1.Ingress) {
-		s := &extensionsv1beta1.IngressSpec{}
+func iRules(opts ...func(*v1beta1.IngressSpec)) func(*v1beta1.Ingress) {
+	return func(i *v1beta1.Ingress) {
+		s := &v1beta1.IngressSpec{}
 		for _, opt := range opts {
 			opt(s)
 		}
@@ -29,9 +29,9 @@ func iRules(opts ...func(*extensionsv1beta1.IngressSpec)) func(*extensionsv1beta
 	}
 }
 
-func iRule(opts ...func(*extensionsv1beta1.IngressRule)) func(*extensionsv1beta1.IngressSpec) {
-	return func(spec *extensionsv1beta1.IngressSpec) {
-		r := &extensionsv1beta1.IngressRule{}
+func iRule(opts ...func(*v1beta1.IngressRule)) func(*v1beta1.IngressSpec) {
+	return func(spec *v1beta1.IngressSpec) {
+		r := &v1beta1.IngressRule{}
 		for _, opt := range opts {
 			opt(r)
 		}
@@ -39,24 +39,24 @@ func iRule(opts ...func(*extensionsv1beta1.IngressRule)) func(*extensionsv1beta1
 	}
 }
 
-func iHost(name string) func(*extensionsv1beta1.IngressRule) {
-	return func(rule *extensionsv1beta1.IngressRule) {
+func iHost(name string) func(*v1beta1.IngressRule) {
+	return func(rule *v1beta1.IngressRule) {
 		rule.Host = name
 	}
 }
 
-func iTLSes(opts ...func(*extensionsv1beta1.IngressTLS)) func(*extensionsv1beta1.Ingress) {
-	return func(i *extensionsv1beta1.Ingress) {
+func iTLSes(opts ...func(*v1beta1.IngressTLS)) func(*v1beta1.Ingress) {
+	return func(i *v1beta1.Ingress) {
 		for _, opt := range opts {
-			iTLS := extensionsv1beta1.IngressTLS{}
+			iTLS := v1beta1.IngressTLS{}
 			opt(&iTLS)
 			i.Spec.TLS = append(i.Spec.TLS, iTLS)
 		}
 	}
 }
 
-func iTLS(secret string, hosts ...string) func(*extensionsv1beta1.IngressTLS) {
-	return func(i *extensionsv1beta1.IngressTLS) {
+func iTLS(secret string, hosts ...string) func(*v1beta1.IngressTLS) {
+	return func(i *v1beta1.IngressTLS) {
 		i.SecretName = secret
 		i.Hosts = hosts
 	}

--- a/pkg/provider/kubernetes/ingress/client.go
+++ b/pkg/provider/kubernetes/ingress/client.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/containous/traefik/v2/pkg/log"
-	"github.com/gogo/protobuf/proto"
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
@@ -48,7 +47,7 @@ type Client interface {
 	GetService(namespace, name string) (*corev1.Service, bool, error)
 	GetSecret(namespace, name string) (*corev1.Secret, bool, error)
 	GetEndpoints(namespace, name string) (*corev1.Endpoints, bool, error)
-	UpdateIngressStatus(namespace, name, ip, hostname string) error
+	UpdateIngressStatus(ing *networkingv1beta1.Ingress, ip, hostname string) error
 }
 
 type clientWrapper struct {
@@ -196,8 +195,10 @@ func (c *clientWrapper) GetIngresses() []*networkingv1beta1.Ingress {
 	return results
 }
 
-func extensionsToNetworking(i proto.Marshaler) (*networkingv1beta1.Ingress, error) {
-	data, err := i.Marshal()
+func extensionsToNetworking(ing *extensionsv1beta1.Ingress) (*networkingv1beta1.Ingress, error) {
+	log.Warnf("Ingress %s/%s: the apiVersion 'extensions/v1beta1' is deprecated, use 'networking.k8s.io/v1beta1' instead.", ing.Namespace, ing.Name)
+
+	data, err := ing.Marshal()
 	if err != nil {
 		return nil, err
 	}
@@ -207,18 +208,23 @@ func extensionsToNetworking(i proto.Marshaler) (*networkingv1beta1.Ingress, erro
 	if err != nil {
 		return nil, err
 	}
+
 	return ni, nil
 }
 
 // UpdateIngressStatus updates an Ingress with a provided status.
-func (c *clientWrapper) UpdateIngressStatus(namespace, name, ip, hostname string) error {
-	if !c.isWatchedNamespace(namespace) {
-		return fmt.Errorf("failed to get ingress %s/%s: namespace is not within watched namespaces", namespace, name)
+func (c *clientWrapper) UpdateIngressStatus(src *networkingv1beta1.Ingress, ip, hostname string) error {
+	if !c.isWatchedNamespace(src.Namespace) {
+		return fmt.Errorf("failed to get ingress %s/%s: namespace is not within watched namespaces", src.Namespace, src.Name)
 	}
 
-	ing, err := c.factories[c.lookupNamespace(namespace)].Extensions().V1beta1().Ingresses().Lister().Ingresses(namespace).Get(name)
+	if src.GetObjectKind().GroupVersionKind().Group != "networking.k8s.io" {
+		return c.updateIngressStatusOld(src, ip, hostname)
+	}
+
+	ing, err := c.factories[c.lookupNamespace(src.Namespace)].Networking().V1beta1().Ingresses().Lister().Ingresses(src.Namespace).Get(src.Name)
 	if err != nil {
-		return fmt.Errorf("failed to get ingress %s/%s: %v", namespace, name, err)
+		return fmt.Errorf("failed to get ingress %s/%s: %v", src.Namespace, src.Name, err)
 	}
 
 	if len(ing.Status.LoadBalancer.Ingress) > 0 {
@@ -228,14 +234,42 @@ func (c *clientWrapper) UpdateIngressStatus(namespace, name, ip, hostname string
 			return nil
 		}
 	}
+
+	ingCopy := ing.DeepCopy()
+	ingCopy.Status = networkingv1beta1.IngressStatus{LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{{IP: ip, Hostname: hostname}}}}
+
+	_, err = c.clientset.NetworkingV1beta1().Ingresses(ingCopy.Namespace).UpdateStatus(ingCopy)
+	if err != nil {
+		return fmt.Errorf("failed to update ingress status %s/%s: %v", src.Namespace, src.Name, err)
+	}
+
+	log.Infof("Updated status on ingress %s/%s", src.Namespace, src.Name)
+	return nil
+}
+
+func (c *clientWrapper) updateIngressStatusOld(src *networkingv1beta1.Ingress, ip, hostname string) error {
+	ing, err := c.factories[c.lookupNamespace(src.Namespace)].Extensions().V1beta1().Ingresses().Lister().Ingresses(src.Namespace).Get(src.Name)
+	if err != nil {
+		return fmt.Errorf("failed to get ingress %s/%s: %v", src.Namespace, src.Name, err)
+	}
+
+	if len(ing.Status.LoadBalancer.Ingress) > 0 {
+		if ing.Status.LoadBalancer.Ingress[0].Hostname == hostname && ing.Status.LoadBalancer.Ingress[0].IP == ip {
+			// If status is already set, skip update
+			log.Debugf("Skipping status update on ingress %s/%s", ing.Namespace, ing.Name)
+			return nil
+		}
+	}
+
 	ingCopy := ing.DeepCopy()
 	ingCopy.Status = extensionsv1beta1.IngressStatus{LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{{IP: ip, Hostname: hostname}}}}
 
 	_, err = c.clientset.ExtensionsV1beta1().Ingresses(ingCopy.Namespace).UpdateStatus(ingCopy)
 	if err != nil {
-		return fmt.Errorf("failed to update ingress status %s/%s: %v", namespace, name, err)
+		return fmt.Errorf("failed to update ingress status %s/%s: %v", src.Namespace, src.Name, err)
 	}
-	log.Infof("Updated status on ingress %s/%s", namespace, name)
+
+	log.Infof("Updated status on ingress %s/%s", src.Namespace, src.Name)
 	return nil
 }
 
@@ -289,11 +323,16 @@ func (c *clientWrapper) newResourceEventHandler(events chan<- interface{}) cache
 	return &cache.FilteringResourceEventHandler{
 		FilterFunc: func(obj interface{}) bool {
 			// Ignore Ingresses that do not match our custom label selector.
-			if ing, ok := obj.(*extensionsv1beta1.Ingress); ok {
-				lbls := labels.Set(ing.GetLabels())
+			switch v := obj.(type) {
+			case *extensionsv1beta1.Ingress:
+				lbls := labels.Set(v.GetLabels())
 				return c.ingressLabelSelector.Matches(lbls)
+			case *networkingv1beta1.Ingress:
+				lbls := labels.Set(v.GetLabels())
+				return c.ingressLabelSelector.Matches(lbls)
+			default:
+				return true
 			}
-			return true
 		},
 		Handler: &resourceEventHandler{ev: events},
 	}

--- a/pkg/provider/kubernetes/ingress/client_mock_test.go
+++ b/pkg/provider/kubernetes/ingress/client_mock_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/containous/traefik/v2/pkg/provider/kubernetes/k8s"
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
-	v1beta12 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 )
 
 var _ Client = (*clientMock)(nil)
 
 type clientMock struct {
-	ingresses []*extensionsv1beta1.Ingress
+	ingresses []*v1beta1.Ingress
 	services  []*corev1.Service
 	secrets   []*corev1.Secret
 	endpoints []*corev1.Endpoints
@@ -44,8 +44,14 @@ func newClientMock(paths ...string) clientMock {
 				c.secrets = append(c.secrets, o)
 			case *corev1.Endpoints:
 				c.endpoints = append(c.endpoints, o)
-			case *v1beta12.Ingress:
+			case *v1beta1.Ingress:
 				c.ingresses = append(c.ingresses, o)
+			case *extensionsv1beta1.Ingress:
+				ing, err := extensionsToNetworking(o)
+				if err != nil {
+					panic(err)
+				}
+				c.ingresses = append(c.ingresses, ing)
 			default:
 				panic(fmt.Sprintf("Unknown runtime object %+v %T", o, o))
 			}
@@ -55,7 +61,7 @@ func newClientMock(paths ...string) clientMock {
 	return c
 }
 
-func (c clientMock) GetIngresses() []*extensionsv1beta1.Ingress {
+func (c clientMock) GetIngresses() []*v1beta1.Ingress {
 	return c.ingresses
 }
 

--- a/pkg/provider/kubernetes/ingress/client_mock_test.go
+++ b/pkg/provider/kubernetes/ingress/client_mock_test.go
@@ -109,6 +109,6 @@ func (c clientMock) WatchAll(namespaces []string, stopCh <-chan struct{}) (<-cha
 	return c.watchChan, nil
 }
 
-func (c clientMock) UpdateIngressStatus(namespace, name, ip, hostname string) error {
+func (c clientMock) UpdateIngressStatus(_ *v1beta1.Ingress, _, _ string) error {
 	return c.apiIngressStatusError
 }

--- a/pkg/provider/kubernetes/ingress/fixtures/2-ingresses-in-different-namespace-with-same-service-name_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/2-ingresses-in-different-namespace-with-same-service-name_ingress.yml
@@ -1,6 +1,6 @@
 ---
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing
@@ -21,7 +21,7 @@ spec:
 
 ---
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: toto

--- a/pkg/provider/kubernetes/ingress/fixtures/Double-Single-Service-Ingress_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Double-Single-Service-Ingress_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing
@@ -11,7 +11,7 @@ spec:
 
 ---
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-Two-rules-with-one-host-and-one-path_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-Two-rules-with-one-host-and-one-path_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-host-only_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-host-only_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-with-one-host-and-two-paths_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-with-one-host-and-two-paths_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-with-one-path-and-one-host_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-with-one-path-and-one-host_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-with-two-paths_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-with-two-paths_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-bad-host-syntax_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-bad-host-syntax_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-bad-path-syntax_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-bad-path-syntax_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(port-==-443)_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(port-==-443)_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(portname-==-https)_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(portname-==-https)_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(portname-starts-with-https)_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(portname-starts-with-https)_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-annotations_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-annotations_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-default-traefik-ingressClass_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-default-traefik-ingressClass_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-ingressClass-without-annotation_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-ingressClass-without-annotation_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-non-matching-provider-traefik-ingressClass-and-annotation_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-non-matching-provider-traefik-ingressClass-and-annotation_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-one-host-without-path_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-one-host-without-path_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-one-service-without-endpoint_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-one-service-without-endpoint_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-one-service-without-endpoints-subset_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-one-service-without-endpoints-subset_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-only-a-bad-host-syntax_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-only-a-bad-host-syntax_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-only-a-bad-path-syntax_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-only-a-bad-path-syntax_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-name-in-backend-and-no-pod-replica_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-name-in-backend-and-no-pod-replica_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-value-in-backend-and-no-pod-replica_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-value-in-backend-and-no-pod-replica_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-service-with-externalName_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-service-with-externalName_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-two-different-rules-with-one-path_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-two-different-rules-with-one-path_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-two-paths-using-same-service-and-different-port-name_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-two-paths-using-same-service-and-different-port-name_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-two-services_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-two-services_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-unknown-service-port-name_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-unknown-service-port-name_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-unknown-service-port_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-unknown-service-port_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-with-port-name-in-backend-and-2-pod-replica_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-with-port-name-in-backend-and-2-pod-replica_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-without-provider-traefik-ingressClass-and-unknown-annotation_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-without-provider-traefik-ingressClass-and-unknown-annotation_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/Single-Service-Ingress-(without-any-rules)_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Single-Service-Ingress-(without-any-rules)_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/fixtures/TLS-support_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/TLS-support_ingress.yml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing
@@ -18,7 +18,7 @@ spec:
 
 ---
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -21,7 +21,7 @@ import (
 	"github.com/containous/traefik/v2/pkg/types"
 	"github.com/mitchellh/hashstructure"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/containous/traefik/v2/pkg/types"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 


### PR DESCRIPTION
### What does this PR do?

Adds support of 'networking.k8s.io/v1beta1' as ingress `apiVersion`.

The following `apiVersion` are supported:
- `networking.k8s.io/v1beta1`
- `extensions/v1beta1`

### Motivation

https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
