### PR TITLE
Fix api path for prefixed api/dashboards path

### DIFF
--- a/webui/quasar.conf.js
+++ b/webui/quasar.conf.js
@@ -118,11 +118,11 @@ module.exports = function (ctx) {
       env: process.env.APP_ENV === 'development'
         ? { // staging:
           APP_ENV: JSON.stringify(process.env.APP_ENV),
-          APP_API: JSON.stringify(process.env.APP_API || '/api')
+          APP_API: JSON.stringify(process.env.APP_API || '../api')
         }
         : { // production:
           APP_ENV: JSON.stringify(process.env.APP_ENV),
-          APP_API: JSON.stringify(process.env.APP_API || '/api')
+          APP_API: JSON.stringify(process.env.APP_API || '../api')
         },
       uglifyOptions: {
         compress: {


### PR DESCRIPTION
The current implementation does not allow to use the dashboard in a prefixed setup. In our setup the api  and the dashboard are exposed on `/random-path`. The dashboard therefore will be delivered at `/random-path/dashboard/#/` but expects the api at `/api` but actually needs to search in `/random-path/api`.

Therefore the fix will change the path to a relative path, in order to search the api next to the dashboard path. This PR will affect the build process of the static files.

This issue is also described here #5853.
