### PR TITLE
Fix ipv6 handling in redirect middleware

### DIFF
--- a/middlewares/redirect/redirect.go
+++ b/middlewares/redirect/redirect.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	defaultRedirectRegex = `^(?:https?:\/\/)?([\w\._-]+)(?::\d+)?(.*)$`
+	defaultRedirectRegex = `^(?:https?:\/\/)?(\[[\w:.]+\]|[\w\._-]+)(?::\d+)?(.*)$`
 )
 
 // NewEntryPointHandler create a new redirection handler base on entry point

--- a/middlewares/redirect/redirect_test.go
+++ b/middlewares/redirect/redirect_test.go
@@ -84,6 +84,34 @@ func TestNewEntryPointHandler(t *testing.T) {
 			url:           "http://foo:80",
 			errorExpected: true,
 		},
+		{
+			desc:           "IPV6 HTTP to HTTP",
+			entryPoint:     &configuration.EntryPoint{Address: ":8080"},
+			url:            "http://[::1]",
+			expectedURL:    "http://[::1]:8080",
+			expectedStatus: http.StatusFound,
+		},
+		{
+			desc:           "IPV6 HTTP to HTTPS",
+			entryPoint:     &configuration.EntryPoint{Address: ":443", TLS: &tls.TLS{}},
+			url:            "http://[::1]",
+			expectedURL:    "https://[::1]:443",
+			expectedStatus: http.StatusFound,
+		},
+		{
+			desc:           "IPV6 HTTP with port 80 to HTTP",
+			entryPoint:     &configuration.EntryPoint{Address: ":8080"},
+			url:            "http://[::1]:80",
+			expectedURL:    "http://[::1]:8080",
+			expectedStatus: http.StatusFound,
+		},
+		{
+			desc:           "IPV6 HTTP with port 80 to HTTPS",
+			entryPoint:     &configuration.EntryPoint{Address: ":443", TLS: &tls.TLS{}},
+			url:            "http://[::1]:80",
+			expectedURL:    "https://[::1]:443",
+			expectedStatus: http.StatusFound,
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes the regex used by redirect middleware to handle properly ipv6 in urls
Fixes #5197
<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
See #5197

### More

- [x] Added/updated tests
- [ ] ~Added/updated documentation~

### Additional Notes

<!-- Anything else we should know when reviewing? -->
