### PR TITLE
feat: update more than one LoadBalancer ip

### DIFF
--- a/pkg/provider/kubernetes/ingress/client_mock_test.go
+++ b/pkg/provider/kubernetes/ingress/client_mock_test.go
@@ -125,6 +125,6 @@ func (c clientMock) WatchAll(namespaces []string, stopCh <-chan struct{}) (<-cha
 	return c.watchChan, nil
 }
 
-func (c clientMock) UpdateIngressStatus(_ *networkingv1beta1.Ingress, _, _ string) error {
+func (c clientMock) UpdateIngressStatus(_ *networkingv1beta1.Ingress, _ []corev1.LoadBalancerIngress) error {
 	return c.apiIngressStatusError
 }

--- a/pkg/provider/kubernetes/ingress/client_test.go
+++ b/pkg/provider/kubernetes/ingress/client_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	kubeerror "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -44,6 +45,83 @@ func TestTranslateNotFoundError(t *testing.T) {
 			exists, err := translateNotFoundError(test.err)
 			assert.Equal(t, test.expectedExists, exists)
 			assert.Equal(t, test.expectedError, err)
+		})
+	}
+}
+
+func TestIsLoadBalancerIngressEquals(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		aSlice        []corev1.LoadBalancerIngress
+		bSlice        []corev1.LoadBalancerIngress
+		expectedEqual bool
+	}{
+		{
+			desc:          "both slices are empty",
+			expectedEqual: true,
+		},
+		{
+			desc: "not the same length",
+			bSlice: []corev1.LoadBalancerIngress{
+				{IP: "192.168.1.1", Hostname: "traefik"},
+			},
+			expectedEqual: false,
+		},
+		{
+			desc: "same ordered content",
+			aSlice: []corev1.LoadBalancerIngress{
+				{IP: "192.168.1.1", Hostname: "traefik"},
+			},
+			bSlice: []corev1.LoadBalancerIngress{
+				{IP: "192.168.1.1", Hostname: "traefik"},
+			},
+			expectedEqual: true,
+		},
+		{
+			desc: "same unordered content",
+			aSlice: []corev1.LoadBalancerIngress{
+				{IP: "192.168.1.1", Hostname: "traefik"},
+				{IP: "192.168.1.2", Hostname: "traefik2"},
+			},
+			bSlice: []corev1.LoadBalancerIngress{
+				{IP: "192.168.1.2", Hostname: "traefik2"},
+				{IP: "192.168.1.1", Hostname: "traefik"},
+			},
+			expectedEqual: true,
+		},
+		{
+			desc: "different ordered content",
+			aSlice: []corev1.LoadBalancerIngress{
+				{IP: "192.168.1.1", Hostname: "traefik"},
+				{IP: "192.168.1.2", Hostname: "traefik2"},
+			},
+			bSlice: []corev1.LoadBalancerIngress{
+				{IP: "192.168.1.1", Hostname: "traefik"},
+				{IP: "192.168.1.2", Hostname: "traefik"},
+			},
+			expectedEqual: false,
+		},
+		{
+			desc: "different unordered content",
+			aSlice: []corev1.LoadBalancerIngress{
+				{IP: "192.168.1.1", Hostname: "traefik"},
+				{IP: "192.168.1.2", Hostname: "traefik2"},
+			},
+			bSlice: []corev1.LoadBalancerIngress{
+				{IP: "192.168.1.2", Hostname: "traefik3"},
+				{IP: "192.168.1.1", Hostname: "traefik"},
+			},
+			expectedEqual: false,
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			gotEqual := isLoadBalancerIngressEquals(test.aSlice, test.bSlice)
+			assert.Equal(t, test.expectedEqual, gotEqual)
 		})
 	}
 }

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -301,7 +301,7 @@ func (p *Provider) updateIngressStatus(ing *networkingv1beta1.Ingress, k8sClient
 			return errors.New("publishedService or ip or hostname must be defined")
 		}
 
-		return k8sClient.UpdateIngressStatus(ing, p.IngressEndpoint.IP, p.IngressEndpoint.Hostname)
+		return k8sClient.UpdateIngressStatus(ing, []corev1.LoadBalancerIngress{{IP: p.IngressEndpoint.IP, Hostname: p.IngressEndpoint.Hostname}})
 	}
 
 	serviceInfo := strings.Split(p.IngressEndpoint.PublishedService, "/")
@@ -326,7 +326,7 @@ func (p *Provider) updateIngressStatus(ing *networkingv1beta1.Ingress, k8sClient
 		return fmt.Errorf("missing service: %s", p.IngressEndpoint.PublishedService)
 	}
 
-	return k8sClient.UpdateIngressStatus(ing, service.Status.LoadBalancer.Ingress[0].IP, service.Status.LoadBalancer.Ingress[0].Hostname)
+	return k8sClient.UpdateIngressStatus(ing, service.Status.LoadBalancer.Ingress)
 }
 
 func (p *Provider) shouldProcessIngress(providerIngressClass string, ingress *networkingv1beta1.Ingress, ingressClass *networkingv1beta1.IngressClass) bool {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

Traefik now updates Kubernetes Ingresses with all of the load balancer IPs from its `providers.kubernetesIngress.ingressEndpoint.publishedService`

Fixes #6950

I haven't yet updated any tests, but it appears to work properly.

### Motivation

We're running `external-dns` on our ingresses to keep DNS records synced up nicely. Before this change, we'd only get one of our IP records into DNS. Bad for load balancing.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation
