### PR TITLE
Fix tab name

### DIFF
--- a/docs/content/https/include-acme-single-domain-example.md
+++ b/docs/content/https/include-acme-single-domain-example.md
@@ -52,7 +52,7 @@ labels:
   - traefik.http.routers.blog.tls.certresolver=myresolver
 ```
 
-```toml tab="Single Domain"
+```toml tab="File (TOML)"
 ## Dynamic configuration
 [http.routers]
   [http.routers.blog]


### PR DESCRIPTION
### What does this PR do?

Fix tab name in sample

### Motivation

In the current docs for the page

https://docs.traefik.io/https/acme/

expanding examples:

![image](https://user-images.githubusercontent.com/43941/77234412-83ec3b80-6bae-11ea-8057-f6be86fa386b.png)

there is a mismatch on the tab `File (TOML)`

### More

- [ ] Added/updated tests
- [x] Added/updated documentation