### PR TITLE
Improve acme CLI options in Let's Encrypt documentation 

### DIFF
--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -105,13 +105,13 @@ Please check the [configuration examples below](#configuration-examples) for mor
     ```
     
     ```bash tab="CLI"
-    --entryPoints.web.address=:80
-    --entryPoints.websecure.address=:443
+    --entrypoints.web.address=:80
+    --entrypoints.websecure.address=:443
     # ...
-    --certificatesResolvers.myresolver.acme.email=your-email@example.com
-    --certificatesResolvers.myresolver.acme.storage=acme.json
+    --certificatesresolvers.myresolver.acme.email=your-email@example.com
+    --certificatesresolvers.myresolver.acme.storage=acme.json
     # used during the challenge
-    --certificatesResolvers.myresolver.acme.httpChallenge.entryPoint=web
+    --certificatesresolvers.myresolver.acme.httpchallenge.entrypoint=web
     ```
 
 !!! important "Defining a certificates resolver does not result in all routers automatically using it. Each router that is supposed to use the resolver must [reference](../routing/routers/index.md#certresolver) it."
@@ -181,7 +181,7 @@ when using the `TLS-ALPN-01` challenge, Traefik must be reachable by Let's Encry
     
     ```bash tab="CLI"
     # ...
-    --certificatesResolvers.myresolver.acme.tlsChallenge=true
+    --certificatesresolvers.myresolver.acme.tlschallenge=true
     ```
 
 ### `httpChallenge`
@@ -189,7 +189,7 @@ when using the `TLS-ALPN-01` challenge, Traefik must be reachable by Let's Encry
 Use the `HTTP-01` challenge to generate and renew ACME certificates by provisioning an HTTP resource under a well-known URI.
 
 As described on the Let's Encrypt [community forum](https://community.letsencrypt.org/t/support-for-ports-other-than-80-and-443/3419/72),
-when using the `HTTP-01` challenge, `certificatesResolvers.myresolver.acme.httpChallenge.entryPoint` must be reachable by Let's Encrypt through port 80.
+when using the `HTTP-01` challenge, `certificatesresolvers.myresolver.acme.httpchallenge.entrypoint` must be reachable by Let's Encrypt through port 80.
 
 ??? example "Using an EntryPoint Called web for the `httpChallenge`"
 
@@ -224,10 +224,10 @@ when using the `HTTP-01` challenge, `certificatesResolvers.myresolver.acme.httpC
     ```
     
     ```bash tab="CLI"
-    --entryPoints.web.address=:80
-    --entryPoints.websecure.address=:443
+    --entrypoints.web.address=:80
+    --entrypoints.websecure.address=:443
     # ...
-    --certificatesResolvers.myresolver.acme.httpChallenge.entryPoint=web
+    --certificatesresolvers.myresolver.acme.httpchallenge.entrypoint=web
     ```
 
 !!! info ""
@@ -261,8 +261,8 @@ Use the `DNS-01` challenge to generate and renew ACME certificates by provisioni
     
     ```bash tab="CLI"
     # ...
-    --certificatesResolvers.myresolver.acme.dnsChallenge.provider=digitalocean
-    --certificatesResolvers.myresolver.acme.dnsChallenge.delayBeforeCheck=0
+    --certificatesresolvers.myresolver.acme.dnschallenge.provider=digitalocean
+    --certificatesresolvers.myresolver.acme.dnschallenge.delaybeforecheck=0
     # ...
     ```
 
@@ -389,7 +389,7 @@ certificatesResolvers:
 
 ```bash tab="CLI"
 # ...
---certificatesResolvers.myresolver.acme.dnsChallenge.resolvers=1.1.1.1:53,8.8.8.8:53
+--certificatesresolvers.myresolver.acme.dnschallenge.resolvers=1.1.1.1:53,8.8.8.8:53
 ```
 
 #### Wildcard Domains
@@ -428,7 +428,7 @@ The CA server to use:
 
     ```bash tab="CLI"
     # ...
-    --certificatesResolvers.myresolver.acme.caServer=https://acme-staging-v02.api.letsencrypt.org/directory
+    --certificatesresolvers.myresolver.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory
     # ...
     ```
 
@@ -456,7 +456,7 @@ certificatesResolvers:
 
 ```bash tab="CLI"
 # ...
---certificatesResolvers.myresolver.acme.storage=acme.json
+--certificatesresolvers.myresolver.acme.storage=acme.json
 # ...
 ```
 

--- a/docs/content/https/ref-acme.txt
+++ b/docs/content/https/ref-acme.txt
@@ -4,13 +4,13 @@
 #
 # Required
 #
---certificatesResolvers.myresolver.acme.email=test@example.com
+--certificatesresolvers.myresolver.acme.email=test@example.com
 
 # File or key used for certificates storage.
 #
 # Required
 #
---certificatesResolvers.myresolver.acme.storage=acme.json
+--certificatesresolvers.myresolver.acme.storage=acme.json
 
 # CA server to use.
 # Uncomment the line to use Let's Encrypt's staging server,
@@ -19,7 +19,7 @@
 # Optional
 # Default: "https://acme-v02.api.letsencrypt.org/directory"
 #
---certificatesResolvers.myresolver.acme.caServer=https://acme-staging-v02.api.letsencrypt.org/directory
+--certificatesresolvers.myresolver.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory
 
 # KeyType to use.
 #
@@ -28,38 +28,38 @@
 #
 # Available values : "EC256", "EC384", "RSA2048", "RSA4096", "RSA8192"
 #
---certificatesResolvers.myresolver.acme.keyType=RSA4096
+--certificatesresolvers.myresolver.acme.keytype=RSA4096
 
 # Use a TLS-ALPN-01 ACME challenge.
 #
 # Optional (but recommended)
 #
---certificatesResolvers.myresolver.acme.tlsChallenge=true
+--certificatesresolvers.myresolver.acme.tlschallenge=true
 
 # Use a HTTP-01 ACME challenge.
 #
 # Optional
 #
---certificatesResolvers.myresolver.acme.httpChallenge=true
+--certificatesresolvers.myresolver.acme.httpchallenge=true
 
 # EntryPoint to use for the HTTP-01 challenges.
 #
 # Required
 #
---certificatesResolvers.myresolver.acme.httpChallenge.entryPoint=web
+--certificatesresolvers.myresolver.acme.httpchallenge.entrypoint=web
 
 # Use a DNS-01 ACME challenge rather than HTTP-01 challenge.
 # Note: mandatory for wildcard certificate generation.
 #
 # Optional
 #
---certificatesResolvers.myresolver.acme.dnsChallenge=true
+--certificatesresolvers.myresolver.acme.dnschallenge=true
 
 # DNS provider used.
 #
 # Required
 #
---certificatesResolvers.myresolver.acme.dnsChallenge.provider=digitalocean
+--certificatesresolvers.myresolver.acme.dnschallenge.provider=digitalocean
 
 # By default, the provider will verify the TXT DNS challenge record before letting ACME verify.
 # If delayBeforeCheck is greater than zero, this check is delayed for the configured duration in seconds.
@@ -68,14 +68,14 @@
 # Optional
 # Default: 0
 #
---certificatesResolvers.myresolver.acme.dnsChallenge.delayBeforeCheck=0
+--certificatesresolvers.myresolver.acme.dnschallenge.delaybeforecheck=0
 
 # Use following DNS servers to resolve the FQDN authority.
 #
 # Optional
 # Default: empty
 #
---certificatesResolvers.myresolver.acme.dnsChallenge.resolvers=1.1.1.1:53,8.8.8.8:53
+--certificatesresolvers.myresolver.acme.dnschallenge.resolvers=1.1.1.1:53,8.8.8.8:53
 
 # Disable the DNS propagation checks before notifying ACME that the DNS challenge is ready.
 #
@@ -85,4 +85,4 @@
 # Optional
 # Default: false
 #
---certificatesResolvers.myresolver.acme.dnsChallenge.disablePropagationCheck=true
+--certificatesresolvers.myresolver.acme.dnschallenge.disablepropagationcheck=true


### PR DESCRIPTION
### What does this PR do?

When reading the current documentation I noticed the Let's Encrypt section shows the acme CLI flags in camelCase format instead of lowercase, which is different from other sections of documentation such as the CLI configuration [reference](https://docs.traefik.io/reference/static-configuration/cli/). Because of that, this PR updates the flags to keep homogeneous documentation. Example:

From: `--certificatesResolvers.<name>.acme.caServer`
To: `--certificatesresolvers.<name>.acme.caserver`

### Motivation

My main motivation is to improve the documentation in a way that avoids newcomers get confused.

### More

- [ ] Added/updated tests
- [X] Added/updated documentation
