### PR TITLE
fix: invalid service definition.

### DIFF
--- a/pkg/provider/docker/config_test.go
+++ b/pkg/provider/docker/config_test.go
@@ -345,6 +345,74 @@ func Test_buildConfiguration(t *testing.T) {
 		expected    *dynamic.Configuration
 	}{
 		{
+			desc: "invalid HTTP service definition",
+			containers: []dockerData{
+				{
+					ServiceName: "Test",
+					Name:        "Test",
+					Labels: map[string]string{
+						"traefik.http.services.test": "",
+					},
+					NetworkSettings: networkSettings{
+						Ports: nat.PortMap{
+							nat.Port("80/tcp"): []nat.PortBinding{},
+						},
+						Networks: map[string]*networkData{
+							"bridge": {
+								Name: "bridge",
+								Addr: "127.0.0.1",
+							},
+						},
+					},
+				},
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:     map[string]*dynamic.Router{},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services:    map[string]*dynamic.Service{},
+				},
+			},
+		},
+		{
+			desc: "invalid TCP service definition",
+			containers: []dockerData{
+				{
+					ServiceName: "Test",
+					Name:        "Test",
+					Labels: map[string]string{
+						"traefik.tcp.services.test": "",
+					},
+					NetworkSettings: networkSettings{
+						Ports: nat.PortMap{
+							nat.Port("80/tcp"): []nat.PortBinding{},
+						},
+						Networks: map[string]*networkData{
+							"bridge": {
+								Name: "bridge",
+								Addr: "127.0.0.1",
+							},
+						},
+					},
+				},
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:     map[string]*dynamic.Router{},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services:    map[string]*dynamic.Service{},
+				},
+			},
+		},
+		{
 			desc: "one container no label",
 			containers: []dockerData{
 				{


### PR DESCRIPTION
### What does this PR do?

Throw an error instead of panic when the service definition is invalid.

```
Stack: goroutine 38 [running]:
runtime/debug.Stack(0xc0000e8000, 0x25581e1, 0x17)
	/usr/local/go/src/runtime/debug/stack.go:24 +0x9d
github.com/containous/traefik/v2/pkg/safe.defaultRecoverGoroutine(0x210c480, 0x3fbcdb0)
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:160 +0xb1
github.com/containous/traefik/v2/pkg/safe.OperationWithRecover.func1.1(0xc00022fd78)
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:168 +0x56
panic(0x210c480, 0x3fbcdb0)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/containous/traefik/v2/pkg/provider/docker.(*Provider).addServer(0xc00014d2d0, 0x29b4960, 0xc00067cc00, 0xc000616300, 0x40, 0xc000647535, 0xb, 0xc000647535, 0xb, 0xc00067c4b0, ...)
	/go/src/github.com/containous/traefik/pkg/provider/docker/config.go:184 +0x116
github.com/containous/traefik/v2/pkg/provider/docker.(*Provider).buildServiceConfiguration(0xc00014d2d0, 0x29b4960, 0xc00067cab0, 0xc000616300, 0x40, 0xc000647535, 0xb, 0xc000647535, 0xb, 0xc00067c4b0, ...)
	/go/src/github.com/containous/traefik/pkg/provider/docker/config.go:113 +0x1dd
github.com/containous/traefik/v2/pkg/provider/docker.(*Provider).buildConfiguration(0xc00014d2d0, 0x29b4960, 0xc0001f2de0, 0xc000653440, 0x2, 0x2, 0x2)
	/go/src/github.com/containous/traefik/pkg/provider/docker/config.go:52 +0x5e0
github.com/containous/traefik/v2/pkg/provider/docker.(*Provider).Provide.func1.1(0x0, 0x0)
	/go/src/github.com/containous/traefik/pkg/provider/docker/docker.go:193 +0x657
github.com/containous/traefik/v2/pkg/safe.OperationWithRecover.func1(0x0, 0x0)
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:172 +0x6c
github.com/cenkalti/backoff/v3.RetryNotify(0xc0001f7920, 0x29729e0, 0xc0003f89a0, 0xc00022fef0, 0x0, 0x0)
	/go/pkg/mod/github.com/cenkalti/backoff/v3@v3.0.0/retry.go:37 +0xb8
github.com/containous/traefik/v2/pkg/provider/docker.(*Provider).Provide.func1(0x29b48a0, 0xc0003d2d40)
	/go/src/github.com/containous/traefik/pkg/provider/docker/docker.go:293 +0x2d6
github.com/containous/traefik/v2/pkg/safe.(*Pool).GoCtx.func1()
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:63 +0x84
github.com/containous/traefik/v2/pkg/safe.GoWithRecover.func1(0x2633df8, 0xc0003f8980)
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:153 +0x57
created by github.com/containous/traefik/v2/pkg/safe.GoWithRecover
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:147 +0x49
```

### Motivation

Fixes #6197

### More

- [x] Added/updated tests
- ~~[ ] Added/updated documentation~~

