### PR TITLE
Add sentence about the resource namespace and middleware

### DIFF
--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -623,7 +623,7 @@ Register the `Middleware` [kind](../../reference/dynamic-configuration/kubernete
 	when the definition of the middleware comes from another provider.
 	In this context, specifying a namespace when referring to the resource does not make any sense, and will be ignored.
 	Additionally, when you want to reference a Middleware from the CRD Provider, you have to append the namespace of the
-    Ressource in the ressource-name as Traefik appends the namespace internally automatically.
+    resource in the ressource-name as Traefik appends the namespace internally automatically.
 
 More information about available middlewares in the dedicated [middlewares section](../../middlewares/overview.md).
 

--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -623,7 +623,7 @@ Register the `Middleware` [kind](../../reference/dynamic-configuration/kubernete
 	when the definition of the middleware comes from another provider.
 	In this context, specifying a namespace when referring to the resource does not make any sense, and will be ignored.
 	Additionally, when you want to reference a Middleware from the CRD Provider, you have to append the namespace of the
-	Ressource in the ressource-name as Traefik appends the namespace internally automatically.
+    Ressource in the ressource-name as Traefik appends the namespace internally automatically.
 
 More information about available middlewares in the dedicated [middlewares section](../../middlewares/overview.md).
 

--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -618,12 +618,12 @@ Register the `Middleware` [kind](../../reference/dynamic-configuration/kubernete
 
 !!! important "Cross-provider namespace"
 
-	As Kubernetes also has its own notion of namespace, one should not confuse the kubernetes namespace of a resource
-	(in the reference to the middleware) with the [provider namespace](../../middlewares/overview.md#provider-namespace),
-	when the definition of the middleware comes from another provider.
-	In this context, specifying a namespace when referring to the resource does not make any sense, and will be ignored.
-	Additionally, when you want to reference a Middleware from the CRD Provider, you have to append the namespace of the
-    resource in the ressource-name as Traefik appends the namespace internally automatically.
+    As Kubernetes also has its own notion of namespace, one should not confuse the kubernetes namespace of a resource
+    (in the reference to the middleware) with the [provider namespace](../../middlewares/overview.md#provider-namespace),
+    when the definition of the middleware comes from another provider.
+    In this context, specifying a namespace when referring to the resource does not make any sense, and will be ignored.
+    Additionally, when you want to reference a Middleware from the CRD Provider,
+    you have to append the namespace of the resource in the resource-name as Traefik appends the namespace internally automatically.
 
 More information about available middlewares in the dedicated [middlewares section](../../middlewares/overview.md).
 

--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -622,6 +622,8 @@ Register the `Middleware` [kind](../../reference/dynamic-configuration/kubernete
 	(in the reference to the middleware) with the [provider namespace](../../middlewares/overview.md#provider-namespace),
 	when the definition of the middleware comes from another provider.
 	In this context, specifying a namespace when referring to the resource does not make any sense, and will be ignored.
+	Additionally, when you want to reference a Middleware from the CRD Provider, you have to append the namespace of the
+	Ressource in the ressource-name as Traefik appends the namespace internally automatically.
 
 More information about available middlewares in the dedicated [middlewares section](../../middlewares/overview.md).
 


### PR DESCRIPTION
### What does this PR do?

Adds a sentence about the fact, that the namespace of a middleware is internally added automatically, as it's important when you want to reference that middleware from another provider.


### Motivation

Enhance our Docs

Fix #6318

### More

- [ ] Added/updated tests
- [X] Added/updated documentation

### Additional Notes
