### PR TITLE
doc: use the same entry point name everywhere

### DIFF
--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -56,7 +56,7 @@ Please check the [configuration examples below](#configuration-examples) for mor
       [entryPoints.web]
         address = ":80"
     
-      [entryPoints.web-secure]
+      [entryPoints.websecure]
         address = ":443"
     
     [certificatesResolvers.le.acme]
@@ -72,7 +72,7 @@ Please check the [configuration examples below](#configuration-examples) for mor
       web:
         address: ":80"
     
-      web-secure:
+      websecure:
         address: ":443"
     
     certificatesResolvers:
@@ -196,7 +196,7 @@ when using the `HTTP-01` challenge, `certificatesResolvers.le.acme.httpChallenge
       [entryPoints.web]
         address = ":80"
       
-      [entryPoints.web-secure]
+      [entryPoints.websecure]
         address = ":443"
     
     [certificatesResolvers.le.acme]
@@ -210,7 +210,7 @@ when using the `HTTP-01` challenge, `certificatesResolvers.le.acme.httpChallenge
       web:
         address: ":80"
     
-      web-secure:
+      websecure:
         address: ":443"
     
     certificatesResolvers:

--- a/docs/content/migration/v1-to-v2.md
+++ b/docs/content/migration/v1-to-v2.md
@@ -190,17 +190,17 @@ TLS parameters used to be specified in the static configuration, as an entryPoin
 With Traefik v2, a new dynamic TLS section at the root contains all the desired TLS configurations.
 Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one of the [TLS configurations](../https/tls.md) defined at the root, hence defining the [TLS configuration](../https/tls.md) for that router.
 
-!!! example "TLS on web-secure entryPoint becomes TLS option on Router-1"
+!!! example "TLS on websecure entryPoint becomes TLS option on Router-1"
 
     !!! info "v1"
     
     ```toml tab="File (TOML)"
     # static configuration
     [entryPoints]
-      [entryPoints.web-secure]
+      [entryPoints.websecure]
         address = ":443"
     
-        [entryPoints.web-secure.tls]
+        [entryPoints.websecure.tls]
           minVersion = "VersionTLS12"
           cipherSuites = [
             "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
@@ -210,13 +210,13 @@ Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one o
             "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
             "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
           ]
-          [[entryPoints.web-secure.tls.certificates]]
+          [[entryPoints.websecure.tls.certificates]]
             certFile = "path/to/my.cert"
             keyFile = "path/to/my.key"
     ```
 
     ```bash tab="CLI"
-    --entryPoints='Name:web-secure Address::443 TLS:path/to/my.cert,path/to/my.key TLS.MinVersion:VersionTLS12 TLS.CipherSuites:TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256'
+    --entryPoints='Name:websecure Address::443 TLS:path/to/my.cert,path/to/my.key TLS.MinVersion:VersionTLS12 TLS.CipherSuites:TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256'
     ```
 
     !!! info "v2"
@@ -818,32 +818,32 @@ with the path `/admin` stripped, e.g. to `http://<IP>:<port>/`. In this case, yo
     
     ```toml tab="File (TOML)"
     # static configuration
-    defaultEntryPoints = ["web-secure","web"]
+    defaultEntryPoints = ["websecure","web"]
     
     [entryPoints.web]
     address = ":80"
       [entryPoints.web.redirect]
       entryPoint = "webs"
-    [entryPoints.web-secure]
+    [entryPoints.websecure]
       address = ":443"
       [entryPoints.https.tls]
     
     [acme]
       email = "your-email-here@my-awesome-app.org"
       storage = "acme.json"
-      entryPoint = "web-secure"
+      entryPoint = "websecure"
       onHostRule = true
       [acme.httpChallenge]
         entryPoint = "web"
     ```
 
     ```bash tab="CLI"
-    --defaultentrypoints=web-secure,web
-    --entryPoints=Name:web Address::80 Redirect.EntryPoint:web-secure
-    --entryPoints=Name:web-secure Address::443 TLS
+    --defaultentrypoints=websecure,web
+    --entryPoints=Name:web Address::80 Redirect.EntryPoint:websecure
+    --entryPoints=Name:websecure Address::443 TLS
     --acme.email=your-email-here@my-awesome-app.org
     --acme.storage=acme.json
-    --acme.entryPoint=web-secure
+    --acme.entryPoint=websecure
     --acme.onHostRule=true
     --acme.httpchallenge.entrypoint=http
     ```
@@ -856,7 +856,7 @@ with the path `/admin` stripped, e.g. to `http://<IP>:<port>/`. In this case, yo
       [entryPoints.web]
         address = ":80"
     
-      [entryPoints.web-secure]
+      [entryPoints.websecure]
         address = ":443"
     
     [certificatesResolvers.sample.acme]
@@ -872,7 +872,7 @@ with the path `/admin` stripped, e.g. to `http://<IP>:<port>/`. In this case, yo
       web:
         address: ":80"
     
-      web-secure:
+      websecure:
         address: ":443"
     
     certificatesResolvers:
@@ -1069,7 +1069,7 @@ Each root item has been moved to a related section or removed.
     providersThrottleDuration = "2s"
     AllowMinWeightZero = true
     debug = true
-    defaultEntryPoints = ["web", "web-secure"]
+    defaultEntryPoints = ["web", "websecure"]
     keepTrailingSlash = false
     ```
 
@@ -1083,7 +1083,7 @@ Each root item has been moved to a related section or removed.
     --providersthrottleduration=2s
     --allowminweightzero=true
     --debug=true
-    --defaultentrypoints=web,web-secure
+    --defaultentrypoints=web,websecure
     --keeptrailingslash=true
     ```
 
@@ -1156,21 +1156,21 @@ As the dashboard access is now secured by default you can either:
     ## static configuration
     # traefik.toml
     
-    [entryPoints.web-secure]
+    [entryPoints.websecure]
       address = ":443"
-      [entryPoints.web-secure.tls]
-      [entryPoints.web-secure.auth]
-        [entryPoints.web-secure.auth.basic]
+      [entryPoints.websecure.tls]
+      [entryPoints.websecure.auth]
+        [entryPoints.websecure.auth.basic]
           users = [
             "test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/"
           ]
     
     [api]
-      entryPoint = "web-secure"
+      entryPoint = "websecure"
     ```
 
     ```bash tab="CLI"
-    --entryPoints='Name:web-secure Address::443 TLS Auth.Basic.Users:test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/'
+    --entryPoints='Name:websecure Address::443 TLS Auth.Basic.Users:test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/'
     --api
     ```
 
@@ -1180,7 +1180,7 @@ As the dashboard access is now secured by default you can either:
     # dynamic configuration
     labels:
       - "traefik.http.routers.api.rule=Host(`traefik.docker.localhost`)"
-      - "traefik.http.routers.api.entrypoints=web-secured"
+      - "traefik.http.routers.api.entrypoints=websecured"
       - "traefik.http.routers.api.service=api@internal"
       - "traefik.http.routers.api.middlewares=myAuth"
       - "traefik.http.routers.api.tls"
@@ -1191,7 +1191,7 @@ As the dashboard access is now secured by default you can either:
     ## static configuration
     # traefik.toml
     
-    [entryPoints.web-secure]
+    [entryPoints.websecure]
       address = ":443"
     
     [api]
@@ -1206,7 +1206,7 @@ As the dashboard access is now secured by default you can either:
     
     [http.routers.api]
       rule = "Host(`traefik.docker.localhost`)"
-      entrypoints = ["web-secure"]
+      entrypoints = ["websecure"]
       service = "api@internal"
       middlewares = ["myAuth"]
       [http.routers.api.tls]
@@ -1222,7 +1222,7 @@ As the dashboard access is now secured by default you can either:
     # traefik.yaml
     
     entryPoints:
-      web-secure:
+      websecure:
         address: ':443'
         
     api: {}
@@ -1241,7 +1241,7 @@ As the dashboard access is now secured by default you can either:
         api:
           rule: Host(`traefik.docker.localhost`)
           entrypoints:
-            - web-secure
+            - websecure
           service: api@internal
           middlewares:
             - myAuth

--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-resource.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-resource.yml
@@ -78,7 +78,7 @@ metadata:
 spec:
   entryPoints:
     - web
-    - web-secure
+    - websecure
   routes:
     - match: Host(`foo.com`) && PathPrefix(`/bar`)
       kind: Rule

--- a/docs/content/reference/dynamic-configuration/kubernetes-crd.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd.yml
@@ -152,7 +152,7 @@ metadata:
 spec:
   entryPoints:
     - web
-    - web-secure
+    - websecure
   routes:
     - match: Host(`foo.com`) && PathPrefix(`/bar`)
       kind: Rule

--- a/integration/fixtures/acme/acme_base.toml
+++ b/integration/fixtures/acme/acme_base.toml
@@ -8,7 +8,7 @@
 [entryPoints]
   [entryPoints.web]
     address = "{{ .PortHTTP }}"
-  [entryPoints.web-secure]
+  [entryPoints.websecure]
     address = "{{ .PortHTTPS }}"
 
 {{range $name, $resolvers := .Acme }}
@@ -45,7 +45,7 @@
 
 [http.routers]
   [http.routers.test]
-    entryPoints = ["web-secure"]
+    entryPoints = ["websecure"]
     rule = "Host(`traefik.acme.wtf`)"
     service = "test"
     [http.routers.test.tls]

--- a/integration/fixtures/acme/acme_domains.toml
+++ b/integration/fixtures/acme/acme_domains.toml
@@ -8,7 +8,7 @@
 [entryPoints]
   [entryPoints.web]
     address = "{{ .PortHTTP }}"
-  [entryPoints.web-secure]
+  [entryPoints.websecure]
     address = "{{ .PortHTTPS }}"
 
 {{range $name, $resolvers := .Acme }}
@@ -45,7 +45,7 @@
 
 [http.routers]
   [http.routers.test]
-    entryPoints = ["web-secure"]
+    entryPoints = ["websecure"]
     rule = "PathPrefix(`/`)"
     service = "test"
     [http.routers.test.tls]

--- a/integration/fixtures/acme/acme_multiple_resolvers.toml
+++ b/integration/fixtures/acme/acme_multiple_resolvers.toml
@@ -8,7 +8,7 @@
 [entryPoints]
   [entryPoints.web]
     address = "{{ .PortHTTP }}"
-  [entryPoints.web-secure]
+  [entryPoints.websecure]
     address = "{{ .PortHTTPS }}"
 
 {{range $name, $resolvers := .Acme }}
@@ -45,14 +45,14 @@
 
 [http.routers]
   [http.routers.test]
-    entryPoints = ["web-secure"]
+    entryPoints = ["websecure"]
     rule = "Host(`traefik.acme.wtf`)"
     service = "test"
     [http.routers.test.tls]
       certResolver = "default"
 
   [http.routers.tchouk]
-    entryPoints = ["web-secure"]
+    entryPoints = ["websecure"]
     rule = "Host(`tchouk.acme.wtf`)"
     service = "test"
     [http.routers.tchouk.tls]

--- a/integration/fixtures/acme/acme_tcp.toml
+++ b/integration/fixtures/acme/acme_tcp.toml
@@ -8,7 +8,7 @@
 [entryPoints]
   [entryPoints.web]
     address = "{{ .PortHTTP }}"
-  [entryPoints.web-secure]
+  [entryPoints.websecure]
     address = "{{ .PortHTTPS }}"
 
 {{range $name, $resolvers := .Acme }}
@@ -45,7 +45,7 @@
 
 [tcp.routers]
   [tcp.routers.test]
-    entryPoints = ["web-secure"]
+    entryPoints = ["websecure"]
     rule = "HostSNI(`traefik.acme.wtf`)"
     service = "test"
     [tcp.routers.test.tls]

--- a/integration/fixtures/acme/acme_tls.toml
+++ b/integration/fixtures/acme/acme_tls.toml
@@ -8,7 +8,7 @@
 [entryPoints]
   [entryPoints.web]
     address = "{{ .PortHTTP }}"
-  [entryPoints.web-secure]
+  [entryPoints.websecure]
     address = "{{ .PortHTTPS }}"
 
 {{range $name, $resolvers := .Acme }}
@@ -45,7 +45,7 @@
 
 [http.routers]
   [http.routers.test]
-    entryPoints = ["web-secure"]
+    entryPoints = ["websecure"]
     rule = "Host(`traefik.acme.wtf`)"
     service = "test"
     [http.routers.test.tls]

--- a/integration/fixtures/acme/acme_tls_dynamic.toml
+++ b/integration/fixtures/acme/acme_tls_dynamic.toml
@@ -8,7 +8,7 @@
 [entryPoints]
   [entryPoints.web]
     address = "{{ .PortHTTP }}"
-  [entryPoints.web-secure]
+  [entryPoints.websecure]
     address = "{{ .PortHTTPS }}"
 
 {{range $name, $resolvers := .Acme }}

--- a/integration/fixtures/acme/acme_tls_multiple_entrypoints.toml
+++ b/integration/fixtures/acme/acme_tls_multiple_entrypoints.toml
@@ -8,7 +8,7 @@
 [entryPoints]
   [entryPoints.web]
     address = "{{ .PortHTTP }}"
-  [entryPoints.web-secure]
+  [entryPoints.websecure]
     address = "{{ .PortHTTPS }}"
 
   [entryPoints.traefik]

--- a/integration/fixtures/acme/certificates.toml
+++ b/integration/fixtures/acme/certificates.toml
@@ -5,7 +5,7 @@
 
 [http.routers]
   [http.routers.test]
-    entryPoints = ["web-secure"]
+    entryPoints = ["websecure"]
     rule = "Host(`traefik.acme.wtf`)"
     service = "test"
     [http.routers.test.tls]

--- a/integration/fixtures/grpc/config.toml
+++ b/integration/fixtures/grpc/config.toml
@@ -9,7 +9,7 @@
   rootCAs = [ """{{ .CertContent }}""" ]
 
 [entryPoints]
-  [entryPoints.web-secure]
+  [entryPoints.websecure]
     address = ":4443"
 
 [api]

--- a/integration/fixtures/grpc/config_h2c_termination.toml
+++ b/integration/fixtures/grpc/config_h2c_termination.toml
@@ -6,7 +6,7 @@
   level = "DEBUG"
 
 [entryPoints]
-  [entryPoints.web-secure]
+  [entryPoints.websecure]
     address = ":4443"
 
 [api]

--- a/integration/fixtures/grpc/config_insecure.toml
+++ b/integration/fixtures/grpc/config_insecure.toml
@@ -9,7 +9,7 @@
   insecureSkipVerify = true
 
 [entryPoints]
-  [entryPoints.web-secure]
+  [entryPoints.websecure]
     address = ":4443"
 
 [api]

--- a/integration/fixtures/grpc/config_retry.toml
+++ b/integration/fixtures/grpc/config_retry.toml
@@ -9,7 +9,7 @@
   rootCAs = [ """{{ .CertContent }}""" ]
 
 [entryPoints]
-  [entryPoints.web-secure]
+  [entryPoints.websecure]
     address = ":4443"
 
 [api]

--- a/integration/fixtures/https/clientca/https_1ca1config.toml
+++ b/integration/fixtures/https/clientca/https_1ca1config.toml
@@ -6,7 +6,7 @@
   level = "DEBUG"
 
 [entryPoints]
-  [entryPoints.web-secure]
+  [entryPoints.websecure]
     address = ":4443"
 
 [api]

--- a/integration/fixtures/https/clientca/https_2ca1config.toml
+++ b/integration/fixtures/https/clientca/https_2ca1config.toml
@@ -6,7 +6,7 @@
   level = "DEBUG"
 
 [entryPoints]
-  [entryPoints.web-secure]
+  [entryPoints.websecure]
     address = ":4443"
 
 [api]

--- a/integration/fixtures/https/clientca/https_2ca2config.toml
+++ b/integration/fixtures/https/clientca/https_2ca2config.toml
@@ -6,7 +6,7 @@
   level = "DEBUG"
 
 [entryPoints]
-  [entryPoints.web-secure]
+  [entryPoints.websecure]
     address = ":4443"
 
 [api]

--- a/integration/fixtures/https/dynamic_https_sni.toml
+++ b/integration/fixtures/https/dynamic_https_sni.toml
@@ -6,7 +6,7 @@
   level = "DEBUG"
 
 [entryPoints]
-  [entryPoints.web-secure]
+  [entryPoints.websecure]
      address = ":4443"
 
   [entryPoints.https02]

--- a/integration/fixtures/https/dynamic_https_sni_default_cert.toml
+++ b/integration/fixtures/https/dynamic_https_sni_default_cert.toml
@@ -6,7 +6,7 @@
   level = "DEBUG"
 
 [entryPoints]
-  [entryPoints.web-secure]
+  [entryPoints.websecure]
     address = ":4443"
 
 [api]

--- a/integration/fixtures/https/https_redirect.toml
+++ b/integration/fixtures/https/https_redirect.toml
@@ -9,7 +9,7 @@
   [entryPoints.web]
     address = ":8888"
 
-  [entryPoints.web-secure]
+  [entryPoints.websecure]
     address = ":8443"
 
 [api]
@@ -28,7 +28,7 @@
     service = "service1"
 
   [http.routers.router1TLS]
-    entryPoints = [ "web-secure" ]
+    entryPoints = [ "websecure" ]
     rule = "Host(`example.com`)"
     service = "service1"
     [http.routers.router1TLS.tls]
@@ -40,7 +40,7 @@
     service = "service1"
 
   [http.routers.router2TLS]
-    entryPoints = [ "web-secure" ]
+    entryPoints = [ "websecure" ]
     rule = "Host(`example2.com`)"
     service = "service1"
     [http.routers.router2TLS.tls]
@@ -52,7 +52,7 @@
     service = "service1"
 
   [http.routers.router3TLS]
-    entryPoints = [ "web-secure" ]
+    entryPoints = [ "websecure" ]
     rule = "Host(`test.com`)"
     service = "service1"
     [http.routers.router3TLS.tls]
@@ -64,7 +64,7 @@
     service = "service1"
 
   [http.routers.router4TLS]
-    entryPoints = [ "web-secure" ]
+    entryPoints = [ "websecure" ]
     rule = "Host(`test2.com`)"
     service = "service1"
     [http.routers.router4TLS.tls]
@@ -76,7 +76,7 @@
     service = "service1"
 
   [http.routers.router5TLS]
-    entryPoints = [ "web-secure" ]
+    entryPoints = [ "websecure" ]
     rule = "Host(`foo.com`)"
     service = "service1"
     [http.routers.router5TLS.tls]
@@ -88,7 +88,7 @@
     service = "service1"
 
   [http.routers.router6TLS]
-    entryPoints = [ "web-secure" ]
+    entryPoints = [ "websecure" ]
     rule = "Host(`foo2.com`)"
     service = "service1"
     [http.routers.router6TLS.tls]
@@ -100,7 +100,7 @@
     service = "service1"
 
   [http.routers.router7TLS]
-    entryPoints = [ "web-secure" ]
+    entryPoints = [ "websecure" ]
     rule = "Host(`bar.com`)"
     service = "service1"
     [http.routers.router7TLS.tls]
@@ -112,7 +112,7 @@
     service = "service1"
 
   [http.routers.router8TLS]
-    entryPoints = [ "web-secure" ]
+    entryPoints = [ "websecure" ]
     rule = "Host(`bar2.com`)"
     service = "service1"
     [http.routers.router8TLS.tls]
@@ -124,7 +124,7 @@
     service = "service1"
 
   [http.routers.router9TLS]
-    entryPoints = [ "web-secure" ]
+    entryPoints = [ "websecure" ]
     rule = "Host(`pow.com`)"
     service = "service1"
     [http.routers.router9TLS.tls]
@@ -136,7 +136,7 @@
     service = "service1"
 
   [http.routers.router10TLS]
-    entryPoints = [ "web-secure" ]
+    entryPoints = [ "websecure" ]
     rule = "Host(`pow2.com`)"
     service = "service1"
     [http.routers.router10TLS.tls]

--- a/integration/fixtures/https/https_sni.toml
+++ b/integration/fixtures/https/https_sni.toml
@@ -6,7 +6,7 @@
   level = "DEBUG"
 
 [entryPoints]
-  [entryPoints.web-secure]
+  [entryPoints.websecure]
     address = ":4443"
 
 [api]

--- a/integration/fixtures/https/https_sni_case_insensitive_dynamic.toml
+++ b/integration/fixtures/https/https_sni_case_insensitive_dynamic.toml
@@ -6,7 +6,7 @@
   level = "DEBUG"
 
 [entryPoints]
-  [entryPoints.web-secure]
+  [entryPoints.websecure]
     address = ":4443"
 
 [api]

--- a/integration/fixtures/https/https_sni_default_cert.toml
+++ b/integration/fixtures/https/https_sni_default_cert.toml
@@ -6,7 +6,7 @@
   level = "DEBUG"
 
 [entryPoints]
-  [entryPoints.web-secure]
+  [entryPoints.websecure]
     address = ":4443"
 
 [api]

--- a/integration/fixtures/https/https_sni_strict.toml
+++ b/integration/fixtures/https/https_sni_strict.toml
@@ -6,7 +6,7 @@
   level = "DEBUG"
 
 [entryPoints]
-  [entryPoints.web-secure]
+  [entryPoints.websecure]
     address = ":4443"
 
 [api]

--- a/integration/fixtures/https/https_tls_options.toml
+++ b/integration/fixtures/https/https_tls_options.toml
@@ -6,7 +6,7 @@
   level = "DEBUG"
 
 [entryPoints]
-  [entryPoints.web-secure]
+  [entryPoints.websecure]
     address = ":4443"
 
 [api]

--- a/integration/fixtures/router_errors.toml
+++ b/integration/fixtures/router_errors.toml
@@ -6,7 +6,7 @@
   level = "DEBUG"
 
 [entryPoints]
-  [entryPoints.web-secure]
+  [entryPoints.websecure]
     address = ":4443"
 
 [api]

--- a/integration/fixtures/service_errors.toml
+++ b/integration/fixtures/service_errors.toml
@@ -6,7 +6,7 @@
   level = "DEBUG"
 
 [entryPoints]
-  [entryPoints.web-secure]
+  [entryPoints.websecure]
     address = ":4443"
 
 [api]

--- a/integration/fixtures/tlsclientheaders/simple.toml
+++ b/integration/fixtures/tlsclientheaders/simple.toml
@@ -9,7 +9,7 @@
   rootCAs = [ """{{ .RootCertContent }}""" ]
 
 [entryPoints]
-  [entryPoints.web-secure]
+  [entryPoints.websecure]
     address = ":8443"
 
 [api]

--- a/pkg/api/handler_entrypoint_test.go
+++ b/pkg/api/handler_entrypoint_test.go
@@ -67,7 +67,7 @@ func TestHandler_EntryPoints(t *testing.T) {
 							TrustedIPs: []string{"192.168.1.3", "192.168.1.4"},
 						},
 					},
-					"web-secure": {
+					"websecure": {
 						Address: ":443",
 						Transport: &static.EntryPointsTransport{
 							LifeCycle: &static.LifeCycle{

--- a/pkg/api/testdata/entrypoints.json
+++ b/pkg/api/testdata/entrypoints.json
@@ -37,7 +37,7 @@
 				"192.168.1.40"
 			]
 		},
-		"name": "web-secure",
+		"name": "websecure",
 		"proxyProtocol": {
 			"insecure": true,
 			"trustedIPs": [

--- a/pkg/provider/kubernetes/crd/fixtures/services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/services.yml
@@ -66,7 +66,7 @@ metadata:
 
 spec:
   ports:
-    - name: web-secure
+    - name: websecure
       port: 443
       targetPort: 8443
   selector:
@@ -85,7 +85,7 @@ subsets:
       - ip: 10.10.0.5
       - ip: 10.10.0.6
     ports:
-      - name: web-secure
+      - name: websecure
         port: 8443
 
 ---
@@ -97,7 +97,7 @@ metadata:
 
 spec:
   ports:
-    - name: web-secure2
+    - name: websecure2
       port: 8443
       scheme: https
   selector:
@@ -116,5 +116,5 @@ subsets:
       - ip: 10.10.0.7
       - ip: 10.10.0.8
     ports:
-      - name: web-secure2
+      - name: websecure2
         port: 8443

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/services.yml
@@ -66,7 +66,7 @@ metadata:
 
 spec:
   ports:
-    - name: web-secure
+    - name: websecure
       port: 443
   selector:
     app: containous
@@ -84,5 +84,5 @@ subsets:
       - ip: 10.10.0.5
       - ip: 10.10.0.6
     ports:
-      - name: web-secure
+      - name: websecure
         port: 443


### PR DESCRIPTION
### What does this PR do?

Uses `websecure` instead of `web-secure`.

### Motivation

Be homogeneous. 

### More

- ~~[ ] Added/updated tests~~
- [x] Added/updated documentation
