### PR TITLE
Add example for entrypoint on one ip address

### DIFF
--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -827,9 +827,9 @@ Full details for how to specify `address` can be found in [net.Listen](https://g
 
 !!! warning
 
-    For published ports, the ip address from host network may not be visible depending on the orchestrator.
+    If using an orchestrator, the IP addresses available to bind to may not be externally accessible.
 
-??? info "docker container"
+??? info "Docker"
 
     Publish the ports only on the desired addresses. The network ip address of the host is not visible.
 
@@ -844,7 +844,7 @@ Full details for how to specify `address` can be found in [net.Listen](https://g
           ...
     ```
 
-??? info "docker swarm"
+??? info "Docker Swarm"
 
     All traffic comes from overlay network, and there is no possibility to limit the binding.
 

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -828,3 +828,31 @@ Full details for how to specify `address` can be found in [net.Listen](https://g
 !!! warning
 
     For published ports, the ip address from host network may not be visible depending on the orchestrator.
+
+??? info "docker container"
+
+    Publish the ports only on the desired addresses. The network ip address of the host is not visible.
+
+    ```yaml
+    service:
+      oneService:
+        ports:
+          - 127:0.0.1:8888:8888 # ip address on host
+          - [2001:db8::1]:8888:8888 # ip address on host
+          - ...
+        labels:
+          ...
+    ```
+
+??? info "docker swarm"
+
+    All traffic comes from overlay network, and there is no possibility to limit the binding.
+
+    More details: https://github.com/moby/moby/issues/26696
+
+    Possible workarounds:
+      * add firewall rules on all nodes (https://github.com/moby/moby/issues/32299#issuecomment-360421915)
+
+??? info "other orchestrators - undocumented"
+
+    please find out how to do it and write above <!-- TODO write for more orchestrators -->

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -800,3 +800,31 @@ entrypoints.websecure.http.tls.domains[1].sans=foo.test.com,bar.test.com
     entrypoints.websecure.address=:443
     entrypoints.websecure.http.tls.certResolver=leresolver
     ```
+
+### listen on some ip addresses only
+
+```toml tab="File (TOML)"
+[entryPoints.oneIPv4Address]
+  address = "192.168.2.7:8888" # network ip address INSIDE container
+[entryPoints.oneIPv6Address]
+  address = "[2001:db8::1]:8888" # network ip address INSIDE container
+```
+
+```yaml tab="File (yaml)"
+entryPoints:
+  oneIPv4Address:
+    address: "192.168.2.7:8888" # network ip address INSIDE container
+  oneIPv6address:
+    address: "[2001:db8::1]:8888" # network ip address INSIDE container
+```
+
+```bash tab="CLI"
+entrypoints.oneIPv4Address.address=192.168.2.7:8888 # network ip address INSIDE container
+entrypoints.oneIPv6Address.address=[2001:db8::1]:8888  # network ip address INSIDE container
+```
+
+Full details for how to specify `address` can be found in [net.Listen](https://golang.org/pkg/net/#Listen) (and [net.Dial](https://golang.org/pkg/net/#Dial)) of the doc for go.
+
+!!! warning
+
+    For published ports, the ip address from host network may not be visible depending on the orchestrator.

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -194,26 +194,26 @@ If both TCP and UDP are wanted for the same port, two entryPoints definitions ar
     --entryPoints.udpep.address=:3179/udp
     ```
 
-### listen on some ip addresses only
+#### listen on some ip addresses only
 
 ```toml tab="File (TOML)"
-[entryPoints.oneIPv4Address]
-  address = "192.168.2.7:8888" # network ip address INSIDE container
-[entryPoints.oneIPv6Address]
-  address = "[2001:db8::1]:8888" # network ip address INSIDE container
+[entryPoints.oneIPv4AddressEp]
+  address = "192.168.2.7:8888"
+[entryPoints.oneIPv6AddressEp]
+  address = "[2001:db8::1]:8888"
 ```
 
 ```yaml tab="File (yaml)"
 entryPoints:
-  oneIPv4Address:
-    address: "192.168.2.7:8888" # network ip address INSIDE container
-  oneIPv6address:
-    address: "[2001:db8::1]:8888" # network ip address INSIDE container
+  oneIPv4AddressEp:
+    address: "192.168.2.7:8888"
+  oneIPv6addressEp:
+    address: "[2001:db8::1]:8888"
 ```
 
 ```bash tab="CLI"
-entrypoints.oneIPv4Address.address=192.168.2.7:8888 # network ip address INSIDE container
-entrypoints.oneIPv6Address.address=[2001:db8::1]:8888  # network ip address INSIDE container
+entrypoints.oneIPv4AddressEp.address=192.168.2.7:8888
+entrypoints.oneIPv6AddressEp.address=[2001:db8::1]:8888
 ```
 
 Full details for how to specify `address` can be found in [net.Listen](https://golang.org/pkg/net/#Listen) (and [net.Dial](https://golang.org/pkg/net/#Dial)) of the doc for go.
@@ -224,7 +224,7 @@ Full details for how to specify `address` can be found in [net.Listen](https://g
 
 ??? info "Docker"
 
-    Publish the ports only on the desired addresses. The network ip address of the host is not visible.
+    Publish the ports only on the desired addresses. The ip address of the host is not visible.
 
     ```yaml
     service:

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -168,7 +168,7 @@ The format is:
 
 If both TCP and UDP are wanted for the same port, two entryPoints definitions are needed, such as in the example below.
 
-??? example "Both TCP and UDP on port 3179"
+??? example "Both TCP and UDP on Port 3179"
 
     ```toml tab="File (TOML)"
     ## Static configuration
@@ -194,61 +194,29 @@ If both TCP and UDP are wanted for the same port, two entryPoints definitions ar
     --entryPoints.udpep.address=:3179/udp
     ```
 
-#### listen on some ip addresses only
+??? example "Listen on Specific IP Addresses Only"
 
-```toml tab="File (TOML)"
-[entryPoints.oneIPv4AddressEp]
-  address = "192.168.2.7:8888"
-[entryPoints.oneIPv6AddressEp]
-  address = "[2001:db8::1]:8888"
-```
-
-```yaml tab="File (yaml)"
-entryPoints:
-  oneIPv4AddressEp:
-    address: "192.168.2.7:8888"
-  oneIPv6addressEp:
-    address: "[2001:db8::1]:8888"
-```
-
-```bash tab="CLI"
-entrypoints.oneIPv4AddressEp.address=192.168.2.7:8888
-entrypoints.oneIPv6AddressEp.address=[2001:db8::1]:8888
-```
-
-Full details for how to specify `address` can be found in [net.Listen](https://golang.org/pkg/net/#Listen) (and [net.Dial](https://golang.org/pkg/net/#Dial)) of the doc for go.
-
-!!! warning
-
-    If using an orchestrator, the IP addresses available to bind to may not be externally accessible.
-
-??? info "Docker"
-
-    Publish the ports only on the desired addresses. The ip address of the host is not visible.
-
-    ```yaml
-    service:
-      oneService:
-        ports:
-          - 127:0.0.1:8888:8888 # ip address on host
-          - [2001:db8::1]:8888:8888 # ip address on host
-          - ...
-        labels:
-          ...
+    ```toml tab="File (TOML)"
+    [entryPoints.specificIPv4]
+      address = "192.168.2.7:8888"
+    [entryPoints.specificIPv6]
+      address = "[2001:db8::1]:8888"
     ```
-
-??? info "Docker Swarm"
-
-    All traffic comes from overlay network, and there is no possibility to limit the binding.
-
-    More details: https://github.com/moby/moby/issues/26696
-
-    Possible workarounds:
-      * add firewall rules on all nodes (https://github.com/moby/moby/issues/32299#issuecomment-360421915)
-
-??? info "other orchestrators - undocumented"
-
-    please find out how to do it and write above <!-- TODO write for more orchestrators -->
+    
+    ```yaml tab="File (yaml)"
+    entryPoints:
+      specificIPv4:
+        address: "192.168.2.7:8888"
+      specificIPv6:
+        address: "[2001:db8::1]:8888"
+    ```
+    
+    ```bash tab="CLI"
+    entrypoints.specificIPv4.address=192.168.2.7:8888
+    entrypoints.specificIPv6.address=[2001:db8::1]:8888
+    ```
+    
+    Full details for how to specify `address` can be found in [net.Listen](https://golang.org/pkg/net/#Listen) (and [net.Dial](https://golang.org/pkg/net/#Dial)) of the doc for go.
 
 ### Forwarded Headers
 

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -194,6 +194,62 @@ If both TCP and UDP are wanted for the same port, two entryPoints definitions ar
     --entryPoints.udpep.address=:3179/udp
     ```
 
+### listen on some ip addresses only
+
+```toml tab="File (TOML)"
+[entryPoints.oneIPv4Address]
+  address = "192.168.2.7:8888" # network ip address INSIDE container
+[entryPoints.oneIPv6Address]
+  address = "[2001:db8::1]:8888" # network ip address INSIDE container
+```
+
+```yaml tab="File (yaml)"
+entryPoints:
+  oneIPv4Address:
+    address: "192.168.2.7:8888" # network ip address INSIDE container
+  oneIPv6address:
+    address: "[2001:db8::1]:8888" # network ip address INSIDE container
+```
+
+```bash tab="CLI"
+entrypoints.oneIPv4Address.address=192.168.2.7:8888 # network ip address INSIDE container
+entrypoints.oneIPv6Address.address=[2001:db8::1]:8888  # network ip address INSIDE container
+```
+
+Full details for how to specify `address` can be found in [net.Listen](https://golang.org/pkg/net/#Listen) (and [net.Dial](https://golang.org/pkg/net/#Dial)) of the doc for go.
+
+!!! warning
+
+    If using an orchestrator, the IP addresses available to bind to may not be externally accessible.
+
+??? info "Docker"
+
+    Publish the ports only on the desired addresses. The network ip address of the host is not visible.
+
+    ```yaml
+    service:
+      oneService:
+        ports:
+          - 127:0.0.1:8888:8888 # ip address on host
+          - [2001:db8::1]:8888:8888 # ip address on host
+          - ...
+        labels:
+          ...
+    ```
+
+??? info "Docker Swarm"
+
+    All traffic comes from overlay network, and there is no possibility to limit the binding.
+
+    More details: https://github.com/moby/moby/issues/26696
+
+    Possible workarounds:
+      * add firewall rules on all nodes (https://github.com/moby/moby/issues/32299#issuecomment-360421915)
+
+??? info "other orchestrators - undocumented"
+
+    please find out how to do it and write above <!-- TODO write for more orchestrators -->
+
 ### Forwarded Headers
 
 You can configure Traefik to trust the forwarded headers information (`X-Forwarded-*`).
@@ -800,59 +856,3 @@ entrypoints.websecure.http.tls.domains[1].sans=foo.test.com,bar.test.com
     entrypoints.websecure.address=:443
     entrypoints.websecure.http.tls.certResolver=leresolver
     ```
-
-### listen on some ip addresses only
-
-```toml tab="File (TOML)"
-[entryPoints.oneIPv4Address]
-  address = "192.168.2.7:8888" # network ip address INSIDE container
-[entryPoints.oneIPv6Address]
-  address = "[2001:db8::1]:8888" # network ip address INSIDE container
-```
-
-```yaml tab="File (yaml)"
-entryPoints:
-  oneIPv4Address:
-    address: "192.168.2.7:8888" # network ip address INSIDE container
-  oneIPv6address:
-    address: "[2001:db8::1]:8888" # network ip address INSIDE container
-```
-
-```bash tab="CLI"
-entrypoints.oneIPv4Address.address=192.168.2.7:8888 # network ip address INSIDE container
-entrypoints.oneIPv6Address.address=[2001:db8::1]:8888  # network ip address INSIDE container
-```
-
-Full details for how to specify `address` can be found in [net.Listen](https://golang.org/pkg/net/#Listen) (and [net.Dial](https://golang.org/pkg/net/#Dial)) of the doc for go.
-
-!!! warning
-
-    If using an orchestrator, the IP addresses available to bind to may not be externally accessible.
-
-??? info "Docker"
-
-    Publish the ports only on the desired addresses. The network ip address of the host is not visible.
-
-    ```yaml
-    service:
-      oneService:
-        ports:
-          - 127:0.0.1:8888:8888 # ip address on host
-          - [2001:db8::1]:8888:8888 # ip address on host
-          - ...
-        labels:
-          ...
-    ```
-
-??? info "Docker Swarm"
-
-    All traffic comes from overlay network, and there is no possibility to limit the binding.
-
-    More details: https://github.com/moby/moby/issues/26696
-
-    Possible workarounds:
-      * add firewall rules on all nodes (https://github.com/moby/moby/issues/32299#issuecomment-360421915)
-
-??? info "other orchestrators - undocumented"
-
-    please find out how to do it and write above <!-- TODO write for more orchestrators -->


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

Show how to bind an entrypoint to a single ip address. Similar as earlyer by #1194.
 
<!-- A brief description of the change being made with this pull request. -->


### Motivation

There is not mentioned anywhere in the doc that an IP address can be set for an entry point. (Except in #1193) 
Started a list showing how to do the address matching for different orchestrators. Instructions for other orchestrators would be handy (as requested in #5059.
<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

I linked to original sources for users can find more details themselves.
<!-- Anything else we should know when reviewing? -->
