### PR TITLE
Provide username in log data on auth failure

### DIFF
--- a/pkg/middlewares/auth/basic_auth.go
+++ b/pkg/middlewares/auth/basic_auth.go
@@ -65,6 +65,14 @@ func (b *basicAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if username := b.auth.CheckAuth(req); username == "" {
 		logger.Debug("Authentication failed")
 		tracing.SetErrorWithEvent(req, "Authentication failed")
+
+		if username, _, ok := req.BasicAuth(); ok {
+			logData := accesslog.GetLogData(req)
+			if logData != nil {
+				logData.Core[accesslog.ClientUsername] = username
+			}
+		}
+
 		b.auth.RequireAuth(rw, req)
 	} else {
 		logger.Debug("Authentication succeeded")

--- a/pkg/middlewares/auth/basic_auth.go
+++ b/pkg/middlewares/auth/basic_auth.go
@@ -62,37 +62,39 @@ func (b *basicAuth) GetTracingInformation() (string, ext.SpanKindEnum) {
 func (b *basicAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	logger := log.FromContext(middlewares.GetLoggerCtx(req.Context(), b.name, basicTypeName))
 
-	if username := b.auth.CheckAuth(req); username == "" {
+	user, password, ok := req.BasicAuth()
+	if ok {
+		secret := b.auth.Secrets(user, b.auth.Realm)
+		if secret == "" || !goauth.CheckSecret(password, secret) {
+			ok = false
+		}
+	}
+
+	logData := accesslog.GetLogData(req)
+	if logData != nil {
+		logData.Core[accesslog.ClientUsername] = user
+	}
+
+	if !ok {
 		logger.Debug("Authentication failed")
 		tracing.SetErrorWithEvent(req, "Authentication failed")
 
-		if username, _, ok := req.BasicAuth(); ok {
-			logData := accesslog.GetLogData(req)
-			if logData != nil {
-				logData.Core[accesslog.ClientUsername] = username
-			}
-		}
-
 		b.auth.RequireAuth(rw, req)
-	} else {
-		logger.Debug("Authentication succeeded")
-		req.URL.User = url.User(username)
-
-		logData := accesslog.GetLogData(req)
-		if logData != nil {
-			logData.Core[accesslog.ClientUsername] = username
-		}
-
-		if b.headerField != "" {
-			req.Header[b.headerField] = []string{username}
-		}
-
-		if b.removeHeader {
-			logger.Debug("Removing authorization header")
-			req.Header.Del(authorizationHeader)
-		}
-		b.next.ServeHTTP(rw, req)
+		return
 	}
+
+	logger.Debug("Authentication succeeded")
+	req.URL.User = url.User(user)
+
+	if b.headerField != "" {
+		req.Header[b.headerField] = []string{user}
+	}
+
+	if b.removeHeader {
+		logger.Debug("Removing authorization header")
+		req.Header.Del(authorizationHeader)
+	}
+	b.next.ServeHTTP(rw, req)
 }
 
 func (b *basicAuth) secretBasic(user, realm string) string {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This PR adds the username in the log data, if present, on auth failure for middlewares basic auth and digest auth.

### Motivation

<!-- What inspired you to submit this pull request? -->
fixes #6722
Providing the user on auth failure in the access log is an expected behavior for some tools, at least fail2ban.

### More

- [x] Added/updated tests
- [ ] ~Added/updated documentation~

### Additional Notes

<!-- Anything else we should know when reviewing? -->
