### PR TITLE
use provider-qualified name when recursing for chain

### DIFF
--- a/pkg/responsemodifiers/response_modifier.go
+++ b/pkg/responsemodifiers/response_modifier.go
@@ -25,6 +25,7 @@ func (f *Builder) Build(ctx context.Context, names []string) func(*http.Response
 	for _, middleName := range names {
 		conf, ok := f.configs[middleName]
 		if !ok {
+			getLogger(ctx, middleName, "undefined").Debug("Middleware name not found in config (ResponseModifier)")
 			continue
 		}
 		if conf == nil || conf.Middleware == nil {

--- a/pkg/responsemodifiers/response_modifier.go
+++ b/pkg/responsemodifiers/response_modifier.go
@@ -3,10 +3,9 @@ package responsemodifiers
 import (
 	"context"
 	"net/http"
-	"strings"
 
 	"github.com/containous/traefik/v2/pkg/config/runtime"
-	"github.com/containous/traefik/v2/pkg/log"
+	"github.com/containous/traefik/v2/pkg/server/provider"
 )
 
 // NewBuilder creates a builder.
@@ -26,7 +25,6 @@ func (f *Builder) Build(ctx context.Context, names []string) func(*http.Response
 	for _, middleName := range names {
 		conf, ok := f.configs[middleName]
 		if !ok {
-			getLogger(ctx, middleName, "undefined").Warn("Middleware name not found in config (ResponseModifier)")
 			continue
 		}
 		if conf == nil || conf.Middleware == nil {
@@ -39,11 +37,11 @@ func (f *Builder) Build(ctx context.Context, names []string) func(*http.Response
 
 			modifiers = append(modifiers, buildHeaders(conf.Headers))
 		} else if conf.Chain != nil {
-			chainCtx := addProviderInContext(ctx, middleName)
+			chainCtx := provider.AddInContext(ctx, middleName)
 			getLogger(chainCtx, middleName, "Chain").Debug("Creating Middleware (ResponseModifier)")
 			var qualifiedNames []string
 			for _, name := range conf.Chain.Middlewares {
-				qualifiedNames = append(qualifiedNames, getQualifiedName(chainCtx, name))
+				qualifiedNames = append(qualifiedNames, provider.GetQualifiedName(chainCtx, name))
 			}
 			modifiers = append(modifiers, f.Build(ctx, qualifiedNames))
 		}
@@ -62,41 +60,4 @@ func (f *Builder) Build(ctx context.Context, names []string) func(*http.Response
 	}
 
 	return func(response *http.Response) error { return nil }
-}
-
-type contextKey int
-
-const (
-	providerKey contextKey = iota
-)
-
-// addProviderInContext adds the provider name in the context
-func addProviderInContext(ctx context.Context, elementName string) context.Context {
-	parts := strings.Split(elementName, "@")
-	if len(parts) == 1 {
-		log.FromContext(ctx).Debugf("Could not find a provider for %s.", elementName)
-		return ctx
-	}
-
-	if name, ok := ctx.Value(providerKey).(string); ok && name == parts[1] {
-		return ctx
-	}
-
-	return context.WithValue(ctx, providerKey, parts[1])
-}
-
-// getQualifiedName gets the fully qualified name.
-func getQualifiedName(ctx context.Context, elementName string) string {
-	parts := strings.Split(elementName, "@")
-	if len(parts) == 1 {
-		if providerName, ok := ctx.Value(providerKey).(string); ok {
-			return makeQualifiedName(providerName, parts[0])
-		}
-	}
-	return elementName
-}
-
-// makeQualifiedName creates a qualified name for an element
-func makeQualifiedName(providerName string, elementName string) string {
-	return elementName + "@" + providerName
 }

--- a/pkg/responsemodifiers/response_modifier.go
+++ b/pkg/responsemodifiers/response_modifier.go
@@ -3,8 +3,10 @@ package responsemodifiers
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/containous/traefik/v2/pkg/config/runtime"
+	"github.com/containous/traefik/v2/pkg/log"
 )
 
 // NewBuilder creates a builder.
@@ -22,21 +24,28 @@ func (f *Builder) Build(ctx context.Context, names []string) func(*http.Response
 	var modifiers []func(*http.Response) error
 
 	for _, middleName := range names {
-		if conf, ok := f.configs[middleName]; ok {
-			if conf == nil || conf.Middleware == nil {
-				getLogger(ctx, middleName, "undefined").Error("Invalid Middleware configuration (ResponseModifier)")
-				continue
+		conf, ok := f.configs[middleName]
+		if !ok {
+			getLogger(ctx, middleName, "undefined").Warn("Middleware name not found in config (ResponseModifier)")
+			continue
+		}
+		if conf == nil || conf.Middleware == nil {
+			getLogger(ctx, middleName, "undefined").Error("Invalid Middleware configuration (ResponseModifier)")
+			continue
+		}
+
+		if conf.Headers != nil {
+			getLogger(ctx, middleName, "Headers").Debug("Creating Middleware (ResponseModifier)")
+
+			modifiers = append(modifiers, buildHeaders(conf.Headers))
+		} else if conf.Chain != nil {
+			chainCtx := addProviderInContext(ctx, middleName)
+			getLogger(chainCtx, middleName, "Chain").Debug("Creating Middleware (ResponseModifier)")
+			var qualifiedNames []string
+			for _, name := range conf.Chain.Middlewares {
+				qualifiedNames = append(qualifiedNames, getQualifiedName(chainCtx, name))
 			}
-
-			if conf.Headers != nil {
-				getLogger(ctx, middleName, "Headers").Debug("Creating Middleware (ResponseModifier)")
-
-				modifiers = append(modifiers, buildHeaders(conf.Headers))
-			} else if conf.Chain != nil {
-				getLogger(ctx, middleName, "Chain").Debug("Creating Middleware (ResponseModifier)")
-
-				modifiers = append(modifiers, f.Build(ctx, conf.Chain.Middlewares))
-			}
+			modifiers = append(modifiers, f.Build(ctx, qualifiedNames))
 		}
 	}
 
@@ -53,4 +62,41 @@ func (f *Builder) Build(ctx context.Context, names []string) func(*http.Response
 	}
 
 	return func(response *http.Response) error { return nil }
+}
+
+type contextKey int
+
+const (
+	providerKey contextKey = iota
+)
+
+// addProviderInContext adds the provider name in the context
+func addProviderInContext(ctx context.Context, elementName string) context.Context {
+	parts := strings.Split(elementName, "@")
+	if len(parts) == 1 {
+		log.FromContext(ctx).Debugf("Could not find a provider for %s.", elementName)
+		return ctx
+	}
+
+	if name, ok := ctx.Value(providerKey).(string); ok && name == parts[1] {
+		return ctx
+	}
+
+	return context.WithValue(ctx, providerKey, parts[1])
+}
+
+// getQualifiedName gets the fully qualified name.
+func getQualifiedName(ctx context.Context, elementName string) string {
+	parts := strings.Split(elementName, "@")
+	if len(parts) == 1 {
+		if providerName, ok := ctx.Value(providerKey).(string); ok {
+			return makeQualifiedName(providerName, parts[0])
+		}
+	}
+	return elementName
+}
+
+// makeQualifiedName creates a qualified name for an element
+func makeQualifiedName(providerName string, elementName string) string {
+	return elementName + "@" + providerName
 }

--- a/pkg/server/aggregator.go
+++ b/pkg/server/aggregator.go
@@ -3,7 +3,7 @@ package server
 import (
 	"github.com/containous/traefik/v2/pkg/config/dynamic"
 	"github.com/containous/traefik/v2/pkg/log"
-	"github.com/containous/traefik/v2/pkg/server/internal"
+	"github.com/containous/traefik/v2/pkg/server/provider"
 	"github.com/containous/traefik/v2/pkg/tls"
 )
 
@@ -25,25 +25,25 @@ func mergeConfiguration(configurations dynamic.Configurations) dynamic.Configura
 	}
 
 	var defaultTLSOptionProviders []string
-	for provider, configuration := range configurations {
+	for pvd, configuration := range configurations {
 		if configuration.HTTP != nil {
 			for routerName, router := range configuration.HTTP.Routers {
-				conf.HTTP.Routers[internal.MakeQualifiedName(provider, routerName)] = router
+				conf.HTTP.Routers[provider.MakeQualifiedName(pvd, routerName)] = router
 			}
 			for middlewareName, middleware := range configuration.HTTP.Middlewares {
-				conf.HTTP.Middlewares[internal.MakeQualifiedName(provider, middlewareName)] = middleware
+				conf.HTTP.Middlewares[provider.MakeQualifiedName(pvd, middlewareName)] = middleware
 			}
 			for serviceName, service := range configuration.HTTP.Services {
-				conf.HTTP.Services[internal.MakeQualifiedName(provider, serviceName)] = service
+				conf.HTTP.Services[provider.MakeQualifiedName(pvd, serviceName)] = service
 			}
 		}
 
 		if configuration.TCP != nil {
 			for routerName, router := range configuration.TCP.Routers {
-				conf.TCP.Routers[internal.MakeQualifiedName(provider, routerName)] = router
+				conf.TCP.Routers[provider.MakeQualifiedName(pvd, routerName)] = router
 			}
 			for serviceName, service := range configuration.TCP.Services {
-				conf.TCP.Services[internal.MakeQualifiedName(provider, serviceName)] = service
+				conf.TCP.Services[provider.MakeQualifiedName(pvd, serviceName)] = service
 			}
 		}
 
@@ -56,9 +56,9 @@ func mergeConfiguration(configurations dynamic.Configurations) dynamic.Configura
 
 			for tlsOptionsName, options := range configuration.TLS.Options {
 				if tlsOptionsName != "default" {
-					tlsOptionsName = internal.MakeQualifiedName(provider, tlsOptionsName)
+					tlsOptionsName = provider.MakeQualifiedName(pvd, tlsOptionsName)
 				} else {
-					defaultTLSOptionProviders = append(defaultTLSOptionProviders, provider)
+					defaultTLSOptionProviders = append(defaultTLSOptionProviders, pvd)
 				}
 
 				conf.TLS.Options[tlsOptionsName] = options

--- a/pkg/server/middleware/middlewares.go
+++ b/pkg/server/middleware/middlewares.go
@@ -28,7 +28,7 @@ import (
 	"github.com/containous/traefik/v2/pkg/middlewares/stripprefix"
 	"github.com/containous/traefik/v2/pkg/middlewares/stripprefixregex"
 	"github.com/containous/traefik/v2/pkg/middlewares/tracing"
-	"github.com/containous/traefik/v2/pkg/server/internal"
+	"github.com/containous/traefik/v2/pkg/server/provider"
 )
 
 type middlewareStackType int
@@ -56,10 +56,10 @@ func NewBuilder(configs map[string]*runtime.MiddlewareInfo, serviceBuilder servi
 func (b *Builder) BuildChain(ctx context.Context, middlewares []string) *alice.Chain {
 	chain := alice.New()
 	for _, name := range middlewares {
-		middlewareName := internal.GetQualifiedName(ctx, name)
+		middlewareName := provider.GetQualifiedName(ctx, name)
 
 		chain = chain.Append(func(next http.Handler) (http.Handler, error) {
-			constructorContext := internal.AddProviderInContext(ctx, middlewareName)
+			constructorContext := provider.AddInContext(ctx, middlewareName)
 			if midInf, ok := b.configs[middlewareName]; !ok || midInf.Middleware == nil {
 				return nil, fmt.Errorf("middleware %q does not exist", middlewareName)
 			}
@@ -144,7 +144,7 @@ func (b *Builder) buildConstructor(ctx context.Context, middlewareName string) (
 
 		var qualifiedNames []string
 		for _, name := range config.Chain.Middlewares {
-			qualifiedNames = append(qualifiedNames, internal.GetQualifiedName(ctx, name))
+			qualifiedNames = append(qualifiedNames, provider.GetQualifiedName(ctx, name))
 		}
 		config.Chain.Middlewares = qualifiedNames
 		middleware = func(next http.Handler) (http.Handler, error) {

--- a/pkg/server/middleware/middlewares_test.go
+++ b/pkg/server/middleware/middlewares_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/containous/traefik/v2/pkg/config/dynamic"
 	"github.com/containous/traefik/v2/pkg/config/runtime"
-	"github.com/containous/traefik/v2/pkg/server/internal"
+	"github.com/containous/traefik/v2/pkg/server/provider"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -262,7 +262,7 @@ func TestBuilder_BuildChainWithContext(t *testing.T) {
 
 			ctx := context.Background()
 			if len(test.contextProvider) > 0 {
-				ctx = internal.AddProviderInContext(ctx, "foobar@"+test.contextProvider)
+				ctx = provider.AddInContext(ctx, "foobar@"+test.contextProvider)
 			}
 
 			rtConf := runtime.NewConfig(dynamic.Configuration{

--- a/pkg/server/provider/provider.go
+++ b/pkg/server/provider/provider.go
@@ -1,4 +1,4 @@
-package internal
+package provider
 
 import (
 	"context"
@@ -10,29 +10,29 @@ import (
 type contextKey int
 
 const (
-	providerKey contextKey = iota
+	key contextKey = iota
 )
 
-// AddProviderInContext Adds the provider name in the context
-func AddProviderInContext(ctx context.Context, elementName string) context.Context {
+// AddInContext Adds the provider name in the context
+func AddInContext(ctx context.Context, elementName string) context.Context {
 	parts := strings.Split(elementName, "@")
 	if len(parts) == 1 {
 		log.FromContext(ctx).Debugf("Could not find a provider for %s.", elementName)
 		return ctx
 	}
 
-	if name, ok := ctx.Value(providerKey).(string); ok && name == parts[1] {
+	if name, ok := ctx.Value(key).(string); ok && name == parts[1] {
 		return ctx
 	}
 
-	return context.WithValue(ctx, providerKey, parts[1])
+	return context.WithValue(ctx, key, parts[1])
 }
 
 // GetQualifiedName Gets the fully qualified name.
 func GetQualifiedName(ctx context.Context, elementName string) string {
 	parts := strings.Split(elementName, "@")
 	if len(parts) == 1 {
-		if providerName, ok := ctx.Value(providerKey).(string); ok {
+		if providerName, ok := ctx.Value(key).(string); ok {
 			return MakeQualifiedName(providerName, parts[0])
 		}
 	}

--- a/pkg/server/provider/provider_test.go
+++ b/pkg/server/provider/provider_test.go
@@ -1,4 +1,4 @@
-package internal
+package provider
 
 import (
 	"context"
@@ -28,19 +28,19 @@ func TestAddProviderInContext(t *testing.T) {
 		},
 		{
 			desc:     "provider name in context",
-			ctx:      context.WithValue(context.Background(), providerKey, "foo"),
+			ctx:      context.WithValue(context.Background(), key, "foo"),
 			name:     "test",
 			expected: "foo",
 		},
 		{
 			desc:     "provider name in context and different provider name embedded in element name",
-			ctx:      context.WithValue(context.Background(), providerKey, "foo"),
+			ctx:      context.WithValue(context.Background(), key, "foo"),
 			name:     "test@fii",
 			expected: "fii",
 		},
 		{
 			desc:     "provider name in context and same provider name embedded in element name",
-			ctx:      context.WithValue(context.Background(), providerKey, "foo"),
+			ctx:      context.WithValue(context.Background(), key, "foo"),
 			name:     "test@foo",
 			expected: "foo",
 		},
@@ -51,10 +51,10 @@ func TestAddProviderInContext(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			newCtx := AddProviderInContext(test.ctx, test.name)
+			newCtx := AddInContext(test.ctx, test.name)
 
 			var providerName string
-			if name, ok := newCtx.Value(providerKey).(string); ok {
+			if name, ok := newCtx.Value(key).(string); ok {
 				providerName = name
 			}
 
@@ -90,13 +90,13 @@ func TestGetQualifiedName(t *testing.T) {
 		},
 		{
 			desc:     "with provider in context",
-			ctx:      context.WithValue(context.Background(), providerKey, "foo"),
+			ctx:      context.WithValue(context.Background(), key, "foo"),
 			name:     "test",
 			expected: "test@foo",
 		},
 		{
 			desc:     "with provider in context and explicit name",
-			ctx:      context.WithValue(context.Background(), providerKey, "foo"),
+			ctx:      context.WithValue(context.Background(), key, "foo"),
 			name:     "test@fii",
 			expected: "test@fii",
 		},

--- a/pkg/server/router/router.go
+++ b/pkg/server/router/router.go
@@ -12,8 +12,8 @@ import (
 	"github.com/containous/traefik/v2/pkg/middlewares/recovery"
 	"github.com/containous/traefik/v2/pkg/middlewares/tracing"
 	"github.com/containous/traefik/v2/pkg/rules"
-	"github.com/containous/traefik/v2/pkg/server/internal"
 	"github.com/containous/traefik/v2/pkg/server/middleware"
+	"github.com/containous/traefik/v2/pkg/server/provider"
 )
 
 const (
@@ -121,7 +121,7 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 	}
 
 	for routerName, routerConfig := range configs {
-		ctxRouter := log.With(internal.AddProviderInContext(ctx, routerName), log.Str(log.RouterName, routerName))
+		ctxRouter := log.With(provider.AddInContext(ctx, routerName), log.Str(log.RouterName, routerName))
 		logger := log.FromContext(ctxRouter)
 
 		handler, err := m.buildRouterHandler(ctxRouter, routerName, routerConfig)
@@ -175,7 +175,7 @@ func (m *Manager) buildRouterHandler(ctx context.Context, routerName string, rou
 func (m *Manager) buildHTTPHandler(ctx context.Context, router *runtime.RouterInfo, routerName string) (http.Handler, error) {
 	var qualifiedNames []string
 	for _, name := range router.Middlewares {
-		qualifiedNames = append(qualifiedNames, internal.GetQualifiedName(ctx, name))
+		qualifiedNames = append(qualifiedNames, provider.GetQualifiedName(ctx, name))
 	}
 	router.Middlewares = qualifiedNames
 	rm := m.modifierBuilder.Build(ctx, qualifiedNames)

--- a/pkg/server/router/tcp/router.go
+++ b/pkg/server/router/tcp/router.go
@@ -10,7 +10,7 @@ import (
 	"github.com/containous/traefik/v2/pkg/config/runtime"
 	"github.com/containous/traefik/v2/pkg/log"
 	"github.com/containous/traefik/v2/pkg/rules"
-	"github.com/containous/traefik/v2/pkg/server/internal"
+	"github.com/containous/traefik/v2/pkg/server/provider"
 	tcpservice "github.com/containous/traefik/v2/pkg/server/service/tcp"
 	"github.com/containous/traefik/v2/pkg/tcp"
 	traefiktls "github.com/containous/traefik/v2/pkg/tls"
@@ -112,7 +112,7 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 			continue
 		}
 
-		ctxRouter := log.With(internal.AddProviderInContext(ctx, routerHTTPName), log.Str(log.RouterName, routerHTTPName))
+		ctxRouter := log.With(provider.AddInContext(ctx, routerHTTPName), log.Str(log.RouterName, routerHTTPName))
 		logger := log.FromContext(ctxRouter)
 
 		domains, err := rules.ParseDomains(routerHTTPConfig.Rule)
@@ -131,7 +131,7 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 			if routerHTTPConfig.TLS != nil {
 				tlsOptionsName := routerHTTPConfig.TLS.Options
 				if tlsOptionsName != defaultTLSConfigName {
-					tlsOptionsName = internal.GetQualifiedName(ctxRouter, routerHTTPConfig.TLS.Options)
+					tlsOptionsName = provider.GetQualifiedName(ctxRouter, routerHTTPConfig.TLS.Options)
 				}
 
 				tlsConf, err := m.tlsManager.Get(defaultTLSStoreName, tlsOptionsName)
@@ -180,7 +180,7 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 	}
 
 	for routerName, routerConfig := range configs {
-		ctxRouter := log.With(internal.AddProviderInContext(ctx, routerName), log.Str(log.RouterName, routerName))
+		ctxRouter := log.With(provider.AddInContext(ctx, routerName), log.Str(log.RouterName, routerName))
 		logger := log.FromContext(ctxRouter)
 
 		if routerConfig.Service == "" {
@@ -226,7 +226,7 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 					}
 
 					if tlsOptionsName != defaultTLSConfigName {
-						tlsOptionsName = internal.GetQualifiedName(ctxRouter, tlsOptionsName)
+						tlsOptionsName = provider.GetQualifiedName(ctxRouter, tlsOptionsName)
 					}
 
 					tlsConf, err := m.tlsManager.Get(defaultTLSStoreName, tlsOptionsName)

--- a/pkg/server/service/service.go
+++ b/pkg/server/service/service.go
@@ -22,7 +22,7 @@ import (
 	"github.com/containous/traefik/v2/pkg/middlewares/pipelining"
 	"github.com/containous/traefik/v2/pkg/safe"
 	"github.com/containous/traefik/v2/pkg/server/cookie"
-	"github.com/containous/traefik/v2/pkg/server/internal"
+	"github.com/containous/traefik/v2/pkg/server/provider"
 	"github.com/containous/traefik/v2/pkg/server/service/loadbalancer/mirror"
 	"github.com/containous/traefik/v2/pkg/server/service/loadbalancer/wrr"
 	"github.com/vulcand/oxy/roundrobin"
@@ -63,8 +63,8 @@ type Manager struct {
 func (m *Manager) BuildHTTP(rootCtx context.Context, serviceName string, responseModifier func(*http.Response) error) (http.Handler, error) {
 	ctx := log.With(rootCtx, log.Str(log.ServiceName, serviceName))
 
-	serviceName = internal.GetQualifiedName(ctx, serviceName)
-	ctx = internal.AddProviderInContext(ctx, serviceName)
+	serviceName = provider.GetQualifiedName(ctx, serviceName)
+	ctx = provider.AddInContext(ctx, serviceName)
 
 	conf, ok := m.configs[serviceName]
 	if !ok {

--- a/pkg/server/service/service_test.go
+++ b/pkg/server/service/service_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/containous/traefik/v2/pkg/config/dynamic"
 	"github.com/containous/traefik/v2/pkg/config/runtime"
-	"github.com/containous/traefik/v2/pkg/server/internal"
+	"github.com/containous/traefik/v2/pkg/server/provider"
 	"github.com/containous/traefik/v2/pkg/testhelpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -336,7 +336,7 @@ func TestManager_Build(t *testing.T) {
 
 			ctx := context.Background()
 			if len(test.providerName) > 0 {
-				ctx = internal.AddProviderInContext(ctx, "foobar@"+test.providerName)
+				ctx = provider.AddInContext(ctx, "foobar@"+test.providerName)
 			}
 
 			_, err := manager.BuildHTTP(ctx, test.serviceName, nil)

--- a/pkg/server/service/tcp/service.go
+++ b/pkg/server/service/tcp/service.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/containous/traefik/v2/pkg/config/runtime"
 	"github.com/containous/traefik/v2/pkg/log"
-	"github.com/containous/traefik/v2/pkg/server/internal"
+	"github.com/containous/traefik/v2/pkg/server/provider"
 	"github.com/containous/traefik/v2/pkg/tcp"
 )
 
@@ -27,8 +27,8 @@ func NewManager(conf *runtime.Configuration) *Manager {
 
 // BuildTCP Creates a tcp.Handler for a service configuration.
 func (m *Manager) BuildTCP(rootCtx context.Context, serviceName string) (tcp.Handler, error) {
-	serviceQualifiedName := internal.GetQualifiedName(rootCtx, serviceName)
-	ctx := internal.AddProviderInContext(rootCtx, serviceQualifiedName)
+	serviceQualifiedName := provider.GetQualifiedName(rootCtx, serviceName)
+	ctx := provider.AddInContext(rootCtx, serviceQualifiedName)
 	ctx = log.With(ctx, log.Str(log.ServiceName, serviceName))
 
 	conf, ok := m.configs[serviceQualifiedName]

--- a/pkg/server/service/tcp/service_test.go
+++ b/pkg/server/service/tcp/service_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/containous/traefik/v2/pkg/config/dynamic"
 	"github.com/containous/traefik/v2/pkg/config/runtime"
-	"github.com/containous/traefik/v2/pkg/server/internal"
+	"github.com/containous/traefik/v2/pkg/server/provider"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -184,7 +184,7 @@ func TestManager_BuildTCP(t *testing.T) {
 
 			ctx := context.Background()
 			if len(test.providerName) > 0 {
-				ctx = internal.AddProviderInContext(ctx, "foobar@"+test.providerName)
+				ctx = provider.AddInContext(ctx, "foobar@"+test.providerName)
 			}
 
 			handler, err := manager.BuildTCP(ctx, test.serviceName)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

Since the references to middlewares in the config of a chain middleware are not necessarily fully provider-qualified names (i.e. without the trailing "@provider" part), when that is the case, and we want to find the corresponding configuration for each of these references, we have to rely on the provider for the chain itself. This was not handled properly when recursively creating http handlers for the response modifier.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

Fixes #5890 

### More

- ~[ ] Added/updated tests~
- ~[ ] Added/updated documentation~


