### PR TITLE
Update Dashboard examples and move it after 'Router Rule' section

### DIFF
--- a/docs/content/operations/dashboard.md
+++ b/docs/content/operations/dashboard.md
@@ -72,9 +72,6 @@ to allow defining:
 - A [router rule](#dashboard-router-rule) for accessing the dashboard,
   through Traefik itself (sometimes referred as "Traefik-ception").
 
-??? example "Dashboard Dynamic Configuration Examples"
-    --8<-- "content/operations/include-api-examples.md"
-
 ### Dashboard Router Rule
 
 As underlined in the [documentation for the `api.dashboard` option](./api.md#dashboard),
@@ -98,6 +95,9 @@ rule = "PathPrefix(`/api`) || PathPrefix(`/dashboard`)"
 # The dashboard can be accessed on http://traefik.example.com/dashboard/
 rule = "Host(`traefik.example.com`) && (PathPrefix(`/api`) || PathPrefix(`/dashboard`))"
 ```
+
+??? example "Dashboard Dynamic Configuration Examples"
+    --8<-- "content/operations/include-dashboard-examples.md"
 
 ## Insecure Mode
 

--- a/docs/content/operations/include-dashboard-examples.md
+++ b/docs/content/operations/include-dashboard-examples.md
@@ -1,0 +1,101 @@
+```yaml tab="Docker"
+# Dynamic Configuration
+labels:
+  - "traefik.http.routers.dashboard.rule=Host(`traefik.example.com`) && (PathPrefix(`/api`) || PathPrefix(`/dashboard`))"
+  - "traefik.http.routers.dashboard.service=api@internal"
+  - "traefik.http.routers.dashboard.middlewares=auth"
+  - "traefik.http.middlewares.auth.basicauth.users=test:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/,test2:$$apr1$$d9hr9HBB$$4HxwgUir3HP4EsggP/QNo0"
+```
+
+```yaml tab="Docker (Swarm)"
+# Dynamic Configuration
+deploy:
+  labels:
+    - "traefik.http.routers.dashboard.rule=Host(`traefik.example.com`) && (PathPrefix(`/api`) || PathPrefix(`/dashboard`))"
+    - "traefik.http.routers.dashboard.service=api@internal"
+    - "traefik.http.routers.dashboard.middlewares=auth"
+    - "traefik.http.middlewares.auth.basicauth.users=test:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/,test2:$$apr1$$d9hr9HBB$$4HxwgUir3HP4EsggP/QNo0"
+    # Dummy service for Swarm port detection. The port can be any valid integer value.
+    - "traefik.http.services.dummy-svc.loadbalancer.server.port=9999"
+```
+
+```yaml tab="Kubernetes CRD"
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: traefik-dashboard
+spec:
+  routes:
+  - match: Host(`traefik.example.com`) && (PathPrefix(`/api`) || PathPrefix(`/dashboard`))
+    kind: Rule
+    services:
+    - name: api@internal
+      kind: TraefikService
+    middlewares:
+      - name: auth
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: auth
+spec:
+  basicAuth:
+    secret: secretName # Kubernetes secret named "secretName"
+```
+
+```yaml tab="Consul Catalog"
+# Dynamic Configuration
+- "traefik.http.routers.dashboard.rule=Host(`traefik.example.com`) && (PathPrefix(`/api`) || PathPrefix(`/dashboard`))"
+- "traefik.http.routers.dashboard.service=api@internal"
+- "traefik.http.routers.dashboard.middlewares=auth"
+- "traefik.http.middlewares.auth.basicauth.users=test:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/,test2:$$apr1$$d9hr9HBB$$4HxwgUir3HP4EsggP/QNo0"
+```
+
+```json tab="Marathon"
+"labels": {
+  "traefik.http.routers.dashboard.rule": "Host(`traefik.example.com`) && (PathPrefix(`/api`) || PathPrefix(`/dashboard`))",
+  "traefik.http.routers.dashboard.service": "api@internal",
+  "traefik.http.routers.dashboard.middlewares": "auth",
+  "traefik.http.middlewares.auth.basicauth.users": "test:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/,test2:$$apr1$$d9hr9HBB$$4HxwgUir3HP4EsggP/QNo0"
+}
+```
+
+```yaml tab="Rancher"
+# Dynamic Configuration
+labels:
+  - "traefik.http.routers.dashboard.rule=Host(`traefik.example.com`) && (PathPrefix(`/api`) || PathPrefix(`/dashboard`))"
+  - "traefik.http.routers.dashboard.service=api@internal"
+  - "traefik.http.routers.dashboard.middlewares=auth"
+  - "traefik.http.middlewares.auth.basicauth.users=test:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/,test2:$$apr1$$d9hr9HBB$$4HxwgUir3HP4EsggP/QNo0"
+```
+
+```toml tab="File (TOML)"
+# Dynamic Configuration
+[http.routers.my-api]
+  rule = "Host(`traefik.example.com`) && (PathPrefix(`/api`) || PathPrefix(`/dashboard`))"
+  service = "api@internal"
+  middlewares = ["auth"]
+
+[http.middlewares.auth.basicAuth]
+  users = [
+    "test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/",
+    "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0",
+  ]
+```
+
+```yaml tab="File (YAML)"
+# Dynamic Configuration
+http:
+  routers:
+    dashboard:
+      rule: Host(`traefik.example.com`) && (PathPrefix(`/api`) || PathPrefix(`/dashboard`))
+      service: api@internal
+      middlewares:
+        - auth
+  middlewares:
+    auth:
+      basicAuth:
+        users:
+          - "test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/"
+          - "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"
+```


### PR DESCRIPTION
### What does this PR do?

Move the Dashboard dynamic configuration examples after the Router Rule section and change them to a combined `Host` and `PathPrefix` rule as its the most complete.

### Motivation

Some users get confused when trying to setup a `PathPrefix` rule on their provider. Moving it after the explanation and giving complete examples for each provider may fix this.

Last raised issue: #6872

### More

- [ ] ~~Added/updated tests~~
- [X] Added/updated documentation
