### PR TITLE
Fix typo in the godoc of TLS option MaxVersion

### DIFF
--- a/pkg/tls/certificate.go
+++ b/pkg/tls/certificate.go
@@ -22,7 +22,7 @@ var (
 		`VersionTLS13`: tls.VersionTLS13,
 	}
 
-	// MaxVersion Map of allowed TLS minimum versions
+	// MaxVersion Map of allowed TLS maximum versions
 	MaxVersion = map[string]uint16{
 		`VersionTLS10`: tls.VersionTLS10,
 		`VersionTLS11`: tls.VersionTLS11,


### PR DESCRIPTION
**What does this PR do?**

Fix a typo.
