### PR TITLE
Router entry points on reload.

### DIFF
--- a/integration/testdata/rawdata-ingress.json
+++ b/integration/testdata/rawdata-ingress.json
@@ -30,8 +30,8 @@
 		},
 		"test-ingress-default-whoami-test-whoami@kubernetes": {
 			"entryPoints": [
-				"web",
-				"traefik"
+				"traefik",
+				"web"
 			],
 			"service": "default-whoami-http",
 			"rule": "Host(`whoami.test`) \u0026\u0026 PathPrefix(`/whoami`)",
@@ -43,8 +43,8 @@
 		},
 		"test-ingress-https-default-whoami-test-https-whoami@kubernetes": {
 			"entryPoints": [
-				"web",
-				"traefik"
+				"traefik",
+				"web"
 			],
 			"service": "default-whoami-http",
 			"rule": "Host(`whoami.test.https`) \u0026\u0026 PathPrefix(`/whoami`)",

--- a/pkg/server/aggregator.go
+++ b/pkg/server/aggregator.go
@@ -120,7 +120,9 @@ func applyModel(cfg dynamic.Configuration) dynamic.Configuration {
 
 	rts := make(map[string]*dynamic.Router)
 
-	for name, router := range cfg.HTTP.Routers {
+	for name, rt := range cfg.HTTP.Routers {
+		router := rt.DeepCopy()
+
 		eps := router.EntryPoints
 		router.EntryPoints = nil
 

--- a/pkg/server/aggregator.go
+++ b/pkg/server/aggregator.go
@@ -7,7 +7,7 @@ import (
 	"github.com/containous/traefik/v2/pkg/tls"
 )
 
-func mergeConfiguration(configurations dynamic.Configurations, entryPoints []string) dynamic.Configuration {
+func mergeConfiguration(configurations dynamic.Configurations, defaultEntryPoints []string) dynamic.Configuration {
 	conf := dynamic.Configuration{
 		HTTP: &dynamic.HTTPConfiguration{
 			Routers:     make(map[string]*dynamic.Router),
@@ -37,8 +37,8 @@ func mergeConfiguration(configurations dynamic.Configurations, entryPoints []str
 				if len(router.EntryPoints) == 0 {
 					log.WithoutContext().
 						WithField(log.RouterName, routerName).
-						Debugf("No entryPoint defined for this router, using the default one(s) instead: %+v", entryPoints)
-					router.EntryPoints = entryPoints
+						Debugf("No entryPoint defined for this router, using the default one(s) instead: %+v", defaultEntryPoints)
+					router.EntryPoints = defaultEntryPoints
 				}
 
 				conf.HTTP.Routers[provider.MakeQualifiedName(pvd, routerName)] = router

--- a/pkg/server/configurationwatcher.go
+++ b/pkg/server/configurationwatcher.go
@@ -18,7 +18,7 @@ import (
 type ConfigurationWatcher struct {
 	provider provider.Provider
 
-	entryPoints []string
+	defaultEntryPoints []string
 
 	providersThrottleDuration time.Duration
 
@@ -38,7 +38,7 @@ func NewConfigurationWatcher(
 	routinesPool *safe.Pool,
 	pvd provider.Provider,
 	providersThrottleDuration time.Duration,
-	entryPoints []string,
+	defaultEntryPoints []string,
 ) *ConfigurationWatcher {
 	watcher := &ConfigurationWatcher{
 		provider:                   pvd,
@@ -47,7 +47,7 @@ func NewConfigurationWatcher(
 		providerConfigUpdateMap:    make(map[string]chan dynamic.Message),
 		providersThrottleDuration:  providersThrottleDuration,
 		routinesPool:               routinesPool,
-		entryPoints:                entryPoints,
+		defaultEntryPoints:         defaultEntryPoints,
 	}
 
 	currentConfigurations := make(dynamic.Configurations)
@@ -143,7 +143,7 @@ func (c *ConfigurationWatcher) loadMessage(configMsg dynamic.Message) {
 
 	c.currentConfigurations.Set(newConfigurations)
 
-	conf := mergeConfiguration(newConfigurations, c.entryPoints)
+	conf := mergeConfiguration(newConfigurations, c.defaultEntryPoints)
 	conf = applyModel(conf)
 
 	for _, listener := range c.configurationListeners {


### PR DESCRIPTION
### What does this PR do?

Create a copy of the router before cleaning the list of entry points.

The bug is related to the following line:
https://github.com/containous/traefik/blob/99861ac808b66ce44322269c819688d04ff22b6f/pkg/server/configurationwatcher.go#L144

To reproduce:

<details>
<summary>docker-compose.yml</summary>

```yml
version: '3.7'

services:
  traefik:
    image: traefik:v2.2.0-rc1
    command:
      - --log.level=DEBUG
      - --api

      - --entrypoints.web.address=:80
      - --entrypoints.web.http.redirections.entrypoint.to=websecure
      - --entrypoints.web.http.redirections.entrypoint.scheme=https

      - --entrypoints.websecure.address=:443
      - --entrypoints.websecure.http.tls=true

      - --providers.docker.exposedbydefault=false

      - --providers.file.directory=/config/
      - --providers.file.watch=true

    ports:
      - 80:80
      - 443:443
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock:ro
      - ./config/:/config
    labels:
      traefik.enable: true

      traefik.http.routers.traefik.rule: Host(`traefik.localhost`)
      traefik.http.routers.traefik.entrypoints: websecure
      traefik.http.routers.traefik.service: api@internal
 
  whoami:
    image: containous/whoami:v1.4.0
    labels:
      traefik.enable: true

      traefik.http.routers.app.rule: Host(`whoami.localhost`)
      traefik.http.routers.app.entrypoints: websecure
      traefik.http.routers.app.middlewares: SecHeader@file
```

</details>

<details>
<summary>/config/dyn.yml</summary>

```yml
http:
  middlewares:
    SecHeader:
      headers:
        frameDeny: true
        contentTypeNosniff: true
        browserXssFilter: true
```

</details>

And editing the file to produce a reload of the configuration

### Motivation

Fixes #6441 #6442 

### More

- ~~[ ] Added/updated tests~~
- ~~[ ] Added/updated documentation~~
