### PR TITLE
Build all UDP services on an entrypoint

### DIFF
--- a/integration/fixtures/tcp/service_errors.toml
+++ b/integration/fixtures/tcp/service_errors.toml
@@ -19,19 +19,19 @@
 
 ## dynamic configuration ##
 
-[http.routers]
-  [http.routers.router1]
+[tcp.routers]
+  [tcp.routers.router1]
     service = "service1"
-    rule = "Host(`snitest.net`)"
+    rule = "HostSNI(`snitest.net`)"
 
-  [http.routers.router2]
+  [tcp.routers.router2]
     service = "service2"
-    rule = "Host(`snitest.com`)"
+    rule = "HostSNI(`snitest.com`)"
 
-[http.services]
-  [http.services.service1]
+[tcp.services]
+  [tcp.services.service1]
 
-  [http.services.service2]
-    [http.services.service2.loadBalancer]
-      [[http.services.service2.loadBalancer.servers]]
-        url = "http://127.0.0.1:9010"
+  [tcp.services.service2]
+    [tcp.services.service2.loadBalancer]
+      [[tcp.services.service2.loadBalancer.servers]]
+        address = "127.0.0.1:9010"

--- a/integration/fixtures/udp/service_errors.toml
+++ b/integration/fixtures/udp/service_errors.toml
@@ -19,19 +19,17 @@
 
 ## dynamic configuration ##
 
-[http.routers]
-  [http.routers.router1]
+[udp.routers]
+  [udp.routers.router1]
     service = "service1"
-    rule = "Host(`snitest.net`)"
 
-  [http.routers.router2]
+  [udp.routers.router2]
     service = "service2"
-    rule = "Host(`snitest.com`)"
 
-[http.services]
-  [http.services.service1]
+[udp.services]
+  [udp.services.service1]
 
-  [http.services.service2]
-    [http.services.service2.loadBalancer]
-      [[http.services.service2.loadBalancer.servers]]
-        url = "http://127.0.0.1:9010"
+  [udp.services.service2]
+    [udp.services.service2.loadBalancer]
+      [[udp.services.service2.loadBalancer.servers]]
+        address = "127.0.0.1:9010"

--- a/integration/simple_test.go
+++ b/integration/simple_test.go
@@ -616,7 +616,7 @@ func (s *SimpleSuite) TestUDPServiceConfigErrors(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	defer cmd.Process.Kill()
 
-	err = try.GetRequest("http://127.0.0.1:8080/api/udp/services", 3000*time.Millisecond, try.BodyContains(`["the udp service \"service1@file\" does not have any type defined"]`))
+	err = try.GetRequest("http://127.0.0.1:8080/api/udp/services", 1000*time.Millisecond, try.BodyContains(`["the udp service \"service1@file\" does not have any type defined"]`))
 	c.Assert(err, checker.IsNil)
 
 	err = try.GetRequest("http://127.0.0.1:8080/api/udp/services/service1@file", 1000*time.Millisecond, try.BodyContains(`"status":"disabled"`))

--- a/integration/simple_test.go
+++ b/integration/simple_test.go
@@ -570,7 +570,7 @@ func (s *SimpleSuite) TestTCPRouterConfigErrors(c *check.C) {
 }
 
 func (s *SimpleSuite) TestTCPServiceConfigErrors(c *check.C) {
-	file := s.adaptFile(c, "fixtures/service_errors.toml", struct{}{})
+	file := s.adaptFile(c, "fixtures/tcp/service_errors.toml", struct{}{})
 	defer os.Remove(file)
 
 	cmd, output := s.traefikCmd(withConfigFile(file))
@@ -606,7 +606,7 @@ func (s *SimpleSuite) TestUDPRouterConfigErrors(c *check.C) {
 }
 
 func (s *SimpleSuite) TestUDPServiceConfigErrors(c *check.C) {
-	file := s.adaptFile(c, "fixtures/service_errors.toml", struct{}{})
+	file := s.adaptFile(c, "fixtures/udp/service_errors.toml", struct{}{})
 	defer os.Remove(file)
 
 	cmd, output := s.traefikCmd(withConfigFile(file))

--- a/pkg/server/router/udp/router.go
+++ b/pkg/server/router/udp/router.go
@@ -52,7 +52,7 @@ func (m *Manager) BuildHandlers(rootCtx context.Context, entryPoints []string) m
 			log.FromContext(ctx).Warn("Config has more than one udp router for a given entrypoint.")
 		}
 
-		handlers, err := m.buildEntryPointHandler(ctx, routers)
+		handlers, err := m.buildEntryPointHandlers(ctx, routers)
 		if err != nil {
 			log.FromContext(ctx).Error(err)
 			continue
@@ -66,7 +66,7 @@ func (m *Manager) BuildHandlers(rootCtx context.Context, entryPoints []string) m
 	return entryPointHandlers
 }
 
-func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string]*runtime.UDPRouterInfo) ([]udp.Handler, error) {
+func (m *Manager) buildEntryPointHandlers(ctx context.Context, configs map[string]*runtime.UDPRouterInfo) ([]udp.Handler, error) {
 	var rtNames []string
 	for routerName := range configs {
 		rtNames = append(rtNames, routerName)

--- a/pkg/server/router/udp/router.go
+++ b/pkg/server/router/udp/router.go
@@ -3,6 +3,7 @@ package udp
 import (
 	"context"
 	"errors"
+	"sort"
 
 	"github.com/containous/traefik/v2/pkg/config/runtime"
 	"github.com/containous/traefik/v2/pkg/log"
@@ -47,23 +48,40 @@ func (m *Manager) BuildHandlers(rootCtx context.Context, entryPoints []string) m
 
 		ctx := log.With(rootCtx, log.Str(log.EntryPointName, entryPointName))
 
-		handler, err := m.buildEntryPointHandler(ctx, routers)
+		handlers, err := m.buildEntryPointHandler(ctx, routers)
 		if err != nil {
 			log.FromContext(ctx).Error(err)
 			continue
 		}
-		entryPointHandlers[entryPointName] = handler
+
+		if len(handlers) > 0 {
+			// As UDP support only one router per entrypoint, we only take the first one.
+			entryPointHandlers[entryPointName] = handlers[0]
+		}
 	}
 	return entryPointHandlers
 }
 
-func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string]*runtime.UDPRouterInfo) (udp.Handler, error) {
+func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string]*runtime.UDPRouterInfo) ([]udp.Handler, error) {
+	var handlers []udp.Handler
 	logger := log.FromContext(ctx)
 
 	if len(configs) > 1 {
 		logger.Warn("Warning: config has more than one udp router for a given entrypoint")
 	}
-	for routerName, routerConfig := range configs {
+
+	var routersName []string
+	for routerName := range configs {
+		routersName = append(routersName, routerName)
+	}
+
+	sort.Slice(routersName, func(i, j int) bool {
+		return routersName[i] > routersName[j]
+	})
+
+	for _, routerName := range routersName {
+		routerConfig := configs[routerName]
+
 		ctxRouter := log.With(provider.AddInContext(ctx, routerName), log.Str(log.RouterName, routerName))
 		logger := log.FromContext(ctxRouter)
 
@@ -80,8 +98,7 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 			logger.Error(err)
 			continue
 		}
-		return handler, nil
+		handlers = append(handlers, handler)
 	}
-
-	return nil, nil
+	return handlers, nil
 }

--- a/pkg/server/router/udp/router.go
+++ b/pkg/server/router/udp/router.go
@@ -49,7 +49,7 @@ func (m *Manager) BuildHandlers(rootCtx context.Context, entryPoints []string) m
 		ctx := log.With(rootCtx, log.Str(log.EntryPointName, entryPointName))
 
 		if len(routers) > 1 {
-			log.FromContext(ctx).Warn("Warning: config has more than one udp router for a given entrypoint")
+			log.FromContext(ctx).Warn("Config has more than one udp router for a given entrypoint.")
 		}
 
 		handlers, err := m.buildEntryPointHandler(ctx, routers)
@@ -67,18 +67,18 @@ func (m *Manager) BuildHandlers(rootCtx context.Context, entryPoints []string) m
 }
 
 func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string]*runtime.UDPRouterInfo) ([]udp.Handler, error) {
-	var handlers []udp.Handler
-
-	var routersName []string
+	var rtNames []string
 	for routerName := range configs {
-		routersName = append(routersName, routerName)
+		rtNames = append(rtNames, routerName)
 	}
 
-	sort.Slice(routersName, func(i, j int) bool {
-		return routersName[i] > routersName[j]
+	sort.Slice(rtNames, func(i, j int) bool {
+		return rtNames[i] > rtNames[j]
 	})
 
-	for _, routerName := range routersName {
+	var handlers []udp.Handler
+
+	for _, routerName := range rtNames {
 		routerConfig := configs[routerName]
 
 		ctxRouter := log.With(provider.AddInContext(ctx, routerName), log.Str(log.RouterName, routerName))
@@ -97,7 +97,9 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 			logger.Error(err)
 			continue
 		}
+
 		handlers = append(handlers, handler)
 	}
+
 	return handlers, nil
 }

--- a/pkg/server/router/udp/router.go
+++ b/pkg/server/router/udp/router.go
@@ -48,6 +48,10 @@ func (m *Manager) BuildHandlers(rootCtx context.Context, entryPoints []string) m
 
 		ctx := log.With(rootCtx, log.Str(log.EntryPointName, entryPointName))
 
+		if len(routers) > 1 {
+			log.FromContext(ctx).Warn("Warning: config has more than one udp router for a given entrypoint")
+		}
+
 		handlers, err := m.buildEntryPointHandler(ctx, routers)
 		if err != nil {
 			log.FromContext(ctx).Error(err)
@@ -64,11 +68,6 @@ func (m *Manager) BuildHandlers(rootCtx context.Context, entryPoints []string) m
 
 func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string]*runtime.UDPRouterInfo) ([]udp.Handler, error) {
 	var handlers []udp.Handler
-	logger := log.FromContext(ctx)
-
-	if len(configs) > 1 {
-		logger.Warn("Warning: config has more than one udp router for a given entrypoint")
-	}
 
 	var routersName []string
 	for routerName := range configs {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

Before this PR, if more than one udp services was attached to same entrypoint, we randomly built only one.
After the PR, all services are built and we use the first one (in natural order on the service name).


### Motivation
Fix a flaky test because, sometimes we didn't build the service with an error.

Fixes #6310

### More

- [x] Added/updated tests
~~- [ ] Added/updated documentation~~

