### PR TITLE
don't create http client for each request in forwardAuth middleware

### DIFF
--- a/pkg/middlewares/auth/forward.go
+++ b/pkg/middlewares/auth/forward.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/containous/traefik/v2/pkg/config/dynamic"
 	"github.com/containous/traefik/v2/pkg/log"
@@ -49,6 +50,7 @@ func NewForward(ctx context.Context, next http.Handler, config dynamic.ForwardAu
 		CheckRedirect: func(r *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
+		Timeout: 30 * time.Second,
 	}
 
 	if config.TLS != nil {
@@ -57,8 +59,9 @@ func NewForward(ctx context.Context, next http.Handler, config dynamic.ForwardAu
 			return nil, err
 		}
 
-		fa.client.Transport = http.DefaultTransport.(*http.Transport).Clone()
-		fa.client.Transport.(*http.Transport).TLSClientConfig = tlsConfig
+		tr := http.DefaultTransport.(*http.Transport).Clone()
+		tr.TLSClientConfig = tlsConfig
+		fa.client.Transport = tr
 	}
 
 	return fa, nil

--- a/pkg/middlewares/auth/forward.go
+++ b/pkg/middlewares/auth/forward.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -29,7 +28,7 @@ type forwardAuth struct {
 	authResponseHeaders []string
 	next                http.Handler
 	name                string
-	tlsConfig           *tls.Config
+	client              http.Client
 	trustForwardHeader  bool
 }
 
@@ -45,13 +44,21 @@ func NewForward(ctx context.Context, next http.Handler, config dynamic.ForwardAu
 		trustForwardHeader:  config.TrustForwardHeader,
 	}
 
+	// Ensure our request client does not follow redirects
+	fa.client = http.Client{
+		CheckRedirect: func(r *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
 	if config.TLS != nil {
 		tlsConfig, err := config.TLS.CreateTLSConfig()
 		if err != nil {
 			return nil, err
 		}
 
-		fa.tlsConfig = tlsConfig
+		fa.client.Transport = http.DefaultTransport.(*http.Transport).Clone()
+		fa.client.Transport.(*http.Transport).TLSClientConfig = tlsConfig
 	}
 
 	return fa, nil
@@ -63,19 +70,6 @@ func (fa *forwardAuth) GetTracingInformation() (string, ext.SpanKindEnum) {
 
 func (fa *forwardAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	logger := log.FromContext(middlewares.GetLoggerCtx(req.Context(), fa.name, forwardedTypeName))
-
-	// Ensure our request client does not follow redirects
-	httpClient := http.Client{
-		CheckRedirect: func(r *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
-
-	if fa.tlsConfig != nil {
-		httpClient.Transport = &http.Transport{
-			TLSClientConfig: fa.tlsConfig,
-		}
-	}
 
 	forwardReq, err := http.NewRequest(http.MethodGet, fa.address, nil)
 	tracing.LogRequest(tracing.GetSpan(req), forwardReq)
@@ -94,7 +88,7 @@ func (fa *forwardAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	writeHeader(req, forwardReq, fa.trustForwardHeader)
 
-	forwardResponse, forwardErr := httpClient.Do(forwardReq)
+	forwardResponse, forwardErr := fa.client.Do(forwardReq)
 	if forwardErr != nil {
 		logMessage := fmt.Sprintf("Error calling %s. Cause: %s", fa.address, forwardErr)
 		logger.Debug(logMessage)


### PR DESCRIPTION
### What does this PR do?
This PR changes the way to create the http client in the forward auth middleware.
Before this modification, the http client was created for each request. When it was done without configuring tls, it was not a big problem, because we reused the `http.DefaultTransport` but when tls was activated, the` http.Transport` was created in each request, and that automatically creates a new connection to the forward auth server, and since we have not configured an expiration time on the idle connection on these transports, we have kept the connections open forever.

### Motivation

Fixes #6229 
