### PR TITLE
Fix statement about lego _FILE env var

### DIFF
--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -275,8 +275,10 @@ Here is a list of supported `providers`, that can automate the DNS verification,
 along with the required environment variables and their [wildcard & root domain support](#wildcard-domains).
 Do not hesitate to complete it.
 
-Many lego environment variables can be overridden by their respective `_FILE` counterpart, which should have a filepath to a file that contains the secret as its value. For more details, refer to the _Additional configuration_ documentation linked for your provider.
+Many lego environment variables can be overridden by their respective `_FILE` counterpart, which should have a filepath to a file that contains the secret as its value.
 For example, `CF_API_EMAIL_FILE=/run/secrets/traefik_cf-api-email` could be used to provide a Cloudflare API email address as a Docker secret named `traefik_cf-api-email`.
+
+For complete details, refer to your provider's _Additional configuration_ link.
 
 | Provider Name                                               | Provider Code  | Environment Variables                                                                                                                       |                                                                             |
 |-------------------------------------------------------------|----------------|---------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|

--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -275,7 +275,7 @@ Here is a list of supported `providers`, that can automate the DNS verification,
 along with the required environment variables and their [wildcard & root domain support](#wildcard-domains).
 Do not hesitate to complete it.
 
-Every lego environment variable can be overridden by their respective `_FILE` counterpart, which should have a filepath to a file that contains the secret as its value.
+Many lego environment variables can be overridden by their respective `_FILE` counterpart, which should have a filepath to a file that contains the secret as its value. For more details, refer to the _Additional configuration_ documentation linked for your provider.
 For example, `CF_API_EMAIL_FILE=/run/secrets/traefik_cf-api-email` could be used to provide a Cloudflare API email address as a Docker secret named `traefik_cf-api-email`.
 
 | Provider Name                                               | Provider Code  | Environment Variables                                                                                                                       |                                                                             |


### PR DESCRIPTION
Lego does not support the `_FILE` variables for everything. For example:

> AWS_ACCESS_KEY_ID	Managed by the AWS client (AWS_ACCESS_KEY_ID_FILE is not supported)

https://go-acme.github.io/lego/dns/route53/

<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Fix statement about lego _FILE env var: s/Every/Many/ and instruct reader to follow linked documentation.

### Motivation

<!-- What inspired you to submit this pull request? -->

I trusted the "every" in this doc so thoroughly I failed completely to notice the contradictory statement in lego's doc. I wasted most of a day chasing around `route53: NoCredentialProviders`. I disliked that, and I want future readers to have a better experience.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Traefik is amazing and I love the work y'all are doing!

I suspect the lack of support for `AWS_ACCESS_KEY_ID_FILE` has more to do with the AWS SDK than with lego or Traefik.
