### PR TITLE
Added X-Forwarded-Tls-Client-Cert to the forward-auth headers

### DIFF
--- a/pkg/middlewares/auth/forward.go
+++ b/pkg/middlewares/auth/forward.go
@@ -19,9 +19,10 @@ import (
 )
 
 const (
-	xForwardedURI     = "X-Forwarded-Uri"
-	xForwardedMethod  = "X-Forwarded-Method"
-	forwardedTypeName = "ForwardedAuthType"
+	xForwardedURI        = "X-Forwarded-Uri"
+	xForwardedMethod     = "X-Forwarded-Method"
+	forwardedTypeName    = "ForwardedAuthType"
+	xForwardedClientCert = "X-Forwarded-Tls-Client-Cert"
 )
 
 type forwardAuth struct {
@@ -216,5 +217,13 @@ func writeHeader(req *http.Request, forwardReq *http.Request, trustForwardHeader
 		forwardReq.Header.Set(xForwardedURI, req.URL.RequestURI())
 	default:
 		forwardReq.Header.Del(xForwardedURI)
+	}
+
+	xfCert := req.Header.Get(xForwardedClientCert)
+	switch {
+	case xfCert != "" && trustForwardHeader:
+		forwardReq.Header.Set(xForwardedClientCert, xfCert)
+	default:
+		forwardReq.Header.Del(xForwardedClientCert)
 	}
 }

--- a/pkg/middlewares/auth/forward_test.go
+++ b/pkg/middlewares/auth/forward_test.go
@@ -346,6 +346,34 @@ func Test_writeHeader(t *testing.T) {
 			},
 		},
 		{
+			name: "trust Forward Header with forwarded tls certificate",
+			headers: map[string]string{
+				"X-Forwarded-Tls-Client-Cert": "MY AWESOME CERTIFICATE",
+			},
+			trustForwardHeader: true,
+			expectedHeaders: map[string]string{
+				"X-Forwarded-Tls-Client-Cert": "MY AWESOME CERTIFICATE",
+			},
+		},
+		{
+			name: "trust Forward Header with forwarded tls certificate header, but its empty",
+			headers: map[string]string{
+				"X-Forwarded-Tls-Client-Cert": "",
+			},
+			trustForwardHeader: true,
+			expectedHeaders: map[string]string{
+			},
+		},
+		{
+			name: "not trust Forward Header with forwarded tls certificate",
+			headers: map[string]string{
+				"X-Forwarded-Tls-Client-Cert": "MY AWESOME CERTIFICATE",
+			},
+			trustForwardHeader: false,
+			expectedHeaders: map[string]string{
+			},
+		},
+		{
 			name: "remove hop-by-hop headers",
 			headers: map[string]string{
 				forward.Connection:         "Connection",

--- a/pkg/middlewares/auth/forward_test.go
+++ b/pkg/middlewares/auth/forward_test.go
@@ -356,24 +356,6 @@ func Test_writeHeader(t *testing.T) {
 			},
 		},
 		{
-			name: "trust Forward Header with forwarded tls certificate header, but its empty",
-			headers: map[string]string{
-				"X-Forwarded-Tls-Client-Cert": "",
-			},
-			trustForwardHeader: true,
-			expectedHeaders: map[string]string{
-			},
-		},
-		{
-			name: "not trust Forward Header with forwarded tls certificate",
-			headers: map[string]string{
-				"X-Forwarded-Tls-Client-Cert": "MY AWESOME CERTIFICATE",
-			},
-			trustForwardHeader: false,
-			expectedHeaders: map[string]string{
-			},
-		},
-		{
 			name: "remove hop-by-hop headers",
 			headers: map[string]string{
 				forward.Connection:         "Connection",


### PR DESCRIPTION
### What does this PR do?

I've added the `X-Forwarded-Tls-Client-Cert` to the forward.go (ForwardAuth Middleware) if `trustForwardHeader` is set to true.

This allows a Forward-Auth Server to check a client certificate. (This requires mTLS on the entrypoint).

The Client Certificate is currently not passed to the forward auth server.


### Motivation

Im working on a forward auth server to authenticate non-CAS Services with our CAS service and allowing the clients to use mTLS (Client Cert Authentication)


### More

- [x] Added/updated tests

### Additional Notes

First time working with Go - im from the Javaland ;D
