### PR TITLE
Add custom ping http code when Traefik is terminating

### DIFF
--- a/docs/content/operations/ping.md
+++ b/docs/content/operations/ping.md
@@ -86,20 +86,23 @@ ping:
 
 _Optional, Default=503_
 
-If you are running traefik behind a external Load-balancer, and want to configure rotation health check on the Load-balancer to take a traefik instance out of rotation gracefully, you can configure lifecycle.requestAcceptGraceTimeout and the ping endpoint will return 503 response on traefik server termination, so that the Load-balancer can take the terminating traefik instance out of rotation, before it stops responding.
-
-You can change this by setting your own http status code
+During the period in which Traefik is gracefully shutting down, the ping handler
+returns a 503 status code by default. If Traefik is behind e.g. a load-balancer
+doing health checks (such as the Kubernetes LivenessProbe), another code might
+be expected as the signal for graceful termination. In which case, the
+terminatingStatusCode can be used to set the code returned by the ping
+handler during termination.
 
 ```toml tab="File (TOML)"
 [ping]
-  terminatingStatusCode = 200
+  terminatingStatusCode = 204
 ```
 
 ```yaml tab="File (YAML)"
 ping:
-  terminatingStatusCode: 200
+  terminatingStatusCode: 204
 ```
 
 ```bash tab="CLI"
---ping.terminatingStatusCode=200
+--ping.terminatingStatusCode=204
 ```

--- a/docs/content/operations/ping.md
+++ b/docs/content/operations/ping.md
@@ -81,3 +81,25 @@ ping:
 ```bash tab="CLI"
 --ping.manualrouting=true
 ```
+
+### `terminatingStatusCode`
+
+_Optional, Default=503_
+
+If you are running traefik behind a external Load-balancer, and want to configure rotation health check on the Load-balancer to take a traefik instance out of rotation gracefully, you can configure lifecycle.requestAcceptGraceTimeout and the ping endpoint will return 503 response on traefik server termination, so that the Load-balancer can take the terminating traefik instance out of rotation, before it stops responding.
+
+You can change this by setting your own http status code
+
+```toml tab="File (TOML)"
+[ping]
+  terminatingStatusCode = 200
+```
+
+```yaml tab="File (YAML)"
+ping:
+  terminatingStatusCode: 200
+```
+
+```bash tab="CLI"
+--ping.terminatingStatusCode=200
+```

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -279,6 +279,9 @@ EntryPoint (Default: ```traefik```)
 `--ping.manualrouting`:  
 Manual routing (Default: ```false```)
 
+`--ping.terminatingstatuscode`:  
+Terminating status code (Default: ```0```)
+
 `--providers.consul`:  
 Enable Consul backend with default settings. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -280,7 +280,7 @@ EntryPoint (Default: ```traefik```)
 Manual routing (Default: ```false```)
 
 `--ping.terminatingstatuscode`:  
-Terminating status code (Default: ```0```)
+Terminating status code (Default: ```503```)
 
 `--providers.consul`:  
 Enable Consul backend with default settings. (Default: ```false```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -280,7 +280,7 @@ EntryPoint (Default: ```traefik```)
 Manual routing (Default: ```false```)
 
 `TRAEFIK_PING_TERMINATINGSTATUSCODE`:  
-Terminating status code (Default: ```0```)
+Terminating status code (Default: ```503```)
 
 `TRAEFIK_PROVIDERS_CONSUL`:  
 Enable Consul backend with default settings. (Default: ```false```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -279,6 +279,9 @@ EntryPoint (Default: ```traefik```)
 `TRAEFIK_PING_MANUALROUTING`:  
 Manual routing (Default: ```false```)
 
+`TRAEFIK_PING_TERMINATINGSTATUSCODE`:  
+Terminating status code (Default: ```0```)
+
 `TRAEFIK_PROVIDERS_CONSUL`:  
 Enable Consul backend with default settings. (Default: ```false```)
 

--- a/integration/fixtures/custom_ping_termination_status_code.toml
+++ b/integration/fixtures/custom_ping_termination_status_code.toml
@@ -1,0 +1,16 @@
+[global]
+  checkNewVersion = false
+  sendAnonymousUsage = false
+
+[log]
+  level = "DEBUG"
+
+[entryPoints]
+
+  [entryPoints.traefik]
+    address = ":8001"
+    [entryPoints.traefik.transport.lifeCycle]
+      requestAcceptGraceTimeout = "10s"
+
+[ping]
+    terminatingStatusCode = 204

--- a/integration/simple_test.go
+++ b/integration/simple_test.go
@@ -186,10 +186,8 @@ func (s *SimpleSuite) TestCustomPingTerminationStatusCode(c *check.C) {
 	c.Assert(err, checker.IsNil)
 
 	// ping endpoint should now return a Service Unavailable.
-	resp, err := http.Get("http://127.0.0.1:8001/ping")
+	err = try.GetRequest("http://127.0.0.1:8001/ping", 2*time.Second, try.StatusCodeIs(http.StatusNoContent))
 	c.Assert(err, checker.IsNil)
-	defer resp.Body.Close()
-	c.Assert(resp.StatusCode, checker.Equals, http.StatusNoContent)
 }
 
 func (s *SimpleSuite) TestStatsWithMultipleEntryPoint(c *check.C) {

--- a/pkg/ping/ping.go
+++ b/pkg/ping/ping.go
@@ -8,9 +8,10 @@ import (
 
 // Handler expose ping routes.
 type Handler struct {
-	EntryPoint    string `description:"EntryPoint" export:"true" json:"entryPoint,omitempty" toml:"entryPoint,omitempty" yaml:"entryPoint,omitempty"`
-	ManualRouting bool   `description:"Manual routing" json:"manualRouting,omitempty" toml:"manualRouting,omitempty" yaml:"manualRouting,omitempty"`
-	terminating   bool
+	EntryPoint            string `description:"EntryPoint" export:"true" json:"entryPoint,omitempty" toml:"entryPoint,omitempty" yaml:"entryPoint,omitempty"`
+	ManualRouting         bool   `description:"Manual routing" json:"manualRouting,omitempty" toml:"manualRouting,omitempty" yaml:"manualRouting,omitempty"`
+	TerminatingStatusCode int    `description:"Terminating status code" json:"terminatingStatusCode,omitempty" toml:"terminatingStatusCode,omitempty" yaml:"terminatingStatusCode,omitempty"`
+	terminating           bool
 }
 
 // SetDefaults sets the default values.
@@ -30,6 +31,10 @@ func (h *Handler) ServeHTTP(response http.ResponseWriter, request *http.Request)
 	statusCode := http.StatusOK
 	if h.terminating {
 		statusCode = http.StatusServiceUnavailable
+
+		if h.TerminatingStatusCode > 0 {
+			statusCode = h.TerminatingStatusCode
+		}
 	}
 	response.WriteHeader(statusCode)
 	fmt.Fprint(response, http.StatusText(statusCode))

--- a/pkg/ping/ping.go
+++ b/pkg/ping/ping.go
@@ -31,12 +31,7 @@ func (h *Handler) WithContext(ctx context.Context) {
 func (h *Handler) ServeHTTP(response http.ResponseWriter, request *http.Request) {
 	statusCode := http.StatusOK
 	if h.terminating {
-		statusCode = http.StatusServiceUnavailable
-
-		// TODO(mpl): check whether this is still needed even with SetDefaults.
-		if h.TerminatingStatusCode > 0 {
-			statusCode = h.TerminatingStatusCode
-		}
+		statusCode = h.TerminatingStatusCode
 	}
 	response.WriteHeader(statusCode)
 	fmt.Fprint(response, http.StatusText(statusCode))

--- a/pkg/ping/ping.go
+++ b/pkg/ping/ping.go
@@ -17,6 +17,7 @@ type Handler struct {
 // SetDefaults sets the default values.
 func (h *Handler) SetDefaults() {
 	h.EntryPoint = "traefik"
+	h.TerminatingStatusCode = http.StatusServiceUnavailable
 }
 
 // WithContext causes the ping endpoint to serve non 200 responses.
@@ -32,6 +33,7 @@ func (h *Handler) ServeHTTP(response http.ResponseWriter, request *http.Request)
 	if h.terminating {
 		statusCode = http.StatusServiceUnavailable
 
+		// TODO(mpl): check whether this is still needed even with SetDefaults.
 		if h.TerminatingStatusCode > 0 {
 			statusCode = h.TerminatingStatusCode
 		}


### PR DESCRIPTION
### What does this PR do?

Allow custom http code in ping route when Traefik is terminating (graceful shutdown)

### Motivation

Issue https://github.com/containous/traefik/issues/6688 
Better handling of graceful shutdown with Kubernetes livenessprobe.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

