### PR TITLE
kubernetes-crd-rbac.yml missing "pods" as resource

### DIFF
--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-rbac.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-rbac.yml
@@ -7,6 +7,7 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - pods
       - services
       - endpoints
       - secrets


### PR DESCRIPTION
Per 2.2 helm chart: https://github.com/containous/traefik-helm-chart/blob/master/traefik/templates/rbac/clusterrole.yaml#L14

<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

Updates documentation to reflect the clusterrole resources.


### Motivation

The resources did not match what I expected to see in my test cluster.


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes
rbac.yaml = https://docs.traefik.io/reference/dynamic-configuration/kubernetes-crd/#rbac

<!-- Anything else we should know when reviewing? -->
```diff
➜  ~ (⎈ |main.k3s:kube-system): k diff -f rbac.yaml
diff -u -N /tmp/LIVE-985407864/rbac.authorization.k8s.io.v1.ClusterRole..traefik /tmp/MERGED-287322231/rbac.authorization.k8s.io.v1.ClusterRole..traefik
--- /tmp/LIVE-985407864/rbac.authorization.k8s.io.v1.ClusterRole..traefik	2020-04-09 04:51:03.323336297 +0000
+++ /tmp/MERGED-287322231/rbac.authorization.k8s.io.v1.ClusterRole..traefik	2020-04-09 04:51:03.327336336 +0000
@@ -15,7 +15,6 @@
 - apiGroups:
   - ""
   resources:
-  - pods
   - services
   - endpoints
   - secrets
```

