### PR TITLE
forwardAuth.addHeadersToResponse

### DIFF
--- a/docs/content/middlewares/forwardauth.md
+++ b/docs/content/middlewares/forwardauth.md
@@ -217,6 +217,61 @@ http:
           - "X-Secret"
 ```
 
+### `addHeadersToResponse`
+
+The `addHeadersToResponse` option is the list of the headers to copy from the authentication server to the response.
+
+```yaml tab="Docker"
+labels:
+  - "traefik.http.middlewares.test-auth.forwardauth.addHeadersToResponse=Set-Cookie, X-Token"
+```
+
+```yaml tab="Kubernetes"
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: test-auth
+spec:
+  forwardAuth:
+    address: https://example.com/auth
+    addHeadersToResponse:
+      - Set-Cookie
+      - X-Token
+```
+
+```yaml tab="Consul Catalog"
+- "traefik.http.middlewares.test-auth.forwardauth.addHeadersToResponse=Set-Cookie, X-Token"
+```
+
+```json tab="Marathon"
+"labels": {
+  "traefik.http.middlewares.test-auth.forwardauth.addHeadersToResponse": "Set-Cookie,X-Token"
+}
+```
+
+```yaml tab="Rancher"
+labels:
+  - "traefik.http.middlewares.test-auth.forwardauth.addHeadersToResponse=Set-Cookie, X-Token"
+```
+
+```toml tab="File (TOML)"
+[http.middlewares]
+  [http.middlewares.test-auth.forwardAuth]
+    address = "https://example.com/auth"
+    addHeadersToResponse = ["Set-Cookie", "X-Token"]
+```
+
+```yaml tab="File (YAML)"
+http:
+  middlewares:
+    test-auth:
+      forwardAuth:
+        address: "https://example.com/auth"
+        addHeadersToResponse:
+          - "Set-Cookie"
+          - "X-Token"
+```
+
 ### `tls`
 
 The `tls` option is the TLS configuration from Traefik to the authentication server.

--- a/integration/fixtures/forwardauth/basic.toml
+++ b/integration/fixtures/forwardauth/basic.toml
@@ -1,0 +1,29 @@
+[global]
+  checkNewVersion = false
+  sendAnonymousUsage = false
+
+[log]
+  level = "DEBUG"
+
+[entryPoints.web]
+  address = ":8000"
+
+[providers.file]
+  filename = "{{ .SelfFilename }}"
+
+## dynamic configuration ##
+
+[http.routers.router1]
+  entryPoints = ["web"]
+  rule = "PathPrefix(`/backend`)"
+  service = "service1"
+  middlewares = ["middleware1"]
+
+[http.middlewares.middleware1.forwardAuth]
+  address = "http://127.0.0.1:{{ .PortAuth }}/auth"
+  authResponseHeaders = ["X-User-Id"]
+  addHeadersToResponse = ["Set-Cookie", "X-Baz"]
+
+[http.services.service1.loadBalancer]
+  [[http.services.service1.loadBalancer.servers]]
+    url = "http://127.0.0.1:{{ .PortBackend }}"

--- a/integration/forwardauth_test.go
+++ b/integration/forwardauth_test.go
@@ -1,0 +1,98 @@
+package integration
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"time"
+
+	"github.com/go-check/check"
+	checker "github.com/vdemeester/shakers"
+
+	"github.com/containous/traefik/v2/integration/try"
+)
+
+const portAuth = "9001"
+const portBackend = "9000"
+const cookieNameAuth = "Foo"
+const cookieNameBoth = "Bar"
+const headerBoth = "Baz"
+const headerAuth = "X-User-Id"
+const headerValueAuth = "Auth"
+const headerValueBackend = "Backend"
+const userID = "123"
+
+// ForwardAuth tests suite.
+type ForwardAuthSuite struct{ BaseSuite }
+
+func (s *ForwardAuthSuite) TestBasic(c *check.C) {
+	params := struct{ PortAuth, PortBackend string }{portAuth, portBackend}
+	file := s.adaptFile(c, "fixtures/forwardauth/basic.toml", params)
+	defer os.Remove(file)
+	cmd, display := s.traefikCmd(withConfigFile(file))
+	defer display(c)
+
+	err := cmd.Start()
+	c.Assert(err, checker.IsNil)
+	defer cmd.Process.Kill()
+
+	auth := startTestServerWithHandler(newAuthHandler(), portAuth)
+	defer auth.Close()
+
+	backend := startTestServerWithHandler(newBackendHandler(), portBackend)
+	defer backend.Close()
+
+	expectedHeaders := map[string][]string{
+		"Set-Cookie": {
+			cookieNameAuth + "=" + headerValueAuth,
+			cookieNameBoth + "=" + headerValueBackend,
+		},
+		headerBoth: {headerValueBackend},
+	}
+
+	err = try.GetRequest(
+		"http://127.0.0.1:8000/backend",
+		1000*time.Millisecond,
+		try.StatusCodeIs(http.StatusOK),
+		try.HasHeaderStruct(expectedHeaders),
+		try.BodyContains(userID),
+	)
+	c.Assert(err, checker.IsNil)
+}
+
+func startTestServerWithHandler(h http.Handler, port string) (ts *httptest.Server) {
+	listener, err := net.Listen("tcp", "127.0.0.1:"+port)
+	if err != nil {
+		panic(err)
+	}
+	ts = &httptest.Server{
+		Listener: listener,
+		Config:   &http.Server{Handler: h},
+	}
+	ts.Start()
+	return ts
+}
+
+func newAuthHandler() http.Handler {
+	m := http.NewServeMux()
+	m.HandleFunc("/auth", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: cookieNameAuth, Value: headerValueAuth})
+		http.SetCookie(w, &http.Cookie{Name: cookieNameBoth, Value: headerValueAuth})
+		w.Header().Set(headerBoth, headerValueAuth)
+		w.Header().Set(headerAuth, userID)
+		w.WriteHeader(http.StatusOK)
+	})
+	return m
+}
+
+func newBackendHandler() http.Handler {
+	m := http.NewServeMux()
+	m.HandleFunc("/backend", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: cookieNameBoth, Value: headerValueBackend})
+		w.Header().Set(headerBoth, headerValueBackend)
+		fmt.Fprint(w, r.Header.Get(headerAuth))
+	})
+	return m
+}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -43,6 +43,7 @@ func Test(t *testing.T) {
 		check.Suite(&DockerSuite{})
 		check.Suite(&ErrorPagesSuite{})
 		check.Suite(&FileSuite{})
+		check.Suite(&ForwardAuthSuite{})
 		check.Suite(&GRPCSuite{})
 		check.Suite(&HealthCheckSuite{})
 		check.Suite(&HeadersSuite{})

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -138,10 +138,11 @@ type ErrorPage struct {
 
 // ForwardAuth holds the http forward authentication configuration.
 type ForwardAuth struct {
-	Address             string     `json:"address,omitempty" toml:"address,omitempty" yaml:"address,omitempty"`
-	TLS                 *ClientTLS `json:"tls,omitempty" toml:"tls,omitempty" yaml:"tls,omitempty"`
-	TrustForwardHeader  bool       `json:"trustForwardHeader,omitempty" toml:"trustForwardHeader,omitempty" yaml:"trustForwardHeader,omitempty" export:"true"`
-	AuthResponseHeaders []string   `json:"authResponseHeaders,omitempty" toml:"authResponseHeaders,omitempty" yaml:"authResponseHeaders,omitempty"`
+	Address              string     `json:"address,omitempty" toml:"address,omitempty" yaml:"address,omitempty"`
+	TLS                  *ClientTLS `json:"tls,omitempty" toml:"tls,omitempty" yaml:"tls,omitempty"`
+	TrustForwardHeader   bool       `json:"trustForwardHeader,omitempty" toml:"trustForwardHeader,omitempty" yaml:"trustForwardHeader,omitempty" export:"true"`
+	AuthResponseHeaders  []string   `json:"authResponseHeaders,omitempty" toml:"authResponseHeaders,omitempty" yaml:"authResponseHeaders,omitempty"`
+	AddHeadersToResponse []string   `json:"addHeadersToResponse,omitempty" toml:"addHeadersToResponse,omitempty" yaml:"addHeadersToResponse,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/provider/kubernetes/crd/traefik/v1alpha1/middleware.go
+++ b/pkg/provider/kubernetes/crd/traefik/v1alpha1/middleware.go
@@ -84,10 +84,11 @@ type DigestAuth struct {
 
 // ForwardAuth holds the http forward authentication configuration.
 type ForwardAuth struct {
-	Address             string     `json:"address,omitempty"`
-	TrustForwardHeader  bool       `json:"trustForwardHeader,omitempty"`
-	AuthResponseHeaders []string   `json:"authResponseHeaders,omitempty"`
-	TLS                 *ClientTLS `json:"tls,omitempty"`
+	Address              string     `json:"address,omitempty"`
+	TrustForwardHeader   bool       `json:"trustForwardHeader,omitempty"`
+	AuthResponseHeaders  []string   `json:"authResponseHeaders,omitempty"`
+	TLS                  *ClientTLS `json:"tls,omitempty"`
+	AddHeadersToResponse []string   `json:"addHeadersToResponse,omitempty"`
 }
 
 // ClientTLS holds TLS specific configurations as client.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
closes #3660 

### Motivation

<!-- What inspired you to submit this pull request? -->
described in #3660 

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Before reviewing this please read [this comment in related issue](https://github.com/containous/traefik/issues/3660#issuecomment-636144753) for understanding desired behaviour.

This PR **CAN** be merged, it does pass headers from `forwardAuth` service to response, but if *backend* has the same header, it overwrites values of the first one (`Set-Cookies` headers will be set from both services if have different `name`s, if both responses have same `Set-Cookie`'s `name` value from **backend** will be set).

Desired behaviour from my point of view is when values of headers from both services will be concatenated (through `Add`). So my question is to someone from the core team: what is the best way to deal with it? Or we can merge it now as it is, but implementing desired behaviour in next iteration will be breaking change

Thanks 🙂