### PR TITLE
Avoid overwriting already received UDP messages

### DIFF
--- a/pkg/udp/conn.go
+++ b/pkg/udp/conn.go
@@ -128,9 +128,11 @@ func (l *Listener) Shutdown(graceTimeout time.Duration) error {
 // we find that session, and otherwise we create a new one.
 // We then send the data the session's readLoop.
 func (l *Listener) readLoop() {
-	buf := make([]byte, receiveMTU)
-
 	for {
+		// Allocating a new buffer for every read avoids
+		// overwriting data in c.msgs in case the next packet is received
+		// before c.msgs is emptied via Read()
+		buf := make([]byte, receiveMTU)
 		n, raddr, err := l.pConn.ReadFrom(buf)
 		if err != nil {
 			return


### PR DESCRIPTION
### What does this PR do?

Fix: Avoid overwriting already received UDP messages.

Receiving UDP datagrams in quick succession may overwrite already received data. If the message queue is not empty, another read from the connection into the buffer seems to alter the content of already received packets.

This PR fixes the issue by creating a new read buffer for every datagram to avoid overwriting existing data.

### Motivation

Fix issue with incoming UDP packets overwriting data of already received UDP packets reported in bug #6796.

### More

- [x] Added/updated tests
  - Add a test which checks data integrity when receiving multiple, consecutive packets.
- [ ] Added/updated documentation

### Additional Notes

Unit tests passed, but integration tests failed (on my machines) with `FAIL: docker_test.go:147: DockerSuite.TestDockerContainersWithTCPLabels` or `FAIL: grpc_test.go:363: GRPCSuite.TestGRPCBufferWithFlushInterval`. However, the integration tests also fail without my changes (on the machines I am testing on), so this seems unrelated.