### PR TITLE
Fix dnspod update.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -477,12 +477,11 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:fa62421bd924623ac10a160686cc55d529f7274b2caedf7d2c607d14bc50c118"
+  digest = "1:295f7aed734ab28daff7c0df7db42bcccf7a043d4e0a5daf5768129346b25f23"
   name = "github.com/decker502/dnspod-go"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "71fbbdbdf1a7eeac949586de15bf96d416d3dd63"
-  version = "v0.2.0"
+  revision = "071171b22a9b65e4f544b61c143befd54a08a64e"
 
 [[projects]]
   digest = "1:7a6852b35eb5bbc184561443762d225116ae630c26a7c4d90546619f1e7d2ad2"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -272,3 +272,7 @@
 [[override]]
   name = "contrib.go.opencensus.io/exporter/ocagent"
   version = "0.4.12"
+
+[[override]]
+  name = "github.com/decker502/dnspod-go"
+  revision = "071171b22a9b65e4f544b61c143befd54a08a64e"

--- a/vendor/github.com/decker502/dnspod-go/domains.go
+++ b/vendor/github.com/decker502/dnspod-go/domains.go
@@ -16,18 +16,18 @@ type DomainsService struct {
 }
 
 type DomainInfo struct {
-	DomainTotal   int    `json:"domain_total,omitempty"`
-	AllTotal      int    `json:"all_total,omitempty"`
-	MineTotal     int    `json:"mine_total,omitempty"`
-	ShareTotal    string `json:"share_total,omitempty"`
-	VipTotal      int    `json:"vip_total,omitempty"`
-	IsMarkTotal   int    `json:"ismark_total,omitempty"`
-	PauseTotal    int    `json:"pause_total,omitempty"`
-	ErrorTotal    int    `json:"error_total,omitempty"`
-	LockTotal     int    `json:"lock_total,omitempty"`
-	SpamTotal     int    `json:"spam_total,omitempty"`
-	VipExpire     int    `json:"vip_expire,omitempty"`
-	ShareOutTotal int    `json:"share_out_total,omitempty"`
+	DomainTotal   int `json:"domain_total,omitempty"`
+	AllTotal      int `json:"all_total,omitempty"`
+	MineTotal     int `json:"mine_total,omitempty"`
+	ShareTotal    int `json:"share_total,omitempty"`
+	VipTotal      int `json:"vip_total,omitempty"`
+	IsMarkTotal   int `json:"ismark_total,omitempty"`
+	PauseTotal    int `json:"pause_total,omitempty"`
+	ErrorTotal    int `json:"error_total,omitempty"`
+	LockTotal     int `json:"lock_total,omitempty"`
+	SpamTotal     int `json:"spam_total,omitempty"`
+	VipExpire     int `json:"vip_expire,omitempty"`
+	ShareOutTotal int `json:"share_out_total,omitempty"`
 }
 
 type Domain struct {

--- a/vendor/github.com/decker502/dnspod-go/domains.go
+++ b/vendor/github.com/decker502/dnspod-go/domains.go
@@ -16,18 +16,18 @@ type DomainsService struct {
 }
 
 type DomainInfo struct {
-	DomainTotal   int    `json:"domain_total,omitempty"`
-	AllTotal      int    `json:"all_total,omitempty"`
-	MineTotal     int    `json:"mine_total,omitempty"`
-	ShareTotal    string `json:"share_total,omitempty"`
-	VipTotal      int    `json:"vip_total,omitempty"`
-	IsMarkTotal   int    `json:"ismark_total,omitempty"`
-	PauseTotal    int    `json:"pause_total,omitempty"`
-	ErrorTotal    int    `json:"error_total,omitempty"`
-	LockTotal     int    `json:"lock_total,omitempty"`
-	SpamTotal     int    `json:"spam_total,omitempty"`
-	VipExpire     int    `json:"vip_expire,omitempty"`
-	ShareOutTotal int    `json:"share_out_total,omitempty"`
+	DomainTotal   json.Number `json:"domain_total,omitempty"`
+	AllTotal      json.Number `json:"all_total,omitempty"`
+	MineTotal     json.Number `json:"mine_total,omitempty"`
+	ShareTotal    json.Number `json:"share_total,omitempty"`
+	VipTotal      json.Number `json:"vip_total,omitempty"`
+	IsMarkTotal   json.Number `json:"ismark_total,omitempty"`
+	PauseTotal    json.Number `json:"pause_total,omitempty"`
+	ErrorTotal    json.Number `json:"error_total,omitempty"`
+	LockTotal     json.Number `json:"lock_total,omitempty"`
+	SpamTotal     json.Number `json:"spam_total,omitempty"`
+	VipExpire     json.Number `json:"vip_expire,omitempty"`
+	ShareOutTotal json.Number `json:"share_out_total,omitempty"`
 }
 
 type Domain struct {

--- a/vendor/github.com/decker502/dnspod-go/domains.go
+++ b/vendor/github.com/decker502/dnspod-go/domains.go
@@ -16,18 +16,18 @@ type DomainsService struct {
 }
 
 type DomainInfo struct {
-	DomainTotal   int `json:"domain_total,omitempty"`
-	AllTotal      int `json:"all_total,omitempty"`
-	MineTotal     int `json:"mine_total,omitempty"`
-	ShareTotal    int `json:"share_total,omitempty"`
-	VipTotal      int `json:"vip_total,omitempty"`
-	IsMarkTotal   int `json:"ismark_total,omitempty"`
-	PauseTotal    int `json:"pause_total,omitempty"`
-	ErrorTotal    int `json:"error_total,omitempty"`
-	LockTotal     int `json:"lock_total,omitempty"`
-	SpamTotal     int `json:"spam_total,omitempty"`
-	VipExpire     int `json:"vip_expire,omitempty"`
-	ShareOutTotal int `json:"share_out_total,omitempty"`
+	DomainTotal   int    `json:"domain_total,omitempty"`
+	AllTotal      int    `json:"all_total,omitempty"`
+	MineTotal     int    `json:"mine_total,omitempty"`
+	ShareTotal    string `json:"share_total,omitempty"`
+	VipTotal      int    `json:"vip_total,omitempty"`
+	IsMarkTotal   int    `json:"ismark_total,omitempty"`
+	PauseTotal    int    `json:"pause_total,omitempty"`
+	ErrorTotal    int    `json:"error_total,omitempty"`
+	LockTotal     int    `json:"lock_total,omitempty"`
+	SpamTotal     int    `json:"spam_total,omitempty"`
+	VipExpire     int    `json:"vip_expire,omitempty"`
+	ShareOutTotal int    `json:"share_out_total,omitempty"`
 }
 
 type Domain struct {


### PR DESCRIPTION
### What does this PR do?

Fix dnspod certificate update.


### Motivation

I have encountered this problem. The certificate cannot be update correctly.

### Issue log

```
acme: error cleaning up: API call failed: json: cannot unmarshal number into Go struct field DomainInfo.share_total of type string
```

### Additional Notes

Dnspod updated API struct. `DomainInfo.ShareTotal` from `string` to `int`.