### PR TITLE
Use consistent protocol determination

### DIFF
--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -315,13 +315,13 @@ Register the `IngressRoute` kind in the Kubernetes cluster before creating `Ingr
 
 !!! important "Configuring Backend Protocol"
 
-	There are 3 ways to configure the backend protocol for communication between Traefik and your pods:
+    There are 3 ways to configure the backend protocol for communication between Traefik and your pods:
 	
     - Setting the scheme explicitly (http/https/h2c)
     - Configuring the name of the kubernetes service port to start with https (https)
     - Setting the kubernetes service port to use port 443 (https)
 
-  If you do not configure the above, Traefik will assume an http connection.
+    If you do not configure the above, Traefik will assume an http connection.
 
 ### Kind: `Middleware`
 

--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -316,9 +316,10 @@ Register the `IngressRoute` kind in the Kubernetes cluster before creating `Ingr
 !!! important "Configuring Backend Protocol"
 
 	There are 3 ways to configure the backend protocol for communication between Traefik and your pods:
-  - Setting the scheme explicitly (http/https/h2c)
-  - Configuring the name of the kubernetes service port to start with https (https)
-  - Setting the kubernetes service port to use port 443 (https)
+	
+    - Setting the scheme explicitly (http/https/h2c)
+    - Configuring the name of the kubernetes service port to start with https (https)
+    - Setting the kubernetes service port to use port 443 (https)
 
   If you do not configure the above, Traefik will assume an http connection.
 

--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -313,6 +313,15 @@ Register the `IngressRoute` kind in the Kubernetes cluster before creating `Ingr
       tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0=
     ```
 
+!!! important "Configuring Backend Protocol"
+
+	There are 3 ways to configure the backend protocol for communication between Traefik and your pods:
+  - Setting the scheme explicitly (http/https/h2c)
+  - Configuring the name of the kubernetes service port to start with https (https)
+  - Setting the kubernetes service port to use port 443 (https)
+
+  If you do not configure the above, Traefik will assume an http connection.
+
 ### Kind: `Middleware`
 
 `Middleware` is the CRD implementation of a [Traefik middleware](../../middlewares/overview.md).

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -2311,3 +2311,72 @@ func TestLoadIngressRoutes(t *testing.T) {
 		})
 	}
 }
+
+func TestParseServiceProtocol(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		scheme        string
+		portName      string
+		portNumber    int32
+		expected      string
+		expectedError bool
+	}{
+		{
+			desc:       "Empty scheme and name",
+			scheme:     "",
+			portName:   "",
+			portNumber: 1000,
+			expected:   "http",
+		},
+		{
+			desc:       "h2c scheme and emptyname",
+			scheme:     "h2c",
+			portName:   "",
+			portNumber: 1000,
+			expected:   "h2c",
+		},
+		{
+			desc:          "invalid scheme",
+			scheme:        "foo",
+			portName:      "",
+			portNumber:    1000,
+			expectedError: true,
+		},
+		{
+			desc:       "Empty scheme and https name",
+			scheme:     "",
+			portName:   "https-secure",
+			portNumber: 1000,
+			expected:   "https",
+		},
+		{
+			desc:       "Empty scheme and port number",
+			scheme:     "",
+			portName:   "",
+			portNumber: 443,
+			expected:   "https",
+		},
+		{
+			desc:       "https scheme",
+			scheme:     "https",
+			portName:   "",
+			portNumber: 1000,
+			expected:   "https",
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			protocol, err := parseServiceProtocol(test.scheme, test.portName, test.portNumber)
+			if test.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.Equal(t, test.expected, protocol)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR allows the same code to determine if an externalName service should use the HTTPS protocol as the non-externalName Service

### Motivation

Fixes #6344 

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

This also should allow h2c as a backend protocol too!