### PR TITLE
docs: terminology, replace 'encoded' by 'hashed'

### DIFF
--- a/docs/content/middlewares/basicauth.md
+++ b/docs/content/middlewares/basicauth.md
@@ -71,7 +71,7 @@ http:
 
 ### General
 
-Passwords must be encoded using MD5, SHA1, or BCrypt.
+Passwords must be hashed using MD5, SHA1, or BCrypt.
 
 !!! tip 
 
@@ -79,7 +79,7 @@ Passwords must be encoded using MD5, SHA1, or BCrypt.
 
 ### `users`
 
-The `users` option is an array of authorized users. Each user will be declared using the `name:encoded-password` format.
+The `users` option is an array of authorized users. Each user will be declared using the `name:hashed-password` format.
 
 !!! note ""
     
@@ -165,7 +165,7 @@ http:
 
 The `usersFile` option is the path to an external file that contains the authorized users for the middleware.
 
-The file content is a list of `name:encoded-password`.
+The file content is a list of `name:hashed-password`.
 
 !!! note ""
     


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

Fix cryptographic-related terminology in documentation.

### Motivation

The term 'encoded' for passwords being hashed (by MD5, SHA1 or BCrypt) is wrong and can be misleading.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation