### PR TITLE
Revert "Allow fsnotify to reload config files on k8s (or symlinks)"

### DIFF
--- a/pkg/provider/file/file.go
+++ b/pkg/provider/file/file.go
@@ -110,19 +110,6 @@ func (p *Provider) addWatcher(pool *safe.Pool, directory string, configurationCh
 			case <-ctx.Done():
 				return
 			case evt := <-watcher.Events:
-				if evt.Op == fsnotify.Remove {
-					err = watcher.Remove(evt.Name)
-					if err != nil {
-						log.WithoutContext().WithField(log.ProviderName, providerName).
-							Errorf("Could not remove watcher for %s: %s", directory, err)
-					}
-					err = watcher.Add(directory)
-					if err != nil {
-						log.WithoutContext().WithField(log.ProviderName, providerName).
-							Errorf("Could not re-add watcher for %s: %s", directory, err)
-					}
-				}
-
 				if p.Directory == "" {
 					_, evtFileName := filepath.Split(evt.Name)
 					_, confFileName := filepath.Split(p.Filename)


### PR DESCRIPTION
### What does this PR do?

This PR revert the PR #5037 

### Motivation
The PR #5037 generates error messaging:
```
ERRO[2020-03-02T23:22:35+01:00] Could not remove watcher for /home/juliens/test: can't remove non-existent inotify watch for: /home/juliens/test/4913  providerName=file
ERRO[2020-03-02T23:23:09+01:00] Could not remove watcher for /home/juliens/test: can't remove non-existent inotify watch for: /home/juliens/test/4913  providerName=file
```

### Additional Notes
We need to think more about a solution to handle this.