### PR TITLE
Force http/1.1 for upgrade (Traefik v2)

### DIFF
--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine
+FROM golang:1.14-alpine
 
 RUN apk --update upgrade \
     && apk --no-cache --no-progress add git mercurial bash gcc musl-dev curl tar ca-certificates tzdata \

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -19,7 +19,7 @@ RUN mkdir -p /usr/local/bin \
     && chmod +x /usr/local/bin/go-bindata
 
 # Download golangci-lint binary to bin folder in $GOPATH
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.23.0
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.23.8
 
 # Download golangci-lint and misspell binary to bin folder in $GOPATH
 RUN GO111MODULE=off go get github.com/client9/misspell/cmd/misspell

--- a/docs/content/contributing/building-testing.md
+++ b/docs/content/contributing/building-testing.md
@@ -60,7 +60,7 @@ PRE_TARGET= make test-unit
 
 Requirements:
 
-- `go` v1.13+
+- `go` v1.14+
 - environment variable `GO111MODULE=on`
 - [go-bindata](https://github.com/containous/go-bindata) `GO111MODULE=off go get -u github.com/containous/go-bindata/...`
 

--- a/exp.Dockerfile
+++ b/exp.Dockerfile
@@ -12,7 +12,7 @@ RUN npm install
 RUN npm run build
 
 # BUILD
-FROM golang:1.13-alpine as gobuild
+FROM golang:1.14-alpine as gobuild
 
 RUN apk --update upgrade \
     && apk --no-cache --no-progress add git mercurial bash gcc musl-dev curl tar ca-certificates tzdata \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containous/traefik/v2
 
-go 1.13
+go 1.14
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect

--- a/pkg/server/service/roundtripper.go
+++ b/pkg/server/service/roundtripper.go
@@ -50,10 +50,6 @@ func createRoundtripper(transportConfiguration *static.ServersTransport) (http.R
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: transportConfiguration.InsecureSkipVerify,
-			RootCAs:            createRootCACertPool(transportConfiguration.RootCAs),
-		},
 	}
 
 	transport.RegisterProtocol("h2c", &h2cTransportWrapper{
@@ -68,6 +64,13 @@ func createRoundtripper(transportConfiguration *static.ServersTransport) (http.R
 	if transportConfiguration.ForwardingTimeouts != nil {
 		transport.ResponseHeaderTimeout = time.Duration(transportConfiguration.ForwardingTimeouts.ResponseHeaderTimeout)
 		transport.IdleConnTimeout = time.Duration(transportConfiguration.ForwardingTimeouts.IdleConnTimeout)
+	}
+
+	if transportConfiguration.InsecureSkipVerify || len(transportConfiguration.RootCAs) > 0 {
+		transport.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: transportConfiguration.InsecureSkipVerify,
+			RootCAs:            createRootCACertPool(transportConfiguration.RootCAs),
+		}
 	}
 
 	smartTransport, err := newSmartRoundTripper(transport)

--- a/pkg/server/service/roundtripper.go
+++ b/pkg/server/service/roundtripper.go
@@ -23,7 +23,7 @@ func (t *h2cTransportWrapper) RoundTrip(req *http.Request) (*http.Response, erro
 	return t.Transport.RoundTrip(req)
 }
 
-// createRoundtripper creates a http.Roundtripper configured with the Transport configuration settings.
+// createRoundtripper creates an http.Roundtripper configured with the Transport configuration settings.
 // For the settings that can't be configured in Traefik it uses the default http.Transport settings.
 // An exception to this is the MaxIdleConns setting as we only provide the option MaxIdleConnsPerHost
 // in Traefik at this point in time. Setting this value to the default of 100 could lead to confusing

--- a/pkg/server/service/smart_roundtripper.go
+++ b/pkg/server/service/smart_roundtripper.go
@@ -26,6 +26,8 @@ type smartRoundTripper struct {
 	http  *http.Transport
 }
 
+// smartRoundTripper implements RoundTrip while making sure that HTTP/2 is not used
+// with protocols that start with a Connection Upgrade, such as SPDY or Websocket.
 func (m *smartRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	// If we have a connection upgrade, we don't use HTTP2
 	if httpguts.HeaderValuesContainsToken(req.Header["Connection"], "Upgrade") {

--- a/pkg/server/service/smart_roundtripper.go
+++ b/pkg/server/service/smart_roundtripper.go
@@ -29,7 +29,7 @@ type smartRoundTripper struct {
 // smartRoundTripper implements RoundTrip while making sure that HTTP/2 is not used
 // with protocols that start with a Connection Upgrade, such as SPDY or Websocket.
 func (m *smartRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	// If we have a connection upgrade, we don't use HTTP2
+	// If we have a connection upgrade, we don't use HTTP/2
 	if httpguts.HeaderValuesContainsToken(req.Header["Connection"], "Upgrade") {
 		return m.http.RoundTrip(req)
 	}

--- a/pkg/server/service/smart_roundtripper.go
+++ b/pkg/server/service/smart_roundtripper.go
@@ -1,0 +1,33 @@
+package service
+
+import (
+	"net/http"
+
+	"golang.org/x/net/http/httpguts"
+	"golang.org/x/net/http2"
+)
+
+func newSmartRoundTripper(transport *http.Transport) (http.RoundTripper, error) {
+	transportHTTP1 := transport.Clone()
+	err := http2.ConfigureTransport(transport)
+	if err != nil {
+		return nil, err
+	}
+	return &smartRoundTripper{
+		http2: transport,
+		http:  transportHTTP1,
+	}, nil
+}
+
+type smartRoundTripper struct {
+	http2 *http.Transport
+	http  *http.Transport
+}
+
+func (m *smartRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// If we have a connection upgrade, we don't use HTTP2
+	if httpguts.HeaderValuesContainsToken(req.Header["Connection"], "Upgrade") {
+		return m.http.RoundTrip(req)
+	}
+	return m.http2.RoundTrip(req)
+}

--- a/pkg/server/service/smart_roundtripper.go
+++ b/pkg/server/service/smart_roundtripper.go
@@ -9,10 +9,12 @@ import (
 
 func newSmartRoundTripper(transport *http.Transport) (http.RoundTripper, error) {
 	transportHTTP1 := transport.Clone()
+
 	err := http2.ConfigureTransport(transport)
 	if err != nil {
 		return nil, err
 	}
+
 	return &smartRoundTripper{
 		http2: transport,
 		http:  transportHTTP1,
@@ -29,5 +31,6 @@ func (m *smartRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 	if httpguts.HeaderValuesContainsToken(req.Header["Connection"], "Upgrade") {
 		return m.http.RoundTrip(req)
 	}
+
 	return m.http2.RoundTrip(req)
 }


### PR DESCRIPTION
### What does this PR do?

This PR forces the use of http1.1 with the backend when the request is a `Connection:Upgrade` because `Connection: Upgrade` is not valid for http2.

Also, this PR fixes the fact that specifying root CAs and specifying insecureskipverify was mutually exclusive.

### Motivation
Some kubernetes api server refuse http2 during tls-alpn (like k3s) but some other just don't (like kind) and so, SPDY upgrade fails. This PR fixes this behavior.

Fixes #6527 

### More

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~
