### PR TITLE
Disable distribution of the WebUI as PWA

### DIFF
--- a/webui/package.json
+++ b/webui/package.json
@@ -9,10 +9,10 @@
     "transfer": "node dev/scripts/transfer.js",
     "lint": "eslint --ext .js,.vue src",
     "test-unit": "mocha-webpack --mode=production './src/**/*.spec.js'",
-    "dev": "export APP_ENV='development' && quasar dev -m pwa",
-    "build-quasar": "quasar build -m pwa",
+    "dev": "export APP_ENV='development' && quasar dev",
+    "build-quasar": "quasar build",
     "build-staging": "export NODE_ENV='production' && export APP_ENV='development' && npm run build-quasar",
-    "build": "export NODE_ENV='production' && export APP_ENV='production' && npm run build-quasar && npm run transfer pwa",
+    "build": "export NODE_ENV='production' && export APP_ENV='production' && npm run build-quasar && npm run transfer spa",
     "build:nc": "npm run build"
   },
   "dependencies": {


### PR DESCRIPTION
### What does this PR do?

It disables the distribution of the WebUI as a PWA, as there is no strong benefit of distributing it as a PWA currently but instead adds some complexity and confuses our users.

### Motivation

Fixes #6514

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes
