### PR TITLE
Fix wss in x-forwarded-proto

### DIFF
--- a/pkg/middlewares/forwardedheaders/forwarded_header.go
+++ b/pkg/middlewares/forwardedheaders/forwarded_header.go
@@ -141,7 +141,7 @@ func (x *XForwarded) rewrite(outreq *http.Request) {
 	}
 
 	if isWebsocketRequest(outreq) {
-		if outreq.Header.Get(xForwardedProto) == "https" {
+		if outreq.Header.Get(xForwardedProto) == "https" || outreq.Header.Get(xForwardedProto) == "wss" {
 			outreq.Header.Set(xForwardedProto, "wss")
 		} else {
 			outreq.Header.Set(xForwardedProto, "ws")

--- a/pkg/middlewares/forwardedheaders/forwarded_header_test.go
+++ b/pkg/middlewares/forwardedheaders/forwarded_header_test.go
@@ -204,6 +204,17 @@ func TestServeHTTP(t *testing.T) {
 			},
 		},
 		{
+			desc:      "xForwardedProto with websocket and tls and already x-forwarded-proto with wss",
+			tls:       true,
+			websocket: true,
+			incomingHeaders: map[string]string{
+				xForwardedProto: "wss",
+			},
+			expectedHeaders: map[string]string{
+				xForwardedProto: "wss",
+			},
+		},
+		{
 			desc: "xForwardedPort with explicit port",
 			host: "foo.com:8080",
 			expectedHeaders: map[string]string{


### PR DESCRIPTION
### What does this PR do?
If we have two Traefik and the first one put x-forwarded-proto to `wss`, the second one will overwrite with `https`


### Motivation
Fix a bug with wss x-forwarded-proto.

### More

- [x] Added/updated tests
~- [ ] Added/updated documentation~