### PR TITLE
fix: return an error when ping is not enabled.

### DIFF
--- a/pkg/server/service/managerfactory.go
+++ b/pkg/server/service/managerfactory.go
@@ -49,6 +49,9 @@ func NewManagerFactory(staticConfiguration static.Configuration, routinesPool *s
 		factory.metricsHandler = metrics.PrometheusHandler()
 	}
 
+	// This check is necessary because even when staticConfiguration.Ping == nil ,
+	// the affectation would make factory.pingHandle become a typed nil, which does not pass the nil test,
+	// and would break things elsewhere.
 	if staticConfiguration.Ping != nil {
 		factory.pingHandler = staticConfiguration.Ping
 	}

--- a/pkg/server/service/managerfactory.go
+++ b/pkg/server/service/managerfactory.go
@@ -49,7 +49,9 @@ func NewManagerFactory(staticConfiguration static.Configuration, routinesPool *s
 		factory.metricsHandler = metrics.PrometheusHandler()
 	}
 
-	factory.pingHandler = staticConfiguration.Ping
+	if staticConfiguration.Ping != nil {
+		factory.pingHandler = staticConfiguration.Ping
+	}
 
 	return factory
 }


### PR DESCRIPTION
### What does this PR do?

fix: return an error when ping is not enabled.

### Motivation

Fixes #6297

```
Stack: goroutine 94 [running]:
github.com/containous/traefik/v2/pkg/middlewares/recovery.recoverFunc(0x29c82c0, 0xc000179aa0, 0x29be840, 0xc000424760, 0xc00021ea00)
	/go/src/github.com/containous/traefik/pkg/middlewares/recovery/recovery.go:47 +0x1db
panic(0x211bd20, 0x3fd7e30)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/containous/traefik/v2/pkg/ping.(*Handler).ServeHTTP(0x0, 0x29be840, 0xc000424760, 0xc00021ec00)
	/go/src/github.com/containous/traefik/pkg/ping/ping.go:31 +0x26
github.com/containous/traefik/v2/pkg/middlewares/tracing.(*forwarderMiddleware).ServeHTTP(0xc000272c60, 0x29be840, 0xc000424760, 0xc00021ec00)
	/go/src/github.com/containous/traefik/pkg/middlewares/tracing/forwarder.go:38 +0x610
github.com/containous/traefik/v2/pkg/middlewares/accesslog.(*FieldHandler).ServeHTTP(0xc0005191c0, 0x29be840, 0xc000424760, 0xc00021ec00)
	/go/src/github.com/containous/traefik/pkg/middlewares/accesslog/field_middleware.go:29 +0x18d
github.com/gorilla/mux.(*Router).ServeHTTP(0xc00065f800, 0x29be840, 0xc000424760, 0xc00021ec00)
	/go/pkg/mod/github.com/containous/mux@v0.0.0-20181024131434-c33f32e26898/mux.go:133 +0x104
github.com/containous/traefik/v2/pkg/middlewares/recovery.(*recovery).ServeHTTP(0xc0002b4be0, 0x29be840, 0xc000424760, 0xc00021ea00)
	/go/src/github.com/containous/traefik/pkg/middlewares/recovery/recovery.go:33 +0x131
github.com/containous/traefik/v2/pkg/middlewares/accesslog.(*FieldHandler).ServeHTTP(0xc000519380, 0x29be840, 0xc000424760, 0xc00021ea00)
	/go/src/github.com/containous/traefik/pkg/middlewares/accesslog/field_middleware.go:29 +0x18d
github.com/containous/traefik/v2/pkg/middlewares/requestdecorator.(*RequestDecorator).ServeHTTP(0xc00000f8f0, 0x29be840, 0xc000424760, 0xc00021e900, 0xc0003fec48)
	/go/src/github.com/containous/traefik/pkg/middlewares/requestdecorator/request_decorator.go:47 +0x37d
github.com/containous/traefik/v2/pkg/middlewares/requestdecorator.WrapHandler.func1.1(0x29be840, 0xc000424760, 0xc00021e900)
	/go/src/github.com/containous/traefik/pkg/middlewares/requestdecorator/request_decorator.go:84 +0x83
net/http.HandlerFunc.ServeHTTP(0xc0002b51c0, 0x29be840, 0xc000424760, 0xc00021e900)
	/usr/local/go/src/net/http/server.go:2007 +0x44
github.com/containous/traefik/v2/pkg/middlewares.(*HTTPHandlerSwitcher).ServeHTTP(0xc00000f8e8, 0x29be840, 0xc000424760, 0xc00021e900)
	/go/src/github.com/containous/traefik/pkg/middlewares/handler_switcher.go:23 +0x70
github.com/containous/traefik/v2/pkg/middlewares/forwardedheaders.(*XForwarded).ServeHTTP(0xc000386f50, 0x29be840, 0xc000424760, 0xc00021e900)
	/go/src/github.com/containous/traefik/pkg/middlewares/forwardedheaders/forwarded_header.go:174 +0x10b
net/http.serverHandler.ServeHTTP(0xc000126460, 0x29be840, 0xc000424760, 0xc00021e900)
	/usr/local/go/src/net/http/server.go:2802 +0xa4
net/http.initNPNRequest.ServeHTTP(0x29c82c0, 0xc000588900, 0xc000329180, 0xc000126460, 0x29be840, 0xc000424760, 0xc00021e900)
	/usr/local/go/src/net/http/server.go:3366 +0x8d
net/http.(*http2serverConn).runHandler(0xc0004c3680, 0xc000424760, 0xc00021e900, 0xc0004ee120)
	/usr/local/go/src/net/http/h2_bundle.go:5713 +0x9f
created by net/http.(*http2serverConn).processHeaders
	/usr/local/go/src/net/http/h2_bundle.go:5447 +0x4eb
```

### More

- ~~[ ] Added/updated tests~~
- ~~[ ] Added/updated documentation~~

## Additional Notes

<details>
<summary>docker-compose.yml</summary>

```yml
version: '3.7'

services:
  traefik:
    image: traefik:v2.1.4
    container_name: traefik
    command:
      - --api
      - --log.level=INFO
      - --entryPoints.web.address=:80
      - --providers.docker.exposedByDefault=false
    ports:
      - 80:80
      - 443:443
    volumes:
      - /etc/localtime:/etc/localtime:ro
      - /var/run/docker.sock:/var/run/docker.sock:ro

    labels:
      traefik.enable: true

      traefik.http.routers.ping.rule: Host(`mydomain.localhost`) && Path(`/ping`)
      traefik.http.routers.ping.service: ping@internal
      traefik.http.routers.ping.entrypoints: web
```

</details>