### PR TITLE
Modify ReplacePathRegex

### DIFF
--- a/pkg/middlewares/replacepathregex/replace_path_regex_test.go
+++ b/pkg/middlewares/replacepathregex/replace_path_regex_test.go
@@ -70,6 +70,15 @@ func TestReplacePathRegex(t *testing.T) {
 			expectedPath: "/invalid/regexp/test",
 			expectsError: true,
 		},
+		{
+			desc: "pre-escaped replacement",
+			path: "/whoami/and/whoami",
+			config: dynamic.ReplacePathRegex{
+				Replacement: "/whoami%2Fand%2Fwhoami",
+				Regex:       `/whoami/and/whoami`,
+			},
+			expectedPath: "/whoami%2Fand%2Fwhoami",
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR modifies the ReplacePathRegex middleware to allow for partially-escaped replacements

### Motivation

Fixes #6355 

### More

- [x] Added/updated tests
- [x] Added/updated documentation - None needed, bugfix

### Additional Notes

From https://golang.org/pkg/net/url/#URL.EscapedPath :

```
EscapedPath returns u.RawPath when it is a valid escaping of u.Path.
Otherwise EscapedPath ignores u.RawPath and computes an escaped form on its own.
```

This PR juggles these to ensure the end result is the intended path.