### PR TITLE
Allow wildcard hosts in ingress provider

### DIFF
--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-wildcard-host_endpoint.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-wildcard-host_endpoint.yml
@@ -1,0 +1,11 @@
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+subsets:
+- addresses:
+  - ip: 10.10.0.1
+  ports:
+  - port: 8080

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-wildcard-host_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-wildcard-host_ingress.yml
@@ -1,0 +1,15 @@
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: ""
+  namespace: testing
+
+spec:
+  rules:
+  - host: "*.foobar.com"
+    http:
+      paths:
+      - path: /bar
+        backend:
+          serviceName: service1
+          servicePort: 80

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-wildcard-host_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-wildcard-host_service.yml
@@ -1,0 +1,11 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+spec:
+  ports:
+  - port: 80
+  clusterIp: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -339,7 +339,7 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 					serviceName := provider.Normalize(ingress.Namespace + "-" + p.Backend.ServiceName + "-" + p.Backend.ServicePort.String())
 					var rules []string
 					if len(rule.Host) > 0 {
-						rules = []string{"Host(`" + rule.Host + "`)"}
+						rules = append(rules, buildHostRule(rule.Host))
 					}
 
 					if len(p.Path) > 0 {
@@ -379,6 +379,14 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 	}
 
 	return conf
+}
+
+func buildHostRule(host string) string {
+	if strings.HasPrefix(host, "*.") {
+		return "HostRegexp(`" + strings.Replace(host, "*.", "{subdomain:[a-zA-Z0-9-]+}.", 1) + "`)"
+	}
+
+	return "Host(`" + host + "`)"
 }
 
 func shouldProcessIngress(ingressClass string, ingressClassAnnotation string) bool {

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -928,6 +928,35 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "Ingress with wildcard host",
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{},
+				HTTP: &dynamic.HTTPConfiguration{
+					Middlewares: map[string]*dynamic.Middleware{},
+					Routers: map[string]*dynamic.Router{
+						"foobar-com-bar": {
+							Rule:    "HostRegexp(`{subdomain:[a-zA-Z0-9-]+}.foobar.com`) && PathPrefix(`/bar`)",
+							Service: "testing-service1-80",
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"testing-service1-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								PassHostHeader: Bool(true),
+								Servers: []dynamic.Server{
+									{
+										URL:    "http://10.10.0.1:8080",
+										Scheme: "",
+										Port:   "",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

Tests the host in an ingress for a wildcard host prefix, and builds a HostRegexp rule instead of a Host rule.

### Motivation

Fixes #6250 

### More

- [x] Added/updated tests
- [x] Added/updated documentation - None needed, bugfix
