### PR TITLE
Doc Fix for 2.2 Redirects

### DIFF
--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -569,7 +569,7 @@ This whole section is dedicated to options, keyed by entry point, that will appl
     ```bash tab="CLI"
     --entrypoints.web.address=:80
     --entrypoints.web.http.redirections.entryPoint.to=websecure
-    --entrypoints.web.http.redirections.entryPoint.https=true
+    --entrypoints.web.http.redirections.entryPoint.scheme=https
     --entrypoints.websecure.address=:443
     ```
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

This PR updates the documentation for CLI entrypoint redirects. I believe there was a typo. The CLI config didn't match the TOML/YAML configs. When I used the parameters in the docs, I got the error shown below. Switching my CLI args to match the TOML and YAML representations fixed the issue.

![image](https://user-images.githubusercontent.com/7400326/77813640-8227e980-7080-11ea-852a-5bf06b30a0ae.png)

### Motivation

<!-- What inspired you to submit this pull request? -->

Quarantine.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Traefik rocks :metal: 
