### PR TITLE
Fix cors bug when Access-Control-Allow-Origin is "*"

### DIFF
--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -105,13 +105,13 @@ Please check the [configuration examples below](#configuration-examples) for mor
     ```
     
     ```bash tab="CLI"
-    --entryPoints.web.address=:80
-    --entryPoints.websecure.address=:443
+    --entrypoints.web.address=:80
+    --entrypoints.websecure.address=:443
     # ...
-    --certificatesResolvers.myresolver.acme.email=your-email@example.com
-    --certificatesResolvers.myresolver.acme.storage=acme.json
+    --certificatesresolvers.myresolver.acme.email=your-email@example.com
+    --certificatesresolvers.myresolver.acme.storage=acme.json
     # used during the challenge
-    --certificatesResolvers.myresolver.acme.httpChallenge.entryPoint=web
+    --certificatesresolvers.myresolver.acme.httpchallenge.entrypoint=web
     ```
 
 !!! important "Defining a certificates resolver does not result in all routers automatically using it. Each router that is supposed to use the resolver must [reference](../routing/routers/index.md#certresolver) it."
@@ -181,7 +181,7 @@ when using the `TLS-ALPN-01` challenge, Traefik must be reachable by Let's Encry
     
     ```bash tab="CLI"
     # ...
-    --certificatesResolvers.myresolver.acme.tlsChallenge=true
+    --certificatesresolvers.myresolver.acme.tlschallenge=true
     ```
 
 ### `httpChallenge`
@@ -189,7 +189,7 @@ when using the `TLS-ALPN-01` challenge, Traefik must be reachable by Let's Encry
 Use the `HTTP-01` challenge to generate and renew ACME certificates by provisioning an HTTP resource under a well-known URI.
 
 As described on the Let's Encrypt [community forum](https://community.letsencrypt.org/t/support-for-ports-other-than-80-and-443/3419/72),
-when using the `HTTP-01` challenge, `certificatesResolvers.myresolver.acme.httpChallenge.entryPoint` must be reachable by Let's Encrypt through port 80.
+when using the `HTTP-01` challenge, `certificatesresolvers.myresolver.acme.httpchallenge.entrypoint` must be reachable by Let's Encrypt through port 80.
 
 ??? example "Using an EntryPoint Called web for the `httpChallenge`"
 
@@ -224,10 +224,10 @@ when using the `HTTP-01` challenge, `certificatesResolvers.myresolver.acme.httpC
     ```
     
     ```bash tab="CLI"
-    --entryPoints.web.address=:80
-    --entryPoints.websecure.address=:443
+    --entrypoints.web.address=:80
+    --entrypoints.websecure.address=:443
     # ...
-    --certificatesResolvers.myresolver.acme.httpChallenge.entryPoint=web
+    --certificatesresolvers.myresolver.acme.httpchallenge.entrypoint=web
     ```
 
 !!! info ""
@@ -261,8 +261,8 @@ Use the `DNS-01` challenge to generate and renew ACME certificates by provisioni
     
     ```bash tab="CLI"
     # ...
-    --certificatesResolvers.myresolver.acme.dnsChallenge.provider=digitalocean
-    --certificatesResolvers.myresolver.acme.dnsChallenge.delayBeforeCheck=0
+    --certificatesresolvers.myresolver.acme.dnschallenge.provider=digitalocean
+    --certificatesresolvers.myresolver.acme.dnschallenge.delaybeforecheck=0
     # ...
     ```
 
@@ -389,7 +389,7 @@ certificatesResolvers:
 
 ```bash tab="CLI"
 # ...
---certificatesResolvers.myresolver.acme.dnsChallenge.resolvers=1.1.1.1:53,8.8.8.8:53
+--certificatesresolvers.myresolver.acme.dnschallenge.resolvers=1.1.1.1:53,8.8.8.8:53
 ```
 
 #### Wildcard Domains
@@ -428,7 +428,7 @@ The CA server to use:
 
     ```bash tab="CLI"
     # ...
-    --certificatesResolvers.myresolver.acme.caServer=https://acme-staging-v02.api.letsencrypt.org/directory
+    --certificatesresolvers.myresolver.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory
     # ...
     ```
 
@@ -456,7 +456,7 @@ certificatesResolvers:
 
 ```bash tab="CLI"
 # ...
---certificatesResolvers.myresolver.acme.storage=acme.json
+--certificatesresolvers.myresolver.acme.storage=acme.json
 # ...
 ```
 

--- a/docs/content/https/ref-acme.txt
+++ b/docs/content/https/ref-acme.txt
@@ -4,13 +4,13 @@
 #
 # Required
 #
---certificatesResolvers.myresolver.acme.email=test@example.com
+--certificatesresolvers.myresolver.acme.email=test@example.com
 
 # File or key used for certificates storage.
 #
 # Required
 #
---certificatesResolvers.myresolver.acme.storage=acme.json
+--certificatesresolvers.myresolver.acme.storage=acme.json
 
 # CA server to use.
 # Uncomment the line to use Let's Encrypt's staging server,
@@ -19,7 +19,7 @@
 # Optional
 # Default: "https://acme-v02.api.letsencrypt.org/directory"
 #
---certificatesResolvers.myresolver.acme.caServer=https://acme-staging-v02.api.letsencrypt.org/directory
+--certificatesresolvers.myresolver.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory
 
 # KeyType to use.
 #
@@ -28,38 +28,38 @@
 #
 # Available values : "EC256", "EC384", "RSA2048", "RSA4096", "RSA8192"
 #
---certificatesResolvers.myresolver.acme.keyType=RSA4096
+--certificatesresolvers.myresolver.acme.keytype=RSA4096
 
 # Use a TLS-ALPN-01 ACME challenge.
 #
 # Optional (but recommended)
 #
---certificatesResolvers.myresolver.acme.tlsChallenge=true
+--certificatesresolvers.myresolver.acme.tlschallenge=true
 
 # Use a HTTP-01 ACME challenge.
 #
 # Optional
 #
---certificatesResolvers.myresolver.acme.httpChallenge=true
+--certificatesresolvers.myresolver.acme.httpchallenge=true
 
 # EntryPoint to use for the HTTP-01 challenges.
 #
 # Required
 #
---certificatesResolvers.myresolver.acme.httpChallenge.entryPoint=web
+--certificatesresolvers.myresolver.acme.httpchallenge.entrypoint=web
 
 # Use a DNS-01 ACME challenge rather than HTTP-01 challenge.
 # Note: mandatory for wildcard certificate generation.
 #
 # Optional
 #
---certificatesResolvers.myresolver.acme.dnsChallenge=true
+--certificatesresolvers.myresolver.acme.dnschallenge=true
 
 # DNS provider used.
 #
 # Required
 #
---certificatesResolvers.myresolver.acme.dnsChallenge.provider=digitalocean
+--certificatesresolvers.myresolver.acme.dnschallenge.provider=digitalocean
 
 # By default, the provider will verify the TXT DNS challenge record before letting ACME verify.
 # If delayBeforeCheck is greater than zero, this check is delayed for the configured duration in seconds.
@@ -68,14 +68,14 @@
 # Optional
 # Default: 0
 #
---certificatesResolvers.myresolver.acme.dnsChallenge.delayBeforeCheck=0
+--certificatesresolvers.myresolver.acme.dnschallenge.delaybeforecheck=0
 
 # Use following DNS servers to resolve the FQDN authority.
 #
 # Optional
 # Default: empty
 #
---certificatesResolvers.myresolver.acme.dnsChallenge.resolvers=1.1.1.1:53,8.8.8.8:53
+--certificatesresolvers.myresolver.acme.dnschallenge.resolvers=1.1.1.1:53,8.8.8.8:53
 
 # Disable the DNS propagation checks before notifying ACME that the DNS challenge is ready.
 #
@@ -85,4 +85,4 @@
 # Optional
 # Default: false
 #
---certificatesResolvers.myresolver.acme.dnsChallenge.disablePropagationCheck=true
+--certificatesresolvers.myresolver.acme.dnschallenge.disablepropagationcheck=true

--- a/pkg/middlewares/forwardedheaders/forwarded_header.go
+++ b/pkg/middlewares/forwardedheaders/forwarded_header.go
@@ -141,7 +141,7 @@ func (x *XForwarded) rewrite(outreq *http.Request) {
 	}
 
 	if isWebsocketRequest(outreq) {
-		if outreq.Header.Get(xForwardedProto) == "https" {
+		if outreq.Header.Get(xForwardedProto) == "https" || outreq.Header.Get(xForwardedProto) == "wss" {
 			outreq.Header.Set(xForwardedProto, "wss")
 		} else {
 			outreq.Header.Set(xForwardedProto, "ws")

--- a/pkg/middlewares/forwardedheaders/forwarded_header_test.go
+++ b/pkg/middlewares/forwardedheaders/forwarded_header_test.go
@@ -204,6 +204,17 @@ func TestServeHTTP(t *testing.T) {
 			},
 		},
 		{
+			desc:      "xForwardedProto with websocket and tls and already x-forwarded-proto with wss",
+			tls:       true,
+			websocket: true,
+			incomingHeaders: map[string]string{
+				xForwardedProto: "wss",
+			},
+			expectedHeaders: map[string]string{
+				xForwardedProto: "wss",
+			},
+		},
+		{
 			desc: "xForwardedPort with explicit port",
 			host: "foo.com:8080",
 			expectedHeaders: map[string]string{

--- a/pkg/middlewares/headers/headers.go
+++ b/pkg/middlewares/headers/headers.go
@@ -270,8 +270,8 @@ func (s *Header) processCorsHeaders(rw http.ResponseWriter, req *http.Request) b
 
 func (s *Header) isOriginAllowed(origin string) (bool, string) {
 	for _, item := range s.headers.AccessControlAllowOriginList {
-		if item == "*" || item == origin {
-			return true, item
+		if item == "*" || item == "origin-list-or-null" || item == origin {
+			return true, origin
 		}
 	}
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Return `origin` instead of `item` in function `isOriginAllowed` in `pkg/middlewares/headers/headers.go`.

### Motivation

<!-- What inspired you to submit this pull request? -->
Chrome reports error when set `accessControlAllowOriginList` to `["*"]`.
Return `origin` instead of `item` in function `isOriginAllowed` in `pkg/middlewares/headers/headers.go` will fix the bug.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
