### PR TITLE
Allow multiple secure middlewares to operate independently 

### DIFF
--- a/integration/fixtures/headers/secure_multiple.toml
+++ b/integration/fixtures/headers/secure_multiple.toml
@@ -1,0 +1,33 @@
+[global]
+  checkNewVersion = false
+  sendAnonymousUsage = false
+
+[log]
+  level = "DEBUG"
+
+[entryPoints]
+  [entryPoints.web]
+    address = ":8000"
+
+[providers.file]
+  filename = "{{ .SelfFilename }}"
+
+## dynamic configuration ##
+
+[http.routers]
+  [http.routers.router1]
+    rule = "Host(`test.localhost`)"
+    middlewares = ["foo", "bar"]
+    service = "service1"
+
+
+[http.middlewares]
+  [http.middlewares.foo.headers]
+    frameDeny = true
+  [http.middlewares.bar.headers]
+    contentTypeNosniff = true
+
+[http.services]
+  [http.services.service1.loadBalancer]
+    [[http.services.service1.loadBalancer.servers]]
+      url = "http://127.0.0.1:9000"

--- a/integration/headers_test.go
+++ b/integration/headers_test.go
@@ -153,3 +153,44 @@ func (s *HeadersSuite) TestSecureHeadersResponses(c *check.C) {
 		c.Assert(err, checker.IsNil)
 	}
 }
+
+func (s *HeadersSuite) TestMultipleSecureHeadersResponses(c *check.C) {
+	file := s.adaptFile(c, "fixtures/headers/secure_multiple.toml", struct{}{})
+	defer os.Remove(file)
+	cmd, display := s.traefikCmd(withConfigFile(file))
+	defer display(c)
+
+	err := cmd.Start()
+	c.Assert(err, checker.IsNil)
+	defer cmd.Process.Kill()
+
+	backend := startTestServer("9000", http.StatusOK)
+	defer backend.Close()
+
+	err = try.GetRequest(backend.URL, 500*time.Millisecond, try.StatusCodeIs(http.StatusOK))
+	c.Assert(err, checker.IsNil)
+
+	testCase := []struct {
+		desc     string
+		expected http.Header
+		reqHost  string
+	}{
+		{
+			desc: "Feature-Policy Set",
+			expected: http.Header{
+				"X-Frame-Options":        {"DENY"},
+				"X-Content-Type-Options": {"nosniff"},
+			},
+			reqHost: "test.localhost",
+		},
+	}
+
+	for _, test := range testCase {
+		req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8000/", nil)
+		c.Assert(err, checker.IsNil)
+		req.Host = test.reqHost
+
+		err = try.Request(req, 500*time.Millisecond, try.HasHeaderStruct(test.expected))
+		c.Assert(err, checker.IsNil)
+	}
+}

--- a/pkg/middlewares/headers/headers.go
+++ b/pkg/middlewares/headers/headers.go
@@ -55,7 +55,7 @@ func New(ctx context.Context, next http.Handler, cfg dynamic.Headers, name strin
 
 	if hasSecureHeaders {
 		logger.Debug("Setting up secureHeaders from %v", cfg)
-		handler = newSecure(next, cfg)
+		handler = newSecure(next, cfg, name)
 		nextHandler = handler
 	}
 
@@ -84,7 +84,7 @@ type secureHeader struct {
 }
 
 // newSecure constructs a new secure instance with supplied options.
-func newSecure(next http.Handler, cfg dynamic.Headers) *secureHeader {
+func newSecure(next http.Handler, cfg dynamic.Headers, contextKey string) *secureHeader {
 	opt := secure.Options{
 		BrowserXssFilter:        cfg.BrowserXSSFilter,
 		ContentTypeNosniff:      cfg.ContentTypeNosniff,
@@ -107,6 +107,7 @@ func newSecure(next http.Handler, cfg dynamic.Headers) *secureHeader {
 		SSLProxyHeaders:         cfg.SSLProxyHeaders,
 		STSSeconds:              cfg.STSSeconds,
 		FeaturePolicy:           cfg.FeaturePolicy,
+		SecureContextKey:        contextKey,
 	}
 
 	return &secureHeader{

--- a/pkg/middlewares/headers/headers_test.go
+++ b/pkg/middlewares/headers/headers_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/containous/traefik/v2/pkg/tracing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/unrolled/secure"
 )
 
 func TestCustomRequestHeader(t *testing.T) {
@@ -627,33 +626,4 @@ func TestCustomResponseHeaders(t *testing.T) {
 			assert.Equal(t, test.expected, rw.Result().Header)
 		})
 	}
-}
-
-func TestMultipleSecureInstances(t *testing.T) {
-	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-
-	header1, _ := New(context.Background(), next, dynamic.Headers{
-		FrameDeny: true,
-	}, "header1")
-
-	header2, _ := New(context.Background(), next, dynamic.Headers{
-		ContentTypeNosniff: true,
-	}, "header2")
-
-	rr := httptest.NewRecorder()
-	req := testhelpers.MustNewRequest(http.MethodGet, "/foo", nil)
-
-	header1.ServeHTTP(rr, req)
-	header2.ServeHTTP(rr, req)
-
-	response := rr.Result()
-
-	// Modify response headers for header1 middleware.
-	secure.New(secure.Options{
-		FrameDeny:        true,
-		SecureContextKey: "header1",
-	}).ModifyResponseHeaders(response)
-
-	assert.Equal(t, http.StatusOK, response.StatusCode)
-	assert.Equal(t, "DENY", response.Header.Get("X-Frame-Options"))
 }

--- a/pkg/responsemodifiers/headers.go
+++ b/pkg/responsemodifiers/headers.go
@@ -8,7 +8,7 @@ import (
 	"github.com/unrolled/secure"
 )
 
-func buildHeaders(hdrs *dynamic.Headers) func(*http.Response) error {
+func buildHeaders(hdrs *dynamic.Headers, contextKey string) func(*http.Response) error {
 	opt := secure.Options{
 		BrowserXssFilter:        hdrs.BrowserXSSFilter,
 		ContentTypeNosniff:      hdrs.ContentTypeNosniff,
@@ -31,6 +31,7 @@ func buildHeaders(hdrs *dynamic.Headers) func(*http.Response) error {
 		SSLProxyHeaders:         hdrs.SSLProxyHeaders,
 		STSSeconds:              hdrs.STSSeconds,
 		FeaturePolicy:           hdrs.FeaturePolicy,
+		SecureContextKey:        contextKey,
 	}
 
 	return func(resp *http.Response) error {

--- a/pkg/responsemodifiers/response_modifier.go
+++ b/pkg/responsemodifiers/response_modifier.go
@@ -36,7 +36,7 @@ func (f *Builder) Build(ctx context.Context, names []string) func(*http.Response
 		if conf.Headers != nil {
 			getLogger(ctx, middleName, "Headers").Debug("Creating Middleware (ResponseModifier)")
 
-			modifiers = append(modifiers, buildHeaders(conf.Headers))
+			modifiers = append(modifiers, buildHeaders(conf.Headers, middleName))
 		} else if conf.Chain != nil {
 			chainCtx := provider.AddInContext(ctx, middleName)
 			getLogger(chainCtx, middleName, "Chain").Debug("Creating Middleware (ResponseModifier)")

--- a/pkg/responsemodifiers/response_modifier_test.go
+++ b/pkg/responsemodifiers/response_modifier_test.go
@@ -62,7 +62,7 @@ func TestBuilderBuild(t *testing.T) {
 				})
 
 				headerM := *middlewares["foo"].Headers
-				handler, err := headers.New(ctx, next, headerM, "secure")
+				handler, err := headers.New(ctx, next, headerM, "foo")
 				require.NoError(t, err)
 
 				handler.ServeHTTP(httptest.NewRecorder(),


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

Utilizes the secureContextKey to allow different header middlewares to operate independently, without overwriting the next middleware's context key.

### Motivation

Fixes #5538 

### More

- [x] Added/updated tests
- [x] Added/updated documentation - none needed, bugfix

### Additional Notes

Because `unrolled/secure` uses a private secureContextKey type for storage, we cannot retrieve from this project. Testing this drills down to the base secure project, which is already tested in their repo.

Therefore integration testing I feel is the best option at this point.