### PR TITLE
Add consul catalog filtering to v2

### DIFF
--- a/docs/content/providers/consul-catalog.md
+++ b/docs/content/providers/consul-catalog.md
@@ -158,6 +158,32 @@ providers:
 
 Use local agent caching for catalog reads.
 
+### `filter`
+
+_Optional_
+
+```toml tab="File (TOML)"
+[providers.consulCatalog]
+  filter = "traefik.enable=true in ServiceTags"
+  # ...
+```
+
+```yaml tab="File (YAML)
+providers:
+  consulCatalog:
+    filter: "traefik.enable=true in ServiceTags"
+    # ...
+```
+
+```bash tab="CLI"
+--providers.consulcatalog.filter="traefik.enable=true in ServiceTags"
+# ...
+```
+
+Defines the Consul filter to send to the server.  See more details at https://www.consul.io/api/features/filtering.html.
+
+Suggested for deployments with large catalogs.
+
 ### `endpoint`
 
 Defines the Consul server endpoint.

--- a/pkg/provider/consulcatalog/consul_catalog.go
+++ b/pkg/provider/consulcatalog/consul_catalog.go
@@ -206,7 +206,7 @@ func (p *Provider) fetchService(ctx context.Context, name string) ([]*api.Catalo
 }
 
 func (p *Provider) fetchServices(ctx context.Context) (map[string][]string, error) {
-	opts := &api.QueryOptions{AllowStale: p.Stale, RequireConsistent: p.RequireConsistent, UseCache: p.Cache, Filter: p.Filter}
+	opts := &api.QueryOptions{AllowStale: p.Stale, RequireConsistent: p.RequireConsistent, UseCache: p.Cache}
 	serviceNames, _, err := p.client.Catalog().Services(opts)
 	return serviceNames, err
 }

--- a/pkg/provider/consulcatalog/consul_catalog.go
+++ b/pkg/provider/consulcatalog/consul_catalog.go
@@ -44,6 +44,7 @@ type Provider struct {
 	Stale             bool            `description:"Use stale consistency for catalog reads." json:"stale,omitempty" toml:"stale,omitempty" yaml:"stale,omitempty" export:"true"`
 	Cache             bool            `description:"Use local agent caching for catalog reads." json:"cache,omitempty" toml:"cache,omitempty" yaml:"cache,omitempty" export:"true"`
 	ExposedByDefault  bool            `description:"Expose containers by default." json:"exposedByDefault,omitempty" toml:"exposedByDefault,omitempty" yaml:"exposedByDefault,omitempty" export:"true"`
+	Filter            string          `description:"Filter to pass to Consul servers" export:"true"`
 	DefaultRule       string          `description:"Default rule." json:"defaultRule,omitempty" toml:"defaultRule,omitempty" yaml:"defaultRule,omitempty"`
 
 	client         *api.Client
@@ -193,7 +194,7 @@ func (p *Provider) fetchService(ctx context.Context, name string) ([]*api.Catalo
 		tagFilter = p.Prefix + ".enable=true"
 	}
 
-	opts := &api.QueryOptions{AllowStale: p.Stale, RequireConsistent: p.RequireConsistent, UseCache: p.Cache}
+	opts := &api.QueryOptions{AllowStale: p.Stale, RequireConsistent: p.RequireConsistent, UseCache: p.Cache, Filter: p.Filter}
 
 	consulServices, _, err := p.client.Catalog().Service(name, tagFilter, opts)
 	if err != nil {
@@ -205,7 +206,7 @@ func (p *Provider) fetchService(ctx context.Context, name string) ([]*api.Catalo
 }
 
 func (p *Provider) fetchServices(ctx context.Context) (map[string][]string, error) {
-	opts := &api.QueryOptions{AllowStale: p.Stale, RequireConsistent: p.RequireConsistent, UseCache: p.Cache}
+	opts := &api.QueryOptions{AllowStale: p.Stale, RequireConsistent: p.RequireConsistent, UseCache: p.Cache, Filter: p.Filter}
 	serviceNames, _, err := p.client.Catalog().Services(opts)
 	return serviceNames, err
 }


### PR DESCRIPTION
### What does this PR do?

Adds https://www.consul.io/api/features/filtering.html to Traefik


### Motivation

At present, Traefik retrieves the entire catalog and then sends two requests (health, and catalog) per service.  This is a way to ensure the traffic sent/received is as small as possible.

### More

- [x] Added/updated documentation

### Additional Notes

Getting the entire catalog is not bad, however getting all services and health of all services may be an issue.  With this change, it allows some endpoints (e.g.: v1/catalog/service/foo) to return `[]` if the filter is not met.  We have some particularly large services which return hundreds of responses for both service/ and health/ endpoints, and simply returning `[]` would be nicer.

Unfortunately the actual catalog itself does not have a filter endpoint outside some node-level filtering.

I would like to propose a followup of filtering the actual catalog/services endpoint within the code itself as well.  This would not be too difficult, as the entire response body of it is a json blob with keys of service names, and tags inside of them.  I believe this would be best done inside of the `fetchServices` function, with another new config flag (I propose "catalogFilter").
