### PR TITLE
Fix secret informer load

### DIFF
--- a/pkg/provider/kubernetes/crd/client.go
+++ b/pkg/provider/kubernetes/crd/client.go
@@ -168,6 +168,7 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 		factoryKube.Extensions().V1beta1().Ingresses().Informer().AddEventHandler(eventHandler)
 		factoryKube.Core().V1().Services().Informer().AddEventHandler(eventHandler)
 		factoryKube.Core().V1().Endpoints().Informer().AddEventHandler(eventHandler)
+		factoryKube.Core().V1().Secrets().Informer().AddEventHandler(eventHandler)
 
 		c.factoriesCrd[ns] = factoryCrd
 		c.factoriesKube[ns] = factoryKube
@@ -190,15 +191,6 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 				return nil, fmt.Errorf("timed out waiting for controller caches to sync %s in namespace %q", t.String(), ns)
 			}
 		}
-	}
-
-	// Do not wait for the Secrets store to get synced since we cannot rely on
-	// users having granted RBAC permissions for this object.
-	// https://github.com/containous/traefik/issues/1784 should improve the
-	// situation here in the future.
-	for _, ns := range namespaces {
-		c.factoriesKube[ns].Core().V1().Secrets().Informer().AddEventHandler(eventHandler)
-		c.factoriesKube[ns].Start(stopCh)
 	}
 
 	return eventCh, nil

--- a/pkg/provider/kubernetes/ingress/client.go
+++ b/pkg/provider/kubernetes/ingress/client.go
@@ -137,6 +137,7 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 		factory.Extensions().V1beta1().Ingresses().Informer().AddEventHandler(eventHandler)
 		factory.Core().V1().Services().Informer().AddEventHandler(eventHandler)
 		factory.Core().V1().Endpoints().Informer().AddEventHandler(eventHandler)
+		factory.Core().V1().Secrets().Informer().AddEventHandler(eventHandler)
 		c.factories[ns] = factory
 	}
 
@@ -150,15 +151,6 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 				return nil, fmt.Errorf("timed out waiting for controller caches to sync %s in namespace %q", t.String(), ns)
 			}
 		}
-	}
-
-	// Do not wait for the Secrets store to get synced since we cannot rely on
-	// users having granted RBAC permissions for this object.
-	// https://github.com/containous/traefik/issues/1784 should improve the
-	// situation here in the future.
-	for _, ns := range namespaces {
-		c.factories[ns].Core().V1().Secrets().Informer().AddEventHandler(eventHandler)
-		c.factories[ns].Start(stopCh)
 	}
 
 	return eventCh, nil


### PR DESCRIPTION
### What does this PR do?

This PR starts the informer on secrets with the other informers, and before the caches are synched. This allows the listers to have access to secrets on the first informer trigger.

### Motivation

Fixes #3667 

Avoid log on startup
```
level=error msg="Error while reading basic auth middleware: failed to load auth credentials: secret 'traefik/traefik' not found" middlewareName=traefik-auth providerName=kubernetescrd
level=error msg="middleware \"traefik-auth@kubernetescrd\" does not exist" routerName=traefik-traefik-86717a050e7497cf6af6@kubernetescrd entryPointName=traefik
level=error msg="middleware \"traefik-auth@kubernetescrd\" does not exist" entryPointName=web routerName=traefik-traefik-86717a050e7497cf6af6@kubernetescrd
level=error msg="Error while reading basic auth middleware: failed to load auth credentials: secret 'traefik/traefik' not found" providerName=kubernetescrd middlewareName=traefik-auth
```

### More

- [x] Added/updated tests
- [x] Added/updated documentation
