### PR TITLE
Use explicitly the word Kubernetes in the migration guide.

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -2,7 +2,10 @@
 
 ## v2.0 to v2.1
 
-In v2.1, a new CRD called `TraefikService` was added. While updating an installation to v2.1,
+### Kubernetes CRD
+
+In v2.1, a new Kubernetes CRD called `TraefikService` was added.
+While updating an installation to v2.1,
 it is required to apply that CRD before as well as enhance the existing `ClusterRole` definition to allow Traefik to use that CRD.
 
 To add that CRD and enhance the permissions, following definitions need to be applied to the cluster.

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -6,7 +6,7 @@
 
 In v2.1, a new Kubernetes CRD called `TraefikService` was added.
 While updating an installation to v2.1,
-it is required to apply that CRD before as well as enhance the existing `ClusterRole` definition to allow Traefik to use that CRD.
+one should apply that CRD, and update the existing `ClusterRole` definition to allow Traefik to use that CRD.
 
 To add that CRD and enhance the permissions, following definitions need to be applied to the cluster.
 


### PR DESCRIPTION
### What does this PR do?

Use explicitly the word Kubernetes in the migration guide.

### Motivation

Have better documentation

Fixes #6378 

### More

- [ ] Added/updated tests
- [x] Added/updated documentation
