### PR TITLE
Delete an unnecessary warning log

### DIFF
--- a/pkg/provider/kubernetes/ingress/client.go
+++ b/pkg/provider/kubernetes/ingress/client.go
@@ -188,8 +188,6 @@ func (c *clientWrapper) GetIngresses() []*networkingv1beta1.Ingress {
 }
 
 func extensionsToNetworking(ing *extensionsv1beta1.Ingress) (*networkingv1beta1.Ingress, error) {
-	log.Warnf("Ingress %s/%s: the apiVersion 'extensions/v1beta1' is deprecated, use 'networking.k8s.io/v1beta1' instead.", ing.Namespace, ing.Name)
-
 	data, err := ing.Marshal()
 	if err != nil {
 		return nil, err

--- a/pkg/provider/kubernetes/ingress/client.go
+++ b/pkg/provider/kubernetes/ingress/client.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/containous/traefik/v2/pkg/log"
+	"github.com/golang/protobuf/proto"
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
@@ -187,7 +188,7 @@ func (c *clientWrapper) GetIngresses() []*networkingv1beta1.Ingress {
 	return results
 }
 
-func extensionsToNetworking(ing *extensionsv1beta1.Ingress) (*networkingv1beta1.Ingress, error) {
+func extensionsToNetworking(ing proto.Marshaler) (*networkingv1beta1.Ingress, error) {
 	data, err := ing.Marshal()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### What does this PR do?

Delete a confusing log when a deprecated apiVersion is used for a Kubernetes Ingress.
How apiVersion is handled depends on the version of Kubernetes and could generate many unnecessary warning logs.

### Motivation

Fixes #6536

### More

- [ ] ~Added/updated tests~
- [ ] ~Added/updated documentation~
