### PR TITLE
fix: consul-catalog use port from label instead of item port.

### DIFF
--- a/pkg/provider/consulcatalog/config.go
+++ b/pkg/provider/consulcatalog/config.go
@@ -149,21 +149,25 @@ func (p *Provider) addServerTCP(ctx context.Context, item itemData, loadBalancer
 		return errors.New("load-balancer is not defined")
 	}
 
+	var port string
+	if len(loadBalancer.Servers) > 0 {
+		port = loadBalancer.Servers[0].Port
+	}
+
 	if len(loadBalancer.Servers) == 0 {
 		loadBalancer.Servers = []dynamic.TCPServer{{}}
 	}
 
-	var port string
 	if item.Port != "" {
 		port = item.Port
-		loadBalancer.Servers[0].Port = ""
 	}
+	loadBalancer.Servers[0].Port = ""
 
 	if port == "" {
 		return errors.New("port is missing")
 	}
 
-	if item.Address == "" {
+	if item.Address == "" && port == "" {
 		return errors.New("address is missing")
 	}
 
@@ -188,10 +192,10 @@ func (p *Provider) addServer(ctx context.Context, item itemData, loadBalancer *d
 		loadBalancer.Servers = []dynamic.Server{server}
 	}
 
-	if item.Port != "" {
+	if item.Port != "" && port == "" {
 		port = item.Port
-		loadBalancer.Servers[0].Port = ""
 	}
+	loadBalancer.Servers[0].Port = ""
 
 	if port == "" {
 		return errors.New("port is missing")

--- a/pkg/provider/consulcatalog/config.go
+++ b/pkg/provider/consulcatalog/config.go
@@ -158,7 +158,7 @@ func (p *Provider) addServerTCP(ctx context.Context, item itemData, loadBalancer
 		loadBalancer.Servers = []dynamic.TCPServer{{}}
 	}
 
-	if item.Port != "" {
+	if item.Port != "" && port == "" {
 		port = item.Port
 	}
 	loadBalancer.Servers[0].Port = ""

--- a/pkg/provider/consulcatalog/config.go
+++ b/pkg/provider/consulcatalog/config.go
@@ -167,7 +167,7 @@ func (p *Provider) addServerTCP(ctx context.Context, item itemData, loadBalancer
 		return errors.New("port is missing")
 	}
 
-	if item.Address == "" && port == "" {
+	if item.Address == "" {
 		return errors.New("address is missing")
 	}
 

--- a/pkg/provider/consulcatalog/config_test.go
+++ b/pkg/provider/consulcatalog/config_test.go
@@ -1371,7 +1371,7 @@ func Test_buildConfiguration(t *testing.T) {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
-										URL: "h2c://127.0.0.1:80",
+										URL: "h2c://127.0.0.1:8080",
 									},
 								},
 								PassHostHeader: Bool(true),
@@ -1419,7 +1419,7 @@ func Test_buildConfiguration(t *testing.T) {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
-										URL: "http://127.0.0.1:80",
+										URL: "http://127.0.0.1:8080",
 									},
 								},
 								PassHostHeader: Bool(true),


### PR DESCRIPTION
### What does this PR do?

fix: consul-catalog use port from label instead of item port.

### Motivation

The label `traefik.http.services.xxx.loadbalancer.server.port` had no effect.

https://community.containo.us/t/override-consul-port-via-tags/4521


### More

- [x] Added/updated tests
- [ ] Added/updated documentation
