### PR TITLE
Fix race condition issues with provided dynamic configuration

### DIFF
--- a/pkg/server/configurationwatcher.go
+++ b/pkg/server/configurationwatcher.go
@@ -224,8 +224,8 @@ func (c *ConfigurationWatcher) throttleProviderConfigReload(ctx context.Context,
 				logger.Info("Skipping same configuration")
 				continue
 			}
-			ring.In() <- nextConfig
 			previousConfig = *nextConfig.DeepCopy()
+			ring.In() <- *nextConfig.DeepCopy()
 		}
 	}
 }

--- a/pkg/server/configurationwatcher.go
+++ b/pkg/server/configurationwatcher.go
@@ -224,8 +224,8 @@ func (c *ConfigurationWatcher) throttleProviderConfigReload(ctx context.Context,
 				logger.Info("Skipping same configuration")
 				continue
 			}
-			previousConfig = nextConfig
 			ring.In() <- nextConfig
+			previousConfig = *nextConfig.DeepCopy()
 		}
 	}
 }

--- a/pkg/server/configurationwatcher_test.go
+++ b/pkg/server/configurationwatcher_test.go
@@ -301,3 +301,95 @@ func TestListenProvidersPublishesConfigForEachProvider(t *testing.T) {
 
 	assert.Equal(t, expected, publishedProviderConfig)
 }
+
+func TestPublishConfigUpdatedByProvider(t *testing.T) {
+	routinesPool := safe.NewPool(context.Background())
+
+	pvdConfiguration := dynamic.Configuration{
+		TCP: &dynamic.TCPConfiguration{
+			Routers: map[string]*dynamic.TCPRouter{
+				"foo": {},
+			},
+		},
+	}
+
+	pvd := &mockProvider{
+		wait: 10 * time.Millisecond,
+		messages: []dynamic.Message{
+			{
+				ProviderName:  "mock",
+				Configuration: &pvdConfiguration,
+			},
+			{
+				ProviderName:  "mock",
+				Configuration: &pvdConfiguration,
+			},
+		},
+	}
+
+	watcher := NewConfigurationWatcher(routinesPool, pvd, 30*time.Millisecond, []string{})
+
+	publishedConfigCount := 0
+	watcher.AddListener(func(configuration dynamic.Configuration) {
+		publishedConfigCount++
+
+		// Update the provider configuration published in next dynamic Message which should trigger a new publish.
+		pvdConfiguration.TCP.Routers["bar"] = &dynamic.TCPRouter{}
+	})
+
+	watcher.Start()
+	defer watcher.Stop()
+
+	// give some time so that the configuration can be processed.
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Equal(t, 2, publishedConfigCount)
+}
+
+func TestPublishConfigUpdatedByConfigWatcherListener(t *testing.T) {
+	routinesPool := safe.NewPool(context.Background())
+
+	pvd := &mockProvider{
+		wait: 10 * time.Millisecond,
+		messages: []dynamic.Message{
+			{
+				ProviderName: "mock",
+				Configuration: &dynamic.Configuration{
+					TCP: &dynamic.TCPConfiguration{
+						Routers: map[string]*dynamic.TCPRouter{
+							"foo": {},
+						},
+					},
+				},
+			},
+			{
+				ProviderName: "mock",
+				Configuration: &dynamic.Configuration{
+					TCP: &dynamic.TCPConfiguration{
+						Routers: map[string]*dynamic.TCPRouter{
+							"foo": {},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	watcher := NewConfigurationWatcher(routinesPool, pvd, 30*time.Millisecond, []string{})
+
+	publishedConfigCount := 0
+	watcher.AddListener(func(configuration dynamic.Configuration) {
+		publishedConfigCount++
+
+		// Modify the configuration stored as previous config in watcher, this should not trigger a new publish.
+		configuration.TCP.Routers["foo@mock"].Rule = "bar"
+	})
+
+	watcher.Start()
+	defer watcher.Stop()
+
+	// give some time so that the configuration can be processed.
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Equal(t, 1, publishedConfigCount)
+}

--- a/pkg/server/configurationwatcher_test.go
+++ b/pkg/server/configurationwatcher_test.go
@@ -381,7 +381,8 @@ func TestPublishConfigUpdatedByConfigWatcherListener(t *testing.T) {
 	watcher.AddListener(func(configuration dynamic.Configuration) {
 		publishedConfigCount++
 
-		// Modify the configuration stored as previous config in watcher, this should not trigger a new publish.
+		// Modify the provided configuration. This should not modify the configuration stored in the configuration
+		// watcher and cause a new publish.
 		configuration.TCP.Routers["foo@mock"].Rule = "bar"
 	})
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes race condition issues with the provided dynamic configuration by:

- Storing a deep copy of the dynamic `Message` in the configuration watcher for later comparisons.
- Providing a deep copy of the dynamic `Message` to the configuration watcher listeners.

Potential fixes: #6566

### Motivation

We discovered that the load balancing was not working anymore on Maesh because unchanged configurations are not skipped by mesh proxy providers, which as a side effect resets the load balancer counters.

### More

- [X] Added/updated tests
- [ ] Added/updated documentation