### PR TITLE
Use EDF schedule algorithm for WeightedRoundRobin

### DIFF
--- a/pkg/server/service/loadbalancer/wrr/wrr.go
+++ b/pkg/server/service/loadbalancer/wrr/wrr.go
@@ -98,7 +98,7 @@ func (b *Balancer) nextServer() (*namedHandler, error) {
 	// curDeadline should be handler's deadline so that new added entry would have a fair
 	// competition environment with the old ones.
 	b.curDeadline = handler.deadline
-	handler.deadline = handler.deadline + 1/handler.weight
+	handler.deadline += 1 / handler.weight
 	b.curIndex++
 	handler.index = b.curIndex
 	heap.Push(b.handlers, handler)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

Use EDF schedule algorithm for WeightedRoundRobin
(https://en.wikipedia.org/wiki/Earliest_deadline_first_scheduling)

Each pick from the schedule has the earliest deadline entry selected. Entries have deadlines set at current time + 1 / weight, providing weighted round robin behavior with floating point weights and an O(log n) pick time.

Picking up complexity of EDF algorithm is stable, but current simple algorithm sometimes takes O(n) pick time.

[Envoy](https://github.com/envoyproxy/envoy) uses the same EDF algorithm for WRR.

### Motivation

Current WRR algorithm has significant bias problem for unbalanced weight endpoints.

e.g.

Endpoints: [{"name":"A", "weight": 11}, {"name":"B", "weight": 3}]

| picking up algorithm | sequence |
| --- | --- |
|current  | A A A A A A A A A B A B A B|
|EDF | A A A B A A A A B A A A B A|

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
