### PR TITLE
Consider SSLv2 as TLS in order to close the handshake correctly

### DIFF
--- a/pkg/tcp/router.go
+++ b/pkg/tcp/router.go
@@ -203,9 +203,17 @@ func clientHelloServerName(br *bufio.Reader) (string, bool, string, error) {
 		return "", false, "", err
 	}
 
+	// No valid TLS record has a type of 0x80, however SSLv2 handshakes
+	// start with a uint16 length where the MSB is set and the first record
+	// is always < 256 bytes long. Therefore typ == 0x80 strongly suggests
+	// an SSLv2 client.
+	const recordTypeSSLv2 = 0x80
 	const recordTypeHandshake = 0x16
 	if hdr[0] != recordTypeHandshake {
-		// log.Errorf("Error not tls")
+		if hdr[0] == recordTypeSSLv2 {
+			// we consider SSLv2 as TLS and it will be refuse by real TLS handshake.
+			return "", true, getPeeked(br), nil
+		}
 		return "", false, getPeeked(br), nil // Not TLS.
 	}
 


### PR DESCRIPTION
### What does this PR do?
We consider SSLv2 as TLS in the routing system, by doing this, the SSLv2 request will be forward to the TLS handshake that will be able to refuse the handshake correctly

### Motivation
Fixes #6358 
