### PR TITLE
Improve kubernetes external name service support

### DIFF
--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -472,7 +472,7 @@ Register the `IngressRoute` [kind](../../reference/dynamic-configuration/kuberne
 !!! important "Using Kubernetes ExternalName Service"
 
     Traefik backends creation needs a port to be set, however Kubernetes [ExternalName Service](https://kubernetes.io/fr/docs/concepts/services-networking/service/#externalname) could be defined without any port.
-    Accordingly, Traefik supports defining a port in three ways:
+    Accordingly, Traefik supports defining a port in two ways:
     
     - only on `IngressRoute` service
     - on both sides, you'll be warned if the ports don't match, and the `IngressRoute` service port is used
@@ -1037,7 +1037,7 @@ Register the `IngressRouteTCP` [kind](../../reference/dynamic-configuration/kube
 !!! important "Using Kubernetes ExternalName Service"
 
     Traefik backends creation needs a port to be set, however Kubernetes [ExternalName Service](https://kubernetes.io/fr/docs/concepts/services-networking/service/#externalname) could be defined without any port.
-    Accordingly, Traefik supports defining a port in three ways:
+    Accordingly, Traefik supports defining a port in two ways:
     
     - only on `IngressRouteTCP` service
     - on both sides, you'll be warned if the ports don't match, and the `IngressRouteTCP` service port is used

--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -474,8 +474,8 @@ Register the `IngressRoute` [kind](../../reference/dynamic-configuration/kuberne
     Traefik backends creation needs a port to be set, however Kubernetes [ExternalName Service](https://kubernetes.io/fr/docs/concepts/services-networking/service/#externalname) could be defined without any port.
     Accordingly, Traefik supports defining a port in three ways:
     
-    - only on `IngresRoute` service
-    - on both sides, you'll be warned if the ports don't match, and the `IngresRoute` service port is used
+    - only on `IngressRoute` service
+    - on both sides, you'll be warned if the ports don't match, and the `IngressRoute` service port is used
     
     Thus, in case of two sides port definition, Traefik expects a match between ports.
     
@@ -1039,17 +1039,17 @@ Register the `IngressRouteTCP` [kind](../../reference/dynamic-configuration/kube
     Traefik backends creation needs a port to be set, however Kubernetes [ExternalName Service](https://kubernetes.io/fr/docs/concepts/services-networking/service/#externalname) could be defined without any port.
     Accordingly, Traefik supports defining a port in three ways:
     
-    - only on `IngresRouteTCP` service
-    - on both sides, you'll be warned if the ports don't match, and the `IngresRouteTCP` service port is used
+    - only on `IngressRouteTCP` service
+    - on both sides, you'll be warned if the ports don't match, and the `IngressRouteTCP` service port is used
     
     Thus, in case of two sides port definition, Traefik expects a match between ports.
     
     ??? example "Examples"
         
-        ```yaml tab="IngresRouteTCP"
+        ```yaml tab="IngressRouteTCP"
         ---
         apiVersion: traefik.containo.us/v1alpha1
-        kind: IngresRouteTCP
+        kind: IngressRouteTCP
         metadata:
           name: test.route
           namespace: default
@@ -1079,7 +1079,7 @@ Register the `IngressRouteTCP` [kind](../../reference/dynamic-configuration/kube
         ```yaml tab="ExternalName Service"
         ---
         apiVersion: traefik.containo.us/v1alpha1
-        kind: IngresRouteTCP
+        kind: IngressRouteTCP
         metadata:
           name: test.route
           namespace: default
@@ -1110,7 +1110,7 @@ Register the `IngressRouteTCP` [kind](../../reference/dynamic-configuration/kube
         ```yaml tab="Both sides"
         ---
         apiVersion: traefik.containo.us/v1alpha1
-        kind: IngresRouteTCP
+        kind: IngressRouteTCP
         metadata:
           name: test.route
           namespace: default

--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -474,9 +474,8 @@ Register the `IngressRoute` [kind](../../reference/dynamic-configuration/kuberne
     Traefik backends creation needs a port to be set, however Kubernetes [ExternalName Service](https://kubernetes.io/fr/docs/concepts/services-networking/service/#externalname) could be defined without any port.
     Accordingly, Traefik supports defining a port in three ways:
     
-    - only on `IngresRoute` CRD
-    - only on Kubernetes `ExternalName Service` CRD 
-    - on both sides
+    - only on `IngresRoute` service
+    - on both sides, you'll be warned if the ports don't match, and the `IngresRoute` service port is used
     
     Thus, in case of two sides port definition, Traefik expects a match between ports.
     
@@ -1040,9 +1039,8 @@ Register the `IngressRouteTCP` [kind](../../reference/dynamic-configuration/kube
     Traefik backends creation needs a port to be set, however Kubernetes [ExternalName Service](https://kubernetes.io/fr/docs/concepts/services-networking/service/#externalname) could be defined without any port.
     Accordingly, Traefik supports defining a port in three ways:
     
-    - only on `IngresRouteTCP` CRD
-    - only on Kubernetes `ExternalName Service` CRD 
-    - on both sides
+    - only on `IngresRouteTCP` service
+    - on both sides, you'll be warned if the ports don't match, and the `IngresRouteTCP` service port is used
     
     Thus, in case of two sides port definition, Traefik expects a match between ports.
     

--- a/integration/fixtures/k8s/02-services.yml
+++ b/integration/fixtures/k8s/02-services.yml
@@ -126,3 +126,13 @@ spec:
   selector:
     app: containous
     task: whoamiudp
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: externalname-svc
+  namespace: default
+spec:
+  externalName: domain.com
+  type: ExternalName

--- a/integration/fixtures/k8s/05-ingressroutetcp.yml
+++ b/integration/fixtures/k8s/05-ingressroutetcp.yml
@@ -13,6 +13,8 @@ spec:
     - name: whoamitcp
       namespace: default
       port: 8080
+    - name: externalname-svc
+      port: 9090
   tls:
     options:
       name: mytlsoption

--- a/integration/testdata/rawdata-crd.json
+++ b/integration/testdata/rawdata-crd.json
@@ -194,15 +194,41 @@
 		}
 	},
 	"tcpServices": {
-		"default-test3.route-673acf455cb2dab0b43a@kubernetescrd": {
+		"default-test3.route-673acf455cb2dab0b43a-externalname-svc-9090@kubernetescrd": {
 			"loadBalancer": {
 				"terminationDelay": 100,
 				"servers": [
 					{
-						"address": "10.42.0.4:8080"
+						"address": "domain.com:9090"
+					}
+				]
+			},
+			"status": "enabled"
+		},
+		"default-test3.route-673acf455cb2dab0b43a-whoamitcp-8080@kubernetescrd": {
+			"loadBalancer": {
+				"terminationDelay": 100,
+				"servers": [
+					{
+						"address": "10.42.0.3:8080"
 					},
 					{
 						"address": "10.42.0.8:8080"
+					}
+				]
+			},
+			"status": "enabled"
+		},
+		"default-test3.route-673acf455cb2dab0b43a@kubernetescrd": {
+			"weighted": {
+				"services": [
+					{
+						"name": "default-test3.route-673acf455cb2dab0b43a-whoamitcp-8080",
+						"weight": 1
+					},
+					{
+						"name": "default-test3.route-673acf455cb2dab0b43a-externalname-svc-9090",
+						"weight": 1
 					}
 				]
 			},

--- a/pkg/provider/kubernetes/crd/fixtures/services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/services.yml
@@ -118,3 +118,44 @@ subsets:
     ports:
       - name: websecure2
         port: 8443
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: external-svc
+  namespace: default
+spec:
+  externalName: external.domain
+  type: ExternalName
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: external-svc-with-http
+  namespace: default
+spec:
+  externalName: external.domain
+  type: ExternalName
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: external-svc-with-https
+  namespace: default
+spec:
+  externalName: external.domain
+  type: ExternalName
+  ports:
+    - name: https
+      protocol: TCP
+      port: 443
+
+
+

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/services.yml
@@ -131,3 +131,40 @@ subsets:
     ports:
       - name: myapp4
         port: 8084
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: external-svc
+  namespace: default
+spec:
+  externalName: external.domain
+  type: ExternalName
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: external.service.with.port
+  namespace: default
+spec:
+  externalName: external.domain
+  type: ExternalName
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: external.service.without.port
+  namespace: default
+spec:
+  externalName: external.domain
+  type: ExternalName
+  ports:
+    - name: http
+      protocol: TCP

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/with_externalname.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/with_externalname.yml
@@ -1,0 +1,15 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: test.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+  - match: HostSNI(`foo.com`)
+    services:
+    - name: external-svc
+      port: 8000

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/with_externalname_with_port.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/with_externalname_with_port.yml
@@ -1,0 +1,15 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: test.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+  - match: HostSNI(`foo.com`)
+    services:
+    - name: external.service.with.port
+      port: 80

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/with_externalname_without_ports.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/with_externalname_without_ports.yml
@@ -1,0 +1,14 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: test.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+  - match: HostSNI(`foo.com`)
+    services:
+    - name: external-svc

--- a/pkg/provider/kubernetes/crd/fixtures/with_externalname.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_externalname.yml
@@ -1,0 +1,16 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: test.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+  - match: Host(`foo.com`)
+    kind: Rule
+    services:
+    - name: external-svc
+      port: 80

--- a/pkg/provider/kubernetes/crd/fixtures/with_externalname_with_http.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_externalname_with_http.yml
@@ -1,0 +1,16 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: test.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+  - match: Host(`foo.com`)
+    kind: Rule
+    services:
+    - name: external-svc-with-http
+      port: 80

--- a/pkg/provider/kubernetes/crd/fixtures/with_externalname_with_https.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_externalname_with_https.yml
@@ -1,0 +1,16 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: test.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+  - match: Host(`foo.com`)
+    kind: Rule
+    services:
+    - name: external-svc-with-https
+      port: 443

--- a/pkg/provider/kubernetes/crd/fixtures/with_externalname_without_ports.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_externalname_without_ports.yml
@@ -1,0 +1,15 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: test.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+  - match: Host(`foo.com`)
+    kind: Rule
+    services:
+    - name: external-svc

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -255,7 +255,7 @@ func getServicePort(svc *corev1.Service, port int32) (*corev1.ServicePort, error
 	}
 
 	if port == 0 {
-		return nil, errors.New("IngressRoute service port not defined")
+		return nil, errors.New("ingressRoute service port not defined")
 	}
 
 	hasValidPort := false

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -251,7 +251,7 @@ func (p *Provider) loadConfigurationFromCRD(ctx context.Context, client Client) 
 
 func getServicePort(svc *corev1.Service, port int32) (*corev1.ServicePort, error) {
 	if svc == nil {
-		return nil, errors.New("svc is not defined")
+		return nil, errors.New("service is not defined")
 	}
 
 	if port == 0 {
@@ -263,22 +263,22 @@ func getServicePort(svc *corev1.Service, port int32) (*corev1.ServicePort, error
 		if p.Port == port {
 			return &p, nil
 		}
+
 		if p.Port != 0 {
 			hasValidPort = true
 		}
 	}
 
 	if svc.Spec.Type != corev1.ServiceTypeExternalName {
-		return nil, errors.New("service port not found")
+		return nil, fmt.Errorf("service port not found: %d", port)
 	}
 
 	if hasValidPort {
-		log.WithoutContext().Warning("%s/%s ExternalName service has no ports matching IngressRoute", svc.Namespace, svc.Name)
+		log.WithoutContext().
+			Warning("The port %d from IngressRoute doesn't match with ports defined in the ExternalName service %s/%s.", port, svc.Namespace, svc.Name)
 	}
 
-	return &corev1.ServicePort{
-		Port: port,
-	}, nil
+	return &corev1.ServicePort{Port: port}, nil
 }
 
 func createErrorPageMiddleware(client Client, namespace string, errorPage *v1alpha1.ErrorPage) (*dynamic.ErrorPage, *dynamic.Service, error) {

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -3582,9 +3582,7 @@ func TestGetServicePort(t *testing.T) {
 					},
 				},
 			},
-			expected: &corev1.ServicePort{
-				Port: 80,
-			},
+			expectError: true,
 		},
 		{
 			desc: "Two different ports defined",
@@ -3612,8 +3610,10 @@ func TestGetServicePort(t *testing.T) {
 					},
 				},
 			},
-			port:        443,
-			expectError: true,
+			port: 443,
+			expected: &corev1.ServicePort{
+				Port: 443,
+			},
 		},
 	}
 	for _, test := range testCases {

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/containous/traefik/v2/pkg/config/dynamic"
 	"github.com/containous/traefik/v2/pkg/provider"
 	"github.com/containous/traefik/v2/pkg/tls"
@@ -904,6 +906,106 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Services:    map[string]*dynamic.Service{},
 				},
+			},
+		},
+		{
+			desc:  "Simple Ingress Route, with externalName service",
+			paths: []string{"tcp/services.yml", "tcp/with_externalname.yml"},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers: map[string]*dynamic.TCPRouter{
+						"default-test.route-fdd3e9338e47a45efefc": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test.route-fdd3e9338e47a45efefc",
+							Rule:        "HostSNI(`foo.com`)",
+						},
+					},
+					Services: map[string]*dynamic.TCPService{
+						"default-test.route-fdd3e9338e47a45efefc": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{
+										Address: "external.domain:8000",
+										Port:    "",
+									},
+								},
+							},
+						},
+					},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:     map[string]*dynamic.Router{},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services:    map[string]*dynamic.Service{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:  "Ingress Route, externalName service with port",
+			paths: []string{"tcp/services.yml", "tcp/with_externalname_with_port.yml"},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers: map[string]*dynamic.TCPRouter{
+						"default-test.route-fdd3e9338e47a45efefc": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test.route-fdd3e9338e47a45efefc",
+							Rule:        "HostSNI(`foo.com`)",
+						},
+					},
+					Services: map[string]*dynamic.TCPService{
+						"default-test.route-fdd3e9338e47a45efefc": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{
+										Address: "external.domain:80",
+										Port:    "",
+									},
+								},
+							},
+						},
+					},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:     map[string]*dynamic.Router{},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services:    map[string]*dynamic.Service{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:  "Ingress Route, externalName service without port",
+			paths: []string{"tcp/services.yml", "tcp/with_externalname_without_ports.yml"},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers: map[string]*dynamic.TCPRouter{
+						"default-test.route-fdd3e9338e47a45efefc": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test.route-fdd3e9338e47a45efefc",
+							Rule:        "HostSNI(`foo.com`)",
+						},
+					},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:     map[string]*dynamic.Router{},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services:    map[string]*dynamic.Service{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
 			},
 		},
 	}
@@ -2860,6 +2962,134 @@ func TestLoadIngressRoutes(t *testing.T) {
 		{
 			desc: "port selected by name (TODO)",
 		},
+		{
+			desc:  "Simple Ingress Route, with externalName service",
+			paths: []string{"services.yml", "with_externalname.yml"},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-test-route-6f97418635c7e18853da": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test-route-6f97418635c7e18853da",
+							Rule:        "Host(`foo.com`)",
+						}},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"default-test-route-6f97418635c7e18853da": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://external.domain:80",
+									},
+								},
+								PassHostHeader: Bool(true),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:  "Ingress Route, externalName service with http",
+			paths: []string{"services.yml", "with_externalname_with_http.yml"},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-test-route-6f97418635c7e18853da": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test-route-6f97418635c7e18853da",
+							Rule:        "Host(`foo.com`)",
+						}},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"default-test-route-6f97418635c7e18853da": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://external.domain:80",
+									},
+								},
+								PassHostHeader: Bool(true),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:  "Ingress Route, externalName service with https",
+			paths: []string{"services.yml", "with_externalname_with_https.yml"},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-test-route-6f97418635c7e18853da": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test-route-6f97418635c7e18853da",
+							Rule:        "Host(`foo.com`)",
+						}},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"default-test-route-6f97418635c7e18853da": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "https://external.domain:443",
+									},
+								},
+								PassHostHeader: Bool(true),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:  "Ingress Route, externalName service without ports",
+			paths: []string{"services.yml", "with_externalname_without_ports.yml"},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:     map[string]*dynamic.Router{},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services:    map[string]*dynamic.Service{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -3251,6 +3481,151 @@ func TestParseServiceProtocol(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.Equal(t, test.expected, protocol)
+			}
+		})
+	}
+}
+
+func TestGetServicePort(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		svc         *corev1.Service
+		port        int32
+		expected    *corev1.ServicePort
+		expectError bool
+	}{
+		{
+			desc:        "Basic",
+			expectError: true,
+		},
+		{
+			desc: "Matching ports, with no service type",
+			svc: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port: 80,
+						},
+					},
+				},
+			},
+			port: 80,
+			expected: &corev1.ServicePort{
+				Port: 80,
+			},
+		},
+		{
+			desc: "Matching ports 0",
+			svc: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			desc: "Matching ports 0 (with external name)",
+			svc: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeExternalName,
+					Ports: []corev1.ServicePort{
+						{},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			desc: "Mismatching, only port(Ingress) defined",
+			svc: &corev1.Service{
+				Spec: corev1.ServiceSpec{},
+			},
+			port:        80,
+			expectError: true,
+		},
+		{
+			desc: "Mismatching, only port(Ingress) defined with external name",
+			svc: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeExternalName,
+				},
+			},
+			port: 80,
+			expected: &corev1.ServicePort{
+				Port: 80,
+			},
+		},
+		{
+			desc: "Mismatching, only Service port defined",
+			svc: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port: 80,
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			desc: "Mismatching, only Service port defined with external name",
+			svc: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeExternalName,
+					Ports: []corev1.ServicePort{
+						{
+							Port: 80,
+						},
+					},
+				},
+			},
+			expected: &corev1.ServicePort{
+				Port: 80,
+			},
+		},
+		{
+			desc: "Two different ports defined",
+			svc: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port: 80,
+						},
+					},
+				},
+			},
+			port:        443,
+			expectError: true,
+		},
+		{
+			desc: "Two different ports defined (with external name)",
+			svc: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeExternalName,
+					Ports: []corev1.ServicePort{
+						{
+							Port: 80,
+						},
+					},
+				},
+			},
+			port:        443,
+			expectError: true,
+		},
+	}
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := getServicePort(test.svc, test.port)
+			if test.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.Equal(t, test.expected, actual)
 			}
 		})
 	}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.1

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

Improve kubernetes external name service support by allowing three ways to define port for backends

<!-- A brief description of the change being made with this pull request. -->


### Motivation
fixes #6390 
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Co-authored-by: jbdoumenjou <jb.doumenjou@gmail.com>
<!-- Anything else we should know when reviewing? -->
