### PR TITLE
Docs: Clarifying format of ingress endpoint service name

### DIFF
--- a/docs/content/providers/kubernetes-ingress.md
+++ b/docs/content/providers/kubernetes-ingress.md
@@ -326,7 +326,8 @@ providers:
 --providers.kubernetesingress.ingressendpoint.publishedservice=namespace/foo-service
 ```
 
-Published Kubernetes Service to copy status from. In the format of `namespace/service`.
+Published Kubernetes Service to copy status from.
+Format: `namespace/servicename`.
 
 ### `throttleDuration`
 

--- a/docs/content/providers/kubernetes-ingress.md
+++ b/docs/content/providers/kubernetes-ingress.md
@@ -310,7 +310,7 @@ _Optional, Default: empty_
 
 ```toml tab="File (TOML)"
 [providers.kubernetesIngress.ingressEndpoint]
-  publishedService = "foo-service"
+  publishedService = "namespace/foo-service"
   # ...
 ```
 
@@ -318,15 +318,15 @@ _Optional, Default: empty_
 providers:
   kubernetesIngress:
     ingressEndpoint:
-      publishedService: "foo-service"
+      publishedService: "namespace/foo-service"
     # ...
 ```
 
 ```bash tab="CLI"
---providers.kubernetesingress.ingressendpoint.publishedservice=foo-service
+--providers.kubernetesingress.ingressendpoint.publishedservice=namespace/foo-service
 ```
 
-Published Kubernetes Service to copy status from.
+Published Kubernetes Service to copy status from. In the format of `namespace/service`.
 
 ### `throttleDuration`
 


### PR DESCRIPTION
### What does this PR do?

Updates a doc page to clarify the format of the value for `providers.kubernetesingress.ingressendpoint.publishedservice`

### Motivation

I used the key=value wrong based on the example. Once I saw the traefik log output saying I needed to enter the value in the format of namespace/service my simple setup worked. I'm assuming for this doc change that it always needs to be in that format for any use of `publishedservice` across TOML/YAML/arg.