### PR TITLE
custom header UUID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/gogo/protobuf v1.3.0 // indirect
 	github.com/golang/protobuf v1.3.4
 	github.com/google/go-github/v28 v28.1.1
+	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.1.0 // indirect
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/websocket v1.4.1

--- a/pkg/middlewares/headers/headers.go
+++ b/pkg/middlewares/headers/headers.go
@@ -173,7 +173,7 @@ func (s *Header) modifyCustomRequestHeaders(req *http.Request) {
 		case strings.EqualFold(header, "Host"):
 			req.Host = value
 
-		case strings.EqualFold(value, "{{uuid}}"):
+		case strings.EqualFold(value, "{uuid}"):
 			if v4, err := uuid.NewRandom(); err == nil {
 				req.Header.Set(header, v4.String())
 			}

--- a/pkg/middlewares/headers/headers.go
+++ b/pkg/middlewares/headers/headers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containous/traefik/v2/pkg/log"
 	"github.com/containous/traefik/v2/pkg/middlewares"
 	"github.com/containous/traefik/v2/pkg/tracing"
+	"github.com/google/uuid"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/unrolled/secure"
 )
@@ -171,6 +172,11 @@ func (s *Header) modifyCustomRequestHeaders(req *http.Request) {
 
 		case strings.EqualFold(header, "Host"):
 			req.Host = value
+
+		case strings.EqualFold(value, "{{uuid}}"):
+			if v4, err := uuid.NewRandom(); err == nil {
+				req.Header.Set(header, v4.String())
+			}
 
 		default:
 			req.Header.Set(header, value)

--- a/pkg/middlewares/headers/headers_test.go
+++ b/pkg/middlewares/headers/headers_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containous/traefik/v2/pkg/config/dynamic"
 	"github.com/containous/traefik/v2/pkg/testhelpers"
 	"github.com/containous/traefik/v2/pkg/tracing"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -31,6 +32,25 @@ func TestCustomRequestHeader(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, res.Code)
 	assert.Equal(t, "test_request", req.Header.Get("X-Custom-Request-Header"))
+}
+
+func TestCustomRequestHeader_uuid(t *testing.T) {
+	emptyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+	header := NewHeader(emptyHandler, dynamic.Headers{
+		CustomRequestHeaders: map[string]string{
+			"X-Request-UUID": "{{uuid}}",
+		},
+	})
+
+	res := httptest.NewRecorder()
+	req := testhelpers.MustNewRequest(http.MethodGet, "/foo", nil)
+
+	header.ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusOK, res.Code)
+	_, err := uuid.Parse(req.Header.Get("X-Request-UUID"))
+	assert.NoError(t, err)
 }
 
 func TestCustomRequestHeader_Host(t *testing.T) {

--- a/pkg/middlewares/headers/headers_test.go
+++ b/pkg/middlewares/headers/headers_test.go
@@ -39,7 +39,7 @@ func TestCustomRequestHeader_uuid(t *testing.T) {
 
 	header := NewHeader(emptyHandler, dynamic.Headers{
 		CustomRequestHeaders: map[string]string{
-			"X-Request-UUID": "{{uuid}}",
+			"X-Request-UUID": "{uuid}",
 		},
 	})
 


### PR DESCRIPTION
### What does this PR do?

Adds ability to create a custom header with a UUIDv4 (aka "Correlation ID" or "X-Request-ID").

### Motivation

This is something several users want (quick search #4640, #1333, #4483, #2290, #2377), including myself.  An **easy** way to match Traefik request logs with other service logs, without having to create an entire tracing ecosystem or additional services.  

It is a common proxy feature.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

@JanMa [put it well](https://github.com/containous/traefik/pull/4483#issuecomment-462833870):

> In my opinion the use case for a correlation differs quite a lot from using a tracing engine. With correlation ids it is very easy to track an external request through all service calls in your environment. You "just" have to make sure your applications log the corresponding header name in their access logs and can easily gather all relevant log entries in a tool like Kibana. Having this information in your logging stack is incredibly useful for debugging, especially in a microservice environment. Using a tracing engine on the other hand is useful when you want to gather low level insights of your inter-service communication and see for example how long single remote procedure call takes. Also implementing full tracing support in all your services takes a lot more effort.

@jrm780 [noted](https://github.com/containous/traefik/pull/2290#issuecomment-422573460):

> `X-Request-Id` is a non-standard but **very common header**, and it's incredibly useful in correlating log entries. **Distributed tracing aims to solve entirely different problems**, so it would seem odd for OpenTracing support and adding an X-Request-Id header to be mutually exclusive.

@aaslamin [noted that this is a feature included in several other Traefik alternatives](https://github.com/containous/traefik/pull/2290#issuecomment-426464339):

> +100 to this feature.
> 
> I was quite surprised to see this issue closed because of opentracing. It is very common for edge > proxies to generate a unique ID for each request:
> 
> • http://nginx.org/en/docs/http/ngx_http_core_module.html#var_request_id
> • https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/headers#config-http-conn-man-headers-x-request-id
> • https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4-unique-id-format
> 
> One can use this to hydrate their access logs to create request scoped loggers for example as a request trickles through the service mesh. 

Finally, tracing (more expensive while processing each request, requires additional services, usually only done on a small percentage of requests during production) and simply adding a request id (inexpensive, no additional services required, can be enabled on all requests in production) are **not the same thing** and does not have the same use-case.  The reply that OpenTracing should be used instead is not a valid argument for not including this feature.

Lastly, I have kept this **as simple as possible**, so maintenance and adverse effects should be minimal.  It expands on the existing Custom Header functionality, and can possibly be expanded on in the future to include other dynamic values (as suggested: #5036, #5063, #4519).

### Simple implementation example

```toml
[http.middlewares]
  [http.middlewares.requestIdHeader.headers]
    [http.middlewares.requestIdHeader.headers.customRequestHeaders]
        X-Request-ID = "{uuid}"

[accessLog]
  filePath = "/path/to/access.log"
  format = "json"
  [accessLog.fields]
    [accessLog.fields.headers]
      defaultMode = "keep"
```