### PR TITLE
udp: replace concurrently reset timer with ticker

### DIFF
--- a/integration/udp_test.go
+++ b/integration/udp_test.go
@@ -101,7 +101,7 @@ func (s *UDPSuite) TestWRR(c *check.C) {
 
 	select {
 	case <-stop:
-	case <-time.Tick(time.Second * 5):
+	case <-time.Tick(5 * time.Second):
 		c.Error("Timeout")
 	}
 }

--- a/pkg/server/server_entrypoint_tcp_test.go
+++ b/pkg/server/server_entrypoint_tcp_test.go
@@ -84,7 +84,7 @@ func testShutdown(t *testing.T, router *tcp.Router) {
 	request, err := http.NewRequest(http.MethodHead, "http://127.0.0.1:8082", nil)
 	require.NoError(t, err)
 
-	time.Sleep(time.Millisecond * 100)
+	time.Sleep(100 * time.Millisecond)
 
 	// We need to do a write on the conn before the shutdown to make it "exist".
 	// Because the connection indeed exists as far as TCP is concerned,
@@ -104,7 +104,7 @@ func testShutdown(t *testing.T, router *tcp.Router) {
 		loopConn, err := net.Dial("tcp", epAddr)
 		if err == nil {
 			loopConn.Close()
-			time.Sleep(time.Millisecond * 100)
+			time.Sleep(100 * time.Millisecond)
 			continue
 		}
 		if !strings.HasSuffix(err.Error(), "connection refused") && !strings.HasSuffix(err.Error(), "reset by peer") {
@@ -135,7 +135,7 @@ func startEntrypoint(entryPoint *TCPEntryPoint, router *tcp.Router) (net.Conn, e
 	for i := 0; i < 10; i++ {
 		conn, err = net.Dial("tcp", entryPoint.listener.Addr().String())
 		if err != nil {
-			time.Sleep(time.Millisecond * 100)
+			time.Sleep(100 * time.Millisecond)
 			continue
 		}
 		epStarted = true
@@ -150,7 +150,7 @@ func startEntrypoint(entryPoint *TCPEntryPoint, router *tcp.Router) (net.Conn, e
 func TestReadTimeoutWithoutFirstByte(t *testing.T) {
 	epConfig := &static.EntryPointsTransport{}
 	epConfig.SetDefaults()
-	epConfig.RespondingTimeouts.ReadTimeout = types.Duration(time.Second * 2)
+	epConfig.RespondingTimeouts.ReadTimeout = types.Duration(2 * time.Second)
 
 	entryPoint, err := NewTCPEntryPoint(context.Background(), &static.EntryPoint{
 		Address:          ":0",
@@ -178,7 +178,7 @@ func TestReadTimeoutWithoutFirstByte(t *testing.T) {
 	select {
 	case err := <-errChan:
 		require.Equal(t, io.EOF, err)
-	case <-time.Tick(time.Second * 5):
+	case <-time.Tick(5 * time.Second):
 		t.Error("Timeout while read")
 	}
 }
@@ -186,7 +186,7 @@ func TestReadTimeoutWithoutFirstByte(t *testing.T) {
 func TestReadTimeoutWithFirstByte(t *testing.T) {
 	epConfig := &static.EntryPointsTransport{}
 	epConfig.SetDefaults()
-	epConfig.RespondingTimeouts.ReadTimeout = types.Duration(time.Second * 2)
+	epConfig.RespondingTimeouts.ReadTimeout = types.Duration(2 * time.Second)
 
 	entryPoint, err := NewTCPEntryPoint(context.Background(), &static.EntryPoint{
 		Address:          ":0",
@@ -217,7 +217,7 @@ func TestReadTimeoutWithFirstByte(t *testing.T) {
 	select {
 	case err := <-errChan:
 		require.Equal(t, io.EOF, err)
-	case <-time.Tick(time.Second * 5):
+	case <-time.Tick(5 * time.Second):
 		t.Error("Timeout while read")
 	}
 }

--- a/pkg/server/server_entrypoint_udp_test.go
+++ b/pkg/server/server_entrypoint_udp_test.go
@@ -92,7 +92,7 @@ func TestShutdownUDPConn(t *testing.T) {
 
 	select {
 	case <-doneChan:
-	case <-time.Tick(time.Second * 10):
+	case <-time.Tick(10 * time.Second):
 		// In case we introduce a regression that would make the test wait forever.
 		t.Fatal("Timeout during shutdown")
 	}

--- a/pkg/server/server_entrypoint_udp_test.go
+++ b/pkg/server/server_entrypoint_udp_test.go
@@ -92,7 +92,7 @@ func TestShutdownUDPConn(t *testing.T) {
 
 	select {
 	case <-doneChan:
-	case <-time.Tick(time.Second * 5):
+	case <-time.Tick(time.Second * 10):
 		// In case we introduce a regression that would make the test wait forever.
 		t.Fatal("Timeout during shutdown")
 	}

--- a/pkg/server/server_entrypoint_udp_test.go
+++ b/pkg/server/server_entrypoint_udp_test.go
@@ -92,7 +92,7 @@ func TestShutdownUDPConn(t *testing.T) {
 
 	select {
 	case <-doneChan:
-	case <-time.Tick(time.Second * 10):
+	case <-time.Tick(time.Second * 5):
 		// In case we introduce a regression that would make the test wait forever.
 		t.Fatal("Timeout during shutdown")
 	}

--- a/pkg/udp/conn.go
+++ b/pkg/udp/conn.go
@@ -14,7 +14,7 @@ const closeRetryInterval = 500 * time.Millisecond
 
 // connTimeout determines how long to wait on an idle session,
 // before releasing all resources related to that session.
-const connTimeout = time.Second * 3
+const connTimeout = 3 * time.Second
 
 var timeoutTicker = connTimeout / 10
 

--- a/pkg/udp/conn_test.go
+++ b/pkg/udp/conn_test.go
@@ -148,7 +148,7 @@ func testTimeout(t *testing.T, withRead bool) {
 
 	assert.Equal(t, 10, len(ln.conns))
 
-	time.Sleep(3 * time.Second)
+	time.Sleep(3500 * time.Millisecond)
 	assert.Equal(t, 0, len(ln.conns))
 }
 
@@ -239,7 +239,7 @@ func TestShutdown(t *testing.T) {
 
 	select {
 	case <-doneChan:
-	case <-time.Tick(time.Second * 5):
+	case <-time.Tick(time.Second * 10):
 		// In case we introduce a regression that would make the test wait forever.
 		t.Fatal("Timeout during shutdown")
 	}

--- a/pkg/udp/conn_test.go
+++ b/pkg/udp/conn_test.go
@@ -43,7 +43,7 @@ func TestListenNotBlocking(t *testing.T) {
 				require.NoError(t, err)
 
 				// This should not block second call
-				time.Sleep(time.Second * 10)
+				time.Sleep(10 * time.Second)
 			}()
 		}
 	}()
@@ -239,7 +239,7 @@ func TestShutdown(t *testing.T) {
 
 	select {
 	case <-doneChan:
-	case <-time.Tick(time.Second * 5):
+	case <-time.Tick(5 * time.Second):
 		// In case we introduce a regression that would make the test wait forever.
 		t.Fatal("Timeout during shutdown")
 	}

--- a/pkg/udp/conn_test.go
+++ b/pkg/udp/conn_test.go
@@ -148,7 +148,7 @@ func testTimeout(t *testing.T, withRead bool) {
 
 	assert.Equal(t, 10, len(ln.conns))
 
-	time.Sleep(6 * time.Second)
+	time.Sleep(4 * time.Second)
 	assert.Equal(t, 0, len(ln.conns))
 }
 
@@ -239,7 +239,7 @@ func TestShutdown(t *testing.T) {
 
 	select {
 	case <-doneChan:
-	case <-time.Tick(time.Second * 10):
+	case <-time.Tick(time.Second * 5):
 		// In case we introduce a regression that would make the test wait forever.
 		t.Fatal("Timeout during shutdown")
 	}

--- a/pkg/udp/conn_test.go
+++ b/pkg/udp/conn_test.go
@@ -148,7 +148,7 @@ func testTimeout(t *testing.T, withRead bool) {
 
 	assert.Equal(t, 10, len(ln.conns))
 
-	time.Sleep(3500 * time.Millisecond)
+	time.Sleep(6 * time.Second)
 	assert.Equal(t, 0, len(ln.conns))
 }
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR removes the use of a timer for timeouts, replacing it with a ticker instead.
The timer was wrongly used because:
1) it was being reset concurrently (without any locking).
2) it was being reset in cases where its channel might have not been drained

The situation might have been fixed in various ways while still using a timer, but it seems simpler for now to have a ticker instead.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

Fixes #6494 

<!-- What inspired you to submit this pull request? -->

### More

- [x] Added/updated tests
~- [ ] Added/updated documentation~

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Co-authored-by: Julien Salleyron <julien.salleyron@gmail.com>
