### PR TITLE
ratelimit: do not default to ipstrategy too early

### DIFF
--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -337,9 +337,6 @@ type RateLimit struct {
 func (r *RateLimit) SetDefaults() {
 	r.Burst = 1
 	r.Period = types.Duration(time.Second)
-	r.SourceCriterion = &SourceCriterion{
-		IPStrategy: &IPStrategy{},
-	}
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -286,13 +286,6 @@ type InFlightReq struct {
 	SourceCriterion *SourceCriterion `json:"sourceCriterion,omitempty" toml:"sourceCriterion,omitempty" yaml:"sourceCriterion,omitempty"`
 }
 
-// SetDefaults Default values for a InFlightReq.
-func (i *InFlightReq) SetDefaults() {
-	i.SourceCriterion = &SourceCriterion{
-		RequestHost: true,
-	}
-}
-
 // +k8s:deepcopy-gen=true
 
 // PassTLSClientCert holds the TLS client cert headers configuration.
@@ -304,8 +297,8 @@ type PassTLSClientCert struct {
 // +k8s:deepcopy-gen=true
 
 // SourceCriterion defines what criterion is used to group requests as originating from a common source.
-// The precedence order is IPStrategy, then RequestHeaderName.
 // If none are set, the default is to use the request's remote address field.
+// All fields are mutually exclusive.
 type SourceCriterion struct {
 	IPStrategy        *IPStrategy `json:"ipStrategy" toml:"ipStrategy, omitempty"`
 	RequestHeaderName string      `json:"requestHeaderName,omitempty" toml:"requestHeaderName,omitempty" yaml:"requestHeaderName,omitempty"`

--- a/pkg/middlewares/extractor.go
+++ b/pkg/middlewares/extractor.go
@@ -13,6 +13,7 @@ import (
 
 // GetSourceExtractor returns the SourceExtractor function corresponding to the given sourceMatcher.
 // It defaults to a RemoteAddrStrategy IPStrategy if need be.
+// It returns an error if more than one source criterion is provided.
 func GetSourceExtractor(ctx context.Context, sourceMatcher *dynamic.SourceCriterion) (utils.SourceExtractor, error) {
 	if sourceMatcher != nil {
 		if sourceMatcher.IPStrategy != nil && sourceMatcher.RequestHeaderName != "" {

--- a/pkg/middlewares/extractor.go
+++ b/pkg/middlewares/extractor.go
@@ -14,6 +14,18 @@ import (
 // GetSourceExtractor returns the SourceExtractor function corresponding to the given sourceMatcher.
 // It defaults to a RemoteAddrStrategy IPStrategy if need be.
 func GetSourceExtractor(ctx context.Context, sourceMatcher *dynamic.SourceCriterion) (utils.SourceExtractor, error) {
+	if sourceMatcher != nil {
+		if sourceMatcher.IPStrategy != nil && sourceMatcher.RequestHeaderName != "" {
+			return nil, errors.New("IPStrategy and RequestHeaderName are mutually exclusive")
+		}
+		if sourceMatcher.IPStrategy != nil && sourceMatcher.RequestHost {
+			return nil, errors.New("IPStrategy and RequestHost are mutually exclusive")
+		}
+		if sourceMatcher.RequestHeaderName != "" && sourceMatcher.RequestHost {
+			return nil, errors.New("RequestHost and RequestHeaderName are mutually exclusive")
+		}
+	}
+
 	if sourceMatcher == nil ||
 		sourceMatcher.IPStrategy == nil &&
 			sourceMatcher.RequestHeaderName == "" && !sourceMatcher.RequestHost {

--- a/pkg/middlewares/extractor.go
+++ b/pkg/middlewares/extractor.go
@@ -17,13 +17,13 @@ import (
 func GetSourceExtractor(ctx context.Context, sourceMatcher *dynamic.SourceCriterion) (utils.SourceExtractor, error) {
 	if sourceMatcher != nil {
 		if sourceMatcher.IPStrategy != nil && sourceMatcher.RequestHeaderName != "" {
-			return nil, errors.New("IPStrategy and RequestHeaderName are mutually exclusive")
+			return nil, errors.New("iPStrategy and RequestHeaderName are mutually exclusive")
 		}
 		if sourceMatcher.IPStrategy != nil && sourceMatcher.RequestHost {
-			return nil, errors.New("IPStrategy and RequestHost are mutually exclusive")
+			return nil, errors.New("iPStrategy and RequestHost are mutually exclusive")
 		}
 		if sourceMatcher.RequestHeaderName != "" && sourceMatcher.RequestHost {
-			return nil, errors.New("RequestHost and RequestHeaderName are mutually exclusive")
+			return nil, errors.New("requestHost and RequestHeaderName are mutually exclusive")
 		}
 	}
 

--- a/pkg/middlewares/inflightreq/inflight_req.go
+++ b/pkg/middlewares/inflightreq/inflight_req.go
@@ -23,6 +23,7 @@ type inFlightReq struct {
 }
 
 // New creates a max request middleware.
+// If no source criterion is provided in the config, it defaults to RequestHost.
 func New(ctx context.Context, next http.Handler, config dynamic.InFlightReq, name string) (http.Handler, error) {
 	ctxLog := log.With(ctx, log.Str(log.MiddlewareName, name), log.Str(log.MiddlewareType, typeName))
 	log.FromContext(ctxLog).Debug("Creating middleware")

--- a/pkg/middlewares/ratelimiter/rate_limiter_test.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter_test.go
@@ -71,7 +71,7 @@ func TestNewRateLimiter(t *testing.T) {
 					RequestHeaderName: "Foo",
 				},
 			},
-			expectedError: "IPStrategy and RequestHeaderName are mutually exclusive",
+			expectedError: "iPStrategy and RequestHeaderName are mutually exclusive",
 		},
 	}
 

--- a/pkg/provider/consulcatalog/config_test.go
+++ b/pkg/provider/consulcatalog/config_test.go
@@ -1003,9 +1003,6 @@ func Test_buildConfiguration(t *testing.T) {
 						"Middleware1": {
 							InFlightReq: &dynamic.InFlightReq{
 								Amount: 42,
-								SourceCriterion: &dynamic.SourceCriterion{
-									RequestHost: true,
-								},
 							},
 						},
 					},
@@ -1055,9 +1052,6 @@ func Test_buildConfiguration(t *testing.T) {
 						"Middleware1": {
 							InFlightReq: &dynamic.InFlightReq{
 								Amount: 42,
-								SourceCriterion: &dynamic.SourceCriterion{
-									RequestHost: true,
-								},
 							},
 						},
 					},

--- a/pkg/provider/docker/config_test.go
+++ b/pkg/provider/docker/config_test.go
@@ -1301,9 +1301,6 @@ func Test_buildConfiguration(t *testing.T) {
 						"Middleware1": {
 							InFlightReq: &dynamic.InFlightReq{
 								Amount: 42,
-								SourceCriterion: &dynamic.SourceCriterion{
-									RequestHost: true,
-								},
 							},
 						},
 					},
@@ -1372,9 +1369,6 @@ func Test_buildConfiguration(t *testing.T) {
 						"Middleware1": {
 							InFlightReq: &dynamic.InFlightReq{
 								Amount: 42,
-								SourceCriterion: &dynamic.SourceCriterion{
-									RequestHost: true,
-								},
 							},
 						},
 					},

--- a/pkg/provider/marathon/config_test.go
+++ b/pkg/provider/marathon/config_test.go
@@ -686,9 +686,6 @@ func TestBuildConfiguration(t *testing.T) {
 						"Middleware1": {
 							InFlightReq: &dynamic.InFlightReq{
 								Amount: 42,
-								SourceCriterion: &dynamic.SourceCriterion{
-									RequestHost: true,
-								},
 							},
 						},
 					},


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR removes ipstrategy being systematically set as the default source
criterion, which was causing any other source criterion provided in the config
to be ignored.

We already take care of setting ipstrategy as the default in the rate limiter
constructor anyway.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

Fixes #6687

<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- ~[ ] Added/updated documentation~

### Additional Notes

<!-- Anything else we should know when reviewing? -->
