### PR TITLE
Use specified network for "container" network mode

### DIFF
--- a/pkg/provider/docker/config.go
+++ b/pkg/provider/docker/config.go
@@ -349,7 +349,13 @@ func (p Provider) getIPAddress(ctx context.Context, container dockerData) string
 		// Check connected container for traefik.docker.network, falling back to
 		// the network specified on the current container.
 		containerParsed := parseContainer(containerInspected)
-		extraConf, _ := p.getConfiguration(containerParsed)
+		extraConf, err := p.getConfiguration(containerParsed)
+
+		if err != nil {
+			logger.Warnf("Unable to get IP address for container %s : failed to get extra configuration for container %s: %s", container.Name, containerInspected.Name, err)
+			return ""
+		}
+
 		if extraConf.Docker.Network == "" {
 			extraConf.Docker.Network = container.ExtraConf.Docker.Network
 		}

--- a/pkg/provider/docker/config.go
+++ b/pkg/provider/docker/config.go
@@ -345,7 +345,17 @@ func (p Provider) getIPAddress(ctx context.Context, container dockerData) string
 			logger.Warnf("Unable to get IP address for container %s : Failed to inspect container ID %s, error: %s", container.Name, connectedContainer, err)
 			return ""
 		}
-		return p.getIPAddress(ctx, parseContainer(containerInspected))
+
+		// Check connected container for traefik.docker.network, falling back to
+		// the network specified on the current container.
+		containerParsed := parseContainer(containerInspected)
+		extraConf, _ := p.getConfiguration(containerParsed)
+		if extraConf.Docker.Network == "" {
+			extraConf.Docker.Network = container.ExtraConf.Docker.Network
+		}
+
+		containerParsed.ExtraConf = extraConf
+		return p.getIPAddress(ctx, containerParsed)
 	}
 
 	for _, network := range container.NetworkSettings.Networks {


### PR DESCRIPTION
### What does this PR do?

When defining a service in the docker provider which is pointing to a container with a networking mode of `host:other-container`, the `traefik.docker.network` was ignored and an arbitrary IP of the `other-container` was used as the upstream.

If that IP is not routable from the Traefik instance, this could cause Gateway Timeouts.

This change adds steps to parse configuration from labels on the connected container from which the service container inherits its network.

My strawman fix prioritises the `traefik.docker.network` label on the network-owning container, but falls back to the network specified on the service container. Perhaps this should be flipped, but the network-owning container is the authoritative source of which networks it is connected to, so this makes sense to me.

### Motivation

I have a configuration where several containers with a `network_mode` of `container:<x>` are services served by a Traefik instance. The container `<x>` has exactly 1 shared network with Traefik, but Traefik is not reliably selecting that interface.

<details>
<summary>More detail and replication case with as <code>docker-compose.yml</code> here</summary>

Without this change, the `docker-compose.yml` below creates a situation where (sometimes, may not be deterministic) Traefik will use the IP address from the `private` network in its service definition.

<details><summary><code>docker-compose.yml</code></summary>

``` yml
version: '3.5'
networks:
  public:
  private:
  traefik:
    internal: true

services:
  traefik:
    image: traefik:v2.2
    container_name: traefik
    # bug present even with --providers.docker.network=traefik_traefik
    command: --api.insecure=true --providers.docker=true --providers.docker.exposedByDefault=false --providers.docker.network=traefik_traefik
    volumes:
      - "/var/run/docker.sock:/var/run/docker.sock"
    ports:
      - "80:80"
      - "8080:8080"
    networks:
      - public
      - traefik

  out:
    image: "wardsco/sleep"
    networks:
      - private
      - traefik
    labels:
      - "traefik.docker.network=traefik_traefik"

  one:
    image: xperimental/goecho:v1.7
    container_name: one
    command: -addr :8003
    network_mode: service:out
    labels:
      - "traefik.enable=true"
      - "traefik.http.services.one.loadbalancer.server.port=8001"

  two:
    image: xperimental/goecho:v1.7
    container_name: two
    command: -addr :8002
    network_mode: service:out
    labels:
      - "traefik.enable=true"
      - "traefik.http.services.two.loadbalancer.server.port=8002"
```

</details>

It will instead print:

```
traefik    | time="2020-05-03T05:51:27Z" level=warning msg="Could not find network named 'traefik_traefik' for container '/one'! Maybe you're missing the project's prefix in the label? Defaulting to first available network." providerName=docker container=one-traefik-cd4e924fe8fc508351a3a548d95ec180429a2a746a05143e11c1f9c2cc9ac6a1 serviceName=one
traefik    | time="2020-05-03T05:51:27Z" level=warning msg="Could not find network named 'traefik_traefik' for container '/two'! Maybe you're missing the project's prefix in the label? Defaulting to first available network." serviceName=two providerName=docker container=two-traefik-97929de8aeb9fdb4a535036267ff57e7006476d9d285811660849d3011c45ccd
```

As can be seen from the Traefik dashboard listing of services and the `docker inspect` dump, it is using the `private` network (`172.30.0.2`) instead of the `traefik` network (`172.31.0.2`)

![image](https://user-images.githubusercontent.com/2560/80904893-28d56900-8d56-11ea-95ea-93f6910e4954.png)

``` jsonc
// $ docker inspect traefik_out_1
// (many fields elided for brevity)
[
    {
        "Id": "04966273dcd0f0bc0f508b03f7b9d88d8c083a4509a636cb36c9a9487c94d1a8",
        "Name": "/traefik_out_1",
        "HostConfig": {
           "NetworkMode": "traefik_private",
        },
        "Mounts": [],
        "Config": {
            "Hostname": "04966273dcd0",
            "Labels": {
                "traefik.docker.network": "traefik_traefik"
            }
        },
        "NetworkSettings": {
            "Bridge": "",
            "Networks": {
                "traefik_private": {
                    "IPAddress": "172.30.0.2",
                },
                "traefik_traefik": {
                    "IPAddress": "172.31.0.2",
                }
            }
        }
    }
]
```


</details>

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

NOTE: This bug is also present when `--providers.docker.network` is set, which was also surprising to me. It is unclear to me at this time whether this patch also fixes that (but I don't think it does), as I don't understand how this functions yet.

<details>
<summary>~There are two pre-existing failing unit tests~ #6768</summary>

These _appear_ to have been caused by 337273b5df198125a1a73fd7d26c1051eb5a42cb but as far as I can see Semaphore does not run the unit tests, or perhaps this only fails when run on devices which have a resolveable `host.docker.internal`.

```
--- FAIL: TestDockerGetIPAddress (0.00s)
    --- FAIL: TestDockerGetIPAddress/no_network,_no_network_label,_mode_host (0.00s)
        config_test.go:3256:
                Error Trace:    config_test.go:3256
                Error:          Not equal:
                                expected: "127.0.0.1"
                                actual  : "10.144.231.49"

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -127.0.0.1
                                +10.144.231.49
                Test:           TestDockerGetIPAddress/no_network,_no_network_label,_mode_host
    --- FAIL: TestDockerGetIPAddress/two_networks,_no_network_label,_mode_host (0.00s)
        config_test.go:3256:
                Error Trace:    config_test.go:3256
                Error:          Not equal:
                                expected: "127.0.0.1"
                                actual  : "10.144.231.49"

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -127.0.0.1
                                +10.144.231.49
                Test:           TestDockerGetIPAddress/two_networks,_no_network_label,_mode_host
```
</details>

I do not yet know the best way to test this. I haven't looked deeply at integration tests yet, but it appears unit tests will be too difficult due to the interaction with the `dockerClient`. Guidance welcome.

cc @ldez