### PR TITLE
Configure retry methods

### DIFF
--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -370,6 +370,7 @@ type ReplacePathRegex struct {
 // Retry holds the retry configuration.
 type Retry struct {
 	Attempts int `json:"attempts,omitempty" toml:"attempts,omitempty" yaml:"attempts,omitempty" export:"true"`
+	Methods []string `json:"methods,omitempty" toml:"methods,omitempty" yaml:"methods,omitempty" export:"true"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -369,8 +369,8 @@ type ReplacePathRegex struct {
 
 // Retry holds the retry configuration.
 type Retry struct {
-	Attempts int `json:"attempts,omitempty" toml:"attempts,omitempty" yaml:"attempts,omitempty" export:"true"`
-	Methods []string `json:"methods,omitempty" toml:"methods,omitempty" yaml:"methods,omitempty" export:"true"`
+	Attempts int      `json:"attempts,omitempty" toml:"attempts,omitempty" yaml:"attempts,omitempty" export:"true"`
+	Methods  []string `json:"methods,omitempty" toml:"methods,omitempty" yaml:"methods,omitempty" export:"true"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/middlewares/retry/retry.go
+++ b/pkg/middlewares/retry/retry.go
@@ -108,14 +108,13 @@ func (r *retry) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 func methodIsAppropriate(requestMethod string, configMethods []string) bool {
 	if len(configMethods) == 0 {
 		return true
-	} else {
-		for _, m := range configMethods {
-			if strings.ToUpper(m) == strings.ToUpper(requestMethod) {
-				return true
-			}
-		}
-		return false
 	}
+	for _, m := range configMethods {
+		if strings.EqualFold(m, requestMethod) {
+			return true
+		}
+	}
+	return false
 }
 
 // Retried exists to implement the Listener interface. It calls Retried on each of its slice entries.

--- a/pkg/middlewares/retry/retry_test.go
+++ b/pkg/middlewares/retry/retry_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httptrace"
@@ -223,8 +222,7 @@ func TestRetryWithRequestBody(t *testing.T) {
 			require.NoError(t, err)
 
 			recorder := httptest.NewRecorder()
-			var reader io.Reader = nil
-			reader = strings.NewReader(test.body)
+			reader := strings.NewReader(test.body)
 			req := httptest.NewRequest(test.method, "http://localhost:3000/ok", reader)
 
 			retry.ServeHTTP(recorder, req)

--- a/pkg/middlewares/retry/retry_test.go
+++ b/pkg/middlewares/retry/retry_test.go
@@ -131,7 +131,7 @@ func TestRetryWithRequestBody(t *testing.T) {
 		wantResponseStatus    int
 		amountFaultyEndpoints int
 		body                  string
-		expectedBody		  string
+		expectedBody          string
 		method                string
 	}{
 		{


### PR DESCRIPTION
### What does this PR do?

This PR adds new config parameter, purpose of it is setting which of HTTP methods traefik should to retry, same as in `methods` in [Spring Cloud Gateway](https://cloud.spring.io/spring-cloud-gateway/reference/html/#the-retry-gatewayfilter-factory).


### Motivation

I want to have ability to enable retries for several methods, not for all, only for GET for example, but skip it for POST ones. 

Let's consider we have game application. It has in-play payment system. I don't want to retry any money charges(POST, PUT for example), but I still want to retry all non-modifying GET queries.


### More

I also added new kind of tests: TestRetryWithRequestBody()