### PR TITLE
Remove unnecessary brackets from ipv6 literals

### DIFF
--- a/pkg/ip/checker.go
+++ b/pkg/ip/checker.go
@@ -90,6 +90,9 @@ func (ip *Checker) ContainsIP(addr net.IP) bool {
 }
 
 func parseIP(addr string) (net.IP, error) {
+	addr = strings.ReplaceAll(addr, "[", "")
+	addr = strings.ReplaceAll(addr, "]", "")
+
 	userIP := net.ParseIP(addr)
 	if userIP == nil {
 		return nil, fmt.Errorf("can't parse IP from address %s", addr)

--- a/pkg/ip/checker_test.go
+++ b/pkg/ip/checker_test.go
@@ -206,12 +206,14 @@ func TestContainsIsAllowed(t *testing.T) {
 			passIPs: []string{
 				"2a03:4000:6:d080::",
 				"2a03:4000:6:d080::1",
+				"[2a03:4000:6:d080::2]",
 				"2a03:4000:6:d080:dead:beef:ffff:ffff",
 				"2a03:4000:6:d080::42",
 			},
 			rejectIPs: []string{
 				"2a03:4000:7:d080::",
 				"2a03:4000:7:d080::1",
+				"[2a03:4000:7:d080::2]",
 				"fe80::",
 				"4242::1",
 			},
@@ -232,6 +234,7 @@ func TestContainsIsAllowed(t *testing.T) {
 			passIPs: []string{
 				"2a03:4000:6:d080::",
 				"2a03:4000:6:d080::1",
+				"[2a03:4000:6:d080::2]",
 				"2a03:4000:6:d080:dead:beef:ffff:ffff",
 				"2a03:4000:6:d080::42",
 				"fe80::1",
@@ -241,6 +244,7 @@ func TestContainsIsAllowed(t *testing.T) {
 			rejectIPs: []string{
 				"2a03:4000:7:d080::",
 				"2a03:4000:7:d080::1",
+				"[2a03:4000:7:d080::2]",
 				"4242::1",
 			},
 		},
@@ -252,6 +256,7 @@ func TestContainsIsAllowed(t *testing.T) {
 				"2a03:4000:6:d080::1",
 				"2a03:4000:6:d080:dead:beef:ffff:ffff",
 				"2a03:4000:6:d080::42",
+				"[2a03:4000:6:d080::43]",
 				"fe80::1",
 				"fe80:aa00:00bb:4232:ff00:eeee:00ff:1111",
 				"fe80::fe80",
@@ -267,6 +272,7 @@ func TestContainsIsAllowed(t *testing.T) {
 			rejectIPs: []string{
 				"2a03:4000:7:d080::",
 				"2a03:4000:7:d080::1",
+				"[2a03:4000:7:d080::2]",
 				"4242::1",
 				"1.2.16.1",
 				"1.2.32.1",


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Removes brackets from IPv6 addresses, eg set by broken proxies.

### Motivation

ipwhitelist middleware failed to work in our setup (netscaler before traefik)
Netscaler (incorrectly) injects for example `[::ffff:a27:f81d]`  in the `X-Forwarded-For` header. 

This breaks ipwhitelist. 

Removing the brackets fixes the issue. (brackets should only be used in URLs or when specifying a port)

<!-- What inspired you to submit this pull request? -->

### More

- [x] tests: added some ipv6 addresses with brackets between the existing tests.
