### PR TITLE
Fix & improve Grafana dashboards

### DIFF
--- a/contrib/grafana/traefik-kubernetes.json
+++ b/contrib/grafana/traefik-kubernetes.json
@@ -130,7 +130,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(kube_pod_status_ready{namespace=\"$namespace\",condition=\"true\",pod=~\"traefik.*\"})",
+          "expr": "count(kube_pod_status_ready{condition=\"true\",pod=~\"traefik.*\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -186,7 +186,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.$percentiles, sum(rate(traefik_entrypoint_request_duration_seconds_bucket{namespace=\"$namespace\", code=~\"2..\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.$percentiles, sum(rate(traefik_entrypoint_request_duration_seconds_bucket{code=~\"2..\"}[5m])) by (le))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -273,7 +273,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.$percentiles, sum(rate(traefik_entrypoint_request_duration_seconds_bucket{namespace=\"$namespace\",code=~\"2..\"}[5m])) by (instance, le))",
+          "expr": "histogram_quantile(0.$percentiles, sum(rate(traefik_entrypoint_request_duration_seconds_bucket{code=~\"2..\"}[5m])) by (instance, le))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ instance }}",
@@ -371,7 +371,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(traefik_entrypoint_open_connections{namespace=\"$namespace\"}) by (method)",
+              "expr": "sum(traefik_entrypoint_open_connections) by (method)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{ method }}",
@@ -457,7 +457,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "(sum(rate(traefik_entrypoint_request_duration_seconds_bucket{namespace=\"$namespace\",le=\"0.1\",code=\"200\"}[5m])) by (job) + sum(rate(traefik_entrypoint_request_duration_seconds_bucket{namespace=\"$namespace\",le=\"0.3\",code=\"200\"}[5m])) by (job)) / 2 / sum(rate(traefik_entrypoint_request_duration_seconds_count{namespace=\"$namespace\",code=\"200\"}[5m])) by (job)",
+              "expr": "(sum(rate(traefik_entrypoint_request_duration_seconds_bucket{le=\"0.1\",code=\"200\"}[5m])) by (job) + sum(rate(traefik_entrypoint_request_duration_seconds_bucket{le=\"0.3\",code=\"200\"}[5m])) by (job)) / 2 / sum(rate(traefik_entrypoint_request_duration_seconds_count{code=\"200\"}[5m])) by (job)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Code 200",
@@ -545,7 +545,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(traefik_entrypoint_requests_total{namespace=\"$namespace\"}[1m])) by (entrypoint)",
+              "expr": "sum(rate(traefik_entrypoint_requests_total[1m])) by (entrypoint)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ entrypoint }}",
@@ -647,7 +647,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(traefik_service_open_connections{namespace=\"$namespace\"}) by (method)",
+              "expr": "sum(traefik_service_open_connections) by (method)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{ method }}",
@@ -733,7 +733,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "(sum(rate(traefik_service_request_duration_seconds_bucket{namespace=\"$namespace\",le=\"0.1\",code=\"200\"}[5m])) by (job) + sum(rate(traefik_service_request_duration_seconds_bucket{namespace=\"$namespace\",le=\"0.3\",code=\"200\"}[5m])) by (job)) / 2 / sum(rate(traefik_service_request_duration_seconds_count{namespace=\"$namespace\",code=\"200\"}[5m])) by (job)",
+              "expr": "(sum(rate(traefik_service_request_duration_seconds_bucket{le=\"0.1\",code=\"200\"}[5m])) by (job) + sum(rate(traefik_service_request_duration_seconds_bucket{le=\"0.3\",code=\"200\"}[5m])) by (job)) / 2 / sum(rate(traefik_service_request_duration_seconds_count{code=\"200\"}[5m])) by (job)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Code 200",
@@ -821,7 +821,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(traefik_service_requests_total{namespace=\"$namespace\"}[1m])) by (service)",
+              "expr": "sum(rate(traefik_service_requests_total[1m])) by (service)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ service }}",
@@ -923,7 +923,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(traefik_service_requests_total{namespace=\"$namespace\",code=~\"2..\"}[5m])) by (method, code)",
+              "expr": "sum(rate(traefik_service_requests_total{code=~\"2..\"}[5m])) by (method, code)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{method}} : {{code}}",
@@ -1009,7 +1009,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(traefik_service_requests_total{namespace=\"$namespace\",code=~\"5..\"}[5m])) by (method, code)",
+              "expr": "sum(rate(traefik_service_requests_total{code=~\"5..\"}[5m])) by (method, code)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{method}} : {{code}}",
@@ -1096,7 +1096,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(traefik_service_requests_total{namespace=\"$namespace\",code!~\"2..|5..\"}[5m])) by (method, code)",
+              "expr": "sum(rate(traefik_service_requests_total{code!~\"2..|5..\"}[5m])) by (method, code)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ method }} : {{code}}",
@@ -1196,21 +1196,21 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(container_memory_usage_bytes{namespace=\"$namespace\", container=\"traefik\"})",
+              "expr": "sum(container_memory_usage_bytes{container=\"traefik\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Memory used",
               "refId": "A"
             },
             {
-              "expr": "sum(kube_pod_container_resource_requests_memory_bytes{namespace=\"$namespace\", container=\"traefik\"})",
+              "expr": "sum(kube_pod_container_resource_requests_memory_bytes{container=\"traefik\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Requested memory",
               "refId": "B"
             },
             {
-              "expr": "sum(kube_pod_container_resource_limits_memory_bytes{namespace=\"$namespace\", container=\"traefik\"})",
+              "expr": "sum(kube_pod_container_resource_limits_memory_bytes{container=\"traefik\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Limit memory usage",
@@ -1295,21 +1295,21 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", container=\"traefik\"}[2m]))",
+              "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"traefik\"}[2m]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Cpu used",
               "refId": "A"
             },
             {
-              "expr": "sum(kube_pod_container_resource_requests_cpu_cores{namespace=\"$namespace\", container=\"traefik\"})",
+              "expr": "sum(kube_pod_container_resource_requests_cpu_cores{container=\"traefik\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Requested cpu",
               "refId": "B"
             },
             {
-              "expr": "sum(kube_pod_container_resource_limits_cpu_cores{namespace=\"$namespace\", container=\"traefik\"})",
+              "expr": "sum(kube_pod_container_resource_limits_cpu_cores{container=\"traefik\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Limit cpu usage",
@@ -1368,26 +1368,6 @@
   ],
   "templating": {
     "list": [
-      {
-        "allValue": null,
-        "current": {},
-        "datasource": "${DS_PROMETHEUS}",
-        "hide": 0,
-        "includeAll": false,
-        "label": null,
-        "multi": false,
-        "name": "namespace",
-        "options": [],
-        "query": "label_values(traefik_config_reloads_total, namespace)",
-        "refresh": 1,
-        "regex": "",
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
       {
         "allValue": null,
         "current": {

--- a/contrib/grafana/traefik-kubernetes.json
+++ b/contrib/grafana/traefik-kubernetes.json
@@ -150,10 +150,7 @@
       "valueName": "current"
     },
     {
-      "aliasColors": {
-        "Latency over 1 min": "rgb(9, 116, 190)",
-        "Latency over 5 min": "#bf1b00"
-      },
+      "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
@@ -183,22 +180,17 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "alias": "Latency over 5 min",
-          "yaxis": 1
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.$percentiles, sum(rate(traefik_entrypoint_request_duration_seconds_bucket{namespace=\"$namespace\", code=\"200\",method=\"GET\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.$percentiles, sum(rate(traefik_entrypoint_request_duration_seconds_bucket{namespace=\"$namespace\", code=~\"2..\"}[5m])) by (le))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
-          "legendFormat": "Latency over 1 min",
+          "legendFormat": "Latency over 5 min",
           "refId": "A"
         }
       ],
@@ -281,7 +273,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.$percentiles, rate(traefik_entrypoint_request_duration_seconds_bucket{namespace=\"$namespace\",code=\"200\",method=\"GET\"}[5m]))",
+          "expr": "histogram_quantile(0.$percentiles, sum(rate(traefik_entrypoint_request_duration_seconds_bucket{namespace=\"$namespace\",code=~\"2..\"}[5m])) by (instance, le))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ instance }}",
@@ -343,7 +335,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_PROMETHEUS}",
           "fill": 7,
           "gridPos": {
             "h": 7,
@@ -431,7 +423,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_PROMETHEUS}",
           "fill": 1,
           "gridPos": {
             "h": 7,
@@ -465,7 +457,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(traefik_entrypoint_request_duration_seconds_bucket{namespace=\"$namespace\",le=\"0.1\",code=\"200\"}[5m])) by (job) / sum(rate(traefik_entrypoint_request_duration_seconds_count{namespace=\"$namespace\",code=\"200\"}[5m])) by (job)",
+              "expr": "(sum(rate(traefik_entrypoint_request_duration_seconds_bucket{namespace=\"$namespace\",le=\"0.1\",code=\"200\"}[5m])) by (job) + sum(rate(traefik_entrypoint_request_duration_seconds_bucket{namespace=\"$namespace\",le=\"0.3\",code=\"200\"}[5m])) by (job)) / 2 / sum(rate(traefik_entrypoint_request_duration_seconds_count{namespace=\"$namespace\",code=\"200\"}[5m])) by (job)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Code 200",
@@ -511,9 +503,97 @@
             "align": false,
             "alignLevel": null
           }
+        },
+        {
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_PROMETHEUS}",
+          "fill": 1,
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 23
+          },
+          "id": 3,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sort": "avg",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(traefik_entrypoint_requests_total{namespace=\"$namespace\"}[1m])) by (entrypoint)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ entrypoint }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Service total requests over 1min per entrypoint",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
-      "title": "Frontends (entrypoints)",
+      "title": "Entrypoints",
       "type": "row"
     },
     {
@@ -522,7 +602,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 33
       },
       "id": 24,
       "panels": [
@@ -531,13 +611,13 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_PROMETHEUS}",
           "fill": 7,
           "gridPos": {
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 17
+            "y": 34
           },
           "id": 25,
           "legend": {
@@ -567,7 +647,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(traefik_backend_open_connections{namespace=\"$namespace\"}) by (method)",
+              "expr": "sum(traefik_service_open_connections{namespace=\"$namespace\"}) by (method)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{ method }}",
@@ -619,13 +699,13 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_PROMETHEUS}",
           "fill": 1,
           "gridPos": {
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 17
+            "y": 34
           },
           "id": 26,
           "legend": {
@@ -653,7 +733,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(traefik_backend_request_duration_seconds_bucket{namespace=\"$namespace\",le=\"0.1\",code=\"200\"}[5m])) by (job) / sum(rate(traefik_backend_request_duration_seconds_count{namespace=\"$namespace\",code=\"200\"}[5m])) by (job)",
+              "expr": "(sum(rate(traefik_service_request_duration_seconds_bucket{namespace=\"$namespace\",le=\"0.1\",code=\"200\"}[5m])) by (job) + sum(rate(traefik_service_request_duration_seconds_bucket{namespace=\"$namespace\",le=\"0.3\",code=\"200\"}[5m])) by (job)) / 2 / sum(rate(traefik_service_request_duration_seconds_count{namespace=\"$namespace\",code=\"200\"}[5m])) by (job)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Code 200",
@@ -699,9 +779,97 @@
             "align": false,
             "alignLevel": null
           }
+        },
+        {
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_PROMETHEUS}",
+          "fill": 1,
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 41
+          },
+          "id": 4,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sort": "avg",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(traefik_service_requests_total{namespace=\"$namespace\"}[1m])) by (service)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ service }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Service total requests over 1min per service",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
-      "title": "Backends",
+      "title": "Services",
       "type": "row"
     },
     {
@@ -710,7 +878,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 51
       },
       "id": 15,
       "panels": [
@@ -725,7 +893,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 18
+            "y": 52
           },
           "id": 5,
           "legend": {
@@ -755,7 +923,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(traefik_backend_requests_total{namespace=\"$namespace\",code=~\"2..\"}[5m])) by (method, code)",
+              "expr": "sum(rate(traefik_service_requests_total{namespace=\"$namespace\",code=~\"2..\"}[5m])) by (method, code)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{method}} : {{code}}",
@@ -813,7 +981,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 18
+            "y": 52
           },
           "id": 27,
           "legend": {
@@ -841,7 +1009,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(traefik_backend_requests_total{namespace=\"$namespace\",code=~\"5..\"}[5m])) by (method, code)",
+              "expr": "sum(rate(traefik_service_requests_total{namespace=\"$namespace\",code=~\"5..\"}[5m])) by (method, code)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{method}} : {{code}}",
@@ -899,95 +1067,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 27
-          },
-          "id": 3,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sort": "avg",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": false,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(rate(traefik_backend_requests_total{namespace=\"$namespace\"}[1m])) by (backend)",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{ backend }}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Backend total requests over 1min per backend",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": true,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
-          "fill": 1,
-          "gridPos": {
-            "h": 9,
-            "w": 12,
-            "x": 12,
-            "y": 27
+            "y": 61
           },
           "id": 6,
           "legend": {
@@ -1016,7 +1096,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(traefik_backend_requests_total{namespace=\"$namespace\",code!~\"2..|5..\"}[5m])) by (method, code)",
+              "expr": "sum(rate(traefik_service_requests_total{namespace=\"$namespace\",code!~\"2..|5..\"}[5m])) by (method, code)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ method }} : {{code}}",
@@ -1026,7 +1106,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Others status code over 5min",
+          "title": "Others statuses code over 5min",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1064,7 +1144,7 @@
           }
         }
       ],
-      "title": "HTTP Codes  stats",
+      "title": "HTTP Codes stats",
       "type": "row"
     },
     {
@@ -1073,7 +1153,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 18
+        "y": 70
       },
       "id": 35,
       "panels": [
@@ -1082,13 +1162,13 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_PROMETHEUS}",
           "fill": 1,
           "gridPos": {
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 19
+            "y": 71
           },
           "id": 31,
           "legend": {
@@ -1116,21 +1196,21 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "max(container_memory_usage_bytes{namespace=\"$namespace\", container_name=\"traefik\"})",
+              "expr": "sum(container_memory_usage_bytes{namespace=\"$namespace\", container=\"traefik\"})",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "Max memory used",
+              "legendFormat": "Memory used",
               "refId": "A"
             },
             {
-              "expr": "avg(kube_pod_container_resource_requests_memory_bytes{namespace=\"$namespace\", container=\"traefik\"})",
+              "expr": "sum(kube_pod_container_resource_requests_memory_bytes{namespace=\"$namespace\", container=\"traefik\"})",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "Requested memory usage",
+              "legendFormat": "Requested memory",
               "refId": "B"
             },
             {
-              "expr": "avg(kube_pod_container_resource_limits_memory_bytes{namespace=\"$namespace\", container=\"traefik\"})",
+              "expr": "sum(kube_pod_container_resource_limits_memory_bytes{namespace=\"$namespace\", container=\"traefik\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Limit memory usage",
@@ -1140,7 +1220,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Traefik max memory usage",
+          "title": "Traefik memory usage",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1182,13 +1262,13 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_PROMETHEUS}",
           "fill": 1,
           "gridPos": {
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 19
+            "y": 71
           },
           "id": 33,
           "legend": {
@@ -1215,21 +1295,21 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "max(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", container_name=\"traefik\"}[1m]))",
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", container=\"traefik\"}[2m]))",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "Max cpu used",
+              "legendFormat": "Cpu used",
               "refId": "A"
             },
             {
-              "expr": "avg(kube_pod_container_resource_requests_cpu_cores{namespace=\"$namespace\", container=\"traefik\"})",
+              "expr": "sum(kube_pod_container_resource_requests_cpu_cores{namespace=\"$namespace\", container=\"traefik\"})",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "Requested cpu usage",
+              "legendFormat": "Requested cpu",
               "refId": "B"
             },
             {
-              "expr": "avg(kube_pod_container_resource_limits_cpu_cores{namespace=\"$namespace\", container=\"traefik\"})",
+              "expr": "sum(kube_pod_container_resource_limits_cpu_cores{namespace=\"$namespace\", container=\"traefik\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Limit cpu usage",
@@ -1239,7 +1319,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Traefik max CPU usage",
+          "title": "Traefik CPU usage",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1277,7 +1357,7 @@
           }
         }
       ],
-      "title": "Pods ressources",
+      "title": "Pods resources",
       "type": "row"
     }
   ],
@@ -1370,5 +1450,5 @@
   "timezone": "",
   "title": "Traefik",
   "uid": "traefik-kubernetes",
-  "version": 1
+  "version": 2
 }

--- a/contrib/grafana/traefik.json
+++ b/contrib/grafana/traefik.json
@@ -64,10 +64,7 @@
       "type": "row"
     },
     {
-      "aliasColors": {
-        "Latency over 1 min": "rgb(9, 116, 190)",
-        "Latency over 5 min": "#bf1b00"
-      },
+      "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
@@ -97,22 +94,17 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "alias": "Latency over 5 min",
-          "yaxis": 1
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.$percentiles, sum(rate(traefik_entrypoint_request_duration_seconds_bucket{code=\"200\",method=\"GET\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.$percentiles, sum(rate(traefik_entrypoint_request_duration_seconds_bucket{code=~\"2..\"}[5m])) by (le))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
-          "legendFormat": "Latency over 1 min",
+          "legendFormat": "Latency over 5 min",
           "refId": "A"
         }
       ],
@@ -195,7 +187,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.$percentiles, rate(traefik_entrypoint_request_duration_seconds_bucket{code=\"200\",method=\"GET\"}[5m]))",
+          "expr": "histogram_quantile(0.$percentiles, sum(rate(traefik_entrypoint_request_duration_seconds_bucket{code=~\"2..\"}[5m])) by (instance, le))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ instance }}",
@@ -257,13 +249,13 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_PROMETHEUS}",
           "fill": 7,
           "gridPos": {
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 2
+            "y": 16
           },
           "id": 19,
           "legend": {
@@ -345,13 +337,13 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_PROMETHEUS}",
           "fill": 1,
           "gridPos": {
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 2
+            "y": 16
           },
           "id": 22,
           "legend": {
@@ -379,7 +371,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(traefik_entrypoint_request_duration_seconds_bucket{le=\"0.1\",code=\"200\"}[5m])) by (job) / sum(rate(traefik_entrypoint_request_duration_seconds_count{code=\"200\"}[5m])) by (job)",
+              "expr": "(sum(rate(traefik_entrypoint_request_duration_seconds_bucket{le=\"0.1\",code=\"200\"}[5m])) by (job) + sum(rate(traefik_entrypoint_request_duration_seconds_bucket{le=\"0.3\",code=\"200\"}[5m])) by (job)) / 2 / sum(rate(traefik_entrypoint_request_duration_seconds_count{code=\"200\"}[5m])) by (job)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Code 200",
@@ -425,9 +417,97 @@
             "align": false,
             "alignLevel": null
           }
+        },
+        {
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_PROMETHEUS}",
+          "fill": 1,
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 23
+          },
+          "id": 3,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sort": "avg",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(traefik_entrypoint_requests_total[1m])) by (entrypoint)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ entrypoint }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Service total requests over 1min per entrypoint",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
-      "title": "Frontends (entrypoints)",
+      "title": "Entrypoints",
       "type": "row"
     },
     {
@@ -436,7 +516,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 33
       },
       "id": 24,
       "panels": [
@@ -445,13 +525,13 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_PROMETHEUS}",
           "fill": 7,
           "gridPos": {
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 3
+            "y": 34
           },
           "id": 25,
           "legend": {
@@ -481,7 +561,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(traefik_backend_open_connections) by (method)",
+              "expr": "sum(traefik_service_open_connections) by (method)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{ method }}",
@@ -533,13 +613,13 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_PROMETHEUS}",
           "fill": 1,
           "gridPos": {
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 3
+            "y": 34
           },
           "id": 26,
           "legend": {
@@ -567,7 +647,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(traefik_backend_request_duration_seconds_bucket{le=\"0.1\",code=\"200\"}[5m])) by (job) / sum(rate(traefik_backend_request_duration_seconds_count{code=\"200\"}[5m])) by (job)",
+              "expr": "(sum(rate(traefik_service_request_duration_seconds_bucket{le=\"0.1\",code=\"200\"}[5m])) by (job) + sum(rate(traefik_service_request_duration_seconds_bucket{le=\"0.3\",code=\"200\"}[5m])) by (job)) / 2 / sum(rate(traefik_service_request_duration_seconds_count{code=\"200\"}[5m])) by (job)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Code 200",
@@ -613,9 +693,97 @@
             "align": false,
             "alignLevel": null
           }
+        },
+        {
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_PROMETHEUS}",
+          "fill": 1,
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 41
+          },
+          "id": 4,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sort": "avg",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(traefik_service_requests_total[1m])) by (service)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ service }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Service total requests over 1min per service",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
-      "title": "Backends",
+      "title": "Services",
       "type": "row"
     },
     {
@@ -624,7 +792,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 51
       },
       "id": 15,
       "panels": [
@@ -639,7 +807,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 4
+            "y": 52
           },
           "id": 5,
           "legend": {
@@ -669,7 +837,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(traefik_backend_requests_total{code=~\"2..\"}[5m])) by (method, code)",
+              "expr": "sum(rate(traefik_service_requests_total{code=~\"2..\"}[5m])) by (method, code)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{method}} : {{code}}",
@@ -727,7 +895,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 4
+            "y": 52
           },
           "id": 27,
           "legend": {
@@ -755,7 +923,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(traefik_backend_requests_total{code=~\"5..\"}[5m])) by (method, code)",
+              "expr": "sum(rate(traefik_service_requests_total{code=~\"5..\"}[5m])) by (method, code)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{method}} : {{code}}",
@@ -813,95 +981,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 13
-          },
-          "id": 3,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sort": "avg",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": false,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(rate(traefik_backend_requests_total[1m])) by (backend)",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{ backend }}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Backend total requests over 1min per backend",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": true,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
-          "fill": 1,
-          "gridPos": {
-            "h": 9,
-            "w": 12,
-            "x": 12,
-            "y": 13
+            "y": 61
           },
           "id": 6,
           "legend": {
@@ -930,7 +1010,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(traefik_backend_requests_total{code!~\"2..|5..\"}[5m])) by (method, code)",
+              "expr": "sum(rate(traefik_service_requests_total{code!~\"2..|5..\"}[5m])) by (method, code)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ method }} : {{code}}",
@@ -940,7 +1020,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Others status code over 5min",
+          "title": "Others statuses code over 5min",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -978,7 +1058,7 @@
           }
         }
       ],
-      "title": "HTTP Codes  stats",
+      "title": "HTTP Codes stats",
       "type": "row"
     }
   ],
@@ -1051,5 +1131,5 @@
   "timezone": "",
   "title": "Traefik",
   "uid": "traefik",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
### What does this PR do?

This PR fixes and improves the Grafana dashboards provided as examples.

### Motivation

Some metrics needed to be updated:

- Prometheus metrics `traefik_backend_open_connections`, `traefik_backend_request_duration_seconds_bucket` and `traefik_backend_requests_total` [have been removed](https://github.com/containous/traefik/commit/8e97af8dc34ddd63e5ccc489089c8dbacb73f29e#diff-00c48dd481887b7f1cfa8e0edabe69d6) and replaced by `traefik_services_*`.
- In Kubernetes, label `container_name` for metrics `container_memory_usage_bytes` and `container_cpu_usage_seconds_total` [has been renamed](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.14.md#urgent-upgrade-notes) to `container`

Some panels had `"datasource": null"`, causing Grafana errors.

Some other Grafana dashboards improvements were much needed:

- Apdex scores were not really [Apdex scores](https://prometheus.io/docs/practices/histograms/#apdex-score)
- There was no panel showing the Traefik entrypoints.
- For Kubernetes pod's usages, the `sum` is more pertinent that `max` or `avg`.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
