### PR TITLE
Fix mem leak on UDP connections

### DIFF
--- a/pkg/udp/conn.go
+++ b/pkg/udp/conn.go
@@ -177,7 +177,7 @@ func (l *Listener) newConn(rAddr net.Addr) *Conn {
 		readCh:    make(chan []byte),
 		sizeCh:    make(chan int),
 		doneCh:    make(chan struct{}),
-		ticker:    time.NewTicker(timeoutTicker),
+		timeout:   timeoutTicker,
 	}
 }
 
@@ -194,7 +194,7 @@ type Conn struct {
 	muActivity   sync.RWMutex
 	lastActivity time.Time // the last time the session saw either read or write activity
 
-	ticker   *time.Ticker // for timeouts
+	timeout  time.Duration // for timeouts
 	doneOnce sync.Once
 	doneCh   chan struct{}
 }
@@ -204,12 +204,15 @@ type Conn struct {
 // that is to say it waits on readCh to receive the slice of bytes that the Read operation wants to read onto.
 // The Read operation receives the signal that the data has been written to the slice of bytes through the sizeCh.
 func (c *Conn) readLoop() {
+	ticker := time.NewTicker(c.timeout)
+	defer ticker.Stop()
+
 	for {
 		if len(c.msgs) == 0 {
 			select {
 			case msg := <-c.receiveCh:
 				c.msgs = append(c.msgs, msg)
-			case <-c.ticker.C:
+			case <-ticker.C:
 				c.muActivity.RLock()
 				deadline := c.lastActivity.Add(connTimeout)
 				c.muActivity.RUnlock()
@@ -229,7 +232,7 @@ func (c *Conn) readLoop() {
 			c.sizeCh <- n
 		case msg := <-c.receiveCh:
 			c.msgs = append(c.msgs, msg)
-		case <-c.ticker.C:
+		case <-ticker.C:
 			c.muActivity.RLock()
 			deadline := c.lastActivity.Add(connTimeout)
 			c.muActivity.RUnlock()
@@ -281,6 +284,5 @@ func (c *Conn) Close() error {
 	c.listener.mu.Lock()
 	defer c.listener.mu.Unlock()
 	delete(c.listener.conns, c.rAddr.String())
-	c.ticker.Stop()
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?

Fix a memory / go routine leak on udp connections, specifically in allocating a new `time.Ticker` under the `Conn` struct.

**No expert here**, but after taking a heap profile in a stress test which created lots of new udp connections it showed that we were leaking memory, and probably go routines (runtime malg), as we allocated a time.Ticker in `udp.(*Listener)newConn`. This is also consistent with the profile sent on #6761.

![traefik_2 1 1_leak](https://user-images.githubusercontent.com/37125990/82128049-45c65f00-978e-11ea-9c58-0c08c4e25df8.png)

It could be that the `Ticker`, which was referenced by the `Conn`, was not being collected by the GC, justifying the dead go routines and memory leak.

Changing the implementation to allocate and stop the ticker in the main `readLoop` seems to solve the memory and go routine problems as demonstrated in the new profile taken after running the same stress test:

![traefik_2 1 1_leak_fix](https://user-images.githubusercontent.com/37125990/82128179-87a3d500-978f-11ea-9c26-056891726b41.png)

### Motivation

Issue #6761

### More

- [ ] ~~Added/updated tests~~
- [ ] ~~Added/updated documentation~~

### Additional Notes


