### PR TITLE
Improvement of the unique name of the router for Ingress.

### DIFF
--- a/integration/testdata/rawdata-ingress.json
+++ b/integration/testdata/rawdata-ingress.json
@@ -28,19 +28,19 @@
 				"traefik"
 			]
 		},
-		"default-test-ingress-https-whoami-test-https-whoami@kubernetes": {
+		"test-ingress-default-whoami-test-whoami@kubernetes": {
 			"service": "default-whoami-http",
-			"rule": "Host(`whoami.test.https`) \u0026\u0026 PathPrefix(`/whoami`)",
-			"tls": {},
+			"rule": "Host(`whoami.test`) \u0026\u0026 PathPrefix(`/whoami`)",
 			"status": "enabled",
 			"using": [
 				"traefik",
 				"web"
 			]
 		},
-		"default-test-ingress-whoami-test-whoami@kubernetes": {
+		"test-ingress-https-default-whoami-test-https-whoami@kubernetes": {
 			"service": "default-whoami-http",
-			"rule": "Host(`whoami.test`) \u0026\u0026 PathPrefix(`/whoami`)",
+			"rule": "Host(`whoami.test.https`) \u0026\u0026 PathPrefix(`/whoami`)",
+			"tls": {},
 			"status": "enabled",
 			"using": [
 				"traefik",
@@ -100,8 +100,8 @@
 			},
 			"status": "enabled",
 			"usedBy": [
-				"default-test-ingress-https-whoami-test-https-whoami@kubernetes",
-				"default-test-ingress-whoami-test-whoami@kubernetes"
+				"test-ingress-default-whoami-test-whoami@kubernetes",
+				"test-ingress-https-default-whoami-test-https-whoami@kubernetes"
 			],
 			"serverStatus": {
 				"http://10.42.0.3:80": "UP",

--- a/integration/testdata/rawdata-ingress.json
+++ b/integration/testdata/rawdata-ingress.json
@@ -28,7 +28,7 @@
 				"traefik"
 			]
 		},
-		"whoami-test-https-whoami@kubernetes": {
+		"default-test-ingress-https-whoami-test-https-whoami@kubernetes": {
 			"service": "default-whoami-http",
 			"rule": "Host(`whoami.test.https`) \u0026\u0026 PathPrefix(`/whoami`)",
 			"tls": {},
@@ -38,7 +38,7 @@
 				"web"
 			]
 		},
-		"whoami-test-whoami@kubernetes": {
+		"default-test-ingress-whoami-test-whoami@kubernetes": {
 			"service": "default-whoami-http",
 			"rule": "Host(`whoami.test`) \u0026\u0026 PathPrefix(`/whoami`)",
 			"status": "enabled",
@@ -90,22 +90,22 @@
 			"loadBalancer": {
 				"servers": [
 					{
-						"url": "http://10.42.0.4:80"
+						"url": "http://10.42.0.3:80"
 					},
 					{
-						"url": "http://10.42.0.6:80"
+						"url": "http://10.42.0.5:80"
 					}
 				],
 				"passHostHeader": true
 			},
 			"status": "enabled",
 			"usedBy": [
-				"whoami-test-https-whoami@kubernetes",
-				"whoami-test-whoami@kubernetes"
+				"default-test-ingress-https-whoami-test-https-whoami@kubernetes",
+				"default-test-ingress-whoami-test-whoami@kubernetes"
 			],
 			"serverStatus": {
-				"http://10.42.0.4:80": "UP",
-				"http://10.42.0.6:80": "UP"
+				"http://10.42.0.3:80": "UP",
+				"http://10.42.0.5:80": "UP"
 			}
 		}
 	}

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -267,7 +267,7 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 				conf.HTTP.Services[serviceName] = service
 				conf.HTTP.Services[serviceName] = service
 
-				routerKey := strings.TrimPrefix(provider.Normalize(rule.Host+pa.Path), "-")
+				routerKey := strings.TrimPrefix(provider.Normalize(ingress.Namespace+"-"+ingress.Name+"-"+rule.Host+pa.Path), "-")
 				conf.HTTP.Routers[routerKey] = loadRouter(ingress, rule, pa, rtConfig, serviceName)
 			}
 		}

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -267,7 +267,7 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 				conf.HTTP.Services[serviceName] = service
 				conf.HTTP.Services[serviceName] = service
 
-				routerKey := strings.TrimPrefix(provider.Normalize(ingress.Namespace+"-"+ingress.Name+"-"+rule.Host+pa.Path), "-")
+				routerKey := strings.TrimPrefix(provider.Normalize(ingress.Name+"-"+ingress.Namespace+"-"+rule.Host+pa.Path), "-")
 				conf.HTTP.Routers[routerKey] = loadRouter(ingress, rule, pa, rtConfig, serviceName)
 			}
 		}

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -57,7 +57,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"bar": {
+						"testing-bar": {
 							Rule:    "PathPrefix(`/bar`)",
 							Service: "testing-service1-80",
 						},
@@ -87,7 +87,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"bar": {
+						"testing-bar": {
 							Rule:        "Path(`/bar`)",
 							EntryPoints: []string{"ep1", "ep2"},
 							Service:     "testing-service1-80",
@@ -141,11 +141,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"bar": {
+						"testing-bar": {
 							Rule:    "PathPrefix(`/bar`)",
 							Service: "testing-service1-80",
 						},
-						"foo": {
+						"testing-foo": {
 							Rule:    "PathPrefix(`/foo`)",
 							Service: "testing-service1-80",
 						},
@@ -175,11 +175,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"bar": {
+						"testing-bar": {
 							Rule:    "PathPrefix(`/bar`)",
 							Service: "testing-service1-80",
 						},
-						"foo": {
+						"testing-foo": {
 							Rule:    "PathPrefix(`/foo`)",
 							Service: "testing-service1-80",
 						},
@@ -209,7 +209,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"traefik-tchouk-bar": {
+						"testing-traefik-tchouk-bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
 							Service: "testing-service1-80",
 						},
@@ -239,7 +239,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"example-com": {
+						"testing-example-com": {
 							Rule:    "Host(`example.com`)",
 							Service: "testing-example-com-80",
 						},
@@ -266,11 +266,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"traefik-tchouk-bar": {
+						"testing-traefik-tchouk-bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
 							Service: "testing-service1-80",
 						},
-						"traefik-tchouk-foo": {
+						"testing-traefik-tchouk-foo": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/foo`)",
 							Service: "testing-service1-80",
 						},
@@ -300,11 +300,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"traefik-tchouk-bar": {
+						"testing-traefik-tchouk-bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
 							Service: "testing-service1-80",
 						},
-						"traefik-courgette-carotte": {
+						"testing-traefik-courgette-carotte": {
 							Rule:    "Host(`traefik.courgette`) && PathPrefix(`/carotte`)",
 							Service: "testing-service1-80",
 						},
@@ -334,11 +334,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"bar": {
+						"testing-bar": {
 							Rule:    "PathPrefix(`/bar`)",
 							Service: "testing-service1-80",
 						},
-						"foo": {
+						"testing-foo": {
 							Rule:    "PathPrefix(`/foo`)",
 							Service: "testing-service1-80",
 						},
@@ -379,7 +379,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"traefik-courgette-carotte": {
+						"testing-traefik-courgette-carotte": {
 							Rule:    "Host(`traefik.courgette`) && PathPrefix(`/carotte`)",
 							Service: "testing-service1-80",
 						},
@@ -420,11 +420,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"traefik-tchouk-bar": {
+						"testing-traefik-tchouk-bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
 							Service: "testing-service1-80",
 						},
-						"traefik-courgette-carotte": {
+						"testing-traefik-courgette-carotte": {
 							Rule:    "Host(`traefik.courgette`) && PathPrefix(`/carotte`)",
 							Service: "testing-service2-8082",
 						},
@@ -520,7 +520,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"traefik-tchouk-bar": {
+						"testing-traefik-tchouk-bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
 							Service: "testing-service1-80",
 						},
@@ -550,7 +550,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"traefik-tchouk-bar": {
+						"testing-traefik-tchouk-bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
 							Service: "testing-service1-tchouk",
 						},
@@ -580,7 +580,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"traefik-tchouk-bar": {
+						"testing-traefik-tchouk-bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
 							Service: "testing-service1-tchouk",
 						},
@@ -610,11 +610,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"traefik-tchouk-bar": {
+						"testing-traefik-tchouk-bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
 							Service: "testing-service1-tchouk",
 						},
-						"traefik-tchouk-foo": {
+						"testing-traefik-tchouk-foo": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/foo`)",
 							Service: "testing-service1-carotte",
 						},
@@ -657,11 +657,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"traefik-tchouk-bar": {
+						"testing-traefik-tchouk-bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
 							Service: "testing-service1-tchouk",
 						},
-						"toto-traefik-tchouk-bar": {
+						"toto-toto-traefik-tchouk-bar": {
 							Rule:    "Host(`toto.traefik.tchouk`) && PathPrefix(`/bar`)",
 							Service: "toto-service1-tchouk",
 						},
@@ -726,7 +726,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"traefik-tchouk-bar": {
+						"testing-traefik-tchouk-bar": {
 							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
 							Service: "testing-service1-8080",
 						},
@@ -753,7 +753,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"example-com": {
+						"testing-example-com": {
 							Rule:    "Host(`example.com`)",
 							Service: "testing-example-com-80",
 							TLS:     &dynamic.RouterTLSConfig{},
@@ -791,7 +791,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"bar": {
+						"testing-bar": {
 							Rule:    "PathPrefix(`/bar`)",
 							Service: "testing-service1-443",
 						},
@@ -821,7 +821,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"bar": {
+						"testing-bar": {
 							Rule:    "PathPrefix(`/bar`)",
 							Service: "testing-service1-8443",
 						},
@@ -852,7 +852,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 
 					Routers: map[string]*dynamic.Router{
-						"bar": {
+						"testing-bar": {
 							Rule:    "PathPrefix(`/bar`)",
 							Service: "testing-service1-8443",
 						},
@@ -913,7 +913,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"bar": {
+						"testing-bar": {
 							Rule:    "PathPrefix(`/bar`)",
 							Service: "testing-service1-80",
 						},
@@ -987,7 +987,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"foobar-com-bar": {
+						"testing-foobar-com-bar": {
 							Rule:    "HostRegexp(`{subdomain:[a-zA-Z0-9-]+}.foobar.com`) && PathPrefix(`/bar`)",
 							Service: "testing-service1-80",
 						},


### PR DESCRIPTION
### What does this PR do?

Use the namespace and the name of the Ingress to create a more unique router name.

### Motivation

Fixes #6320

### More

- [x] Added/updated tests
- ~~[ ] Added/updated documentation~~
