### PR TITLE
Launch healhcheck only one time instead of two

### DIFF
--- a/pkg/server/router/router.go
+++ b/pkg/server/router/router.go
@@ -109,8 +109,6 @@ func (m *Manager) BuildHandlers(rootCtx context.Context, entryPoints []string, t
 		entryPointHandlers[entryPointName] = handlerWithMiddlewares
 	}
 
-	m.serviceManager.LaunchHealthCheck()
-
 	return entryPointHandlers
 }
 

--- a/pkg/server/tcprouterfactory.go
+++ b/pkg/server/tcprouterfactory.go
@@ -58,6 +58,8 @@ func (f *TCPRouterFactory) CreateTCPRouters(conf dynamic.Configuration) map[stri
 	handlersNonTLS := routerManager.BuildHandlers(ctx, f.entryPoints, false)
 	handlersTLS := routerManager.BuildHandlers(ctx, f.entryPoints, true)
 
+	serviceManager.LaunchHealthCheck()
+
 	// TCP
 	svcTCPManager := tcp.NewManager(rtConf)
 


### PR DESCRIPTION
### What does this PR do?
Healthcheck was launch two times at each configuration refresh, and it can create some side effect. Now the healthcheck is launch only one time at each configuration refresh.

### Motivation
Fixes #6096