### PR TITLE
Add CustomHeaderStrategy

### DIFF
--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -237,14 +237,17 @@ func (h *Headers) HasSecureHeadersDefined() bool {
 
 // IPStrategy holds the ip strategy configuration.
 type IPStrategy struct {
-	Depth       int      `json:"depth,omitempty" toml:"depth,omitempty" yaml:"depth,omitempty" export:"true"`
-	ExcludedIPs []string `json:"excludedIPs,omitempty" toml:"excludedIPs,omitempty" yaml:"excludedIPs,omitempty"`
+	Depth              int      `json:"depth,omitempty" toml:"depth,omitempty" yaml:"depth,omitempty" export:"true"`
+	ExcludedIPs        []string `json:"excludedIPs,omitempty" toml:"excludedIPs,omitempty" yaml:"excludedIPs,omitempty"`
+	TrueClientIPHeader string   `json:"trueClientIPHeader" toml:"trueClientIPHeader" yaml:"trueClientIPHeader"`
 	// TODO(mpl): I think we should make RemoteAddr an explicit field. For one thing, it would yield better documentation.
 }
 
 // Get an IP selection strategy.
 // If nil return the RemoteAddr strategy
-// else return a strategy base on the configuration using the X-Forwarded-For Header.
+// else return a strategy based on the configuration
+// using either the X-Forwarded-For Header, or custom
+// header when using CustomHeaderStrategy.
 // Depth override the ExcludedIPs
 func (s *IPStrategy) Get() (ip.Strategy, error) {
 	if s == nil {
@@ -254,6 +257,12 @@ func (s *IPStrategy) Get() (ip.Strategy, error) {
 	if s.Depth > 0 {
 		return &ip.DepthStrategy{
 			Depth: s.Depth,
+		}, nil
+	}
+
+	if s.TrueClientIPHeader != "" {
+		return &ip.CustomHeaderStrategy{
+			Header: s.TrueClientIPHeader,
 		}, nil
 	}
 

--- a/pkg/ip/strategy.go
+++ b/pkg/ip/strategy.go
@@ -43,6 +43,18 @@ func (s *DepthStrategy) GetIP(req *http.Request) string {
 	return strings.TrimSpace(xffs[len(xffs)-s.Depth])
 }
 
+// CustomHeaderStrategy is a strategy which allows
+// to check the trusted IP list against a header
+// other than X-Forwarded-For
+type CustomHeaderStrategy struct {
+	Header string
+}
+
+// GetIP returns the IP from the custom header
+func (s *CustomHeaderStrategy) GetIP(req *http.Request) string {
+	return strings.TrimSpace(req.Header.Get(s.Header))
+}
+
 // CheckerStrategy a strategy based on an IP Checker
 // allows to check that addresses are in a trusted IPs
 type CheckerStrategy struct {

--- a/pkg/ip/strategy_test.go
+++ b/pkg/ip/strategy_test.go
@@ -33,6 +33,35 @@ func TestRemoteAddrStrategy_GetIP(t *testing.T) {
 	}
 }
 
+func TestCustomHeaderStrategy_GetIP(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		expected       string
+		cfConnectingIP string
+	}{
+		{
+			desc:           "Use CustomHeader",
+			expected:       "192.0.2.1",
+			cfConnectingIP: "192.0.2.1",
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			strategy := CustomHeaderStrategy{
+				Header: "CF-Connecting-IP",
+			}
+			req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1", nil)
+			req.Header.Set("CF-Connecting-IP", test.cfConnectingIP)
+			actual := strategy.GetIP(req)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
 func TestDepthStrategy_GetIP(t *testing.T) {
 	testCases := []struct {
 		desc          string


### PR DESCRIPTION
Default behavior was to rely on X-Forwarded-For header in order to get the true client IP.
In some cases, especially ones where a CDN is in use, this behavior won't suffice.
This PR resolves that with a new strategy for IP checking.

### What does this PR do?

This PR adds a new IP strategy to allow true client IP resolution method to be changed.

### Motivation

A friend of mine was struggling with using CloudFlare with Traefik, so I decided to implement a potential fix. (Please thoroughly review as I am new to this project :))

fixes #5713

### More

- [X] Added/updated tests
- [-PARTIAL-] Added/updated documentation

### Additional Notes

Please let me know where to update the documentation for this change, I updated comments but not any other docs.
