### PR TITLE
fix: Ingress TLS support

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -172,3 +172,133 @@ rules:
 ```
 
 After having both resources applied, Traefik will work properly.
+
+### Kubernetes Ingress
+
+The TLS section in the Ingress is now not enough to have HTTPS.
+
+#### Expose an Ingress on 80 and 443
+
+Define the default TLS configuration on the HTTPS entry point. 
+
+```yaml tab="Ingress"
+kind: Ingress
+apiVersion: networking.k8s.io/v1beta1
+metadata:
+  name: example
+
+spec:
+  tls:
+  - secretName: myTlsSecret
+
+  rules:
+  - host: example.com
+    http:
+      paths:
+      - path: "/foo"
+        backend:
+          serviceName: example-com
+          servicePort: 80
+```
+
+Entry points definition and enable Ingress provider:
+
+```yaml tab="File (YAML)"
+# Static configuration
+
+entryPoints:
+  web:
+    address: :80
+  websecure:
+    address: :443
+    http:
+      tls: {}
+
+providers:
+  kubernetesIngress: {}
+```
+
+```toml tab="File (TOML)"
+# Static configuration
+
+[entryPoints.web]
+  address = ":80"
+
+[entryPoints.websecure]
+  address = ":443"
+  [entryPoints.websecure.http]
+    [entryPoints.websecure.http.tls]
+
+[providers.kubernetesIngress]
+```
+
+```bash tab="CLI"
+# Static configuration
+
+--entryPoints.web.address=:80
+--entryPoints.websecure.address=:443
+--entryPoints.websecure.http.tls=true
+--providers.kubernetesIngress=true
+```
+
+#### Use TLS only on one Ingress
+
+Define the TLS restriction with annotations.
+
+```yaml tab="Ingress"
+kind: Ingress
+apiVersion: networking.k8s.io/v1beta1
+metadata:
+  name: example-tls
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+
+spec:
+  tls:
+  - secretName: myTlsSecret
+
+  rules:
+  - host: example.com
+    http:
+      paths:
+      - path: ""
+        backend:
+          serviceName: example-com
+          servicePort: 80
+```
+
+Entry points definition and enable Ingress provider:
+
+```yaml tab="File (YAML)"
+# Static configuration
+
+entryPoints:
+  web:
+    address: :80
+  websecure:
+    address: :443
+
+providers:
+  kubernetesIngress: {}
+```
+
+```toml tab="File (TOML)"
+# Static configuration
+
+[entryPoints.web]
+  address = ":80"
+
+[entryPoints.websecure]
+  address = ":443"
+
+[providers.kubernetesIngress]
+```
+
+```bash tab="CLI"
+# Static configuration
+
+--entryPoints.web.address=:80
+--entryPoints.websecure.address=:443
+--providers.kubernetesIngress=true
+```

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -175,7 +175,7 @@ After having both resources applied, Traefik will work properly.
 
 ### Kubernetes Ingress
 
-The TLS section in the Ingress is now not enough to have HTTPS.
+To enable HTTPS, it is not sufficient anymore to only rely on a TLS section in the Ingress.
 
 #### Expose an Ingress on 80 and 443
 

--- a/docs/content/routing/providers/kubernetes-ingress.md
+++ b/docs/content/routing/providers/kubernetes-ingress.md
@@ -202,7 +202,7 @@ which in turn will create the resulting routers, services, handlers, etc.
     See [middlewares](../routers/index.md#middlewares) and [middlewares overview](../../middlewares/overview.md) for more information.
 
     ```yaml
-    traefik.ingress.kubernetes.io/router.middlewares: auth@file,prefix@kuberntes-crd,cb@file
+    traefik.ingress.kubernetes.io/router.middlewares: auth@file,prefix@kuberntescrd,cb@file
     ```
 
 ??? info "`traefik.ingress.kubernetes.io/router.priority`"

--- a/integration/testdata/rawdata-ingress.json
+++ b/integration/testdata/rawdata-ingress.json
@@ -45,7 +45,6 @@
 			],
 			"service": "default-whoami-http",
 			"rule": "Host(`whoami.test.https`) \u0026\u0026 PathPrefix(`/whoami`)",
-			"tls": {},
 			"status": "enabled",
 			"using": [
 				"web"

--- a/pkg/provider/kubernetes/ingress/fixtures/TLS-support_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/TLS-support_ingress.yml
@@ -3,6 +3,8 @@ apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: ""
   namespace: testing
+  annotations:
+    traefik.ingress.kubernetes.io/router.tls: "true"
 
 spec:
   tls:

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -265,10 +265,10 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 
 				serviceName := provider.Normalize(ingress.Namespace + "-" + pa.Backend.ServiceName + "-" + pa.Backend.ServicePort.String())
 				conf.HTTP.Services[serviceName] = service
-				conf.HTTP.Services[serviceName] = service
 
 				routerKey := strings.TrimPrefix(provider.Normalize(ingress.Name+"-"+ingress.Namespace+"-"+rule.Host+pa.Path), "-")
-				conf.HTTP.Routers[routerKey] = loadRouter(ingress, rule, pa, rtConfig, serviceName)
+
+				conf.HTTP.Routers[routerKey] = loadRouter(rule, pa, rtConfig, serviceName)
 			}
 		}
 	}
@@ -526,7 +526,7 @@ func getProtocol(portSpec corev1.ServicePort, portName string, svcConfig *Servic
 	return protocol
 }
 
-func loadRouter(ingress *v1beta1.Ingress, rule v1beta1.IngressRule, pa v1beta1.HTTPIngressPath, rtConfig *RouterConfig, serviceName string) *dynamic.Router {
+func loadRouter(rule v1beta1.IngressRule, pa v1beta1.HTTPIngressPath, rtConfig *RouterConfig, serviceName string) *dynamic.Router {
 	var rules []string
 	if len(rule.Host) > 0 {
 		rules = []string{buildHostRule(rule.Host)}
@@ -544,11 +544,6 @@ func loadRouter(ingress *v1beta1.Ingress, rule v1beta1.IngressRule, pa v1beta1.H
 	rt := &dynamic.Router{
 		Rule:    strings.Join(rules, " && "),
 		Service: serviceName,
-	}
-
-	if len(ingress.Spec.TLS) > 0 {
-		// TLS enabled for this ingress, add TLS router
-		rt.TLS = &dynamic.RouterTLSConfig{}
 	}
 
 	if rtConfig != nil && rtConfig.Router != nil {


### PR DESCRIPTION
### What does this PR do?

Now, the TLS section in a Ingress don't control the activation of the TLS.

To enable TLS:
- use the TLS configuration on the entry point: https://docs.traefik.io/v2.2/routing/entrypoints/#tls
- use annotation `traefik.ingress.kubernetes.io/router.tls: "true"`: https://docs.traefik.io/v2.2/routing/providers/kubernetes-ingress/#on-ingress

### Motivation

Fixes #6501,#6506

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Co-authored-by: Julien Salleyron <julien@containo.us>
