### PR TITLE
don't create http client in each request in forward auth

### DIFF
--- a/middlewares/auth/forward.go
+++ b/middlewares/auth/forward.go
@@ -18,7 +18,7 @@ const (
 	xForwardedMethod = "X-Forwarded-Method"
 )
 
-// Forward the authentication to a external server
+// Forward the authentication to an external server
 func Forward(config *types.Forward, httpClient http.Client, w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	forwardReq, err := http.NewRequest(http.MethodGet, config.Address, http.NoBody)
 	tracing.LogRequest(tracing.GetSpan(r), forwardReq)

--- a/middlewares/auth/forward.go
+++ b/middlewares/auth/forward.go
@@ -19,27 +19,7 @@ const (
 )
 
 // Forward the authentication to a external server
-func Forward(config *types.Forward, w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-	// Ensure our request client does not follow redirects
-	httpClient := http.Client{
-		CheckRedirect: func(r *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
-
-	if config.TLS != nil {
-		tlsConfig, err := config.TLS.CreateTLSConfig()
-		if err != nil {
-			tracing.SetErrorAndDebugLog(r, "Unable to configure TLS to call %s. Cause %s", config.Address, err)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-
-		httpClient.Transport = &http.Transport{
-			TLSClientConfig: tlsConfig,
-		}
-	}
-
+func Forward(config *types.Forward, httpClient http.Client, w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	forwardReq, err := http.NewRequest(http.MethodGet, config.Address, http.NoBody)
 	tracing.LogRequest(tracing.GetSpan(r), forwardReq)
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

Same as #6267 but for v1.7

This PR changes the way to create the http client in the forward auth middleware.
Before this modification, the http client was created for each request. When it was done without configuring tls, it was not a big problem, because we reused the `http.DefaultTransport` but when tls was activated, the` http.Transport` was created in each request, and that automatically creates a new connection to the forward auth server, and since we have not configured an expiration time on the idle connection on these transports, we have kept the connections open forever.

### Motivation

Fixes #6229 
