### PR TITLE
Add decryption option for keyfiles

### DIFF
--- a/docs/content/https/tls.md
+++ b/docs/content/https/tls.md
@@ -42,6 +42,40 @@ tls:
     It is the only available method to configure the certificates (as well as the options and the stores).
     However, in [Kubernetes](../providers/kubernetes-crd.md), the certificates can and must be provided by [secrets](https://kubernetes.io/docs/concepts/configuration/secret/). 
 
+### Encrypted private keys
+
+To use TLS certificates with encrypted private keys, the passphrase must be provided with which to decrypt the key.
+
+```toml tab="File (TOML)"
+# Dynamic configuration
+
+[[tls.certificates]]
+  certFile = "/path/to/domain-encrypted.cert"
+  keyFile = "/path/to/domain-encrypted.key"
+  passphrase = "mysuperpassphrase"
+```
+
+```yaml tab="File (YAML)"
+# Dynamic configuration
+
+tls:
+  certificates:
+    - certFile: /path/to/domain-encrypted.cert
+      keyFile: /path/to/domain-encrypted.key
+      passphrase: mysuperpassphrase
+```
+
+!!! important "Incorrect passphrase"
+
+    An incorrect/missing passphrase when using an encrypted private key will result in the certificate being unusable.
+    There will also be corresponding decryption failures in the logs.
+    These errors may generate a lot of log volume, so exercise care to ensure the passphrase is correct.
+
+!!! important "Restriction"
+
+    In the above example, we've used the [file provider](../providers/file.md) to handle these definitions.
+    However, in [Kubernetes](../providers/kubernetes-crd.md), the certificates can and must be provided by [secrets](https://kubernetes.io/docs/concepts/configuration/secret/), and the passphrase must also be provided in a secret.
+
 ## Certificates Stores
 
 In Traefik, certificates are grouped together in certificates stores, which are defined as such:

--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -353,6 +353,7 @@ Register the `IngressRoute` [kind](../../reference/dynamic-configuration/kuberne
           sans:                         # [17]
           - a.foo.com
           - b.foo.com
+        passphraseSecretName: superpassphrasesecret # [18]
     ```
 
 | Ref  | Attribute                  | Purpose                                                                                                                                                                                                                  |
@@ -374,6 +375,7 @@ Register the `IngressRoute` [kind](../../reference/dynamic-configuration/kuberne
 | [15] | `tls.domains`              | List of [domains](../routers/index.md#domains)                                                                                                                                                                           |
 | [16] | `domains[n].main`          | Defines the main domain name                                                                                                                                                                                             |
 | [17] | `domains[n].sans`          | List of SANs (alternative domains)                                                                                                                                                                                       |
+| [18] | `tls.passphraseSecretName`           | Defines the [secret](https://kubernetes.io/docs/concepts/configuration/secret/) name used to store the certificate passphrase (in the `IngressRoute` namespace)                                                                     |
 
 ??? example "Declaring an IngressRoute"
 
@@ -421,6 +423,7 @@ Register the `IngressRoute` [kind](../../reference/dynamic-configuration/kuberne
           name: opt
           namespace: default
         secretName: supersecret
+        passphraseSecretName: superpassphrasesecret
     ```
 
     ```yaml tab="Middlewares"
@@ -456,6 +459,16 @@ Register the `IngressRoute` [kind](../../reference/dynamic-configuration/kuberne
     data:
       tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0=
       tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0=
+    ```
+
+    ```yaml tab="Passphrase Secret"
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: superpassphrasesecret
+    
+    data:
+      passphrase: Zm9v
     ```
 
 !!! important "Configuring Backend Protocol"
@@ -952,6 +965,7 @@ Register the `IngressRouteTCP` [kind](../../reference/dynamic-configuration/kube
           - a.foo.com
           - b.foo.com
         passthrough: false          # [18]
+        passphraseSecretName: superpassphrasesecret # [19]
     ```
 
 | Ref  | Attribute                      | Purpose                                                                                                                                                                                                                                                                                                                                                                                  |
@@ -974,6 +988,7 @@ Register the `IngressRouteTCP` [kind](../../reference/dynamic-configuration/kube
 | [16] | `domains[n].main`              | Defines the main domain name                                                                                                                                                                                                                                                                                                                                                             |
 | [17] | `domains[n].sans`              | List of SANs (alternative domains)                                                                                                                                                                                                                                                                                                                                                       |
 | [18] | `tls.passthrough`              | If `true`, delegates the TLS termination to the backend                                                                                                                                                                                                                                                                                                                                  |
+| [19] | `tls.passphraseSecretName`               | Defines the [secret](https://kubernetes.io/docs/concepts/configuration/secret/) name used to store the certificate passphrase (in the `IngressRoute` namespace)                                                                                                                                                                                                                                     |
 
 ??? example "Declaring an IngressRouteTCP"
 
@@ -1010,6 +1025,7 @@ Register the `IngressRouteTCP` [kind](../../reference/dynamic-configuration/kube
           namespace: default
         secretName: supersecret
         passthrough: false
+        passphraseSecretName: superpassphrasesecret
     ```
     
     ```yaml tab="TLSOption"
@@ -1032,6 +1048,16 @@ Register the `IngressRouteTCP` [kind](../../reference/dynamic-configuration/kube
     data:
       tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0=
       tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0=
+    ```
+
+    ```yaml tab="Passphrase Secret"
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: superpassphrasesecret
+    
+    data:
+      passphrase: Zm9v
     ```
 
 !!! important "Using Kubernetes ExternalName Service"

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/with_tls_passphrase.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/with_tls_passphrase.yml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: supersecret
+  namespace: default
+
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0=
+  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0=
+
+---
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: supersecretpassphrase
+    namespace: default
+  
+  data:
+    passphrase: Zm9v
+  
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: test.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+  - match: HostSNI(`foo.com`)
+    services:
+    - name: whoamitcp
+      port: 8000
+
+  tls:
+    secretName: supersecret
+    passphraseSecretName: supersecretpassphrase
+    

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/with_tls_passphrase.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/with_tls_passphrase.yml
@@ -38,4 +38,3 @@ spec:
   tls:
     secretName: supersecret
     passphraseSecretName: supersecretpassphrase
-    

--- a/pkg/provider/kubernetes/crd/fixtures/with_tls_passphrase.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_tls_passphrase.yml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: supersecret
+  namespace: default
+
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0=
+  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0=
+
+---
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: supersecretpassphrase
+    namespace: default
+  
+  data:
+    passphrase: Zm9v
+  
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: test.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - web
+
+  routes:
+  - match: Host(`foo.com`) && PathPrefix(`/bar`)
+    kind: Rule
+    priority: 12
+    services:
+    - name: whoami
+      port: 80
+
+  tls:
+    secretName: supersecret
+    passphraseSecretName: supersecretpassphrase

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -675,6 +675,22 @@ func getTLSConfig(tlsConfigs map[string]*tls.CertAndStores) []*tls.CertAndStores
 	return configs
 }
 
+func getTLSPassphrase(k8sClient Client, secretName, namespace string) (string, error) {
+	secret, exists, err := k8sClient.GetSecret(namespace, secretName)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch passphrase secret %s/%s: %w", namespace, secretName, err)
+	}
+	if !exists {
+		return "", fmt.Errorf("passphrase secret %s/%s does not exist", namespace, secretName)
+	}
+
+	if _, ok := secret.Data["passphrase"]; ok {
+		return string(secret.Data["passphrase"]), nil
+	}
+
+	return "", fmt.Errorf("passphrase secret %s/%s does not contain the correct data key \"passphrase\"", namespace, secretName)
+}
+
 func getCertificateBlocks(secret *corev1.Secret, namespace, secretName string) (string, string, error) {
 	var missingEntries []string
 

--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -435,15 +435,11 @@ func getTLSHTTP(ctx context.Context, ingressRoute *v1alpha1.IngressRoute, k8sCli
 
 	// If there is a passphrase configured, load it into the certificate config.
 	if ingressRoute.Spec.TLS.PassphraseSecretName != "" {
-		secret, exists, err := k8sClient.GetSecret(ingressRoute.Namespace, ingressRoute.Spec.TLS.PassphraseSecretName)
+		passphrase, err := getTLSPassphrase(k8sClient, ingressRoute.Spec.TLS.PassphraseSecretName, ingressRoute.Namespace)
 		if err != nil {
-			return fmt.Errorf("failed to fetch secret %s/%s: %w", ingressRoute.Namespace, ingressRoute.Spec.TLS.PassphraseSecretName, err)
+			return err
 		}
-		if !exists {
-			return fmt.Errorf("secret %s/%s does not exist", ingressRoute.Namespace, ingressRoute.Spec.TLS.PassphraseSecretName)
-		}
-
-		tlsConfigs[configKey].Passphrase = string(secret.Data["passphrase"])
+		tlsConfigs[configKey].Passphrase = passphrase
 	}
 
 	return nil

--- a/pkg/provider/kubernetes/crd/kubernetes_tcp.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_tcp.go
@@ -231,15 +231,11 @@ func getTLSTCP(ctx context.Context, ingressRoute *v1alpha1.IngressRouteTCP, k8sC
 
 	// If there is a passphrase configured, load it into the certificate config.
 	if ingressRoute.Spec.TLS.PassphraseSecretName != "" {
-		secret, exists, err := k8sClient.GetSecret(ingressRoute.Namespace, ingressRoute.Spec.TLS.PassphraseSecretName)
+		passphrase, err := getTLSPassphrase(k8sClient, ingressRoute.Spec.TLS.PassphraseSecretName, ingressRoute.Namespace)
 		if err != nil {
-			return fmt.Errorf("failed to fetch secret %s/%s: %w", ingressRoute.Namespace, ingressRoute.Spec.TLS.PassphraseSecretName, err)
+			return err
 		}
-		if !exists {
-			return fmt.Errorf("secret %s/%s does not exist", ingressRoute.Namespace, ingressRoute.Spec.TLS.PassphraseSecretName)
-		}
-
-		tlsConfigs[configKey].Passphrase = string(secret.Data["passphrase"])
+		tlsConfigs[configKey].Passphrase = passphrase
 	}
 
 	return nil

--- a/pkg/provider/kubernetes/crd/kubernetes_tcp.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_tcp.go
@@ -229,5 +229,18 @@ func getTLSTCP(ctx context.Context, ingressRoute *v1alpha1.IngressRouteTCP, k8sC
 		tlsConfigs[configKey] = tlsConf
 	}
 
+	// If there is a passphrase configured, load it into the certificate config.
+	if ingressRoute.Spec.TLS.PassphraseSecretName != "" {
+		secret, exists, err := k8sClient.GetSecret(ingressRoute.Namespace, ingressRoute.Spec.TLS.PassphraseSecretName)
+		if err != nil {
+			return fmt.Errorf("failed to fetch secret %s/%s: %w", ingressRoute.Namespace, ingressRoute.Spec.TLS.PassphraseSecretName, err)
+		}
+		if !exists {
+			return fmt.Errorf("secret %s/%s does not exist", ingressRoute.Namespace, ingressRoute.Spec.TLS.PassphraseSecretName)
+		}
+
+		tlsConfigs[configKey].Passphrase = string(secret.Data["passphrase"])
+	}
+
 	return nil
 }

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -444,6 +444,58 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 			},
 		},
 		{
+			desc:  "TLS with passphrase",
+			paths: []string{"tcp/services.yml", "tcp/with_tls_passphrase.yml"},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TLS: &dynamic.TLSConfiguration{
+					Certificates: []*tls.CertAndStores{
+						{
+							Certificate: tls.Certificate{
+								CertFile:   tls.FileOrContent("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----"),
+								KeyFile:    tls.FileOrContent("-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----"),
+								Passphrase: "foo",
+							},
+						},
+					},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers: map[string]*dynamic.TCPRouter{
+						"default-test.route-fdd3e9338e47a45efefc": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test.route-fdd3e9338e47a45efefc",
+							Rule:        "HostSNI(`foo.com`)",
+							TLS:         &dynamic.RouterTCPTLSConfig{},
+						},
+					},
+					Services: map[string]*dynamic.TCPService{
+						"default-test.route-fdd3e9338e47a45efefc": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{
+										Address: "10.10.0.1:8000",
+										Port:    "",
+									},
+									{
+										Address: "10.10.0.2:8000",
+										Port:    "",
+									},
+								},
+							},
+						},
+					},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:     map[string]*dynamic.Router{},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services:    map[string]*dynamic.Service{},
+				},
+			},
+		},
+		{
 			desc:  "TLS with passthrough",
 			paths: []string{"tcp/services.yml", "tcp/with_tls_passthrough.yml"},
 			expected: &dynamic.Configuration{
@@ -2183,6 +2235,58 @@ func TestLoadIngressRoutes(t *testing.T) {
 							Certificate: tls.Certificate{
 								CertFile: tls.FileOrContent("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----"),
 								KeyFile:  tls.FileOrContent("-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----"),
+							},
+						},
+					},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-test-route-6b204d94623b3df4370c": {
+							EntryPoints: []string{"web"},
+							Service:     "default-test-route-6b204d94623b3df4370c",
+							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
+							Priority:    12,
+							TLS:         &dynamic.RouterTLSConfig{},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"default-test-route-6b204d94623b3df4370c": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: Bool(true),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:  "TLS with passphrase",
+			paths: []string{"services.yml", "with_tls_passphrase.yml"},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TLS: &dynamic.TLSConfiguration{
+					Certificates: []*tls.CertAndStores{
+						{
+							Certificate: tls.Certificate{
+								CertFile:   tls.FileOrContent("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----"),
+								KeyFile:    tls.FileOrContent("-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----"),
+								Passphrase: "foo",
 							},
 						},
 					},

--- a/pkg/provider/kubernetes/crd/traefik/v1alpha1/ingressroute.go
+++ b/pkg/provider/kubernetes/crd/traefik/v1alpha1/ingressroute.go
@@ -37,6 +37,9 @@ type TLS struct {
 	// SecretName is the name of the referenced Kubernetes Secret to specify the
 	// certificate details.
 	SecretName string `json:"secretName"`
+	// PassphraseSecretName is the name of the referenced Kubernetes Secret to specify the
+	// certificate passphrase.
+	PassphraseSecretName string `json:"passphraseSecretName,omitempty"`
 	// Options is a reference to a TLSOption, that specifies the parameters of the TLS connection.
 	Options *TLSOptionRef `json:"options,omitempty"`
 	// Store is a reference to a TLSStore, that specifies the parameters of the TLS store.

--- a/pkg/provider/kubernetes/crd/traefik/v1alpha1/ingressroutetcp.go
+++ b/pkg/provider/kubernetes/crd/traefik/v1alpha1/ingressroutetcp.go
@@ -29,8 +29,11 @@ type RouteTCP struct {
 type TLSTCP struct {
 	// SecretName is the name of the referenced Kubernetes Secret to specify the
 	// certificate details.
-	SecretName  string `json:"secretName"`
-	Passthrough bool   `json:"passthrough"`
+	SecretName string `json:"secretName"`
+	// PassphraseSecretName is the name of the referenced Kubernetes Secret to specify the
+	// certificate passphrase.
+	PassphraseSecretName string `json:"passphraseSecretName,omitempty"`
+	Passthrough          bool   `json:"passthrough"`
 	// Options is a reference to a TLSOption, that specifies the parameters of the TLS connection.
 	Options *TLSOptionTCPRef `json:"options"`
 	// Store is a reference to a TLSStore, that specifies the parameters of the TLS store.

--- a/pkg/provider/kv/kv_test.go
+++ b/pkg/provider/kv/kv_test.go
@@ -264,6 +264,7 @@ func Test_buildConfiguration(t *testing.T) {
 		"traefik/tls/stores/Store1/defaultCertificate/keyFile":                                       "foobar",
 		"traefik/tls/certificates/0/certFile":                                                        "foobar",
 		"traefik/tls/certificates/0/keyFile":                                                         "foobar",
+		"traefik/tls/certificates/0/passphrase":                                                      "foobar",
 		"traefik/tls/certificates/0/stores/0":                                                        "foobar",
 		"traefik/tls/certificates/0/stores/1":                                                        "foobar",
 		"traefik/tls/certificates/1/certFile":                                                        "foobar",
@@ -794,8 +795,9 @@ func Test_buildConfiguration(t *testing.T) {
 			Certificates: []*tls.CertAndStores{
 				{
 					Certificate: tls.Certificate{
-						CertFile: tls.FileOrContent("foobar"),
-						KeyFile:  tls.FileOrContent("foobar"),
+						CertFile:   tls.FileOrContent("foobar"),
+						KeyFile:    tls.FileOrContent("foobar"),
+						Passphrase: "foobar",
 					},
 					Stores: []string{
 						"foobar",

--- a/pkg/tls/certificate.go
+++ b/pkg/tls/certificate.go
@@ -259,7 +259,7 @@ func DecodePrivateKey(keyContent []byte, passphrase string) ([]byte, error) {
 	if x509.IsEncryptedPEMBlock(keyPemBlock) {
 		keyDecoded, err = x509.DecryptPEMBlock(keyPemBlock, []byte(passphrase))
 		if err != nil {
-			return keyDecoded, fmt.Errorf("unable to decrypt TLS certificate key : %v", err)
+			return nil, fmt.Errorf("unable to decrypt TLS certificate key : %w", err)
 		}
 
 		keyDecoded = pem.EncodeToMemory(&pem.Block{

--- a/pkg/tls/certificate_test.go
+++ b/pkg/tls/certificate_test.go
@@ -1,0 +1,94 @@
+package tls
+
+import (
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+	"time"
+
+	"github.com/containous/traefik/v2/pkg/tls/generate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecryptCertificatePrivateKey(t *testing.T) {
+	testCases := []struct {
+		desc             string
+		encryptedKey     bool
+		passphrase       string
+		expectedCertLoad bool
+	}{
+		{
+			desc:             "Encrypted Key with Correct Passphrase",
+			encryptedKey:     true,
+			passphrase:       "test",
+			expectedCertLoad: true,
+		},
+		{
+			desc:             "Encrypted Key with Incorrect Passphrase",
+			encryptedKey:     true,
+			passphrase:       "bacon",
+			expectedCertLoad: false,
+		},
+		{
+			desc:             "Non Encrypted Key with Passphrase",
+			encryptedKey:     false,
+			passphrase:       "test",
+			expectedCertLoad: true,
+		},
+		{
+			desc:             "Non Encrypted Key",
+			encryptedKey:     false,
+			expectedCertLoad: true,
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			// Create a keypair.
+			cert, key, err := generate.KeyPair("foo.bar", time.Time{})
+			require.NoError(t, err)
+
+			if test.encryptedKey {
+				// Encrypt the key with passphrase "test".
+				key, err = generateEncryptedKey(key, "test")
+				require.NoError(t, err)
+			}
+
+			certs := Certificates{
+				{
+					CertFile:   FileOrContent(cert),
+					KeyFile:    FileOrContent(key),
+					Passphrase: test.passphrase,
+				},
+			}
+
+			config, err := certs.CreateTLSConfig("test")
+			assert.NoError(t, err)
+			if test.expectedCertLoad {
+				assert.Equal(t, 1, len(config.Certificates))
+			} else {
+				assert.Equal(t, 0, len(config.Certificates))
+			}
+		})
+	}
+}
+
+func generateEncryptedKey(data []byte, pwd string) ([]byte, error) {
+	var block *pem.Block
+	// Convert the data to pem block.
+	block, _ = pem.Decode(data)
+
+	// Encrypt the block.
+	if pwd != "" {
+		var err error
+		block, err = x509.EncryptPEMBlock(rand.Reader, block.Type, block.Bytes, []byte(pwd), x509.PEMCipherAES256)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return pem.EncodeToMemory(block), nil
+}

--- a/pkg/tls/certificate_test.go
+++ b/pkg/tls/certificate_test.go
@@ -68,9 +68,9 @@ func TestDecryptCertificatePrivateKey(t *testing.T) {
 			config, err := certs.CreateTLSConfig("test")
 			assert.NoError(t, err)
 			if test.expectedCertLoad {
-				assert.Equal(t, 1, len(config.Certificates))
+				assert.Len(t, config.Certificates, 1)
 			} else {
-				assert.Equal(t, 0, len(config.Certificates))
+				assert.Len(t, config.Certificates, 0)
 			}
 		})
 	}

--- a/pkg/tls/tlsmanager.go
+++ b/pkg/tls/tlsmanager.go
@@ -276,7 +276,12 @@ func buildDefaultCertificate(defaultCertificate *Certificate) (*tls.Certificate,
 		return nil, fmt.Errorf("failed to get key file content: %v", err)
 	}
 
-	cert, err := tls.X509KeyPair(certFile, keyFile)
+	keyDecoded, err := DecodePrivateKey(keyFile, defaultCertificate.Passphrase)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode KeyFile : %v", err)
+	}
+
+	cert, err := tls.X509KeyPair(certFile, keyDecoded)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load X509 key pair: %v", err)
 	}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR provides a passphrase with which to decrypt encrypted private keys

### Motivation

Many users have expressed the need to utilize encrypted keys. Manually decrypting and storing these copies is not always acceptable.

Fixes #1262 

### More

Updates:
- File provider
- K8s CRD provider
- KV provider (nothing needed after file provider handled)

Completed:
- [x] Added/updated tests
- [x] Added/updated documentation
