### PR TITLE
Do not log error when kubernetes endpoints are empty

### DIFF
--- a/pkg/provider/kubernetes/crd/errors.go
+++ b/pkg/provider/kubernetes/crd/errors.go
@@ -1,0 +1,29 @@
+package crd
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrResourceNotFound ...
+	ErrResourceNotFound = fmt.Errorf("resource not found")
+)
+
+// Error is an error wrapper with a Log property which indicates
+// whether the error should be logged or not.
+type Error struct {
+	err error
+	// Log tells wether or not this error should be logged.
+	Log bool
+}
+
+// Error implements error interface.
+func (e Error) Error() string {
+	return e.err.Error()
+}
+
+// Unwrap allows Error to be unwrapped.
+func (e Error) Unwrap() error {
+	return errors.Unwrap(e.err)
+}


### PR DESCRIPTION
### What does this PR do?

Remove the error log when a kubernetes service endpoint subset is empty.

### Motivation

There are valid use cases where we have no subset because all resources have been voluntary scaled down but this generates a lot of log lines in Traefik.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
