### PR TITLE
Doc improvement on entrypoints whitelist for v1.7

### DIFF
--- a/docs/configuration/entrypoints.md
+++ b/docs/configuration/entrypoints.md
@@ -485,6 +485,11 @@ To enable IP white listing at the entry point level.
       # useXForwardedFor = true
 ```
 
+By setting the `useXForwardedFor` option, the `sourceRange` addresses will be matched against the request header `X-Forwarded-For` address list, from left to right.
+
+!!! danger
+    When using Traefik behind another load-balancer, it's own internal address will be appended in the `X-Forwarded-For` header. Be sure to carefully configure the `sourceRange` as adding the internal network CIDR, or the load-balancer address directly, will cause all requests coming from it to pass through.
+
 ## ProxyProtocol
 
 To enable [ProxyProtocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) support.

--- a/docs/configuration/entrypoints.md
+++ b/docs/configuration/entrypoints.md
@@ -488,7 +488,7 @@ To enable IP white listing at the entry point level.
 By setting the `useXForwardedFor` option, the `sourceRange` addresses will be matched against the request header `X-Forwarded-For` address list, from left to right.
 
 !!! danger
-    When using Traefik behind another load-balancer, it's own internal address will be appended in the `X-Forwarded-For` header.
+    When using Traefik behind another load-balancer, its own internal address will be appended in the `X-Forwarded-For` header.
     Be sure to carefully configure the `sourceRange` as adding the internal network CIDR,
     or the load-balancer address directly, will cause all requests coming from it to pass through.
 

--- a/docs/configuration/entrypoints.md
+++ b/docs/configuration/entrypoints.md
@@ -488,7 +488,9 @@ To enable IP white listing at the entry point level.
 By setting the `useXForwardedFor` option, the `sourceRange` addresses will be matched against the request header `X-Forwarded-For` address list, from left to right.
 
 !!! danger
-    When using Traefik behind another load-balancer, it's own internal address will be appended in the `X-Forwarded-For` header. Be sure to carefully configure the `sourceRange` as adding the internal network CIDR, or the load-balancer address directly, will cause all requests coming from it to pass through.
+    When using Traefik behind another load-balancer, it's own internal address will be appended in the `X-Forwarded-For` header.
+    Be sure to carefully configure the `sourceRange` as adding the internal network CIDR,
+    or the load-balancer address directly, will cause all requests coming from it to pass through.
 
 ## ProxyProtocol
 


### PR DESCRIPTION
### What does this PR do?

Improve doc on v1.7 regarding entrypoints whitelisting by adding a brief description of the behavior when enabling `useXForwardedFor` and a warning to users behind another load balancer.

### Motivation

To fix #5816

### More

- [ ] ~~Added/updated tests~~
- [X] Added/updated documentation

### Additional Notes
