### PR TITLE
Add missing accessControlAllowOrigin list to middleware view

### DIFF
--- a/webui/src/components/_commons/PanelMiddlewares.vue
+++ b/webui/src/components/_commons/PanelMiddlewares.vue
@@ -371,15 +371,16 @@
             </div>
           </div>
         </q-card-section>
-        <!-- EXTRA FIELDS FROM MIDDLEWARES - [headers] - accessControlAllowOrigin -->
+        <!-- EXTRA FIELDS FROM MIDDLEWARES - [headers] - accessControlAllowOriginList -->
         <q-card-section v-if="middleware.headers">
           <div class="row items-start no-wrap">
             <div class="col">
               <div class="text-subtitle2">Access Control Allow Origin</div>
               <q-chip
+                v-for="(val, key) in exData(middleware).accessControlAllowOriginList" :key="key"
                 dense
                 class="app-chip app-chip-green">
-                {{ exData(middleware).accessControlAllowOrigin }}
+                {{ val }}
               </q-chip>
             </div>
           </div>


### PR DESCRIPTION
### What does this PR do?

`ACCESS CONTROL ALLOW ORIGIN` section in middleware section of router view doesn't list values from `accessControlAllowOriginList` options, but instead tries to print `accessControlAllowOrigin`. This PR fixes it.

### Motivation

I wanted to see the value set in `accessControlAllowOriginList` option in Traefik dashboard.

### More

- [x] ~~Added/updated tests~~ No tests present
- [x] ~~Added/updated documentation~~ No documentation necessary

### Additional Notes

I didn't have a chance to run it locally.
