### PR TITLE
feature: forward body

### DIFF
--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -142,6 +142,7 @@ type ForwardAuth struct {
 	TLS                 *ClientTLS `json:"tls,omitempty" toml:"tls,omitempty" yaml:"tls,omitempty"`
 	TrustForwardHeader  bool       `json:"trustForwardHeader,omitempty" toml:"trustForwardHeader,omitempty" yaml:"trustForwardHeader,omitempty" export:"true"`
 	AuthResponseHeaders []string   `json:"authResponseHeaders,omitempty" toml:"authResponseHeaders,omitempty" yaml:"authResponseHeaders,omitempty"`
+	ForwardBody         bool       `json:"forwardBody,omitempty" toml:"forwardBody,omitempty" yaml:"forwardBody,omitempty" export:"true"`
 }
 
 // +k8s:deepcopy-gen=true


### PR DESCRIPTION
### What does this PR do?

This PR adds the ability to forward the request body to the auth server when using ForwardAuth Middleware.
There is a new option for this middleware called `ForwardBody`. If true, the body will be forwarded.

### Motivation

I want to use Traefik in combination with a gatekeeper using Open Policy Agent to make decisions. Decisions should be made based on request bodies.

This topic was discussed in Issue #6068  

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

If merged I can add a PR for documentation as well.