### PR TITLE
Documentation fix for acme.md CLI

### DIFF
--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -379,7 +379,7 @@ certificatesResolvers:
 
 ```bash tab="CLI"
 # ...
---certificatesResolvers.le.acme.dnsChallenge.resolvers:=1.1.1.1:53,8.8.8.8:53
+--certificatesResolvers.le.acme.dnsChallenge.resolvers="1.1.1.1:53,8.8.8.8:53"
 ```
 
 #### Wildcard Domains

--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -379,7 +379,7 @@ certificatesResolvers:
 
 ```bash tab="CLI"
 # ...
---certificatesResolvers.le.acme.dnsChallenge.resolvers="1.1.1.1:53,8.8.8.8:53"
+--certificatesResolvers.le.acme.dnsChallenge.resolvers=1.1.1.1:53,8.8.8.8:53
 ```
 
 #### Wildcard Domains


### PR DESCRIPTION
### What does this PR do?

Small documentation fix to change

```
--certificatesResolvers.le.acme.dnsChallenge.resolvers:=1.1.1.1:53,8.8.8.8:53
```
to
```
--certificatesResolvers.le.acme.dnsChallenge.resolvers=1.1.1.1:53,8.8.8.8:53
```

### Motivation

The existing documentation is wrong and results in the syntax error:

> command traefik error: failed to decode configuration from flags: field not found, node: resolvers:

### More

- [ ] Added/updated tests
- [x] Added/updated documentation