### PR TITLE
Add HTTP Provider

### DIFF
--- a/docs/content/providers/http.md
+++ b/docs/content/providers/http.md
@@ -4,7 +4,7 @@ Provide your configuration via an http endpoint and let Traefik do the rest!
 
 ## Routing Configuration
 
-The HTTP provider uses the same configuration as the [File Provider](../file.md).
+The HTTP provider uses the same configuration as the [File Provider](./file.md).
 
 ## Provider Configuration
 

--- a/docs/content/providers/http.md
+++ b/docs/content/providers/http.md
@@ -1,0 +1,73 @@
+# Traefik & HTTP
+
+Provide your configuration via an http endpoint and let Traefik do the rest!
+
+## Routing Configuration
+
+The HTTP provider uses the same configuration as the [File Provider](../file.md).
+
+## Provider Configuration
+
+### `endpoint`
+
+_Required_
+
+Configures the endpoint to access.
+
+```toml tab="File (TOML)"
+[providers.http]
+  endpoint = "http://127.0.0.1:9000/api"
+```
+
+```yaml tab="File (YAML)"
+providers:
+  http:
+    endpoint:
+      - "http://127.0.0.1:9000/api"
+```
+
+```bash tab="CLI"
+--providers.http.endpoint=http://127.0.0.1:9000/api
+```
+
+### `pollInterval`
+
+Defines the interval with which to poll the endpoint.
+
+_Optional, Default="15s"_
+
+```toml tab="File (TOML)"
+[providers.http]
+  pollInterval = "15s"
+```
+
+```yaml tab="File (YAML)"
+providers:
+  http:
+    pollInterval: "15s"
+```
+
+```bash tab="CLI"
+--providers.http.pollinterval=15s
+```
+
+### `pollTimeout`
+
+Defines a timeout when connecting to the endpoint.
+
+_Optional, Default="15s"_
+
+```toml tab="File (TOML)"
+[providers.http]
+  pollTimeout = "15s"
+```
+
+```yaml tab="File (YAML)"
+providers:
+  http:
+    pollTimeout: "15s"
+```
+
+```bash tab="CLI"
+--providers.http.polltimeout=15s
+```

--- a/docs/content/providers/overview.md
+++ b/docs/content/providers/overview.md
@@ -35,9 +35,10 @@ Below is the list of the currently supported providers in Traefik.
 | [Rancher](./rancher.md)               | Orchestrator | Label                      |
 | [File](./file.md)                     | Manual       | TOML/YAML format           |
 | [Consul](./consul.md)                 | KV           | KV                         |
-| [etcd](./etcd.md)                     | KV           | KV                         |
+| [Etcd](./etcd.md)                     | KV           | KV                         |
 | [Redis](./redis.md)                   | KV           | KV                         |
 | [ZooKeeper](./zookeeper.md)           | KV           | KV                         |
+| [Http](./http.md)                     | Manual       | JSON format                |
 
 !!! info "More Providers"
 

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -456,6 +456,18 @@ Load dynamic configuration from a file.
 `--providers.file.watch`:  
 Watch provider. (Default: ```true```)
 
+`--providers.http`:  
+Enable Http backend with default settings. (Default: ```false```)
+
+`--providers.http.endpoint`:  
+Load configuration from this endpoint.
+
+`--providers.http.pollinterval`:  
+Polling interval for endpoint. (Default: ```0```)
+
+`--providers.http.polltimeout`:  
+Polling timeout for endpoint. (Default: ```0```)
+
 `--providers.kubernetescrd`:  
 Enable Kubernetes backend with default settings. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -456,6 +456,18 @@ Load dynamic configuration from a file.
 `TRAEFIK_PROVIDERS_FILE_WATCH`:  
 Watch provider. (Default: ```true```)
 
+`TRAEFIK_PROVIDERS_HTTP`:  
+Enable Http backend with default settings. (Default: ```false```)
+
+`TRAEFIK_PROVIDERS_HTTP_ENDPOINT`:  
+Load configuration from this endpoint.
+
+`TRAEFIK_PROVIDERS_HTTP_POLLINTERVAL`:  
+Polling interval for endpoint. (Default: ```0```)
+
+`TRAEFIK_PROVIDERS_HTTP_POLLTIMEOUT`:  
+Polling timeout for endpoint. (Default: ```0```)
+
 `TRAEFIK_PROVIDERS_KUBERNETESCRD`:  
 Enable Kubernetes backend with default settings. (Default: ```false```)
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
       - 'Etcd': 'providers/etcd.md'
       - 'ZooKeeper': 'providers/zookeeper.md'
       - 'Redis': 'providers/redis.md'
+      - 'HTTP': 'providers/http.md'
   - 'Routing & Load Balancing':
       - 'Overview': 'routing/overview.md'
       - 'EntryPoints': 'routing/entrypoints.md'

--- a/integration/fixtures/http/simple.toml
+++ b/integration/fixtures/http/simple.toml
@@ -1,0 +1,19 @@
+[global]
+  checkNewVersion = false
+  sendAnonymousUsage = false
+
+[log]
+  level = "DEBUG"
+
+[entryPoints]
+  [entryPoints.web]
+    address = ":8000"
+  [entryPoints.traefik]
+    address = ":9090"
+
+[api]
+  insecure = true
+
+[providers]
+  [providers.http]
+    endpoint = "http://127.0.0.1:9000"

--- a/integration/fixtures/http/simple.toml
+++ b/integration/fixtures/http/simple.toml
@@ -17,3 +17,4 @@
 [providers]
   [providers.http]
     endpoint = "http://127.0.0.1:9000"
+    pollInterval = "100ms"

--- a/integration/http_test.go
+++ b/integration/http_test.go
@@ -71,9 +71,6 @@ func (s *HTTPSuite) TestSimpleConfiguration(c *check.C) {
 
 		err = try.GetRequest("http://127.0.0.1:9090/api/rawdata", 3*time.Second, try.BodyContains("bacon"))
 		c.Assert(err, checker.IsNil)
-
-		err = try.GetRequest("http://127.0.0.1:8000/", 1000*time.Millisecond, try.StatusCodeIs(http.StatusOK))
-		c.Assert(err, checker.IsNil)
 	}
 }
 

--- a/integration/http_test.go
+++ b/integration/http_test.go
@@ -1,0 +1,95 @@
+package integration
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/containous/traefik/v2/integration/try"
+	"github.com/containous/traefik/v2/pkg/config/dynamic"
+	"github.com/go-check/check"
+	checker "github.com/vdemeester/shakers"
+)
+
+type HTTPSuite struct{ BaseSuite }
+
+func (s *HTTPSuite) SetUpSuite(c *check.C) {
+}
+
+func (s *HTTPSuite) TestSimpleConfiguration(c *check.C) {
+	cmd, display := s.traefikCmd(withConfigFile("fixtures/http/simple.toml"))
+
+	defer display(c)
+	err := cmd.Start()
+	c.Assert(err, checker.IsNil)
+	defer cmd.Process.Kill()
+
+	// Expected a 404 as we did not configure anything.
+	err = try.GetRequest("http://127.0.0.1:8000/", 1000*time.Millisecond, try.StatusCodeIs(http.StatusNotFound))
+	c.Assert(err, checker.IsNil)
+
+	testCase := []struct {
+		desc   string
+		config *dynamic.Configuration
+	}{
+		{
+			desc: "http configuration",
+			config: &dynamic.Configuration{
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"routerHTTP": {
+							EntryPoints: []string{"web"},
+							Middlewares: []string{},
+							Service:     "serviceHTTP",
+							Rule:        "PathPrefix(`/`)",
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"serviceHTTP": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://bacon:80",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range testCase {
+		data, err := json.Marshal(test.config)
+		c.Assert(err, checker.IsNil)
+
+		ts := startTestServerWithResponse(string(data))
+		defer ts.Close()
+
+		err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 3*time.Second, try.BodyContains("bacon"))
+		c.Assert(err, checker.IsNil)
+
+		err = try.GetRequest("http://127.0.0.1:8000/", 1000*time.Millisecond, try.StatusCodeIs(http.StatusOK))
+		c.Assert(err, checker.IsNil)
+	}
+}
+
+func startTestServerWithResponse(response string) (ts *httptest.Server) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(response))
+	})
+	listener, err := net.Listen("tcp", "127.0.0.1:9000")
+	if err != nil {
+		panic(err)
+	}
+
+	ts = &httptest.Server{
+		Listener: listener,
+		Config:   &http.Server{Handler: handler},
+	}
+	ts.Start()
+	return ts
+}

--- a/integration/http_test.go
+++ b/integration/http_test.go
@@ -69,7 +69,7 @@ func (s *HTTPSuite) TestSimpleConfiguration(c *check.C) {
 		ts := startTestServerWithResponse(string(data))
 		defer ts.Close()
 
-		err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 3*time.Second, try.BodyContains("bacon"))
+		err = try.GetRequest("http://127.0.0.1:9090/api/rawdata", 3*time.Second, try.BodyContains("bacon"))
 		c.Assert(err, checker.IsNil)
 
 		err = try.GetRequest("http://127.0.0.1:8000/", 1000*time.Millisecond, try.StatusCodeIs(http.StatusOK))

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -47,6 +47,7 @@ func Test(t *testing.T) {
 		check.Suite(&HealthCheckSuite{})
 		check.Suite(&HeadersSuite{})
 		check.Suite(&HostResolverSuite{})
+		check.Suite(&HTTPSuite{})
 		check.Suite(&HTTPSSuite{})
 		check.Suite(&KeepAliveSuite{})
 		check.Suite(&LogRotationSuite{})

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containous/traefik/v2/pkg/provider/consulcatalog"
 	"github.com/containous/traefik/v2/pkg/provider/docker"
 	"github.com/containous/traefik/v2/pkg/provider/file"
+	"github.com/containous/traefik/v2/pkg/provider/http"
 	"github.com/containous/traefik/v2/pkg/provider/kubernetes/crd"
 	"github.com/containous/traefik/v2/pkg/provider/kubernetes/ingress"
 	"github.com/containous/traefik/v2/pkg/provider/kv/consul"
@@ -175,6 +176,7 @@ type Providers struct {
 	Etcd      *etcd.Provider   `description:"Enable Etcd backend with default settings." json:"etcd,omitempty" toml:"etcd,omitempty" yaml:"etcd,omitempty" export:"true" label:"allowEmpty"`
 	ZooKeeper *zk.Provider     `description:"Enable ZooKeeper backend with default settings." json:"zooKeeper,omitempty" toml:"zooKeeper,omitempty" yaml:"zooKeeper,omitempty" export:"true" label:"allowEmpty"`
 	Redis     *redis.Provider  `description:"Enable Redis backend with default settings." json:"redis,omitempty" toml:"redis,omitempty" yaml:"redis,omitempty" export:"true" label:"allowEmpty"`
+	Http      *http.Provider   `description:"Enable Http backend with default settings." json:"http,omitempty" toml:"http,omitempty" yaml:"http,omitempty" export:"true" label:"allowEmpty"`
 }
 
 // SetEffectiveConfiguration adds missing configuration parameters derived from existing ones.

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -176,7 +176,7 @@ type Providers struct {
 	Etcd      *etcd.Provider   `description:"Enable Etcd backend with default settings." json:"etcd,omitempty" toml:"etcd,omitempty" yaml:"etcd,omitempty" export:"true" label:"allowEmpty"`
 	ZooKeeper *zk.Provider     `description:"Enable ZooKeeper backend with default settings." json:"zooKeeper,omitempty" toml:"zooKeeper,omitempty" yaml:"zooKeeper,omitempty" export:"true" label:"allowEmpty"`
 	Redis     *redis.Provider  `description:"Enable Redis backend with default settings." json:"redis,omitempty" toml:"redis,omitempty" yaml:"redis,omitempty" export:"true" label:"allowEmpty"`
-	Http      *http.Provider   `description:"Enable Http backend with default settings." json:"http,omitempty" toml:"http,omitempty" yaml:"http,omitempty" export:"true" label:"allowEmpty"`
+	HTTP      *http.Provider   `description:"Enable HTTP backend with default settings." json:"http,omitempty" toml:"http,omitempty" yaml:"http,omitempty" export:"true" label:"allowEmpty"`
 }
 
 // SetEffectiveConfiguration adds missing configuration parameters derived from existing ones.

--- a/pkg/provider/aggregator/aggregator.go
+++ b/pkg/provider/aggregator/aggregator.go
@@ -69,6 +69,10 @@ func NewProviderAggregator(conf static.Providers) ProviderAggregator {
 		p.quietAddProvider(conf.Redis)
 	}
 
+	if conf.HTTP != nil {
+		p.quietAddProvider(conf.HTTP)
+	}
+
 	return p
 }
 

--- a/pkg/provider/http/http.go
+++ b/pkg/provider/http/http.go
@@ -51,10 +51,6 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 		logger := log.FromContext(ctxLog)
 
 		operation := func() error {
-			ctx, cancel := context.WithCancel(ctxLog)
-			defer cancel()
-
-			ctx = log.With(ctx, log.Str(log.ProviderName, "http"))
 			errChan := make(chan error)
 			ticker := time.NewTicker(time.Duration(p.PollInterval))
 
@@ -138,7 +134,7 @@ func (p *Provider) getDataFromEndpoint(ctx context.Context) ([]byte, error) {
 		return nil, fmt.Errorf("unable to get data from endpoint: %w", err)
 	}
 
-	return nil, fmt.Errorf("recieved no data from endpoint")
+	return nil, fmt.Errorf("received no data from endpoint")
 }
 
 // buildConfiguration builds a configuration from the provided data.

--- a/pkg/provider/http/http.go
+++ b/pkg/provider/http/http.go
@@ -1,0 +1,147 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/containous/traefik/v2/pkg/config/dynamic"
+	"github.com/containous/traefik/v2/pkg/job"
+	"github.com/containous/traefik/v2/pkg/log"
+	"github.com/containous/traefik/v2/pkg/provider"
+	"github.com/containous/traefik/v2/pkg/safe"
+)
+
+var _ provider.Provider = (*Provider)(nil)
+
+// Provider is a provider.Provider implementation that queries an endpoint for a configuration.
+type Provider struct {
+	endpoint         string
+	endpointInsecure bool
+	pollInterval     time.Duration
+	pollTimeout      time.Duration
+}
+
+// Init the provider.
+func (p *Provider) Init() error {
+	if len(p.endpoint) > 0 {
+		return nil
+	}
+
+	return fmt.Errorf("a non-empty endpoint is required")
+}
+
+// Provide allows the provider to provide configurations to traefik
+// using the given configuration channel.
+func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.Pool) error {
+	pool.GoCtx(func(routineCtx context.Context) {
+		ctxLog := log.With(routineCtx, log.Str(log.ProviderName, "http"))
+		logger := log.FromContext(ctxLog)
+
+		operation := func() error {
+			ctx, cancel := context.WithCancel(ctxLog)
+			defer cancel()
+
+			ctx = log.With(ctx, log.Str(log.ProviderName, "http"))
+			errChan := make(chan error)
+			ticker := time.NewTicker(time.Duration(p.pollInterval))
+
+			pool.GoCtx(func(ctx context.Context) {
+				ctx = log.With(ctx, log.Str(log.ProviderName, "http"))
+				logger := log.FromContext(ctx)
+
+				defer close(errChan)
+				for {
+					select {
+					case <-ticker.C:
+						data, err := p.getDataFromEndpoint(ctxLog)
+						if err != nil {
+							logger.Errorf("Failed to get config from endpoint: %w", err)
+							errChan <- err
+							return
+						}
+
+						configuration := p.buildConfiguration(ctx, data)
+						if configuration != nil {
+							configurationChan <- dynamic.Message{
+								ProviderName:  "http",
+								Configuration: configuration,
+							}
+						}
+
+					case <-ctx.Done():
+						ticker.Stop()
+						return
+					}
+				}
+			})
+			if err, ok := <-errChan; ok {
+				return err
+			}
+			// channel closed
+			return nil
+		}
+
+		notify := func(err error, time time.Duration) {
+			logger.Errorf("Provider connection error %w, retrying in %s", err, time)
+		}
+		err := backoff.RetryNotify(safe.OperationWithRecover(operation), backoff.WithContext(job.NewBackOff(backoff.NewExponentialBackOff()), ctxLog), notify)
+		if err != nil {
+			logger.Errorf("Cannot connect to http server %w", err)
+		}
+	})
+
+	return nil
+}
+
+// getDataFromEndpoint gets data from the configured provider endpoint, and returns the data.
+func (p *Provider) getDataFromEndpoint(ctx context.Context) ([]byte, error) {
+	b := []byte{}
+	req, err := http.NewRequest(http.MethodGet, p.endpoint, bytes.NewBuffer(b))
+	if err != nil {
+		return nil, fmt.Errorf("unable to create request: %w", err)
+	}
+
+	client := &http.Client{Timeout: p.pollTimeout}
+	resp, err := client.Do(req)
+
+	if resp != nil {
+		defer resp.Body.Close()
+
+		var bodyData []byte
+		var bodyErr error
+		if bodyData, bodyErr = ioutil.ReadAll(resp.Body); bodyErr != nil {
+			return nil, fmt.Errorf("unable to read response body: %w", bodyErr)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("received non-ok response code: %d", resp.StatusCode)
+		}
+
+		log.FromContext(ctx).Debugf("Successfully received data from endpoint: %q", p.endpoint)
+		return bodyData, nil
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to get data from endpoint: %w", err)
+	}
+
+	return nil, fmt.Errorf("recieved no data from endpoint")
+}
+
+// buildConfiguration builds a configuration from the provided data.
+func (p *Provider) buildConfiguration(ctx context.Context, data []byte) *dynamic.Configuration {
+	configuration := &dynamic.Configuration{}
+
+	if err := json.Unmarshal(data, configuration); err != nil {
+		log.FromContext(ctx).Errorf("Error parsing configuration %w", err)
+		return nil
+	}
+
+	return configuration
+}

--- a/pkg/provider/http/http.go
+++ b/pkg/provider/http/http.go
@@ -21,10 +21,9 @@ var _ provider.Provider = (*Provider)(nil)
 
 // Provider is a provider.Provider implementation that queries an endpoint for a configuration.
 type Provider struct {
-	endpoint         string
-	endpointInsecure bool
-	pollInterval     time.Duration
-	pollTimeout      time.Duration
+	endpoint     string
+	pollInterval time.Duration
+	pollTimeout  time.Duration
 }
 
 // Init the provider.

--- a/pkg/provider/http/http_test.go
+++ b/pkg/provider/http/http_test.go
@@ -51,7 +51,6 @@ func TestBuildConfiguration(t *testing.T) {
 
 	config := provider.buildConfiguration(context.Background(), []byte("{}"))
 	assert.NotEqual(t, nil, config)
-
 }
 
 func TestProvide(t *testing.T) {
@@ -84,5 +83,4 @@ func TestProvide(t *testing.T) {
 	case <-timeout:
 		t.Errorf("timeout while waiting for config")
 	}
-
 }

--- a/pkg/provider/http/http_test.go
+++ b/pkg/provider/http/http_test.go
@@ -23,13 +23,15 @@ func TestProviderInit(t *testing.T) {
 }
 
 func TestGetDataFromEndpoint(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte("{OK}"))
-	}))
-	defer ts.Close()
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	mux.HandleFunc("/endpoint", func(rw http.ResponseWriter, req *http.Request) {
+		_, _ = rw.Write([]byte("{OK}"))
+	})
 
 	provider := Provider{
-		endpoint: ts.URL,
+		endpoint: server.URL + "/endpoint",
 	}
 
 	assert.NoError(t, provider.Init())
@@ -52,13 +54,15 @@ func TestBuildConfiguration(t *testing.T) {
 }
 
 func TestProvide(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte("{}"))
-	}))
-	defer ts.Close()
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	mux.HandleFunc("/endpoint", func(rw http.ResponseWriter, req *http.Request) {
+		_, _ = rw.Write([]byte("{}"))
+	})
 
 	provider := Provider{
-		endpoint:     ts.URL,
+		endpoint:     server.URL + "/endpoint",
 		pollTimeout:  1 * time.Second,
 		pollInterval: 100 * time.Millisecond,
 	}

--- a/pkg/provider/http/http_test.go
+++ b/pkg/provider/http/http_test.go
@@ -1,0 +1,54 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProviderInit(t *testing.T) {
+	provider := &Provider{}
+	assert.Error(t, provider.Init())
+
+	provider = &Provider{
+		endpoint: "localhost",
+	}
+	assert.NoError(t, provider.Init())
+}
+
+func TestGetDataFromEndpoint(t *testing.T) {
+	handler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		_, _ = rw.Write([]byte("{OK}"))
+	})
+	router := mux.NewRouter()
+
+	router.HandleFunc("/endpoint", handler)
+
+	go http.ListenAndServe("127.0.0.1:9000", router)
+
+	provider := Provider{
+		endpoint: "http://127.0.0.1:9000/endpoint",
+	}
+
+	assert.NoError(t, provider.Init())
+
+	data, err := provider.getDataFromEndpoint(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, "{OK}", string(data))
+
+}
+
+func TestBuildConfiguration(t *testing.T) {
+	provider := Provider{
+		endpoint: "http://127.0.0.1:9000/endpoint",
+	}
+
+	assert.NoError(t, provider.Init())
+
+	config := provider.buildConfiguration(context.Background(), []byte("{}"))
+	assert.NotEqual(t, nil, config)
+
+}

--- a/pkg/provider/http/http_test.go
+++ b/pkg/provider/http/http_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/containous/traefik/v2/pkg/config/dynamic"
 	"github.com/containous/traefik/v2/pkg/safe"
+	"github.com/containous/traefik/v2/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,7 +18,7 @@ func TestProviderInit(t *testing.T) {
 	assert.Error(t, provider.Init())
 
 	provider = &Provider{
-		endpoint: "localhost",
+		Endpoint: "localhost",
 	}
 	assert.NoError(t, provider.Init())
 }
@@ -31,7 +32,7 @@ func TestGetDataFromEndpoint(t *testing.T) {
 	})
 
 	provider := Provider{
-		endpoint: server.URL + "/endpoint",
+		Endpoint: server.URL + "/endpoint",
 	}
 
 	assert.NoError(t, provider.Init())
@@ -43,7 +44,7 @@ func TestGetDataFromEndpoint(t *testing.T) {
 
 func TestBuildConfiguration(t *testing.T) {
 	provider := Provider{
-		endpoint: "http://127.0.0.1:9000/endpoint",
+		Endpoint: "http://127.0.0.1:9000/endpoint",
 	}
 
 	assert.NoError(t, provider.Init())
@@ -62,9 +63,9 @@ func TestProvide(t *testing.T) {
 	})
 
 	provider := Provider{
-		endpoint:     server.URL + "/endpoint",
-		pollTimeout:  1 * time.Second,
-		pollInterval: 100 * time.Millisecond,
+		Endpoint:     server.URL + "/endpoint",
+		PollTimeout:  types.Duration(1 * time.Second),
+		PollInterval: types.Duration(100 * time.Millisecond),
 	}
 
 	assert.NoError(t, provider.Init())


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR introduces a new provider (http) that polls an endpoint for a published configuration, and provides it to the server for use.

### Motivation

Fixes #1053 

### More

- [x] Added/updated tests
- [x] Added/updated documentation

