### PR TITLE
Fix cors bug when migrate from v2.0 to v2.2 and accessControlAllowOrigin is "origin-list-or-null"

### DIFF
--- a/pkg/middlewares/headers/headers.go
+++ b/pkg/middlewares/headers/headers.go
@@ -272,6 +272,8 @@ func (s *Header) isOriginAllowed(origin string) (bool, string) {
 	for _, item := range s.headers.AccessControlAllowOriginList {
 		if item == "*" || item == origin {
 			return true, item
+		} else if item == "origin-list-or-null" {
+			return true, origin
 		}
 	}
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Return `origin` instead of `item` in function `isOriginAllowed` in `pkg/middlewares/headers/headers.go`when item is `origin-list-or-null`.

### Motivation

<!-- What inspired you to submit this pull request? -->
Chrome reports error when migrate traefik from v2.0 to v2.2 and  set `accessControlAllowOrigin` to `"origin-list-or-null"`.
Return `origin` instead of `item` in function `isOriginAllowed` in `pkg/middlewares/headers/headers.go` will fix the bug.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
