### PR TITLE
It's just the one TLS, actually.

### DIFF
--- a/webui/src/components/_commons/PanelTLS.vue
+++ b/webui/src/components/_commons/PanelTLS.vue
@@ -70,7 +70,7 @@
             <img v-if="$q.dark.isActive" alt="empty" src="~assets/middlewares-empty-dark.svg">
             <img v-else alt="empty" src="~assets/middlewares-empty.svg">
           </div>
-          <div class="block-empty-label">There are no<br>TLS configured</div>
+          <div class="block-empty-label">There is no<br>TLS configured</div>
         </div>
       </div>
     </q-card-section>


### PR DESCRIPTION
### What does this PR do?

Correct a typo when no TLS is configured.

### Motivation

Um, grammar?

### More

- ~[ ] Added/updated tests~
- ~[ ] Added/updated documentation~

### Additional Notes

This is based on the assumption that a router can only have 1 TLS configuration. If not, then the language still needs changing, just in a slightly different way.