### PR TITLE
Update kubernetes-crd-resource.yml

### DIFF
--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-resource.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-resource.yml
@@ -123,7 +123,7 @@ spec:
   tls:
     secretName: supersecret
     options:
-      name: myTLSOption
+      name: my-tls-option
       namespace: default
 
 ---
@@ -145,7 +145,7 @@ spec:
     secretName: foosecret
     passthrough: false
     options:
-      name: myTLSOption
+      name: my-tls-option
       namespace: default
 
 ---


### PR DESCRIPTION
example has not a valid syntax for kubernetes (must be dns-conform)

### Motivation
<!-- What inspired you to submit this pull request? -->

`The TLSOption "minVersionTLS12" is invalid: metadata.name: Invalid value: "minVersionTLS12": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`