### PR TITLE
Fix v1-> v2 migration: unify domain name in documentation example

### DIFF
--- a/docs/content/migration/v1-to-v2.md
+++ b/docs/content/migration/v1-to-v2.md
@@ -97,7 +97,7 @@ Then any router can refer to an instance of the wanted middleware.
 
     ```yaml tab="Docker"
     labels:
-      - "traefik.http.routers.router0.rule=Host(`example.com`) && PathPrefix(`/test`)"
+      - "traefik.http.routers.router0.rule=Host(`test.localhost`) && PathPrefix(`/test`)"
       - "traefik.http.routers.router0.middlewares=auth"
       - "traefik.http.middlewares.auth.basicauth.users=test:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/,test2:$$apr1$$d9hr9HBB$$4HxwgUir3HP4EsggP/QNo0"
     ```


### PR DESCRIPTION
What does this PR do?

Unify domain name in migration v1->v2 documentation.
Motivation

Have compact and clear examples.