### PR TITLE
feat: document how to use intermediate certificates

### DIFF
--- a/docs/content/https/tls.md
+++ b/docs/content/https/tls.md
@@ -130,6 +130,15 @@ tls:
 
 If no default certificate is provided, Traefik generates and uses a self-signed certificate.
 
+### Intermediate Certificate
+
+If you need to chain certificates to establish the chain of trust, you
+can concatenate your intermediate certificate after the certificate:
+
+```bash tab="CLI"
+cat foo.crt intermediate.crt > cert.crt
+```
+
 ## TLS Options
 
 The TLS options allow one to configure some parameters of the TLS connection.

--- a/docs/content/https/tls.md
+++ b/docs/content/https/tls.md
@@ -132,8 +132,8 @@ If no default certificate is provided, Traefik generates and uses a self-signed 
 
 ### Intermediate Certificate
 
-If you need to chain certificates to establish the chain of trust, you
-can concatenate your intermediate certificate after the certificate:
+If you need to chain certificates to establish the chain of trust,
+you can concatenate your intermediate certificate after the certificate:
 
 ```bash tab="CLI"
 cat foo.crt intermediate.crt > cert.crt


### PR DESCRIPTION
### What does this PR do?

Just add a sentence on how we support intermediate certificates in Traefik


### Motivation

Looking at the documentation, I asked myself if Traefik supports intermediate certificates, and it wasn't obvious. I am not the only one to ask the question: https://github.com/containous/traefik/issues/2957.


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

I am not sure about the location of that new paragraph ?