### PR TITLE
Document how to use multiple rules in docker label 'rule'

### DIFF
--- a/docs/content/routing/providers/docker.md
+++ b/docs/content/routing/providers/docker.md
@@ -159,6 +159,11 @@ For example, to change the rule, you could add the label ```traefik.http.routers
     ```yaml
     - "traefik.http.routers.myrouter.rule=Host(`example.com`)"
     ```
+    
+    Separate multiple rules with a semicolon:
+    ```yaml
+    - "traefik.http.routers.myrouter.rule=Host:example.com; Path:/app2"
+    ```
 
 ??? info "`traefik.http.routers.<router_name>.entrypoints`"
 


### PR DESCRIPTION
### What does this PR do?

Document how to use multiple rules in docker label 'rule' .


### Motivation
It took me a while and only stackoverflow could help me in the end:
https://stackoverflow.com/questions/44232354/define-host-and-path-frontend-rule-for-traefik


### More

- [x] Added/updated documentation

### Additional Notes

I'm not sure if the only way to do this is in the `Host:domain.com` notation, but ``Host(`..`) &&`` did not work.

Also, I don't know how to do OR rules in this notation.