### PR TITLE
Fix case-sensitive header Sec-Websocket-Version

### DIFF
--- a/pkg/server/service/proxy.go
+++ b/pkg/server/service/proxy.go
@@ -62,12 +62,15 @@ func buildProxy(passHostHeader *bool, responseForwarding *dynamic.ResponseForwar
 			}
 
 			// Even if the websocket RFC says that headers should be case-insensitive,
-			// some servers need Sec-WebSocket-Key and Sec-WebSocket-Protocol to be case-sensitive.
+			// some servers need Sec-WebSocket-Key, Sec-WebSocket-Protocol and Sec-WebSocket-Version
+			// to be case-sensitive.
 			// https://tools.ietf.org/html/rfc6455#page-20
 			outReq.Header["Sec-WebSocket-Key"] = outReq.Header["Sec-Websocket-Key"]
 			outReq.Header["Sec-WebSocket-Protocol"] = outReq.Header["Sec-Websocket-Protocol"]
+			outReq.Header["Sec-WebSocket-Version"] = outReq.Header["Sec-Websocket-Version"]
 			delete(outReq.Header, "Sec-Websocket-Key")
 			delete(outReq.Header, "Sec-Websocket-Protocol")
+			delete(outReq.Header, "Sec-Websocket-Version")
 		},
 		Transport:      defaultRoundTripper,
 		FlushInterval:  time.Duration(flushInterval),


### PR DESCRIPTION
### What does this PR do?

Force Sec-WebSocket-Version header case to fix Handshake problem on various Websocket implementations

### Motivation

There are various Websocket implementations out there, which are not case insensitive. This fix makes the Websocket implementation more robust.


### More

~~- [ ] Added/updated tests~~
~~- [ ] Added/updated documentation~~
