### PR TITLE
Updated rbac and demonset example bloc

### DIFF
--- a/docs/user-guide/kubernetes.md
+++ b/docs/user-guide/kubernetes.md
@@ -53,6 +53,12 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+    - extensions
+    resources:
+    - ingresses/status
+    verbs:
+    - update
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -171,6 +177,10 @@ metadata:
   labels:
     k8s-app: traefik-ingress-lb
 spec:
+  selector:
+    matchLabels:
+      k8s-app: traefik-ingress-lb
+      name: traefik-ingress-lb
   template:
     metadata:
       labels:
@@ -188,6 +198,7 @@ spec:
           hostPort: 80
         - name: admin
           containerPort: 8080
+          hostPort: 8080
         securityContext:
           capabilities:
             drop:


### PR DESCRIPTION

<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
The rbac and demonset deployment bloc are out of date with the linked yaml files. This PR updates the example bloc with the yaml code linked in the associated URL


### Motivation

<!-- What inspired you to submit this pull request? -->
if you try to copy those blocs and deploy with "kubectl apply -f local_file" you'll fail with

error: error validating "traefik-ds.yaml": error validating data: ValidationError(DaemonSet.spec): missing required field "selector" in io.k8s.api.apps.v1.DaemonSetSpec; if you choose to ignore these errors, turn validation off with --validate=false

as the "selector" fields are required in v1 of the API.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
