### PR TITLE
Force http/1.1 for upgrade (Traefik v1)

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -220,7 +220,7 @@ func NewServer(globalConfiguration configuration.GlobalConfiguration, provider p
 
 	server.defaultForwardingRoundTripper, err = newSmartRoundTripper(transport)
 	if err != nil {
-		log.Errorf("failed to create HTTP transport: %v", err)
+		log.Errorf("Failed to create HTTP transport: %v", err)
 	}
 
 	server.tracingMiddleware = globalConfiguration.Tracing

--- a/server/server.go
+++ b/server/server.go
@@ -218,7 +218,10 @@ func NewServer(globalConfiguration configuration.GlobalConfiguration, provider p
 		log.Errorf("failed to create HTTP transport: %v", err)
 	}
 
-	server.defaultForwardingRoundTripper = transport
+	server.defaultForwardingRoundTripper, err = newSmartRoundTripper(transport)
+	if err != nil {
+		log.Errorf("failed to create HTTP transport: %v", err)
+	}
 
 	server.tracingMiddleware = globalConfiguration.Tracing
 	if server.tracingMiddleware != nil && server.tracingMiddleware.Backend != "" {

--- a/server/server_configuration.go
+++ b/server/server_configuration.go
@@ -237,11 +237,17 @@ func (s *Server) buildForwarder(entryPointName string, entryPoint *configuration
 		}
 	}
 
+	var tlsConfig *tls.Config
+	if smartRt, ok := roundTripper.(*smartRoundTripper); ok {
+		tlsConfig = smartRt.GetTLSClientConfig()
+	}
+
 	var fwd http.Handler
 	fwd, err = forward.New(
 		forward.Stream(true),
 		forward.PassHostHeader(frontend.PassHostHeader),
 		forward.RoundTripper(roundTripper),
+		forward.WebsocketTLSClientConfig(tlsConfig),
 		forward.Rewriter(rewriter),
 		forward.ResponseModifier(responseModifier),
 		forward.BufferPool(s.bufferPool),

--- a/server/server_loadbalancer.go
+++ b/server/server_loadbalancer.go
@@ -291,13 +291,10 @@ func createHTTPTransport(globalConfiguration configuration.GlobalConfiguration) 
 		transport.ResponseHeaderTimeout = time.Duration(globalConfiguration.ForwardingTimeouts.ResponseHeaderTimeout)
 	}
 
-	if globalConfiguration.InsecureSkipVerify {
-		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	}
-
-	if len(globalConfiguration.RootCAs) > 0 {
+	if globalConfiguration.InsecureSkipVerify || len(globalConfiguration.RootCAs) > 0 {
 		transport.TLSClientConfig = &tls.Config{
-			RootCAs: createRootCACertPool(globalConfiguration.RootCAs),
+			InsecureSkipVerify: globalConfiguration.InsecureSkipVerify,
+			RootCAs:            createRootCACertPool(globalConfiguration.RootCAs),
 		}
 	}
 
@@ -305,6 +302,10 @@ func createHTTPTransport(globalConfiguration configuration.GlobalConfiguration) 
 }
 
 func createRootCACertPool(rootCAs traefiktls.FilesOrContents) *x509.CertPool {
+	if len(rootCAs) == 0 {
+		return nil
+	}
+
 	roots := x509.NewCertPool()
 
 	for _, cert := range rootCAs {

--- a/server/server_loadbalancer.go
+++ b/server/server_loadbalancer.go
@@ -240,6 +240,11 @@ func (s *Server) getRoundTripper(entryPointName string, passTLSCert bool, tls *t
 			return nil, fmt.Errorf("failed to create HTTP transport: %v", err)
 		}
 
+		err = http2.ConfigureTransport(transport)
+		if err != nil {
+			return nil, err
+		}
+
 		transport.TLSClientConfig = tlsConfig
 		return transport, nil
 	}
@@ -293,11 +298,6 @@ func createHTTPTransport(globalConfiguration configuration.GlobalConfiguration) 
 		transport.TLSClientConfig = &tls.Config{
 			RootCAs: createRootCACertPool(globalConfiguration.RootCAs),
 		}
-	}
-
-	err := http2.ConfigureTransport(transport)
-	if err != nil {
-		return nil, err
 	}
 
 	return transport, nil

--- a/server/smart_roundtripper.go
+++ b/server/smart_roundtripper.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"crypto/tls"
 	"net/http"
 
 	"golang.org/x/net/http/httpguts"
@@ -30,4 +31,8 @@ func (m *smartRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 		return m.http.RoundTrip(req)
 	}
 	return m.http2.RoundTrip(req)
+}
+
+func (m *smartRoundTripper) GetTLSClientConfig() *tls.Config {
+	return m.http2.TLSClientConfig
 }

--- a/server/smart_roundtripper.go
+++ b/server/smart_roundtripper.go
@@ -10,10 +10,12 @@ import (
 
 func newSmartRoundTripper(transport *http.Transport) (http.RoundTripper, error) {
 	transportHTTP1 := transport.Clone()
+
 	err := http2.ConfigureTransport(transport)
 	if err != nil {
 		return nil, err
 	}
+
 	return &smartRoundTripper{
 		http2: transport,
 		http:  transportHTTP1,
@@ -21,7 +23,7 @@ func newSmartRoundTripper(transport *http.Transport) (http.RoundTripper, error) 
 }
 
 // smartRoundTripper implements RoundTrip while making sure that HTTP/2 is not used
-// with protocols that start with a Connection Upgrade,  such as SPDY or Websocket.
+// with protocols that start with a Connection Upgrade, such as SPDY or Websocket.
 type smartRoundTripper struct {
 	http2 *http.Transport
 	http  *http.Transport
@@ -32,6 +34,7 @@ func (m *smartRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 	if httpguts.HeaderValuesContainsToken(req.Header["Connection"], "Upgrade") {
 		return m.http.RoundTrip(req)
 	}
+
 	return m.http2.RoundTrip(req)
 }
 

--- a/server/smart_roundtripper.go
+++ b/server/smart_roundtripper.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"net/http"
+
+	"golang.org/x/net/http/httpguts"
+	"golang.org/x/net/http2"
+)
+
+func newSmartRoundTripper(transport *http.Transport) (http.RoundTripper, error) {
+	transportHTTP1 := transport.Clone()
+	err := http2.ConfigureTransport(transport)
+	if err != nil {
+		return nil, err
+	}
+	return &smartRoundTripper{
+		http2: transport,
+		http:  transportHTTP1,
+	}, nil
+}
+
+type smartRoundTripper struct {
+	http2 *http.Transport
+	http  *http.Transport
+}
+
+func (m *smartRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// If we have a connection upgrade, we don't use HTTP2
+	if httpguts.HeaderValuesContainsToken(req.Header["Connection"], "Upgrade") {
+		return m.http.RoundTrip(req)
+	}
+	return m.http2.RoundTrip(req)
+}

--- a/server/smart_roundtripper.go
+++ b/server/smart_roundtripper.go
@@ -20,6 +20,8 @@ func newSmartRoundTripper(transport *http.Transport) (http.RoundTripper, error) 
 	}, nil
 }
 
+// smartRoundTripper implements RoundTrip while making sure that HTTP/2 is not used
+// with protocols that start with a Connection Upgrade,  such as SPDY or Websocket.
 type smartRoundTripper struct {
 	http2 *http.Transport
 	http  *http.Transport

--- a/server/smart_roundtripper.go
+++ b/server/smart_roundtripper.go
@@ -9,6 +9,9 @@ import (
 )
 
 func newSmartRoundTripper(transport *http.Transport) (http.RoundTripper, error) {
+	if transport == nil {
+		return nil, nil
+	}
 	transportHTTP1 := transport.Clone()
 	err := http2.ConfigureTransport(transport)
 	if err != nil {

--- a/server/smart_roundtripper.go
+++ b/server/smart_roundtripper.go
@@ -9,9 +9,6 @@ import (
 )
 
 func newSmartRoundTripper(transport *http.Transport) (http.RoundTripper, error) {
-	if transport == nil {
-		return nil, nil
-	}
 	transportHTTP1 := transport.Clone()
 	err := http2.ConfigureTransport(transport)
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

This PR force the use of http1.1 with the backend when the request is a `Connection:Upgrade` because `Connection: Upgrade` is not valid for http2.

### Motivation
Some kubernetes api server refuse http2 during tls-alpn (like k3s) but some other just don't (like kind) and so, SPDY upgrade fails. This PR fixes this behavior.

Fixes #6527 

### More

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~
