### PR TITLE
Add UDP in providers with labels

### DIFF
--- a/docs/content/routing/providers/consul-catalog.md
+++ b/docs/content/routing/providers/consul-catalog.md
@@ -364,6 +364,7 @@ You can declare TCP Routers and/or Services using tags.
     ```yaml
     traefik.tcp.services.mytcpservice.loadbalancer.terminationdelay=100
     ```
+
 ### UDP
 
 You can declare UDP Routers and/or Services using tags.
@@ -384,7 +385,7 @@ You can declare UDP Routers and/or Services using tags.
 
 ??? info "`traefik.udp.routers.<router_name>.entrypoints`"
     
-    See [entry points](../routers/index.md#entrypoints_1) for more information.
+    See [entry points](../routers/index.md#entrypoints_2) for more information.
     
     ```yaml
     traefik.udp.routers.myudprouter.entrypoints=ep1,ep2
@@ -392,7 +393,7 @@ You can declare UDP Routers and/or Services using tags.
 
 ??? info "`traefik.udp.routers.<router_name>.service`"
     
-    See [service](../routers/index.md#services) for more information.
+    See [service](../routers/index.md#services_1) for more information.
     
     ```yaml
     traefik.udp.routers.myudprouter.service=myservice

--- a/docs/content/routing/providers/consul-catalog.md
+++ b/docs/content/routing/providers/consul-catalog.md
@@ -364,6 +364,49 @@ You can declare TCP Routers and/or Services using tags.
     ```yaml
     traefik.tcp.services.mytcpservice.loadbalancer.terminationdelay=100
     ```
+### UDP
+
+You can declare UDP Routers and/or Services using tags.
+
+??? example "Declaring UDP Routers and Services"
+
+    ```yaml
+    traefik.udp.routers.my-router.entrypoints=udp
+    traefik.udp.services.my-service.loadbalancer.server.port=4123
+    ```
+
+!!! warning "UDP and HTTP"
+
+    If you declare a UDP Router/Service, it will prevent Traefik from automatically creating an HTTP Router/Service (like it does by default if no UDP Router/Service is defined).
+    You can declare both a UDP Router/Service and an HTTP Router/Service for the same consul service (but you have to do so manually).
+
+#### UDP Routers
+
+??? info "`traefik.udp.routers.<router_name>.entrypoints`"
+    
+    See [entry points](../routers/index.md#entrypoints_1) for more information.
+    
+    ```yaml
+    traefik.udp.routers.myudprouter.entrypoints=ep1,ep2
+    ```
+
+??? info "`traefik.udp.routers.<router_name>.service`"
+    
+    See [service](../routers/index.md#services) for more information.
+    
+    ```yaml
+    traefik.udp.routers.myudprouter.service=myservice
+    ```
+
+#### UDP Services
+
+??? info "`traefik.udp.services.<service_name>.loadbalancer.server.port`"
+    
+    Registers a port of the application.
+    
+    ```yaml
+    traefik.udp.services.myudpservice.loadbalancer.server.port=423
+    ```
 
 ### Specific Provider Options
 

--- a/docs/content/routing/providers/docker.md
+++ b/docs/content/routing/providers/docker.md
@@ -508,6 +508,54 @@ You can declare TCP Routers and/or Services using labels.
     - "traefik.tcp.services.mytcpservice.loadbalancer.terminationdelay=100"
     ```
 
+### UDP
+
+You can declare UDP Routers and/or Services using labels.
+
+??? example "Declaring UDP Routers and Services"
+
+    ```yaml
+       services:
+         my-container:
+           # ...
+           labels:
+             - "traefik.UDP.routers.my-router.entrypoints=mydns"
+             - "traefik.UDP.services.my-service.loadbalancer.server.port=4123"
+    ```
+
+!!! warning "UDP and HTTP"
+
+    If you declare a UDP Router/Service, it will prevent Traefik from automatically creating an HTTP Router/Service (like it does by default if no UDP Router/Service is defined).
+    You can declare both a UDP Router/Service and an HTTP Router/Service for the same container (but you have to do so manually).
+
+#### UDP Routers
+
+??? info "`traefik.UDP.routers.<router_name>.entrypoints`"
+
+    See [entry points](../routers/index.md#entrypoints_1) for more information.
+
+    ```yaml
+    - "traefik.UDP.routers.myUDProuter.entrypoints=ep1,ep2"
+    ```
+
+??? info "`traefik.UDP.routers.<router_name>.service`"
+
+    See [service](../routers/index.md#services) for more information.
+
+    ```yaml
+    - "traefik.UDP.routers.myUDProuter.service=myservice"
+    ```
+
+#### UDP Services
+
+??? info "`traefik.UDP.services.<service_name>.loadbalancer.server.port`"
+
+    Registers a port of the application.
+
+    ```yaml
+    - "traefik.UDP.services.myUDPservice.loadbalancer.server.port=423"
+    ```
+
 ### Specific Provider Options
 
 #### `traefik.enable`

--- a/docs/content/routing/providers/docker.md
+++ b/docs/content/routing/providers/docker.md
@@ -507,7 +507,7 @@ You can declare TCP Routers and/or Services using labels.
     ```yaml
     - "traefik.tcp.services.mytcpservice.loadbalancer.terminationdelay=100"
     ```
-
+    
 ### UDP
 
 You can declare UDP Routers and/or Services using labels.
@@ -519,8 +519,8 @@ You can declare UDP Routers and/or Services using labels.
          my-container:
            # ...
            labels:
-             - "traefik.UDP.routers.my-router.entrypoints=mydns"
-             - "traefik.UDP.services.my-service.loadbalancer.server.port=4123"
+             - "traefik.udp.routers.my-router.entrypoint=udp"
+             - "traefik.udp.services.my-service.loadbalancer.server.port=4123"
     ```
 
 !!! warning "UDP and HTTP"
@@ -530,30 +530,30 @@ You can declare UDP Routers and/or Services using labels.
 
 #### UDP Routers
 
-??? info "`traefik.UDP.routers.<router_name>.entrypoints`"
+??? info "`traefik.udp.routers.<router_name>.entrypoints`"
 
     See [entry points](../routers/index.md#entrypoints_1) for more information.
 
     ```yaml
-    - "traefik.UDP.routers.myUDProuter.entrypoints=ep1,ep2"
+    - "traefik.udp.routers.myudprouter.entrypoints=ep1,ep2"
     ```
 
-??? info "`traefik.UDP.routers.<router_name>.service`"
+??? info "`traefik.udp.routers.<router_name>.service`"
 
     See [service](../routers/index.md#services) for more information.
 
     ```yaml
-    - "traefik.UDP.routers.myUDProuter.service=myservice"
+    - "traefik.udp.routers.myudprouter.service=myservice"
     ```
 
 #### UDP Services
 
-??? info "`traefik.UDP.services.<service_name>.loadbalancer.server.port`"
+??? info "`traefik.udp.services.<service_name>.loadbalancer.server.port`"
 
     Registers a port of the application.
 
     ```yaml
-    - "traefik.UDP.services.myUDPservice.loadbalancer.server.port=423"
+    - "traefik.udp.services.myudpservice.loadbalancer.server.port=423"
     ```
 
 ### Specific Provider Options

--- a/docs/content/routing/providers/docker.md
+++ b/docs/content/routing/providers/docker.md
@@ -507,7 +507,7 @@ You can declare TCP Routers and/or Services using labels.
     ```yaml
     - "traefik.tcp.services.mytcpservice.loadbalancer.terminationdelay=100"
     ```
-    
+
 ### UDP
 
 You can declare UDP Routers and/or Services using labels.
@@ -532,7 +532,7 @@ You can declare UDP Routers and/or Services using labels.
 
 ??? info "`traefik.udp.routers.<router_name>.entrypoints`"
 
-    See [entry points](../routers/index.md#entrypoints_1) for more information.
+    See [entry points](../routers/index.md#entrypoints_2) for more information.
 
     ```yaml
     - "traefik.udp.routers.myudprouter.entrypoints=ep1,ep2"
@@ -540,7 +540,7 @@ You can declare UDP Routers and/or Services using labels.
 
 ??? info "`traefik.udp.routers.<router_name>.service`"
 
-    See [service](../routers/index.md#services) for more information.
+    See [service](../routers/index.md#services_1) for more information.
 
     ```yaml
     - "traefik.udp.routers.myudprouter.service=myservice"

--- a/docs/content/routing/providers/marathon.md
+++ b/docs/content/routing/providers/marathon.md
@@ -405,6 +405,55 @@ You can declare TCP Routers and/or Services using labels.
     "traefik.tcp.services.mytcpservice.loadbalancer.terminationdelay": "100"
     ```
 
+### UDP
+
+You can declare UDP Routers and/or Services using labels.
+
+??? example "Declaring UDP Routers and Services"
+
+    ```json
+	{
+		...
+		"labels": {
+			"traefik.udp.routers.my-router.entrypoints": "udp",
+			"traefik.udp.services.my-service.loadbalancer.server.port": "4123"
+		}
+	}
+    ```
+
+!!! warning "UDP and HTTP"
+
+    If you declare a UDP Router/Service, it will prevent Traefik from automatically creating an HTTP Router/Service (like it does by default if no UDP Router/Service is defined).
+    You can declare both a UDP Router/Service and an HTTP Router/Service for the same container (but you have to do so manually).
+
+#### UDP Routers
+
+??? info "`traefik.udp.routers.<router_name>.entrypoints`"
+    
+    See [entry points](../routers/index.md#entrypoints_1) for more information.
+    
+     ```json
+     "traefik.udp.routers.myudprouter.entrypoints": "ep1,ep2"
+     ```
+
+??? info "`traefik.udp.routers.<router_name>.service`"
+    
+    See [service](../routers/index.md#services) for more information.
+    
+    ```json
+    "traefik.udp.routers.myudprouter.service": "myservice"
+    ```
+
+#### UDP Services
+
+??? info "`traefik.udp.services.<service_name>.loadbalancer.server.port`"
+    
+    Registers a port of the application.
+    
+    ```json
+    "traefik.udp.services.myudpservice.loadbalancer.server.port": "423"
+    ```
+
 ### Specific Provider Options
 
 #### `traefik.enable`

--- a/docs/content/routing/providers/marathon.md
+++ b/docs/content/routing/providers/marathon.md
@@ -430,7 +430,7 @@ You can declare UDP Routers and/or Services using labels.
 
 ??? info "`traefik.udp.routers.<router_name>.entrypoints`"
     
-    See [entry points](../routers/index.md#entrypoints_1) for more information.
+    See [entry points](../routers/index.md#entrypoints_2) for more information.
     
      ```json
      "traefik.udp.routers.myudprouter.entrypoints": "ep1,ep2"
@@ -438,7 +438,7 @@ You can declare UDP Routers and/or Services using labels.
 
 ??? info "`traefik.udp.routers.<router_name>.service`"
     
-    See [service](../routers/index.md#services) for more information.
+    See [service](../routers/index.md#services_1) for more information.
     
     ```json
     "traefik.udp.routers.myudprouter.service": "myservice"

--- a/docs/content/routing/providers/rancher.md
+++ b/docs/content/routing/providers/rancher.md
@@ -432,7 +432,7 @@ You can declare UDP Routers and/or Services using labels.
 
 ??? info "`traefik.udp.routers.<router_name>.entrypoints`"
     
-    See [entry points](../routers/index.md#entrypoints_1) for more information.
+    See [entry points](../routers/index.md#entrypoints_2) for more information.
     
     ```yaml
     - "traefik.udp.routers.myudprouter.entrypoints=ep1,ep2"
@@ -440,7 +440,7 @@ You can declare UDP Routers and/or Services using labels.
 
 ??? info "`traefik.udp.routers.<router_name>.service`"
     
-    See [service](../routers/index.md#services) for more information.
+    See [service](../routers/index.md#services_1) for more information.
     
     ```yaml
     - "traefik.udp.routers.myudprouter.service=myservice"

--- a/docs/content/routing/providers/rancher.md
+++ b/docs/content/routing/providers/rancher.md
@@ -408,6 +408,54 @@ You can declare TCP Routers and/or Services using labels.
     - "traefik.tcp.services.mytcpservice.loadbalancer.terminationdelay=100"
     ```
 
+### UDP
+
+You can declare UDP Routers and/or Services using labels.
+
+??? example "Declaring UDP Routers and Services"
+
+    ```yaml
+       services:
+         my-container:
+           # ...
+           labels:
+             - "traefik.udp.routers.my-router.entrypoints=udp"
+             - "traefik.udp.services.my-service.loadbalancer.server.port=4123"
+    ```
+
+!!! warning "UDP and HTTP"
+
+    If you declare a UDP Router/Service, it will prevent Traefik from automatically creating an HTTP Router/Service (like it does by default if no UDP Router/Service is defined).
+    You can declare both a UDP Router/Service and an HTTP Router/Service for the same container (but you have to do so manually).
+
+#### UDP Routers
+
+??? info "`traefik.udp.routers.<router_name>.entrypoints`"
+    
+    See [entry points](../routers/index.md#entrypoints_1) for more information.
+    
+    ```yaml
+    - "traefik.udp.routers.myudprouter.entrypoints=ep1,ep2"
+    ```
+
+??? info "`traefik.udp.routers.<router_name>.service`"
+    
+    See [service](../routers/index.md#services) for more information.
+    
+    ```yaml
+    - "traefik.udp.routers.myudprouter.service=myservice"
+    ```
+
+#### UDP Services
+
+??? info "`traefik.udp.services.<service_name>.loadbalancer.server.port`"
+    
+    Registers a port of the application.
+    
+    ```yaml
+    - "traefik.udp.services.myudpservice.loadbalancer.server.port=423"
+    ```
+
 ### Specific Provider Options
 
 #### `traefik.enable`

--- a/pkg/config/label/label.go
+++ b/pkg/config/label/label.go
@@ -11,9 +11,10 @@ func DecodeConfiguration(labels map[string]string) (*dynamic.Configuration, erro
 	conf := &dynamic.Configuration{
 		HTTP: &dynamic.HTTPConfiguration{},
 		TCP:  &dynamic.TCPConfiguration{},
+		UDP:  &dynamic.UDPConfiguration{},
 	}
 
-	err := parser.Decode(labels, conf, parser.DefaultRootName, "traefik.http", "traefik.tcp")
+	err := parser.Decode(labels, conf, parser.DefaultRootName, "traefik.http", "traefik.tcp", "traefik.udp")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/label/label_test.go
+++ b/pkg/config/label/label_test.go
@@ -177,6 +177,13 @@ func TestDecodeConfiguration(t *testing.T) {
 		"traefik.tcp.services.Service0.loadbalancer.TerminationDelay":                  "42",
 		"traefik.tcp.services.Service1.loadbalancer.server.Port":                       "42",
 		"traefik.tcp.services.Service1.loadbalancer.TerminationDelay":                  "42",
+
+		"traefik.udp.routers.Router0.entrypoints":                "foobar, fiibar",
+		"traefik.udp.routers.Router0.service":                    "foobar",
+		"traefik.udp.routers.Router1.entrypoints":                "foobar, fiibar",
+		"traefik.udp.routers.Router1.service":                    "foobar",
+		"traefik.udp.services.Service0.loadbalancer.server.Port": "42",
+		"traefik.udp.services.Service1.loadbalancer.server.Port": "42",
 	}
 
 	configuration, err := DecodeConfiguration(labels)
@@ -229,6 +236,44 @@ func TestDecodeConfiguration(t *testing.T) {
 							},
 						},
 						TerminationDelay: func(i int) *int { return &i }(42),
+					},
+				},
+			},
+		},
+		UDP: &dynamic.UDPConfiguration{
+			Routers: map[string]*dynamic.UDPRouter{
+				"Router0": {
+					EntryPoints: []string{
+						"foobar",
+						"fiibar",
+					},
+					Service: "foobar",
+				},
+				"Router1": {
+					EntryPoints: []string{
+						"foobar",
+						"fiibar",
+					},
+					Service: "foobar",
+				},
+			},
+			Services: map[string]*dynamic.UDPService{
+				"Service0": {
+					LoadBalancer: &dynamic.UDPServersLoadBalancer{
+						Servers: []dynamic.UDPServer{
+							{
+								Port: "42",
+							},
+						},
+					},
+				},
+				"Service1": {
+					LoadBalancer: &dynamic.UDPServersLoadBalancer{
+						Servers: []dynamic.UDPServer{
+							{
+								Port: "42",
+							},
+						},
 					},
 				},
 			},
@@ -627,11 +672,51 @@ func TestEncodeConfiguration(t *testing.T) {
 								Port: "42",
 							},
 						},
+						TerminationDelay: func(i int) *int { return &i }(42),
 					},
 				},
 				"Service1": {
 					LoadBalancer: &dynamic.TCPServersLoadBalancer{
 						Servers: []dynamic.TCPServer{
+							{
+								Port: "42",
+							},
+						},
+						TerminationDelay: func(i int) *int { return &i }(42),
+					},
+				},
+			},
+		},
+		UDP: &dynamic.UDPConfiguration{
+			Routers: map[string]*dynamic.UDPRouter{
+				"Router0": {
+					EntryPoints: []string{
+						"foobar",
+						"fiibar",
+					},
+					Service: "foobar",
+				},
+				"Router1": {
+					EntryPoints: []string{
+						"foobar",
+						"fiibar",
+					},
+					Service: "foobar",
+				},
+			},
+			Services: map[string]*dynamic.UDPService{
+				"Service0": {
+					LoadBalancer: &dynamic.UDPServersLoadBalancer{
+						Servers: []dynamic.UDPServer{
+							{
+								Port: "42",
+							},
+						},
+					},
+				},
+				"Service1": {
+					LoadBalancer: &dynamic.UDPServersLoadBalancer{
+						Servers: []dynamic.UDPServer{
 							{
 								Port: "42",
 							},
@@ -1147,18 +1232,27 @@ func TestEncodeConfiguration(t *testing.T) {
 		"traefik.HTTP.Services.Service1.LoadBalancer.server.Scheme":                    "foobar",
 		"traefik.HTTP.Services.Service0.LoadBalancer.HealthCheck.Headers.name0":        "foobar",
 
-		"traefik.TCP.Routers.Router0.Rule":                       "foobar",
-		"traefik.TCP.Routers.Router0.EntryPoints":                "foobar, fiibar",
-		"traefik.TCP.Routers.Router0.Service":                    "foobar",
-		"traefik.TCP.Routers.Router0.TLS.Passthrough":            "false",
-		"traefik.TCP.Routers.Router0.TLS.Options":                "foo",
-		"traefik.TCP.Routers.Router1.Rule":                       "foobar",
-		"traefik.TCP.Routers.Router1.EntryPoints":                "foobar, fiibar",
-		"traefik.TCP.Routers.Router1.Service":                    "foobar",
-		"traefik.TCP.Routers.Router1.TLS.Passthrough":            "false",
-		"traefik.TCP.Routers.Router1.TLS.Options":                "foo",
-		"traefik.TCP.Services.Service0.LoadBalancer.server.Port": "42",
-		"traefik.TCP.Services.Service1.LoadBalancer.server.Port": "42",
+		"traefik.TCP.Routers.Router0.Rule":                            "foobar",
+		"traefik.TCP.Routers.Router0.EntryPoints":                     "foobar, fiibar",
+		"traefik.TCP.Routers.Router0.Service":                         "foobar",
+		"traefik.TCP.Routers.Router0.TLS.Passthrough":                 "false",
+		"traefik.TCP.Routers.Router0.TLS.Options":                     "foo",
+		"traefik.TCP.Routers.Router1.Rule":                            "foobar",
+		"traefik.TCP.Routers.Router1.EntryPoints":                     "foobar, fiibar",
+		"traefik.TCP.Routers.Router1.Service":                         "foobar",
+		"traefik.TCP.Routers.Router1.TLS.Passthrough":                 "false",
+		"traefik.TCP.Routers.Router1.TLS.Options":                     "foo",
+		"traefik.TCP.Services.Service0.LoadBalancer.server.Port":      "42",
+		"traefik.TCP.Services.Service0.LoadBalancer.TerminationDelay": "42",
+		"traefik.TCP.Services.Service1.LoadBalancer.server.Port":      "42",
+		"traefik.TCP.Services.Service1.LoadBalancer.TerminationDelay": "42",
+
+		"traefik.UDP.Routers.Router0.EntryPoints":                "foobar, fiibar",
+		"traefik.UDP.Routers.Router0.Service":                    "foobar",
+		"traefik.UDP.Routers.Router1.EntryPoints":                "foobar, fiibar",
+		"traefik.UDP.Routers.Router1.Service":                    "foobar",
+		"traefik.UDP.Services.Service0.LoadBalancer.server.Port": "42",
+		"traefik.UDP.Services.Service1.LoadBalancer.server.Port": "42",
 	}
 
 	for key, val := range expected {

--- a/pkg/provider/configuration.go
+++ b/pkg/provider/configuration.go
@@ -284,19 +284,20 @@ func BuildTCPRouterConfiguration(ctx context.Context, configuration *dynamic.TCP
 func BuildUDPRouterConfiguration(ctx context.Context, configuration *dynamic.UDPConfiguration) {
 	for routerName, router := range configuration.Routers {
 		loggerRouter := log.FromContext(ctx).WithField(log.RouterName, routerName)
+		if len(router.Service) > 0 {
+			continue
+		}
 
-		if len(router.Service) == 0 {
-			if len(configuration.Services) > 1 {
-				delete(configuration.Routers, routerName)
-				loggerRouter.
-					Error("Could not define the service name for the router: too many services")
-				continue
-			}
+		if len(configuration.Services) > 1 {
+			delete(configuration.Routers, routerName)
+			loggerRouter.
+				Error("Could not define the service name for the router: too many services")
+			continue
+		}
 
-			for serviceName := range configuration.Services {
-				router.Service = serviceName
-				break
-			}
+		for serviceName := range configuration.Services {
+			router.Service = serviceName
+			break
 		}
 	}
 }

--- a/pkg/provider/configuration.go
+++ b/pkg/provider/configuration.go
@@ -139,13 +139,13 @@ func Merge(ctx context.Context, configurations map[string]*dynamic.Configuration
 
 	for serviceName := range servicesUDPToDelete {
 		logger.WithField(log.ServiceName, serviceName).
-			Errorf("Service UDP defined multiple times with different configurations in %v", servicesUDP[serviceName])
+			Errorf("UDP service defined multiple times with different configurations in %v", servicesUDP[serviceName])
 		delete(configuration.UDP.Services, serviceName)
 	}
 
 	for routerName := range routersUDPToDelete {
 		logger.WithField(log.RouterName, routerName).
-			Errorf("Router UDP defined multiple times with different configurations in %v", routersUDP[routerName])
+			Errorf("UDP router defined multiple times with different configurations in %v", routersUDP[routerName])
 		delete(configuration.UDP.Routers, routerName)
 	}
 
@@ -173,7 +173,7 @@ func AddServiceTCP(configuration *dynamic.TCPConfiguration, serviceName string, 
 	return true
 }
 
-// AddServiceUDP Adds a service to a configurations.
+// AddServiceUDP adds a service to a configuration.
 func AddServiceUDP(configuration *dynamic.UDPConfiguration, serviceName string, service *dynamic.UDPService) bool {
 	if _, ok := configuration.Services[serviceName]; !ok {
 		configuration.Services[serviceName] = service
@@ -198,7 +198,7 @@ func AddRouterTCP(configuration *dynamic.TCPConfiguration, routerName string, ro
 	return reflect.DeepEqual(configuration.Routers[routerName], router)
 }
 
-// AddRouterUDP Adds a router to a configurations.
+// AddRouterUDP adds a router to a configuration.
 func AddRouterUDP(configuration *dynamic.UDPConfiguration, routerName string, router *dynamic.UDPRouter) bool {
 	if _, ok := configuration.Routers[routerName]; !ok {
 		configuration.Routers[routerName] = router
@@ -295,6 +295,7 @@ func BuildUDPRouterConfiguration(ctx context.Context, configuration *dynamic.UDP
 
 			for serviceName := range configuration.Services {
 				router.Service = serviceName
+				break
 			}
 		}
 	}

--- a/pkg/provider/consulcatalog/config.go
+++ b/pkg/provider/consulcatalog/config.go
@@ -40,9 +40,9 @@ func (p *Provider) buildConfiguration(ctx context.Context, items []itemData) *dy
 			err := p.buildTCPServiceConfiguration(ctxSvc, item, confFromLabel.TCP)
 			if err != nil {
 				logger.Error(err)
-			} else {
-				provider.BuildTCPRouterConfiguration(ctxSvc, confFromLabel.TCP)
+				continue
 			}
+			provider.BuildTCPRouterConfiguration(ctxSvc, confFromLabel.TCP)
 		}
 
 		if len(confFromLabel.UDP.Routers) > 0 || len(confFromLabel.UDP.Services) > 0 {
@@ -51,9 +51,9 @@ func (p *Provider) buildConfiguration(ctx context.Context, items []itemData) *dy
 			err := p.buildUDPServiceConfiguration(ctxSvc, item, confFromLabel.UDP)
 			if err != nil {
 				logger.Error(err)
-			} else {
-				provider.BuildUDPRouterConfiguration(ctxSvc, confFromLabel.UDP)
+				continue
 			}
+			provider.BuildUDPRouterConfiguration(ctxSvc, confFromLabel.UDP)
 		}
 
 		if tcpOrUDP && len(confFromLabel.HTTP.Routers) == 0 &&

--- a/pkg/provider/consulcatalog/config.go
+++ b/pkg/provider/consulcatalog/config.go
@@ -35,36 +35,32 @@ func (p *Provider) buildConfiguration(ctx context.Context, items []itemData) *dy
 
 		var tcpOrUDP bool
 		if len(confFromLabel.TCP.Routers) > 0 || len(confFromLabel.TCP.Services) > 0 {
+			tcpOrUDP = true
+
 			err := p.buildTCPServiceConfiguration(ctxSvc, item, confFromLabel.TCP)
 			if err != nil {
 				logger.Error(err)
-				continue
+			} else {
+				provider.BuildTCPRouterConfiguration(ctxSvc, confFromLabel.TCP)
 			}
-
-			provider.BuildTCPRouterConfiguration(ctxSvc, confFromLabel.TCP)
-
-			tcpOrUDP = true
 		}
 
 		if len(confFromLabel.UDP.Routers) > 0 || len(confFromLabel.UDP.Services) > 0 {
+			tcpOrUDP = true
+
 			err := p.buildUDPServiceConfiguration(ctxSvc, item, confFromLabel.UDP)
 			if err != nil {
 				logger.Error(err)
-				continue
+			} else {
+				provider.BuildUDPRouterConfiguration(ctxSvc, confFromLabel.UDP)
 			}
-
-			provider.BuildUDPRouterConfiguration(ctxSvc, confFromLabel.UDP)
-
-			tcpOrUDP = true
 		}
 
-		if tcpOrUDP {
-			if len(confFromLabel.HTTP.Routers) == 0 &&
-				len(confFromLabel.HTTP.Middlewares) == 0 &&
-				len(confFromLabel.HTTP.Services) == 0 {
-				configurations[svcName] = confFromLabel
-				continue
-			}
+		if tcpOrUDP && len(confFromLabel.HTTP.Routers) == 0 &&
+			len(confFromLabel.HTTP.Middlewares) == 0 &&
+			len(confFromLabel.HTTP.Services) == 0 {
+			configurations[svcName] = confFromLabel
+			continue
 		}
 
 		err = p.buildServiceConfiguration(ctxSvc, item, confFromLabel.HTTP)

--- a/pkg/provider/consulcatalog/config.go
+++ b/pkg/provider/consulcatalog/config.go
@@ -33,6 +33,7 @@ func (p *Provider) buildConfiguration(ctx context.Context, items []itemData) *dy
 			continue
 		}
 
+		var tcpOrUDP bool
 		if len(confFromLabel.TCP.Routers) > 0 || len(confFromLabel.TCP.Services) > 0 {
 			err := p.buildTCPServiceConfiguration(ctxSvc, item, confFromLabel.TCP)
 			if err != nil {
@@ -42,6 +43,22 @@ func (p *Provider) buildConfiguration(ctx context.Context, items []itemData) *dy
 
 			provider.BuildTCPRouterConfiguration(ctxSvc, confFromLabel.TCP)
 
+			tcpOrUDP = true
+		}
+
+		if len(confFromLabel.UDP.Routers) > 0 || len(confFromLabel.UDP.Services) > 0 {
+			err := p.buildUDPServiceConfiguration(ctxSvc, item, confFromLabel.UDP)
+			if err != nil {
+				logger.Error(err)
+				continue
+			}
+
+			provider.BuildUDPRouterConfiguration(ctxSvc, confFromLabel.UDP)
+
+			tcpOrUDP = true
+		}
+
+		if tcpOrUDP {
 			if len(confFromLabel.HTTP.Routers) == 0 &&
 				len(confFromLabel.HTTP.Middlewares) == 0 &&
 				len(confFromLabel.HTTP.Services) == 0 {
@@ -121,6 +138,28 @@ func (p *Provider) buildTCPServiceConfiguration(ctx context.Context, item itemDa
 	return nil
 }
 
+func (p *Provider) buildUDPServiceConfiguration(ctx context.Context, item itemData, configuration *dynamic.UDPConfiguration) error {
+	if len(configuration.Services) == 0 {
+		configuration.Services = make(map[string]*dynamic.UDPService)
+
+		lb := &dynamic.UDPServersLoadBalancer{}
+
+		configuration.Services[item.Name] = &dynamic.UDPService{
+			LoadBalancer: lb,
+		}
+	}
+
+	for name, service := range configuration.Services {
+		ctxSvc := log.With(ctx, log.Str(log.ServiceName, name))
+		err := p.addServerUDP(ctxSvc, item, service.LoadBalancer)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (p *Provider) buildServiceConfiguration(ctx context.Context, item itemData, configuration *dynamic.HTTPConfiguration) error {
 	if len(configuration.Services) == 0 {
 		configuration.Services = make(map[string]*dynamic.Service)
@@ -151,6 +190,33 @@ func (p *Provider) addServerTCP(ctx context.Context, item itemData, loadBalancer
 
 	if len(loadBalancer.Servers) == 0 {
 		loadBalancer.Servers = []dynamic.TCPServer{{}}
+	}
+
+	var port string
+	if item.Port != "" {
+		port = item.Port
+		loadBalancer.Servers[0].Port = ""
+	}
+
+	if port == "" {
+		return errors.New("port is missing")
+	}
+
+	if item.Address == "" {
+		return errors.New("address is missing")
+	}
+
+	loadBalancer.Servers[0].Address = net.JoinHostPort(item.Address, port)
+	return nil
+}
+
+func (p *Provider) addServerUDP(ctx context.Context, item itemData, loadBalancer *dynamic.UDPServersLoadBalancer) error {
+	if loadBalancer == nil {
+		return errors.New("load-balancer is not defined")
+	}
+
+	if len(loadBalancer.Servers) == 0 {
+		loadBalancer.Servers = []dynamic.UDPServer{{}}
 	}
 
 	var port string

--- a/pkg/provider/consulcatalog/config_test.go
+++ b/pkg/provider/consulcatalog/config_test.go
@@ -1840,6 +1840,51 @@ func Test_buildConfiguration(t *testing.T) {
 			},
 		},
 		{
+			desc: "udp with label",
+			items: []itemData{
+				{
+					ID:   "Test",
+					Name: "Test",
+					Labels: map[string]string{
+						"traefik.udp.routers.foo.entrypoints": "mydns",
+					},
+					Address: "127.0.0.1",
+					Port:    "80",
+					Status:  api.HealthPassing,
+				},
+			},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers: map[string]*dynamic.UDPRouter{
+						"foo": {
+							Service:     "Test",
+							EntryPoints: []string{"mydns"},
+						},
+					},
+					Services: map[string]*dynamic.UDPService{
+						"Test": {
+							LoadBalancer: &dynamic.UDPServersLoadBalancer{
+								Servers: []dynamic.UDPServer{
+									{
+										Address: "127.0.0.1:80",
+									},
+								},
+							},
+						},
+					},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:     map[string]*dynamic.Router{},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services:    map[string]*dynamic.Service{},
+				},
+			},
+		},
+		{
 			desc: "tcp with label without rule",
 			items: []itemData{
 				{
@@ -1923,6 +1968,52 @@ func Test_buildConfiguration(t *testing.T) {
 				UDP: &dynamic.UDPConfiguration{
 					Routers:  map[string]*dynamic.UDPRouter{},
 					Services: map[string]*dynamic.UDPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:     map[string]*dynamic.Router{},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services:    map[string]*dynamic.Service{},
+				},
+			},
+		},
+		{
+			desc: "udp with label and port",
+			items: []itemData{
+				{
+					ID:   "Test",
+					Name: "Test",
+					Labels: map[string]string{
+						"traefik.udp.routers.foo.entrypoints":               "mydns",
+						"traefik.udp.services.foo.loadbalancer.server.port": "80",
+					},
+					Address: "127.0.0.1",
+					Port:    "80",
+					Status:  api.HealthPassing,
+				},
+			},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers: map[string]*dynamic.UDPRouter{
+						"foo": {
+							Service:     "foo",
+							EntryPoints: []string{"mydns"},
+						},
+					},
+					Services: map[string]*dynamic.UDPService{
+						"foo": {
+							LoadBalancer: &dynamic.UDPServersLoadBalancer{
+								Servers: []dynamic.UDPServer{
+									{
+										Address: "127.0.0.1:80",
+									},
+								},
+							},
+						},
+					},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers:     map[string]*dynamic.Router{},
@@ -2017,6 +2108,87 @@ func Test_buildConfiguration(t *testing.T) {
 			},
 		},
 		{
+			desc: "udp with label and port and http service",
+			items: []itemData{
+				{
+					ID:   "1",
+					Name: "Test",
+					Labels: map[string]string{
+						"traefik.udp.routers.foo.entrypoints":                        "mydns",
+						"traefik.udp.services.foo.loadbalancer.server.port":          "80",
+						"traefik.http.services.Service1.loadbalancer.passhostheader": "true",
+					},
+					Address: "127.0.0.1",
+					Port:    "80",
+					Status:  api.HealthPassing,
+				},
+				{
+					ID:   "2",
+					Name: "Test",
+					Labels: map[string]string{
+						"traefik.udp.routers.foo.entrypoints":                        "mydns",
+						"traefik.udp.services.foo.loadbalancer.server.port":          "80",
+						"traefik.http.services.Service1.loadbalancer.passhostheader": "true",
+					},
+					Address: "127.0.0.2",
+					Port:    "80",
+					Status:  api.HealthPassing,
+				},
+			},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers: map[string]*dynamic.UDPRouter{
+						"foo": {
+							Service:     "foo",
+							EntryPoints: []string{"mydns"},
+						},
+					},
+					Services: map[string]*dynamic.UDPService{
+						"foo": {
+							LoadBalancer: &dynamic.UDPServersLoadBalancer{
+								Servers: []dynamic.UDPServer{
+									{
+										Address: "127.0.0.1:80",
+									},
+									{
+										Address: "127.0.0.2:80",
+									},
+								},
+							},
+						},
+					},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"Test": {
+							Service: "Service1",
+							Rule:    "Host(`Test.traefik.wtf`)",
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"Service1": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://127.0.0.1:80",
+									},
+									{
+										URL: "http://127.0.0.2:80",
+									},
+								},
+								PassHostHeader: Bool(true),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			desc: "tcp with label for tcp service",
 			items: []itemData{
 				{
@@ -2049,6 +2221,46 @@ func Test_buildConfiguration(t *testing.T) {
 				UDP: &dynamic.UDPConfiguration{
 					Routers:  map[string]*dynamic.UDPRouter{},
 					Services: map[string]*dynamic.UDPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:     map[string]*dynamic.Router{},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services:    map[string]*dynamic.Service{},
+				},
+			},
+		},
+		{
+			desc: "udp with label for tcp service",
+			items: []itemData{
+				{
+					ID:   "Test",
+					Name: "Test",
+					Labels: map[string]string{
+						"traefik.udp.services.foo.loadbalancer.server.port": "80",
+					},
+					Address: "127.0.0.1",
+					Port:    "80",
+					Status:  api.HealthPassing,
+				},
+			},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers: map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{
+						"foo": {
+							LoadBalancer: &dynamic.UDPServersLoadBalancer{
+								Servers: []dynamic.UDPServer{
+									{
+										Address: "127.0.0.1:80",
+									},
+								},
+							},
+						},
+					},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers:     map[string]*dynamic.Router{},

--- a/pkg/provider/docker/config.go
+++ b/pkg/provider/docker/config.go
@@ -36,32 +36,32 @@ func (p *Provider) buildConfiguration(ctx context.Context, containersInspected [
 
 		var tcpOrUDP bool
 		if len(confFromLabel.TCP.Routers) > 0 || len(confFromLabel.TCP.Services) > 0 {
+			tcpOrUDP = true
+
 			err := p.buildTCPServiceConfiguration(ctxContainer, container, confFromLabel.TCP)
 			if err != nil {
 				logger.Error(err)
-				continue
+			} else {
+				provider.BuildTCPRouterConfiguration(ctxContainer, confFromLabel.TCP)
 			}
-			provider.BuildTCPRouterConfiguration(ctxContainer, confFromLabel.TCP)
-			tcpOrUDP = true
 		}
 
 		if len(confFromLabel.UDP.Routers) > 0 || len(confFromLabel.UDP.Services) > 0 {
+			tcpOrUDP = true
+
 			err := p.buildUDPServiceConfiguration(ctxContainer, container, confFromLabel.UDP)
 			if err != nil {
 				logger.Error(err)
-				continue
+			} else {
+				provider.BuildUDPRouterConfiguration(ctxContainer, confFromLabel.UDP)
 			}
-			provider.BuildUDPRouterConfiguration(ctxContainer, confFromLabel.UDP)
-			tcpOrUDP = true
 		}
 
-		if tcpOrUDP {
-			if len(confFromLabel.HTTP.Routers) == 0 &&
-				len(confFromLabel.HTTP.Middlewares) == 0 &&
-				len(confFromLabel.HTTP.Services) == 0 {
-				configurations[containerName] = confFromLabel
-				continue
-			}
+		if tcpOrUDP && len(confFromLabel.HTTP.Routers) == 0 &&
+			len(confFromLabel.HTTP.Middlewares) == 0 &&
+			len(confFromLabel.HTTP.Services) == 0 {
+			configurations[containerName] = confFromLabel
+			continue
 		}
 
 		err = p.buildServiceConfiguration(ctxContainer, container, confFromLabel.HTTP)

--- a/pkg/provider/docker/config.go
+++ b/pkg/provider/docker/config.go
@@ -41,9 +41,9 @@ func (p *Provider) buildConfiguration(ctx context.Context, containersInspected [
 			err := p.buildTCPServiceConfiguration(ctxContainer, container, confFromLabel.TCP)
 			if err != nil {
 				logger.Error(err)
-			} else {
-				provider.BuildTCPRouterConfiguration(ctxContainer, confFromLabel.TCP)
+				continue
 			}
+			provider.BuildTCPRouterConfiguration(ctxContainer, confFromLabel.TCP)
 		}
 
 		if len(confFromLabel.UDP.Routers) > 0 || len(confFromLabel.UDP.Services) > 0 {
@@ -52,9 +52,9 @@ func (p *Provider) buildConfiguration(ctx context.Context, containersInspected [
 			err := p.buildUDPServiceConfiguration(ctxContainer, container, confFromLabel.UDP)
 			if err != nil {
 				logger.Error(err)
-			} else {
-				provider.BuildUDPRouterConfiguration(ctxContainer, confFromLabel.UDP)
+				continue
 			}
+			provider.BuildUDPRouterConfiguration(ctxContainer, confFromLabel.UDP)
 		}
 
 		if tcpOrUDP && len(confFromLabel.HTTP.Routers) == 0 &&

--- a/pkg/provider/kv/kv_test.go
+++ b/pkg/provider/kv/kv_test.go
@@ -224,6 +224,16 @@ func Test_buildConfiguration(t *testing.T) {
 		"traefik/tcp/services/TCPService02/weighted/services/0/weight":                               "42",
 		"traefik/tcp/services/TCPService02/weighted/services/1/name":                                 "foobar",
 		"traefik/tcp/services/TCPService02/weighted/services/1/weight":                               "43",
+		"traefik/udp/routers/UDPRouter0/entrypoints/0":                                               "foobar",
+		"traefik/udp/routers/UDPRouter0/entrypoints/1":                                               "foobar",
+		"traefik/udp/routers/UDPRouter0/service":                                                     "foobar",
+		"traefik/udp/routers/UDPRouter1/entrypoints/0":                                               "foobar",
+		"traefik/udp/routers/UDPRouter1/entrypoints/1":                                               "foobar",
+		"traefik/udp/routers/UDPRouter1/service":                                                     "foobar",
+		"traefik/udp/services/UDPService01/loadBalancer/servers/0/address":                           "foobar",
+		"traefik/udp/services/UDPService01/loadBalancer/servers/1/address":                           "foobar",
+		"traefik/udp/services/UDPService02/loadBalancer/servers/0/address":                           "foobar",
+		"traefik/udp/services/UDPService02/loadBalancer/servers/1/address":                           "foobar",
 		"traefik/tls/options/Options0/minVersion":                                                    "foobar",
 		"traefik/tls/options/Options0/maxVersion":                                                    "foobar",
 		"traefik/tls/options/Options0/cipherSuites/0":                                                "foobar",
@@ -735,6 +745,36 @@ func Test_buildConfiguration(t *testing.T) {
 								Name:   "foobar",
 								Weight: func(v int) *int { return &v }(43),
 							},
+						},
+					},
+				},
+			},
+		},
+		UDP: &dynamic.UDPConfiguration{
+			Routers: map[string]*dynamic.UDPRouter{
+				"UDPRouter0": {
+					EntryPoints: []string{"foobar", "foobar"},
+					Service:     "foobar",
+				},
+				"UDPRouter1": {
+					EntryPoints: []string{"foobar", "foobar"},
+					Service:     "foobar",
+				},
+			},
+			Services: map[string]*dynamic.UDPService{
+				"UDPService01": {
+					LoadBalancer: &dynamic.UDPServersLoadBalancer{
+						Servers: []dynamic.UDPServer{
+							{Address: "foobar"},
+							{Address: "foobar"},
+						},
+					},
+				},
+				"UDPService02": {
+					LoadBalancer: &dynamic.UDPServersLoadBalancer{
+						Servers: []dynamic.UDPServer{
+							{Address: "foobar"},
+							{Address: "foobar"},
 						},
 					},
 				},

--- a/pkg/provider/marathon/config.go
+++ b/pkg/provider/marathon/config.go
@@ -56,9 +56,9 @@ func (p *Provider) buildConfiguration(ctx context.Context, applications *maratho
 			err := p.buildTCPServiceConfiguration(ctxApp, app, extraConf, confFromLabel.TCP)
 			if err != nil {
 				logger.Error(err)
-			} else {
-				provider.BuildTCPRouterConfiguration(ctxApp, confFromLabel.TCP)
+				continue
 			}
+			provider.BuildTCPRouterConfiguration(ctxApp, confFromLabel.TCP)
 		}
 
 		if len(confFromLabel.UDP.Routers) > 0 || len(confFromLabel.UDP.Services) > 0 {

--- a/pkg/provider/rancher/config.go
+++ b/pkg/provider/rancher/config.go
@@ -34,32 +34,32 @@ func (p *Provider) buildConfiguration(ctx context.Context, services []rancherDat
 
 		var tcpOrUDP bool
 		if len(confFromLabel.TCP.Routers) > 0 || len(confFromLabel.TCP.Services) > 0 {
+			tcpOrUDP = true
+
 			err := p.buildTCPServiceConfiguration(ctxService, service, confFromLabel.TCP)
 			if err != nil {
 				logger.Error(err)
-				continue
+			} else {
+				provider.BuildTCPRouterConfiguration(ctxService, confFromLabel.TCP)
 			}
-			provider.BuildTCPRouterConfiguration(ctxService, confFromLabel.TCP)
-			tcpOrUDP = true
 		}
 
 		if len(confFromLabel.UDP.Routers) > 0 || len(confFromLabel.UDP.Services) > 0 {
+			tcpOrUDP = true
+
 			err := p.buildUDPServiceConfiguration(ctxService, service, confFromLabel.UDP)
 			if err != nil {
 				logger.Error(err)
-				continue
+			} else {
+				provider.BuildUDPRouterConfiguration(ctxService, confFromLabel.UDP)
 			}
-			provider.BuildUDPRouterConfiguration(ctxService, confFromLabel.UDP)
-			tcpOrUDP = true
 		}
 
-		if tcpOrUDP {
-			if len(confFromLabel.HTTP.Routers) == 0 &&
-				len(confFromLabel.HTTP.Middlewares) == 0 &&
-				len(confFromLabel.HTTP.Services) == 0 {
-				configurations[service.Name] = confFromLabel
-				continue
-			}
+		if tcpOrUDP && len(confFromLabel.HTTP.Routers) == 0 &&
+			len(confFromLabel.HTTP.Middlewares) == 0 &&
+			len(confFromLabel.HTTP.Services) == 0 {
+			configurations[service.Name] = confFromLabel
+			continue
 		}
 
 		err = p.buildServiceConfiguration(ctx, service, confFromLabel.HTTP)

--- a/pkg/provider/rancher/config.go
+++ b/pkg/provider/rancher/config.go
@@ -39,9 +39,9 @@ func (p *Provider) buildConfiguration(ctx context.Context, services []rancherDat
 			err := p.buildTCPServiceConfiguration(ctxService, service, confFromLabel.TCP)
 			if err != nil {
 				logger.Error(err)
-			} else {
-				provider.BuildTCPRouterConfiguration(ctxService, confFromLabel.TCP)
+				continue
 			}
+			provider.BuildTCPRouterConfiguration(ctxService, confFromLabel.TCP)
 		}
 
 		if len(confFromLabel.UDP.Routers) > 0 || len(confFromLabel.UDP.Services) > 0 {
@@ -50,9 +50,9 @@ func (p *Provider) buildConfiguration(ctx context.Context, services []rancherDat
 			err := p.buildUDPServiceConfiguration(ctxService, service, confFromLabel.UDP)
 			if err != nil {
 				logger.Error(err)
-			} else {
-				provider.BuildUDPRouterConfiguration(ctxService, confFromLabel.UDP)
+				continue
 			}
+			provider.BuildUDPRouterConfiguration(ctxService, confFromLabel.UDP)
 		}
 
 		if tcpOrUDP && len(confFromLabel.HTTP.Routers) == 0 &&

--- a/pkg/provider/rancher/config.go
+++ b/pkg/provider/rancher/config.go
@@ -32,6 +32,7 @@ func (p *Provider) buildConfiguration(ctx context.Context, services []rancherDat
 			continue
 		}
 
+		var tcpOrUDP bool
 		if len(confFromLabel.TCP.Routers) > 0 || len(confFromLabel.TCP.Services) > 0 {
 			err := p.buildTCPServiceConfiguration(ctxService, service, confFromLabel.TCP)
 			if err != nil {
@@ -39,6 +40,20 @@ func (p *Provider) buildConfiguration(ctx context.Context, services []rancherDat
 				continue
 			}
 			provider.BuildTCPRouterConfiguration(ctxService, confFromLabel.TCP)
+			tcpOrUDP = true
+		}
+
+		if len(confFromLabel.UDP.Routers) > 0 || len(confFromLabel.UDP.Services) > 0 {
+			err := p.buildUDPServiceConfiguration(ctxService, service, confFromLabel.UDP)
+			if err != nil {
+				logger.Error(err)
+				continue
+			}
+			provider.BuildUDPRouterConfiguration(ctxService, confFromLabel.UDP)
+			tcpOrUDP = true
+		}
+
+		if tcpOrUDP {
 			if len(confFromLabel.HTTP.Routers) == 0 &&
 				len(confFromLabel.HTTP.Middlewares) == 0 &&
 				len(confFromLabel.HTTP.Services) == 0 {
@@ -83,6 +98,28 @@ func (p *Provider) buildTCPServiceConfiguration(ctx context.Context, service ran
 
 	for _, confService := range configuration.Services {
 		err := p.addServerTCP(ctx, service, confService.LoadBalancer)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (p *Provider) buildUDPServiceConfiguration(ctx context.Context, service rancherData, configuration *dynamic.UDPConfiguration) error {
+	serviceName := service.Name
+
+	if len(configuration.Services) == 0 {
+		configuration.Services = make(map[string]*dynamic.UDPService)
+		lb := &dynamic.UDPServersLoadBalancer{}
+
+		configuration.Services[serviceName] = &dynamic.UDPService{
+			LoadBalancer: lb,
+		}
+	}
+
+	for _, confService := range configuration.Services {
+		err := p.addServerUDP(ctx, service, confService.LoadBalancer)
 		if err != nil {
 			return err
 		}
@@ -174,6 +211,43 @@ func (p *Provider) addServerTCP(ctx context.Context, service rancherData, loadBa
 	var servers []dynamic.TCPServer
 	for _, containerIP := range service.Containers {
 		servers = append(servers, dynamic.TCPServer{
+			Address: net.JoinHostPort(containerIP, port),
+		})
+	}
+
+	loadBalancer.Servers = servers
+	return nil
+}
+
+func (p *Provider) addServerUDP(ctx context.Context, service rancherData, loadBalancer *dynamic.UDPServersLoadBalancer) error {
+	log.FromContext(ctx).Debugf("Trying to add servers for service  %s \n", service.Name)
+
+	serverPort := ""
+
+	if loadBalancer != nil && len(loadBalancer.Servers) > 0 {
+		serverPort = loadBalancer.Servers[0].Port
+	}
+
+	port := getServicePort(service)
+
+	if len(loadBalancer.Servers) == 0 {
+		server := dynamic.UDPServer{}
+
+		loadBalancer.Servers = []dynamic.UDPServer{server}
+	}
+
+	if serverPort != "" {
+		port = serverPort
+		loadBalancer.Servers[0].Port = ""
+	}
+
+	if port == "" {
+		return errors.New("port is missing")
+	}
+
+	var servers []dynamic.UDPServer
+	for _, containerIP := range service.Containers {
+		servers = append(servers, dynamic.UDPServer{
 			Address: net.JoinHostPort(containerIP, port),
 		})
 	}


### PR DESCRIPTION
### What does this PR do?
This PR handles UDP on all providers with labels .

### Motivation
Being able to define UDP load balancing using labels in rancher, consulcatalog, docker and marathon.


### More

- [x] Added/updated tests
- [x] Added/updated documentation

