### PR TITLE
Add link to tracing with elastic

### DIFF
--- a/docs/content/observability/tracing/overview.md
+++ b/docs/content/observability/tracing/overview.md
@@ -7,7 +7,7 @@ The tracing system allows developers to visualize call flows in their infrastruc
 
 Traefik uses OpenTracing, an open standard designed for distributed tracing.
 
-Traefik supports five tracing backends:
+Traefik supports six tracing backends:
 
 - [Jaeger](./jaeger.md)
 - [Zipkin](./zipkin.md)

--- a/docs/content/observability/tracing/overview.md
+++ b/docs/content/observability/tracing/overview.md
@@ -14,6 +14,7 @@ Traefik supports five tracing backends:
 - [Datadog](./datadog.md)
 - [Instana](./instana.md)
 - [Haystack](./haystack.md)
+- [Elastic](./elastic.md)
 
 ## Configuration
 


### PR DESCRIPTION
### What does this PR do?

- Makes it easier to find page with docs on tracing powered by elastic APM from [overview page](https://docs.traefik.io/observability/tracing/overview/).

### Motivation

- I was looking for documentation on how to enable tracing using elastic. At first glance on the overview page, there is a list of all the supported tracing backends but it leaves out `Elastic` which is included on the side navigation. To save anyone else looking for the page on integrating with elastic some seconds, I have included the link on the overview page.


### More

- [x] Updated documentation

