### PR TITLE
spnegoclient middleware

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -91,6 +91,7 @@ require (
 	gopkg.in/DataDog/dd-trace-go.v1 v1.19.0
 	gopkg.in/fsnotify.v1 v1.4.7
 	gopkg.in/jcmturner/goidentity.v3 v3.0.0 // indirect
+	gopkg.in/jcmturner/gokrb5.v7 v7.2.3
 	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.17.3
 	k8s.io/apimachinery v0.17.3

--- a/pkg/config/dynamic/http_config.go
+++ b/pkg/config/dynamic/http_config.go
@@ -117,6 +117,13 @@ type Cookie struct {
 
 // +k8s:deepcopy-gen=true
 
+// SpnegoClient holds the configuration for the spnego client
+type SpnegoClient struct {
+	KrbConfPath	string	`json:"krbConfPath" toml:"krbConfPath" yaml:"krbConfPath"`
+        CCachePath	string	`json:"cCachePath,omitempty" toml:"cCachePath,omitempty" yaml:"cCachePath,omitempty"`
+        Spn		string  `json:"spn,omitempty" toml:"spn,omitempty" yaml:"spn,omitempty"`
+}
+
 // ServersLoadBalancer holds the ServersLoadBalancer configuration.
 type ServersLoadBalancer struct {
 	Sticky             *Sticky             `json:"sticky,omitempty" toml:"sticky,omitempty" yaml:"sticky,omitempty" label:"allowEmpty"`
@@ -124,6 +131,7 @@ type ServersLoadBalancer struct {
 	HealthCheck        *HealthCheck        `json:"healthCheck,omitempty" toml:"healthCheck,omitempty" yaml:"healthCheck,omitempty"`
 	PassHostHeader     *bool               `json:"passHostHeader" toml:"passHostHeader" yaml:"passHostHeader"`
 	ResponseForwarding *ResponseForwarding `json:"responseForwarding,omitempty" toml:"responseForwarding,omitempty" yaml:"responseForwarding,omitempty"`
+        SpnegoClient       *SpnegoClient       `json:"spnegoClient,omitempty" toml:"spnegoClient,omitempty" yaml:"spnegoClient,omitempty"`
 }
 
 // Mergeable tells if the given service is mergeable.

--- a/pkg/middlewares/spnegoclient/spnegoclient.go
+++ b/pkg/middlewares/spnegoclient/spnegoclient.go
@@ -1,0 +1,71 @@
+package spnegoclient
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/containous/alice"
+        "github.com/containous/traefik/v2/pkg/config/dynamic"
+	"github.com/containous/traefik/v2/pkg/log"
+	"github.com/containous/traefik/v2/pkg/middlewares"
+
+        "gopkg.in/jcmturner/gokrb5.v7/client"
+        "gopkg.in/jcmturner/gokrb5.v7/config"
+        "gopkg.in/jcmturner/gokrb5.v7/credentials"
+        "gopkg.in/jcmturner/gokrb5.v7/spnego"
+)
+
+const (
+	typeName       = "SpnegoClient"
+	nameService    = "spnegoclient-service"
+)
+
+type spnegoClientMiddleware struct {
+	next    http.Handler
+        config	*dynamic.SpnegoClient
+        client  *client.Client
+}
+
+// NewSpnegoClientMiddleware creates a new middleware to add SPNEGO header to outgoing http requests.
+func NewSpnegoClientMiddleware(ctx context.Context, next http.Handler, conf *dynamic.SpnegoClient) (http.Handler, error) {
+        logger := log.FromContext(middlewares.GetLoggerCtx(ctx, nameService, typeName))
+	logger.Debug("Creating middleware")
+
+        ccache, err := credentials.LoadCCache(conf.CCachePath)
+        if err != nil {
+                logger.Errorf("error loading CredentialCache from file %s: %s", conf.CCachePath, err)
+                return nil, err
+        }
+        krbconf, err := config.Load(conf.KrbConfPath)
+        if err != nil {
+                logger.Errorf("error loading Kerberos config from file %s: %s", conf.KrbConfPath, err)
+		return nil, err
+        }
+        krbclient, err := client.NewClientFromCCache(ccache, krbconf)
+        if err != nil {
+                logger.Errorf("error creating Kerberos Client %s", err)
+		return nil, err
+        }
+        return &spnegoClientMiddleware{
+                next:           next,
+                config:         conf,
+                client:         krbclient,
+        }, nil
+
+}
+
+// WrapHandler Wraps the handler to alice.Constructor.
+func WrapHandler(ctx context.Context, config *dynamic.SpnegoClient) alice.Constructor {
+	return func(next http.Handler) (http.Handler, error) {
+		return NewSpnegoClientMiddleware(ctx, next, config)
+	}
+}
+
+func (m *spnegoClientMiddleware) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+        err := spnego.SetSPNEGOHeader(m.client, req, m.config.Spn)
+        if err != nil {
+                log.WithoutContext().Errorf("error setting SPNEGO Header %s", err)
+        }
+	m.next.ServeHTTP(rw, req)
+}
+

--- a/pkg/server/service/service.go
+++ b/pkg/server/service/service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containous/traefik/v2/pkg/middlewares/emptybackendhandler"
 	metricsMiddle "github.com/containous/traefik/v2/pkg/middlewares/metrics"
 	"github.com/containous/traefik/v2/pkg/middlewares/pipelining"
+        "github.com/containous/traefik/v2/pkg/middlewares/spnegoclient"
 	"github.com/containous/traefik/v2/pkg/safe"
 	"github.com/containous/traefik/v2/pkg/server/cookie"
 	"github.com/containous/traefik/v2/pkg/server/provider"
@@ -184,6 +185,9 @@ func (m *Manager) getLoadBalancerServiceHandler(
 	chain := alice.New()
 	if m.metricsRegistry != nil && m.metricsRegistry.IsSvcEnabled() {
 		chain = chain.Append(metricsMiddle.WrapServiceHandler(ctx, m.metricsRegistry, serviceName))
+	}
+        if service.SpnegoClient != nil {
+	        chain = chain.Append(spnegoclient.WrapHandler(ctx, service.SpnegoClient))
 	}
 
 	handler, err := chain.Append(alHandler).Then(pipelining.New(ctx, fwd, "pipelining"))


### PR DESCRIPTION


### What does this PR do?

Adds an spnegoclient middleware which can be used to add SPNEGO headers to the outgoing http requests

The client can be turned on in a loadBalancer with the spnegoClient option.

### Motivation

It allows us to add traefik as a sidecar in the containers and handing the outgoing spnego authentication for the application in the container.

### More

- [-] Added/updated tests - No. The logic is really in the added go kerberos library
- [-] Added/updated documentation - Not yet. I will add the docs later.

### Additional Notes

