### PR TITLE
fix: consider UDP when checking for empty config

### DIFF
--- a/pkg/server/configurationwatcher.go
+++ b/pkg/server/configurationwatcher.go
@@ -241,10 +241,14 @@ func isEmptyConfiguration(conf *dynamic.Configuration) bool {
 	if conf.HTTP == nil {
 		conf.HTTP = &dynamic.HTTPConfiguration{}
 	}
+	if conf.UDP == nil {
+		conf.UDP = &dynamic.UDPConfiguration{}
+	}
 
 	httpEmpty := conf.HTTP.Routers == nil && conf.HTTP.Services == nil && conf.HTTP.Middlewares == nil
 	tlsEmpty := conf.TLS == nil || conf.TLS.Certificates == nil && conf.TLS.Stores == nil && conf.TLS.Options == nil
 	tcpEmpty := conf.TCP.Routers == nil && conf.TCP.Services == nil
+	udpEmpty := conf.UDP.Routers == nil && conf.UDP.Services == nil
 
-	return httpEmpty && tlsEmpty && tcpEmpty
+	return httpEmpty && tlsEmpty && tcpEmpty && udpEmpty
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR considers UDP when checking for an empty configuration in the configuration watcher.


### Motivation

Allow UDP only dynamic configurations.

### Additional Notes

<!-- Anything else we should know when reviewing? -->
