### PR TITLE
Update kubernetes-crd.md

### DIFF
--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -108,24 +108,24 @@ The Kubernetes Ingress Controller, The Custom Resource Way.
       name: myingressroute
       namespace: default
     
-    spec:
-      entryPoints:
-        - web
+      spec:
+        entryPoints:
+          - web
     
-      routes:
-      - match: Host(`foo`) && PathPrefix(`/bar`)
-        kind: Rule
-        services:
-        - name: whoami
-          port: 80
+        routes:
+          - match: Host(`foo`) && PathPrefix(`/bar`)
+            kind: Rule
+            services:
+            - name: whoami
+              port: 80
     
     ---
     apiVersion: traefik.containo.us/v1alpha1
-      kind: IngressRouteTCP
-      metadata:
-        name: ingressroute.tcp
+    kind: IngressRouteTCP
+    metadata:
+      name: ingressroute.tcp
       namespace: default
-      
+    
       spec:
         entryPoints:
           - tcpep
@@ -135,22 +135,22 @@ The Kubernetes Ingress Controller, The Custom Resource Way.
             services:
               - name: whoamitcp
                 port: 8080
-        
+    
     ---
     apiVersion: traefik.containo.us/v1alpha1
-       kind: IngressRouteUDP
-       metadata:
-         name: ingressroute.udp
-         namespace: default
-         
-       spec:
-         entryPoints:
-           - fooudp
-         routes:
-           - kind: Rule
-             services:
-               - name: whoamiudp
-                 port: 8080
+    kind: IngressRouteUDP
+    metadata:
+      name: ingressroute.udp
+      namespace: default
+    
+      spec:
+        entryPoints:
+          - fooudp
+        routes:
+          - kind: Rule
+            services:
+              - name: whoamiudp
+                port: 8080
     ```
     
     ```yaml tab="Whoami"


### PR DESCRIPTION
### What does this PR do?

The contents of the IngressRoute tab have whitespace errors. When you copy that and paste it into a file you get the following error:

```
ingressroute.traefik.containo.us/myingressroute created
error: error parsing traefik-4.yaml: error converting YAML to JSON: yaml: line 2: mapping values are not allowed in this context
```

This change corrects the format for that file so that it properly creates the ingress routes:

```
deployment.apps/whoami created
service/whoami created
deployment.apps/whoamitcp created
service/whoamitcp created
deployment.apps/whoamiudp created
service/whoamiudp created
```

### Motivation

I'm trying to get Traefik working in Kubernetes to integrate into a deployable solution. It's hard to figure these things out when the samples don't work :)

### More

- [ ] Added/updated tests
- [X] Added/updated documentation
