### PR TITLE
Add Anonymous Authentication middleware

### DIFF
--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -31,6 +31,7 @@ type Middleware struct {
 	BasicAuth         *BasicAuth         `json:"basicAuth,omitempty" toml:"basicAuth,omitempty" yaml:"basicAuth,omitempty"`
 	DigestAuth        *DigestAuth        `json:"digestAuth,omitempty" toml:"digestAuth,omitempty" yaml:"digestAuth,omitempty"`
 	ForwardAuth       *ForwardAuth       `json:"forwardAuth,omitempty" toml:"forwardAuth,omitempty" yaml:"forwardAuth,omitempty"`
+	AnonAuth          *AnonAuth          `json:"anonAuth,omitempty" toml:"anonAuth,omitempty" yaml:"anonAuth,omitempty"`
 	InFlightReq       *InFlightReq       `json:"inFlightReq,omitempty" toml:"inFlightReq,omitempty" yaml:"inFlightReq,omitempty"`
 	Buffering         *Buffering         `json:"buffering,omitempty" toml:"buffering,omitempty" yaml:"buffering,omitempty"`
 	CircuitBreaker    *CircuitBreaker    `json:"circuitBreaker,omitempty" toml:"circuitBreaker,omitempty" yaml:"circuitBreaker,omitempty"`
@@ -69,6 +70,7 @@ type Auth struct {
 	Basic   *BasicAuth   `json:"basic,omitempty" toml:"basic,omitempty" yaml:"basic,omitempty" export:"true"`
 	Digest  *DigestAuth  `json:"digest,omitempty" toml:"digest,omitempty" yaml:"digest,omitempty" export:"true"`
 	Forward *ForwardAuth `json:"forward,omitempty" toml:"forward,omitempty" yaml:"forward,omitempty" export:"true"`
+	Anon    *AnonAuth    `json:"anon,omitempty" toml:"anon,omitempty" yaml:"anon,omitempty" export:"true"`
 }
 
 // +k8s:deepcopy-gen=true
@@ -142,6 +144,17 @@ type ForwardAuth struct {
 	TLS                 *ClientTLS `json:"tls,omitempty" toml:"tls,omitempty" yaml:"tls,omitempty"`
 	TrustForwardHeader  bool       `json:"trustForwardHeader,omitempty" toml:"trustForwardHeader,omitempty" yaml:"trustForwardHeader,omitempty" export:"true"`
 	AuthResponseHeaders []string   `json:"authResponseHeaders,omitempty" toml:"authResponseHeaders,omitempty" yaml:"authResponseHeaders,omitempty"`
+}
+
+// +k8s:deepcopy-gen=true
+
+// AnonAuth holds the HTTP anon authentication configuration.
+type AnonAuth struct {
+	Users        Users  `json:"users,omitempty" toml:"users,omitempty" yaml:"users,omitempty"`
+	UsersFile    string `json:"usersFile,omitempty" toml:"usersFile,omitempty" yaml:"usersFile,omitempty"`
+	Realm        string `json:"realm,omitempty" toml:"realm,omitempty" yaml:"realm,omitempty"`
+	RemoveHeader bool   `json:"removeHeader,omitempty" toml:"removeHeader,omitempty" yaml:"removeHeader,omitempty"`
+	HeaderField  string `json:"headerField,omitempty" toml:"headerField,omitempty" yaml:"headerField,omitempty" export:"true"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/middlewares/auth/anon_auth.go
+++ b/pkg/middlewares/auth/anon_auth.go
@@ -1,0 +1,129 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+
+	goauth "github.com/abbot/go-http-auth"
+	"github.com/containous/traefik/v2/pkg/config/dynamic"
+	"github.com/containous/traefik/v2/pkg/log"
+	"github.com/containous/traefik/v2/pkg/middlewares"
+	"github.com/containous/traefik/v2/pkg/middlewares/accesslog"
+	"github.com/containous/traefik/v2/pkg/tracing"
+	"github.com/opentracing/opentracing-go/ext"
+)
+
+const (
+	anonTypeName = "AnonAuth"
+)
+
+type anonAuth struct {
+	next         http.Handler
+	auth         *goauth.BasicAuth
+	users        []*regexp.Regexp
+	headerField  string
+	removeHeader bool
+	name         string
+}
+
+// NewAnon creates a anonAuth middleware.
+func NewAnon(ctx context.Context, next http.Handler, authConfig dynamic.AnonAuth, name string) (http.Handler, error) {
+	log.FromContext(middlewares.GetLoggerCtx(ctx, name, anonTypeName)).Debug("Creating middleware")
+	users, err := loadUsers(authConfig.UsersFile, authConfig.Users)
+
+	var usersRegexp []*regexp.Regexp
+
+	usersRegexp, err = anonUsersParser(users)
+
+	if err != nil {
+		return nil, err
+	}
+
+	aa := &anonAuth{
+		next:         next,
+		users:        usersRegexp,
+		headerField:  authConfig.HeaderField,
+		removeHeader: authConfig.RemoveHeader,
+		name:         name,
+	}
+
+	realm := defaultRealm
+	if len(authConfig.Realm) > 0 {
+		realm = authConfig.Realm
+	}
+	aa.auth = goauth.NewBasicAuthenticator(realm, func(user, realm string) string { return "" })
+
+	return aa, nil
+}
+
+func (a *anonAuth) GetTracingInformation() (string, ext.SpanKindEnum) {
+	return a.name, tracing.SpanKindNoneEnum
+}
+
+func (a *anonAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	logger := log.FromContext(middlewares.GetLoggerCtx(req.Context(), a.name, anonTypeName))
+
+	username, _, ok := req.BasicAuth()
+
+	if ok && a.anonUserCheck(username) {
+		logger.Debug("Authentication succeeded")
+		req.URL.User = url.User(username)
+
+		logData := accesslog.GetLogData(req)
+		if logData != nil {
+			logData.Core[accesslog.ClientUsername] = username
+		}
+
+		if a.headerField != "" {
+			req.Header[a.headerField] = []string{username}
+		}
+
+		if a.removeHeader {
+			logger.Debug("Removing authorization header")
+			req.Header.Del(authorizationHeader)
+		}
+		a.next.ServeHTTP(rw, req)
+
+	} else {
+		logger.Debug("Authentication required")
+		tracing.SetErrorWithEvent(req, "Authentication required")
+		a.auth.RequireAuth(rw, req)
+
+	}
+}
+
+func anonUsersParser(users []string) ([]*regexp.Regexp, error) {
+
+	var usersRegexp []*regexp.Regexp
+
+	for _, user := range users {
+
+		userRegexp, err := regexp.Compile(fmt.Sprintf(`^%v$`, user))
+
+		if err != nil {
+			return nil, err
+		}
+
+		usersRegexp = append(usersRegexp, userRegexp)
+	}
+
+	return usersRegexp, nil
+}
+
+func (a *anonAuth) anonUserCheck(user string) bool {
+
+	if len(a.users) > 0 {
+		for _, userRegexp := range a.users {
+
+			if userRegexp.MatchString(user) {
+				return true
+			}
+		}
+		return false
+	} else {
+		return true
+	}
+}

--- a/pkg/middlewares/auth/anon_auth.go
+++ b/pkg/middlewares/auth/anon_auth.go
@@ -34,6 +34,10 @@ func NewAnon(ctx context.Context, next http.Handler, authConfig dynamic.AnonAuth
 	log.FromContext(middlewares.GetLoggerCtx(ctx, name, anonTypeName)).Debug("Creating middleware")
 	users, err := loadUsers(authConfig.UsersFile, authConfig.Users)
 
+	if err != nil {
+		return nil, err
+	}
+
 	var usersRegexp []*regexp.Regexp
 
 	usersRegexp, err = anonUsersParser(users)

--- a/pkg/middlewares/auth/anon_auth.go
+++ b/pkg/middlewares/auth/anon_auth.go
@@ -86,21 +86,17 @@ func (a *anonAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			req.Header.Del(authorizationHeader)
 		}
 		a.next.ServeHTTP(rw, req)
-
 	} else {
 		logger.Debug("Authentication required")
 		tracing.SetErrorWithEvent(req, "Authentication required")
 		a.auth.RequireAuth(rw, req)
-
 	}
 }
 
 func anonUsersParser(users []string) ([]*regexp.Regexp, error) {
-
 	var usersRegexp []*regexp.Regexp
 
 	for _, user := range users {
-
 		userRegexp, err := regexp.Compile(fmt.Sprintf(`^%v$`, user))
 
 		if err != nil {
@@ -114,16 +110,13 @@ func anonUsersParser(users []string) ([]*regexp.Regexp, error) {
 }
 
 func (a *anonAuth) anonUserCheck(user string) bool {
-
 	if len(a.users) > 0 {
 		for _, userRegexp := range a.users {
-
 			if userRegexp.MatchString(user) {
 				return true
 			}
 		}
 		return false
-	} else {
-		return true
 	}
+	return true
 }

--- a/pkg/middlewares/auth/anon_auth_test.go
+++ b/pkg/middlewares/auth/anon_auth_test.go
@@ -1,0 +1,266 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/containous/traefik/v2/pkg/config/dynamic"
+	"github.com/containous/traefik/v2/pkg/testhelpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnonAuthFail(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "traefik")
+	})
+
+	auth := dynamic.AnonAuth{
+		Users: []string{`\i`},
+	}
+	_, err := NewAnon(context.Background(), next, auth, "authName")
+	require.Error(t, err)
+
+	auth2 := dynamic.AnonAuth{
+		Users: []string{"testtest"},
+	}
+	authMiddleware, err := NewAnon(context.Background(), next, auth2, "authTest")
+	require.NoError(t, err)
+
+	ts := httptest.NewServer(authMiddleware)
+	defer ts.Close()
+
+	req := testhelpers.MustNewRequest(http.MethodGet, ts.URL, nil)
+	req.SetBasicAuth("test", "test")
+
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusUnauthorized, res.StatusCode, "they should be equal")
+}
+
+func TestAnonAuthSuccess(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "traefik")
+	})
+
+	auth := dynamic.AnonAuth{
+		Users: []string{"test.*"},
+	}
+	authMiddleware, err := NewAnon(context.Background(), next, auth, "authName")
+	require.NoError(t, err)
+
+	ts := httptest.NewServer(authMiddleware)
+	defer ts.Close()
+
+	req := testhelpers.MustNewRequest(http.MethodGet, ts.URL, nil)
+	req.SetBasicAuth("testtest", "test")
+
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, res.StatusCode, "they should be equal")
+
+	body, err := ioutil.ReadAll(res.Body)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	assert.Equal(t, "traefik\n", string(body), "they should be equal")
+}
+
+func TestAnonAuthUserHeader(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "test", r.Header["X-Webauth-User"][0], "auth user should be set")
+		fmt.Fprintln(w, "traefik")
+	})
+
+	auth := dynamic.AnonAuth{
+		Users:       []string{"test"},
+		HeaderField: "X-Webauth-User",
+	}
+	middleware, err := NewAnon(context.Background(), next, auth, "authName")
+	require.NoError(t, err)
+
+	ts := httptest.NewServer(middleware)
+	defer ts.Close()
+
+	req := testhelpers.MustNewRequest(http.MethodGet, ts.URL, nil)
+	req.SetBasicAuth("test", "test")
+
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+
+	body, err := ioutil.ReadAll(res.Body)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	assert.Equal(t, "traefik\n", string(body))
+}
+
+func TestAnonAuthHeaderRemoved(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(t, r.Header.Get(authorizationHeader))
+		fmt.Fprintln(w, "traefik")
+	})
+
+	auth := dynamic.AnonAuth{
+		RemoveHeader: true,
+	}
+	middleware, err := NewAnon(context.Background(), next, auth, "authName")
+	require.NoError(t, err)
+
+	ts := httptest.NewServer(middleware)
+	defer ts.Close()
+
+	req := testhelpers.MustNewRequest(http.MethodGet, ts.URL, nil)
+	req.SetBasicAuth("test", "test")
+
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+
+	body, err := ioutil.ReadAll(res.Body)
+	require.NoError(t, err)
+	err = res.Body.Close()
+	require.NoError(t, err)
+
+	assert.Equal(t, "traefik\n", string(body))
+}
+
+func TestAnonAuthHeaderPresent(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.NotEmpty(t, r.Header.Get(authorizationHeader))
+		fmt.Fprintln(w, "traefik")
+	})
+
+	auth := dynamic.AnonAuth{}
+
+	middleware, err := NewAnon(context.Background(), next, auth, "authName")
+	require.NoError(t, err)
+
+	ts := httptest.NewServer(middleware)
+	defer ts.Close()
+
+	req := testhelpers.MustNewRequest(http.MethodGet, ts.URL, nil)
+	req.SetBasicAuth("test", "test")
+
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+
+	body, err := ioutil.ReadAll(res.Body)
+	require.NoError(t, err)
+	err = res.Body.Close()
+	require.NoError(t, err)
+
+	assert.Equal(t, "traefik\n", string(body))
+}
+
+func TestAnonAuthUsersFromFile(t *testing.T) {
+	testCases := []struct {
+		desc            string
+		userFileContent string
+		expectedUsers   map[string]string
+		givenUsers      []string
+		realm           string
+	}{
+		{
+			desc:            "Finds the users in the file",
+			userFileContent: "test\ntest2\n",
+			givenUsers:      []string{},
+			expectedUsers:   map[string]string{"test": "test", "test2": "test2"},
+		},
+		{
+			desc:            "Merges given users with users from the file",
+			userFileContent: "test\n",
+			givenUsers:      []string{"test2", "test3"},
+			expectedUsers:   map[string]string{"test": "test", "test2": "test2", "test3": "test3"},
+		},
+		{
+			desc:            "Should skip comments",
+			userFileContent: "#foo\ntest\ntest2",
+			givenUsers:      []string{},
+			expectedUsers:   map[string]string{"test": "test", "test2": "test2"},
+			realm:           "traefiker",
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			// Creates the temporary configuration file with the users
+			usersFile, err := ioutil.TempFile("", "auth-users")
+			require.NoError(t, err)
+			defer os.Remove(usersFile.Name())
+
+			_, err = usersFile.Write([]byte(test.userFileContent))
+			require.NoError(t, err)
+
+			// Creates the configuration for our Authenticator
+			authenticatorConfiguration := dynamic.AnonAuth{
+				Users:     test.givenUsers,
+				UsersFile: usersFile.Name(),
+				Realm:     test.realm,
+			}
+
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintln(w, "traefik")
+			})
+
+			authenticator, err := NewAnon(context.Background(), next, authenticatorConfiguration, "authName")
+			require.NoError(t, err)
+
+			ts := httptest.NewServer(authenticator)
+			defer ts.Close()
+
+			for userName, userPwd := range test.expectedUsers {
+				req := testhelpers.MustNewRequest(http.MethodGet, ts.URL, nil)
+				req.SetBasicAuth(userName, userPwd)
+
+				var res *http.Response
+				res, err = http.DefaultClient.Do(req)
+				require.NoError(t, err)
+
+				require.Equal(t, http.StatusOK, res.StatusCode, "Cannot authenticate user "+userName)
+
+				var body []byte
+				body, err = ioutil.ReadAll(res.Body)
+				require.NoError(t, err)
+				err = res.Body.Close()
+				require.NoError(t, err)
+
+				require.Equal(t, "traefik\n", string(body))
+			}
+
+			// Checks that user foo doesn't work
+			req := testhelpers.MustNewRequest(http.MethodGet, ts.URL, nil)
+			req.SetBasicAuth("foo", "foo")
+
+			res, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+
+			require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+			if len(test.realm) > 0 {
+				require.Equal(t, `Basic realm="`+test.realm+`"`, res.Header.Get("WWW-Authenticate"))
+			}
+
+			body, err := ioutil.ReadAll(res.Body)
+			require.NoError(t, err)
+			err = res.Body.Close()
+			require.NoError(t, err)
+
+			require.NotContains(t, "traefik", string(body))
+		})
+	}
+}

--- a/pkg/middlewares/auth/auth.go
+++ b/pkg/middlewares/auth/auth.go
@@ -60,6 +60,5 @@ func getLinesFromFile(filename string) ([]string, error) {
 			filteredLines = append(filteredLines, line)
 		}
 	}
-
 	return filteredLines, nil
 }

--- a/pkg/server/middleware/middlewares.go
+++ b/pkg/server/middleware/middlewares.go
@@ -217,6 +217,16 @@ func (b *Builder) buildConstructor(ctx context.Context, middlewareName string) (
 		}
 	}
 
+	// AnonAuth
+	if config.AnonAuth != nil {
+		if middleware != nil {
+			return nil, badConf
+		}
+		middleware = func(next http.Handler) (http.Handler, error) {
+			return auth.NewAnon(ctx, next, *config.AnonAuth, middlewareName)
+		}
+	}
+
 	// Headers
 	if config.Headers != nil {
 		if middleware != nil {


### PR DESCRIPTION
### What does this PR do?
 The Anonymous Authentication middleware (anonAuth) is inspired by the Apache Module [`mod_authn_anon`](https://httpd.apache.org/docs/2.4/mod/mod_authn_anon.html).

### Motivation
It can be used to force the authentication, filter the allowed usernames (by a list of regexps) or pass the provided username to the downstream middlewares and put it in the access logs.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes
The current implementation supports only the HTTP Basic authentication.