### PR TITLE
Consul Catalog to read the token from the env

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ _(But if you'd rather configure some of your routes manually, Traefik supports t
 
 - [Docker](https://docs.traefik.io/providers/docker/) / [Swarm mode](https://docs.traefik.io/providers/docker/)
 - [Kubernetes](https://docs.traefik.io/providers/kubernetes-crd/)
+- [Consul Catalog](https://docs.traefik.io/providers/consul-catalog/)
 - [Marathon](https://docs.traefik.io/providers/marathon/)
 - [Rancher](https://docs.traefik.io/providers/rancher/) (Metadata)
 - [File](https://docs.traefik.io/providers/file/)

--- a/docs/content/providers/consul-catalog.md
+++ b/docs/content/providers/consul-catalog.md
@@ -265,7 +265,7 @@ providers:
 # ...
 ```
 
-Token is used to provide a per-request ACL token which overrides the agent's default token.
+Token is used to provide a per-request ACL token which overrides the agent's default token. The environment variable `CONSUL_HTTP_TOKEN` will be used alternatively.
 
 #### `endpointWaitTime`
 

--- a/pkg/provider/consulcatalog/consul_catalog.go
+++ b/pkg/provider/consulcatalog/consul_catalog.go
@@ -3,6 +3,7 @@ package consulcatalog
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"text/template"
 	"time"
@@ -217,6 +218,10 @@ func createClient(cfg *EndpointConfig) (*api.Client, error) {
 		Datacenter: cfg.DataCenter,
 		WaitTime:   time.Duration(cfg.EndpointWaitTime),
 		Token:      cfg.Token,
+	}
+
+	if config.Token == "" {
+		config.Token = os.Getenv("CONSUL_HTTP_TOKEN")
 	}
 
 	if cfg.HTTPAuth != nil {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

The Consul Catalog token will be read from the environment using the usual name `CONSUL_HTTP_TOKEN`. It's usually not a big secret but it feels nicer to have it separately from the rest of the configuration (if needed)

<!-- A brief description of the change being made with this pull request. -->


### Motivation

<!-- What inspired you to submit this pull request? -->

I didn't like having a secret in my config.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Any recommendations on how to set up a test for this?

<!-- Anything else we should know when reviewing? -->
