### PR TITLE
Update Let's Encrypt documentation about resolvers for certificateresolvers

### DIFF
--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -371,7 +371,7 @@ For example, `CF_API_EMAIL_FILE=/run/secrets/traefik_cf-api-email` could be used
 
 #### `resolvers`
 
-Use custom DNS servers to resolve the FQDN authority.
+Use custom DNS servers to resolve the FQDN authority. Only IP addresses are supported as resolvers, not domain names.
 
 ```toml tab="File (TOML)"
 [certificatesResolvers.myresolver.acme]


### PR DESCRIPTION
### What does this PR do?

Update documentation about certificatesresolvers to point out that domain names are not supported as resolvers.

### Motivation

I had to find out the hard way that domain names are not supported. I migrated my domain from Cloudflare toDdigitalOcean and thus had to update my certificatesresolvers with the new config and new API auth token, etc etc. After a lot of time struggling and failing to get it to work. I came up with the idea to try an IP address instead of a domain name, and it actually worked.

### Additional Notes

Feel free to change the text I put. I just wanted to point this out. Please excuse me if this is already documented elsewhere and I looked over it.