### PR TITLE
Fix example values for swarmModeRefreshSeconds

### DIFF
--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -473,19 +473,19 @@ _Optional, Default=15_
 
 ```toml tab="File (TOML)"
 [providers.docker]
-  swarmModeRefreshSeconds = "30s"
+  swarmModeRefreshSeconds = "30"
   # ...
 ```
 
 ```yaml tab="File (YAML)"
 providers:
   docker:
-    swarmModeRefreshSeconds: "30s"
+    swarmModeRefreshSeconds: "30"
     # ...
 ```
 
 ```bash tab="CLI"
---providers.docker.swarmModeRefreshSeconds=30s
+--providers.docker.swarmModeRefreshSeconds=30
 # ...
 ```
 

--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -473,14 +473,14 @@ _Optional, Default=15_
 
 ```toml tab="File (TOML)"
 [providers.docker]
-  swarmModeRefreshSeconds = "30"
+  swarmModeRefreshSeconds = 30
   # ...
 ```
 
 ```yaml tab="File (YAML)"
 providers:
   docker:
-    swarmModeRefreshSeconds: "30"
+    swarmModeRefreshSeconds: 30
     # ...
 ```
 


### PR DESCRIPTION
## What does this PR do?

Fix typo in documentation
The default doesn't have the `s` unit, the example should probably not have it either :)
https://github.com/containous/traefik/blob/09c07f45ee999fad6dc97463b4b825fb08c7c34b/pkg/provider/docker/docker.go#L68



## Motivation

Was reading the documentation, find it confusing :grin: 

## More

- [ ] Added/updated tests
- [x] Added/updated documentation

## Additional Notes

You're all incredible people and this is an amazing software! :tada: 