### PR TITLE
Add Access log chapter for migration v1->v2

### DIFF
--- a/docs/content/migration/v1-to-v2.md
+++ b/docs/content/migration/v1-to-v2.md
@@ -801,7 +801,10 @@ There is no more log configuration at the root level.
 
 ## Access Logs
 
-Access Logs are configured in the same way as before. But all request headers are now filtered out by default in Traefik v2. So during migration, you might want to consider enabling some needed fields (see [access log configuration](../observability/access-logs.md)).
+Access Logs are configured in the same way as before.
+
+But all request headers are now filtered out by default in Traefik v2.
+So during migration, you might want to consider enabling some needed fields (see [access log configuration](../observability/access-logs.md)).
 
 ## Tracing
 

--- a/docs/content/migration/v1-to-v2.md
+++ b/docs/content/migration/v1-to-v2.md
@@ -801,7 +801,7 @@ There is no more log configuration at the root level.
 
 ## Access Logs
 
-Access Logs are configured in the same way as before. But v2 filters request headers by default. So during migration, you might want to consider enabling some needed fields (see [access log configuration](../observability/access-logs.md)).
+Access Logs are configured in the same way as before. But all request headers are now filtered out by default in Traefik v2. So during migration, you might want to consider enabling some needed fields (see [access log configuration](../observability/access-logs.md)).
 
 ## Tracing
 

--- a/docs/content/migration/v1-to-v2.md
+++ b/docs/content/migration/v1-to-v2.md
@@ -798,6 +798,9 @@ There is no more log configuration at the root level.
     --log.filePath=/path/to/traefik.log
     --log.format=json
     ```
+## Access Logs
+
+Access Logs are configured in the same way as before. But v2 filters request headers by default. So during migration, you might want to consider enabling some needed fields (see [access log configuration](../observability/access-logs.md)).
 
 ## Tracing
 

--- a/docs/content/migration/v1-to-v2.md
+++ b/docs/content/migration/v1-to-v2.md
@@ -798,6 +798,7 @@ There is no more log configuration at the root level.
     --log.filePath=/path/to/traefik.log
     --log.format=json
     ```
+
 ## Access Logs
 
 Access Logs are configured in the same way as before. But v2 filters request headers by default. So during migration, you might want to consider enabling some needed fields (see [access log configuration](../observability/access-logs.md)).


### PR DESCRIPTION
### What does this PR do?

Add a hint to the migration documentation, that the default configuration of the access logs in v2 won't log the same details as v1 anymore.

### Motivation

Stumbled across the need of reconfiguration later in my migration path and would loved to get a hint right at the beginning of my configuration adaptions.


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

-
