### PR TITLE
Remove TLS cipher suites for TLS minVersion 1.3

### DIFF
--- a/docs/content/migration/v1-to-v2.md
+++ b/docs/content/migration/v1-to-v2.md
@@ -238,9 +238,6 @@ Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one o
     [tls.options]
       [tls.options.default]
         minVersion = "VersionTLS12"
-    
-      [tls.options.myTLSOptions]
-        minVersion = "VersionTLS13"
         cipherSuites = [
           "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
           "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
@@ -249,6 +246,9 @@ Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one o
           "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
           "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
         ]
+    
+      [tls.options.myTLSOptions]
+        minVersion = "VersionTLS13"
     ```
 
     ```yaml tab="File (YAML)"
@@ -268,12 +268,6 @@ Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one o
       options:
         myTLSOptions:
           minVersion: VersionTLS13
-          cipherSuites:
-	        - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-	        - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
-	        - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
-	        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-	        - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     ```
 
     ```yaml tab="K8s IngressRoute"
@@ -287,12 +281,6 @@ Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one o
     
     spec:
       minVersion: VersionTLS13
-      cipherSuites:
-	    - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-	    - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
-	    - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
-	    - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-	    - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     
     ---
     apiVersion: traefik.containo.us/v1alpha1

--- a/docs/content/migration/v1-to-v2.md
+++ b/docs/content/migration/v1-to-v2.md
@@ -236,7 +236,7 @@ Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one o
       keyFile = "/path/to/domain.key"
     
     [tls.options]
-      [tls.options.default]
+      [tls.options.myTLSOptions]
         minVersion = "VersionTLS12"
         cipherSuites = [
           "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
@@ -246,9 +246,6 @@ Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one o
           "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
           "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
         ]
-    
-      [tls.options.myTLSOptions]
-        minVersion = "VersionTLS13"
     ```
 
     ```yaml tab="File (YAML)"
@@ -267,7 +264,13 @@ Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one o
           keyFile: /path/to/domain.key
       options:
         myTLSOptions:
-          minVersion: VersionTLS13
+          minVersion: VersionTLS12
+          cipherSuites:
+	        - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+	        - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+	        - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+	        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+	        - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     ```
 
     ```yaml tab="K8s IngressRoute"
@@ -280,7 +283,13 @@ Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one o
       namespace: default
     
     spec:
-      minVersion: VersionTLS13
+      minVersion: VersionTLS12
+      cipherSuites:
+	    - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+	    - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+	    - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+	    - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+	    - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     
     ---
     apiVersion: traefik.containo.us/v1alpha1


### PR DESCRIPTION
### What does this PR do?

Removes TLS cipher suites from configuration where TLS minVersion is set to 1.3.


### Motivation

According to the Traefik [cipher suites documentation](https://docs.traefik.io/https/tls/#cipher-suites), cipher suites cannot be configured for TLS 1.3. In the v1 to v2 migration section, they are being configured for TLS 1.3.


### More

- [ ] Added/updated tests
- [x] Added/updated documentation