### PR TITLE
Disable domain fronting

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -25,6 +25,7 @@ import (
 	"github.com/containous/traefik/v2/pkg/provider/acme"
 	"github.com/containous/traefik/v2/pkg/provider/aggregator"
 	"github.com/containous/traefik/v2/pkg/provider/traefik"
+	"github.com/containous/traefik/v2/pkg/rules"
 	"github.com/containous/traefik/v2/pkg/safe"
 	"github.com/containous/traefik/v2/pkg/server"
 	"github.com/containous/traefik/v2/pkg/server/middleware"
@@ -161,6 +162,8 @@ func runCmd(staticConfiguration *static.Configuration) error {
 }
 
 func setupServer(staticConfiguration *static.Configuration) (*server.Server, error) {
+	rules.EnableDomainFronting(staticConfiguration.Global.InsecureSNI)
+
 	providerAggregator := aggregator.NewProviderAggregator(*staticConfiguration.Providers)
 
 	// adds internal provider

--- a/docs/content/https/tls.md
+++ b/docs/content/https/tls.md
@@ -130,6 +130,18 @@ tls:
 
 If no default certificate is provided, Traefik generates and uses a self-signed certificate.
 
+## Domain fronting
+
+Basically, the [domain fronting](https://en.wikipedia.org/wiki/Domain_fronting) allows to open a connection with a
+specific domain name thanks to the [Server Name Indication](https://en.wikipedia.org/wiki/Server_Name_Indication) then
+access a service with another domain set in the `Host` header.
+
+Since the `v2.2.2`, Traefik avoids (by default) using this capability.
+As it is a valid but advanced use case, the `HostHeader` and `HostSNI` [rules](../routing/routers/index.md#rule) allow to fine tune the routing with the `Server Name Indication` and `Host header` value.
+ 
+If you encounter routing issues (404 Not found response) with a previously working configuration, 
+please refer to the [migration guide](../migration/v2.md) to update your configuration.
+
 ## TLS Options
 
 The TLS options allow one to configure some parameters of the TLS connection.
@@ -317,7 +329,7 @@ spec:
 ### Strict SNI Checking
 
 With strict SNI checking, Traefik won't allow connections from clients connections
-that do not specify a server_name extension.
+that do not specify a server_name extension or don't match any certificate configured on the tlsOption.
 
 ```toml tab="File (TOML)"
 # Dynamic configuration

--- a/docs/content/https/tls.md
+++ b/docs/content/https/tls.md
@@ -132,15 +132,17 @@ If no default certificate is provided, Traefik generates and uses a self-signed 
 
 ## Domain fronting
 
-Basically, the [domain fronting](https://en.wikipedia.org/wiki/Domain_fronting) allows to open a connection with a
-specific domain name thanks to the [Server Name Indication](https://en.wikipedia.org/wiki/Server_Name_Indication) then
-access a service with another domain set in the `Host` header.
+Basically, [domain fronting](https://en.wikipedia.org/wiki/Domain_fronting) is a technique that allows to open a 
+connection with a specific domain name, thanks to the 
+[Server Name Indication](https://en.wikipedia.org/wiki/Server_Name_Indication), then access a service with another 
+domain set in the HTTP `Host` header.
 
-Since the `v2.2.2`, Traefik avoids (by default) using this capability.
-As it is a valid but advanced use case, the `HostHeader` and `HostSNI` [rules](../routing/routers/index.md#rule) allow to fine tune the routing with the `Server Name Indication` and `Host header` value.
- 
-If you encounter routing issues (404 Not found response) with a previously working configuration, 
-please refer to the [migration guide](../migration/v2.md) to update your configuration.
+Since the `v2.2.2`, Traefik avoids (by default) using domain fronting.
+As it is valid for advanced use cases, the `HostHeader` and `HostSNI` [rules](../routing/routers/index.md#rule) allow 
+to fine tune the routing with the `Server Name Indication` and `Host header` value.
+
+If you encounter routing issues with a previously working configuration, please refer to the 
+[migration guide](../migration/v2.md) to update your configuration.
 
 ## TLS Options
 

--- a/docs/content/migration/v1-to-v2.md
+++ b/docs/content/migration/v1-to-v2.md
@@ -39,8 +39,8 @@ Then any router can refer to an instance of the wanted middleware.
       - "traefik.frontend.auth.basic.users=test:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/,test2:$$apr1$$d9hr9HBB$$4HxwgUir3HP4EsggP/QNo0"
     ```
 
-```yaml tab="K8s Ingress"
-apiVersion: networking.k8s.io/v1beta1
+    ```yaml tab="K8s Ingress"
+    apiVersion: networking.k8s.io/v1beta1
     kind: Ingress
     metadata:
       name: traefik

--- a/docs/content/migration/v1-to-v2.md
+++ b/docs/content/migration/v1-to-v2.md
@@ -39,8 +39,8 @@ Then any router can refer to an instance of the wanted middleware.
       - "traefik.frontend.auth.basic.users=test:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/,test2:$$apr1$$d9hr9HBB$$4HxwgUir3HP4EsggP/QNo0"
     ```
 
-    ```yaml tab="K8s Ingress"
-    apiVersion: networking.k8s.io/v1beta1
+```yaml tab="K8s Ingress"
+apiVersion: networking.k8s.io/v1beta1
     kind: Ingress
     metadata:
       name: traefik

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -1,5 +1,33 @@
 # Migration: Steps needed between the versions
 
+## v2.x to v2.2.2
+
+### Domain fronting
+
+In `v2.2.2` we introduced the ability to avoid [Domain fronting](https://en.wikipedia.org/wiki/Domain_fronting), 
+and enabled it by default for [https routers](../routing/routers/index.md#rule) configured with ```Host(`something`)```.
+
+As a fallback, a new flag is available as a global option:
+
+!!! example "Enabling Domain Fronting"
+    
+    ```toml tab="File (TOML)"
+    [global]
+      # Enabling domain fronting
+      insecureSNI = true
+    ```
+    
+    ```yaml tab="File (YAML)"
+    global:
+      # Enabling domain fronting
+      insecureSNI: true
+    ```
+    
+    ```bash tab="CLI"
+    # Enabling domain fronting
+    --global.insecureSNI
+    ```
+
 ## v2.0 to v2.1
 
 ### Kubernetes CRD

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -7,17 +7,101 @@
 In `v2.2.2` we introduced the ability to avoid [Domain fronting](https://en.wikipedia.org/wiki/Domain_fronting), 
 and enabled it by default for [https routers](../routing/routers/index.md#rule) configured with ```Host(`something`)```.
 
+!!! example "Allow Domain Fronting on a Specific Router"
+    
+    !!! info "Before v2.2.2"
+    
+    ```yaml tab="Docker"
+    labels:
+      - "traefik.http.routers.router0.rule=Host(`test.localhost`)"
+    ```
+    
+    ```yaml tab="K8s Ingress"
+    apiVersion: traefik.containo.us/v1alpha1
+    kind: IngressRoute
+    metadata:
+      name: ingressroutebar
+    
+    spec:
+      entryPoints:
+        - http
+      routes:
+      - match: Host(`test.localhost`)
+        kind: Rule
+        services:
+        - name: server0
+          port: 80
+        - name: server1
+          port: 80
+    ```
+        
+    ```toml tab="File (TOML)"
+    [http.routers.router0]
+        rule = "Host(`test.localhost`)"
+        service = "my-service"
+    ```
+    
+    ```toml tab="File (YAML)"
+    http:
+      routers:
+        router0:
+          rule: "Host(`test.localhost`)"
+          service: my-service
+    ```
+
+    !!! info "v2.2.2"
+    
+    ```yaml tab="Docker"
+    labels:
+      - "traefik.http.routers.router0.rule=HostHeader(`test.localhost`)"
+    ```
+    
+    ```yaml tab="K8s Ingress"
+    apiVersion: traefik.containo.us/v1alpha1
+    kind: IngressRoute
+    metadata:
+      name: ingressroutebar
+    
+    spec:
+      entryPoints:
+        - http
+      routes:
+      - match: HostHeader(`test.localhost`)
+        kind: Rule
+        services:
+        - name: server0
+          port: 80
+        - name: server1
+          port: 80
+    ```
+        
+    ```toml tab="File (TOML)"
+    [http.routers.router0]
+        rule = "HostHeader(`test.localhost`)"
+        service = "my-service"
+    ```
+    
+    ```toml tab="File (YAML)"
+    http:
+      routers:
+        router0:
+          rule: "HostHeader(`test.localhost`)"
+          service: my-service
+    ```
+
 As a fallback, a new flag is available as a global option:
 
-!!! example "Enabling Domain Fronting"
+!!! example "Enabling Domain Fronting for All Routers"
     
     ```toml tab="File (TOML)"
+    # Static configuration
     [global]
       # Enabling domain fronting
       insecureSNI = true
     ```
     
     ```yaml tab="File (YAML)"
+    # Static configuration
     global:
       # Enabling domain fronting
       insecureSNI: true

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -162,6 +162,9 @@ WriteTimeout is the maximum duration before timing out writes of the response. I
 `--global.checknewversion`:  
 Periodically check if a new version has been released. (Default: ```false```)
 
+`--global.insecuresni`:  
+Allow domain fronting. If the option is not specified, it will be disabled by default. (Default: ```false```)
+
 `--global.sendanonymoususage`:  
 Periodically send anonymous usage statistics. If the option is not specified, it will be enabled by default. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -162,6 +162,9 @@ WriteTimeout is the maximum duration before timing out writes of the response. I
 `TRAEFIK_GLOBAL_CHECKNEWVERSION`:  
 Periodically check if a new version has been released. (Default: ```false```)
 
+`TRAEFIK_GLOBAL_INSECURESNI`:  
+Allow domain fronting. If the option is not specified, it will be disabled by default. (Default: ```false```)
+
 `TRAEFIK_GLOBAL_SENDANONYMOUSUSAGE`:  
 Periodically send anonymous usage statistics. If the option is not specified, it will be enabled by default. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -1,6 +1,7 @@
 [global]
   checkNewVersion = true
   sendAnonymousUsage = true
+  insecureSNI = false
 
 [serversTransport]
   insecureSkipVerify = true

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -1,6 +1,8 @@
 global:
   checkNewVersion: true
   sendAnonymousUsage: true
+  insecureSNI: false
+
 serversTransport:
   insecureSkipVerify: true
   rootCAs:

--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -228,18 +228,18 @@ If the rule is verified, the router becomes active, calls middlewares, and then 
 
 The table below lists all the available matchers:
 
-| Rule                                                                   | Description                                                                                                                       |
-|------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
-| ```Headers(`key`, `value`)```                                          | Check if there is a key `key`defined in the headers, with the value `value`                                                       |
-| ```HeadersRegexp(`key`, `regexp`)```                                   | Check if there is a key `key`defined in the headers, with a value that matches the regular expression `regexp`                    |
-| ```Host(`example.com`, ...)```                                         | By default, is equivalent to `HostHeader` **AND** `HostSNI` rules. If `insecureSNI` is true, equivalent to the `HostHeader` rule  |
-| ```HostHeader(`example.com`, ...)```                                   | Check if the request domain (host header value) targets one of the given `domains`.                                               |
-| ```HostSNI(`example.com`, ...)```                                      | Check if the [Server Name Indication](https://en.wikipedia.org/wiki/Server_Name_Indication) corresponds to the given `domains`.   |
-| ```HostRegexp(`example.com`, `{subdomain:[a-z]+}.example.com`, ...)``` | Check if the request domain matches the given `regexp`.                                                                           |
-| ```Method(`GET`, ...)```                                               | Check if the request method is one of the given `methods` (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`)                               |
-| ```Path(`/path`, `/articles/{cat:[a-z]+}/{id:[0-9]+}`, ...)```         | Match exact request path. It accepts a sequence of literal and regular expression paths.                                          |
-| ```PathPrefix(`/products/`, `/articles/{cat:[a-z]+}/{id:[0-9]+}`)```   | Match request prefix path. It accepts a sequence of literal and regular expression prefix paths.                                  |
-| ```Query(`foo=bar`, `bar=baz`)```                                      | Match Query String parameters. It accepts a sequence of key=value pairs.                                                          |
+| Rule                                                                   | Description                                                                                                                                                                                                     |
+|------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ```Headers(`key`, `value`)```                                          | Check if there is a key `key`defined in the headers, with the value `value`                                                                                                                                     |
+| ```HeadersRegexp(`key`, `regexp`)```                                   | Check if there is a key `key`defined in the headers, with a value that matches the regular expression `regexp`                                                                                                  |
+| ```Host(`example.com`, ...)```                                         | By default, is equivalent to `HostHeader` **AND** `HostSNI` rules. See [Domain Fronting](../../https/tls.md#domain-fronting) and the [migration guide](../../migration/v2.md#domain-fronting) for more details. |
+| ```HostHeader(`example.com`, ...)```                                   | Check if the request domain (host header value) targets one of the given `domains`.                                                                                                                             |
+| ```HostSNI(`example.com`, ...)```                                      | Check if the [Server Name Indication](https://en.wikipedia.org/wiki/Server_Name_Indication) corresponds to the given `domains`.                                                                                 |
+| ```HostRegexp(`example.com`, `{subdomain:[a-z]+}.example.com`, ...)``` | Check if the request domain matches the given `regexp`.                                                                                                                                                         |
+| ```Method(`GET`, ...)```                                               | Check if the request method is one of the given `methods` (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`)                                                                                                             |
+| ```Path(`/path`, `/articles/{cat:[a-z]+}/{id:[0-9]+}`, ...)```         | Match exact request path. It accepts a sequence of literal and regular expression paths.                                                                                                                        |
+| ```PathPrefix(`/products/`, `/articles/{cat:[a-z]+}/{id:[0-9]+}`)```   | Match request prefix path. It accepts a sequence of literal and regular expression prefix paths.                                                                                                                |
+| ```Query(`foo=bar`, `bar=baz`)```                                      | Match Query String parameters. It accepts a sequence of key=value pairs.                                                                                                                                        | 
 
 !!! important "Regexp Syntax"
 

--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -228,16 +228,18 @@ If the rule is verified, the router becomes active, calls middlewares, and then 
 
 The table below lists all the available matchers:
 
-| Rule                                                                   | Description                                                                                                    |
-|------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
-| ```Headers(`key`, `value`)```                                          | Check if there is a key `key`defined in the headers, with the value `value`                                    |
-| ```HeadersRegexp(`key`, `regexp`)```                                   | Check if there is a key `key`defined in the headers, with a value that matches the regular expression `regexp` |
-| ```Host(`example.com`, ...)```                                         | Check if the request domain targets one of the given `domains`.                                                |
-| ```HostRegexp(`example.com`, `{subdomain:[a-z]+}.example.com`, ...)``` | Check if the request domain matches the given `regexp`.                                                        |
-| ```Method(`GET`, ...)```                                               | Check if the request method is one of the given `methods` (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`)            |
-| ```Path(`/path`, `/articles/{cat:[a-z]+}/{id:[0-9]+}`, ...)```         | Match exact request path. It accepts a sequence of literal and regular expression paths.                       |
-| ```PathPrefix(`/products/`, `/articles/{cat:[a-z]+}/{id:[0-9]+}`)```   | Match request prefix path. It accepts a sequence of literal and regular expression prefix paths.               |
-| ```Query(`foo=bar`, `bar=baz`)```                                      | Match Query String parameters. It accepts a sequence of key=value pairs.                                       |
+| Rule                                                                   | Description                                                                                                                       |
+|------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| ```Headers(`key`, `value`)```                                          | Check if there is a key `key`defined in the headers, with the value `value`                                                       |
+| ```HeadersRegexp(`key`, `regexp`)```                                   | Check if there is a key `key`defined in the headers, with a value that matches the regular expression `regexp`                    |
+| ```Host(`example.com`, ...)```                                         | By default, is equivalent to `HostHeader` **AND** `HostSNI` rules. If `insecureSNI` is true, equivalent to the `HostHeader` rule  |
+| ```HostHeader(`example.com`, ...)```                                   | Check if the request domain (host header value) targets one of the given `domains`.                                               |
+| ```HostSNI(`example.com`, ...)```                                      | Check if the [Server Name Indication](https://en.wikipedia.org/wiki/Server_Name_Indication) corresponds to the given `domains`.   |
+| ```HostRegexp(`example.com`, `{subdomain:[a-z]+}.example.com`, ...)``` | Check if the request domain matches the given `regexp`.                                                                           |
+| ```Method(`GET`, ...)```                                               | Check if the request method is one of the given `methods` (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`)                               |
+| ```Path(`/path`, `/articles/{cat:[a-z]+}/{id:[0-9]+}`, ...)```         | Match exact request path. It accepts a sequence of literal and regular expression paths.                                          |
+| ```PathPrefix(`/products/`, `/articles/{cat:[a-z]+}/{id:[0-9]+}`)```   | Match request prefix path. It accepts a sequence of literal and regular expression prefix paths.                                  |
+| ```Query(`foo=bar`, `bar=baz`)```                                      | Match Query String parameters. It accepts a sequence of key=value pairs.                                                          |
 
 !!! important "Regexp Syntax"
 

--- a/integration/fixtures/grpc/config.toml
+++ b/integration/fixtures/grpc/config.toml
@@ -22,7 +22,7 @@
 
 [http.routers]
   [http.routers.router1]
-    rule = "Host(`127.0.0.1`)"
+    rule = "Host(`localhost`)"
     service = "service1"
     [http.routers.router1.tls]
 

--- a/integration/fixtures/grpc/config_h2c_termination.toml
+++ b/integration/fixtures/grpc/config_h2c_termination.toml
@@ -19,7 +19,7 @@
 
 [http.routers]
   [http.routers.router1]
-    rule = "Host(`127.0.0.1`)"
+    rule = "Host(`localhost`)"
     service = "service1"
     [http.routers.router1.tls]
 

--- a/integration/fixtures/grpc/config_insecure.toml
+++ b/integration/fixtures/grpc/config_insecure.toml
@@ -22,7 +22,7 @@
 
 [http.routers]
   [http.routers.router1]
-    rule = "Host(`127.0.0.1`)"
+    rule = "Host(`localhost`)"
     service = "service1"
     [http.routers.router1.tls]
 

--- a/integration/fixtures/grpc/config_retry.toml
+++ b/integration/fixtures/grpc/config_retry.toml
@@ -22,7 +22,7 @@
 
 [http.routers]
   [http.routers.router1]
-    rule = "Host(`127.0.0.1`)"
+    rule = "Host(`localhost`)"
     service = "service1"
     middlewares = ["retryer"]
     [http.routers.router1.tls]

--- a/integration/grpc_test.go
+++ b/integration/grpc_test.go
@@ -86,7 +86,7 @@ func starth2cGRPCServer(lis net.Listener, server *myserver) error {
 func getHelloClientGRPC() (helloworld.GreeterClient, func() error, error) {
 	roots := x509.NewCertPool()
 	roots.AppendCertsFromPEM(LocalhostCert)
-	credsClient := credentials.NewClientTLSFromCert(roots, "")
+	credsClient := credentials.NewClientTLSFromCert(roots, "localhost")
 	conn, err := grpc.Dial("127.0.0.1:4443", grpc.WithTransportCredentials(credsClient))
 	if err != nil {
 		return nil, func() error { return nil }, err
@@ -167,7 +167,7 @@ func (s *GRPCSuite) TestGRPC(c *check.C) {
 	defer cmd.Process.Kill()
 
 	// wait for Traefik
-	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("Host(`127.0.0.1`)"))
+	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("Host(`localhost`)"))
 	c.Assert(err, check.IsNil)
 
 	var response string
@@ -247,7 +247,7 @@ func (s *GRPCSuite) TestGRPCh2cTermination(c *check.C) {
 	defer cmd.Process.Kill()
 
 	// wait for Traefik
-	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("Host(`127.0.0.1`)"))
+	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("Host(`localhost`)"))
 	c.Assert(err, check.IsNil)
 
 	var response string
@@ -289,7 +289,7 @@ func (s *GRPCSuite) TestGRPCInsecure(c *check.C) {
 	defer cmd.Process.Kill()
 
 	// wait for Traefik
-	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("Host(`127.0.0.1`)"))
+	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("Host(`localhost`)"))
 	c.Assert(err, check.IsNil)
 
 	var response string
@@ -336,7 +336,7 @@ func (s *GRPCSuite) TestGRPCBuffer(c *check.C) {
 	defer cmd.Process.Kill()
 
 	// wait for Traefik
-	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("Host(`127.0.0.1`)"))
+	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("Host(`localhost`)"))
 	c.Assert(err, check.IsNil)
 	var client helloworld.Greeter_StreamExampleClient
 	client, closer, err := callStreamExampleClientGRPC()
@@ -395,7 +395,7 @@ func (s *GRPCSuite) TestGRPCBufferWithFlushInterval(c *check.C) {
 	defer cmd.Process.Kill()
 
 	// wait for Traefik
-	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("Host(`127.0.0.1`)"))
+	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("Host(`localhost`)"))
 	c.Assert(err, check.IsNil)
 
 	var client helloworld.Greeter_StreamExampleClient
@@ -453,7 +453,7 @@ func (s *GRPCSuite) TestGRPCWithRetry(c *check.C) {
 	defer cmd.Process.Kill()
 
 	// wait for Traefik
-	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("Host(`127.0.0.1`)"))
+	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("Host(`localhost`)"))
 	c.Assert(err, check.IsNil)
 
 	var response string

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -79,6 +79,7 @@ type CertificateResolver struct {
 type Global struct {
 	CheckNewVersion    bool `description:"Periodically check if a new version has been released." json:"checkNewVersion,omitempty" toml:"checkNewVersion,omitempty" yaml:"checkNewVersion,omitempty" label:"allowEmpty" export:"true"`
 	SendAnonymousUsage bool `description:"Periodically send anonymous usage statistics. If the option is not specified, it will be enabled by default." json:"sendAnonymousUsage,omitempty" toml:"sendAnonymousUsage,omitempty" yaml:"sendAnonymousUsage,omitempty" label:"allowEmpty" export:"true"`
+	InsecureSNI        bool `description:"Allow domain fronting. If the option is not specified, it will be disabled by default." json:"insecureSNI,omitempty" toml:"insecureSNI,omitempty" yaml:"insecureSNI,omitempty" label:"allowEmpty" export:"true"`
 }
 
 // ServersTransport options to configure communication between Traefik and the servers.

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -216,12 +216,15 @@ func matchSNI(req *http.Request, hosts ...string) bool {
 }
 
 func hostSecure(route *mux.Route, hosts ...string) error {
-	for i, host := range hosts {
-		hosts[i] = strings.ToLower(host)
-	}
-
 	route.MatcherFunc(func(req *http.Request, _ *mux.RouteMatch) bool {
-		return matchSNI(req, hosts...) && matchHost(req, false, hosts...)
+		for _, host := range hosts {
+			host = strings.ToLower(host)
+
+			if matchSNI(req, host) && matchHost(req, false, host) {
+				return true
+			}
+		}
+		return false
 	})
 	return nil
 }

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -28,7 +28,7 @@ var funcs = map[string]func(*mux.Route, ...string) error{
 // InsecureSNI defines if the domain fronting is allowed.
 func EnableDomainFronting(ok bool) {
 	if ok {
-		log.WithoutContext().Warn("With insecureSNI enabled, router rules do not prevent domain fronting technique, please prefer using `HostHeader` and `HostSNI` rules.")
+		log.WithoutContext().Warn("With insecureSNI enabled, router rules do not prevent domain fronting techniques. Please use `HostHeader` and `HostSNI` rules if domain fronting is not desired.")
 		funcs["Host"] = host
 		return
 	}

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -118,9 +118,11 @@ func host(route *mux.Route, hosts ...string) error {
 }
 
 func matchHost(req *http.Request, insecureSNI bool, hosts ...string) bool {
+	logger := log.FromContext(req.Context())
+
 	reqHost := requestdecorator.GetCanonizedHost(req.Context())
 	if len(reqHost) == 0 {
-		log.FromContext(req.Context()).Warnf("Could not retrieve CanonizedHost, rejecting %s", req.Host)
+		logger.Warnf("Could not retrieve CanonizedHost, rejecting %s", req.Host)
 		return false
 	}
 
@@ -130,7 +132,7 @@ func matchHost(req *http.Request, insecureSNI bool, hosts ...string) bool {
 			if strings.EqualFold(reqHost, host) || strings.EqualFold(flatH, host) {
 				return true
 			}
-			log.FromContext(req.Context()).Debugf("CNAMEFlattening: request %s which resolved to %s, is not matched to route %s", reqHost, flatH, host)
+			logger.Debugf("CNAMEFlattening: request %s which resolved to %s, is not matched to route %s", reqHost, flatH, host)
 		}
 		return false
 	}
@@ -138,7 +140,7 @@ func matchHost(req *http.Request, insecureSNI bool, hosts ...string) bool {
 	for _, host := range hosts {
 		if reqHost == host {
 			if insecureSNI && req.TLS != nil && reqHost != req.TLS.ServerName {
-				log.FromContext(req.Context()).Debugf("Router reached with Host(%q) different from SNI(%q)", reqHost, req.TLS.ServerName)
+				logger.Debugf("Router reached with Host(%q) different from SNI(%q)", reqHost, req.TLS.ServerName)
 			}
 			return true
 		}
@@ -148,7 +150,7 @@ func matchHost(req *http.Request, insecureSNI bool, hosts ...string) bool {
 			h := host[:last]
 			if reqHost == h {
 				if insecureSNI && req.TLS != nil && reqHost != req.TLS.ServerName {
-					log.FromContext(req.Context()).Debugf("Router reached with Host(%q) different from SNI(%q)", reqHost, req.TLS.ServerName)
+					logger.Debugf("Router reached with Host(%q) different from SNI(%q)", reqHost, req.TLS.ServerName)
 				}
 				return true
 			}
@@ -159,7 +161,7 @@ func matchHost(req *http.Request, insecureSNI bool, hosts ...string) bool {
 			h := reqHost[:last]
 			if h == host {
 				if insecureSNI && req.TLS != nil && reqHost != req.TLS.ServerName {
-					log.FromContext(req.Context()).Debugf("Router reached with Host(%q) different from SNI(%q)", reqHost, req.TLS.ServerName)
+					logger.Debugf("Router reached with Host(%q) different from SNI(%q)", reqHost, req.TLS.ServerName)
 				}
 				return true
 			}
@@ -176,6 +178,7 @@ func hostSNI(route *mux.Route, hosts ...string) error {
 	route.MatcherFunc(func(req *http.Request, _ *mux.RouteMatch) bool {
 		return matchSNI(req, hosts...)
 	})
+
 	return nil
 }
 
@@ -212,6 +215,7 @@ func matchSNI(req *http.Request, hosts ...string) bool {
 			}
 		}
 	}
+
 	return false
 }
 
@@ -226,6 +230,7 @@ func hostSecure(route *mux.Route, hosts ...string) error {
 		}
 		return false
 	})
+
 	return nil
 }
 

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -682,6 +682,18 @@ func TestParseDomains(t *testing.T) {
 			errorExpected: false,
 		},
 		{
+			description:   "Many host rules upper",
+			expression:    "HOST(`foo.bar`,`test.bar`)",
+			domain:        []string{"foo.bar", "test.bar"},
+			errorExpected: false,
+		},
+		{
+			description:   "Many host rules lower",
+			expression:    "host(`foo.bar`,`test.bar`)",
+			domain:        []string{"foo.bar", "test.bar"},
+			errorExpected: false,
+		},
+		{
 			description:   "No host rule",
 			expression:    "Path(`/test`)",
 			errorExpected: false,

--- a/pkg/server/router/router_test.go
+++ b/pkg/server/router/router_test.go
@@ -2,11 +2,14 @@ package router
 
 import (
 	"context"
+	"crypto/tls"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/containous/traefik/v2/pkg/rules"
 
 	"github.com/containous/traefik/v2/pkg/config/dynamic"
 	"github.com/containous/traefik/v2/pkg/config/runtime"
@@ -300,6 +303,223 @@ func TestRouterManager_Get(t *testing.T) {
 
 			reqHost := requestdecorator.New(nil)
 			reqHost.ServeHTTP(w, req, handlers["web"].ServeHTTP)
+
+			assert.Equal(t, test.expected.StatusCode, w.Code)
+
+			for key, value := range test.expected.RequestHeaders {
+				assert.Equal(t, value, req.Header.Get(key))
+			}
+		})
+	}
+}
+
+func TestRouterManager_SNI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	type expectedResult struct {
+		StatusCode     int
+		RequestHeaders map[string]string
+	}
+
+	testCases := []struct {
+		desc              string
+		routersConfig     map[string]*dynamic.Router
+		serviceConfig     map[string]*dynamic.Service
+		middlewaresConfig map[string]*dynamic.Middleware
+		entryPoint        string
+		sni               string
+		insecureSNI       bool
+		expected          expectedResult
+	}{
+		{
+			desc: "Insecure SNI without TLS",
+			routersConfig: map[string]*dynamic.Router{
+				"foo@provider-1": {
+					EntryPoints: []string{"web"},
+					Service:     "foo-service",
+					Rule:        "Host(`foo.bar`)",
+					Priority:    0,
+				},
+			},
+			serviceConfig: map[string]*dynamic.Service{
+				"foo-service@provider-1": {
+					LoadBalancer: &dynamic.ServersLoadBalancer{
+						Servers: []dynamic.Server{
+							{
+								URL: server.URL,
+							},
+						},
+					},
+				},
+			},
+			insecureSNI: true,
+			entryPoint:  "web",
+			expected:    expectedResult{StatusCode: http.StatusOK},
+		},
+		{
+			desc: "Secure SNI without TLS",
+			routersConfig: map[string]*dynamic.Router{
+				"foo@provider-1": {
+					EntryPoints: []string{"web"},
+					Service:     "foo-service",
+					Rule:        "Host(`foo.bar`)",
+					Priority:    0,
+				},
+			},
+			serviceConfig: map[string]*dynamic.Service{
+				"foo-service@provider-1": {
+					LoadBalancer: &dynamic.ServersLoadBalancer{
+						Servers: []dynamic.Server{
+							{
+								URL: server.URL,
+							},
+						},
+					},
+				},
+			},
+			entryPoint: "web",
+			expected:   expectedResult{StatusCode: http.StatusOK},
+		},
+		{
+			desc: "Secure SNI with TLS without sni",
+			routersConfig: map[string]*dynamic.Router{
+				"foo@provider-1": {
+					EntryPoints: []string{"websecure"},
+					Service:     "foo-service",
+					Rule:        "Host(`foo.bar`)",
+					Priority:    0,
+					TLS:         &dynamic.RouterTLSConfig{},
+				},
+			},
+			serviceConfig: map[string]*dynamic.Service{
+				"foo-service@provider-1": {
+					LoadBalancer: &dynamic.ServersLoadBalancer{
+						Servers: []dynamic.Server{
+							{
+								URL: server.URL,
+							},
+						},
+					},
+				},
+			},
+			entryPoint: "websecure",
+			expected:   expectedResult{StatusCode: http.StatusNotFound},
+		},
+		{
+			desc: "Secure SNI with TLS with sni request",
+			routersConfig: map[string]*dynamic.Router{
+				"foo@provider-1": {
+					EntryPoints: []string{"websecure"},
+					Service:     "foo-service",
+					Rule:        "Host(`foo.bar`)",
+					Priority:    0,
+					TLS:         &dynamic.RouterTLSConfig{},
+				},
+			},
+			serviceConfig: map[string]*dynamic.Service{
+				"foo-service@provider-1": {
+					LoadBalancer: &dynamic.ServersLoadBalancer{
+						Servers: []dynamic.Server{
+							{
+								URL: server.URL,
+							},
+						},
+					},
+				},
+			},
+			entryPoint: "websecure",
+			sni:        "foo.bar",
+			expected:   expectedResult{StatusCode: http.StatusOK},
+		},
+		{
+			desc: "Insecure SNI with TLS without sni",
+			routersConfig: map[string]*dynamic.Router{
+				"foo@provider-1": {
+					EntryPoints: []string{"websecure"},
+					Service:     "foo-service",
+					Rule:        "Host(`foo.bar`)",
+					Priority:    0,
+					TLS:         &dynamic.RouterTLSConfig{},
+				},
+			},
+			serviceConfig: map[string]*dynamic.Service{
+				"foo-service@provider-1": {
+					LoadBalancer: &dynamic.ServersLoadBalancer{
+						Servers: []dynamic.Server{
+							{
+								URL: server.URL,
+							},
+						},
+					},
+				},
+			},
+			entryPoint:  "websecure",
+			insecureSNI: true,
+			expected:    expectedResult{StatusCode: http.StatusOK},
+		},
+		{
+			desc: "Secure SNI with TLS with sni uppercase",
+			routersConfig: map[string]*dynamic.Router{
+				"foo@provider-1": {
+					EntryPoints: []string{"websecure"},
+					Service:     "foo-service",
+					Rule:        "Host(`Foo.bar`)",
+					Priority:    0,
+					TLS:         &dynamic.RouterTLSConfig{},
+				},
+			},
+			serviceConfig: map[string]*dynamic.Service{
+				"foo-service@provider-1": {
+					LoadBalancer: &dynamic.ServersLoadBalancer{
+						Servers: []dynamic.Server{
+							{
+								URL: server.URL,
+							},
+						},
+					},
+				},
+			},
+			entryPoint: "websecure",
+			sni:        "Foo.bar",
+			expected:   expectedResult{StatusCode: http.StatusOK},
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+
+		t.Run(test.desc, func(t *testing.T) {
+			rtConf := runtime.NewConfig(dynamic.Configuration{
+				HTTP: &dynamic.HTTPConfiguration{
+					Services:    test.serviceConfig,
+					Routers:     test.routersConfig,
+					Middlewares: test.middlewaresConfig,
+				},
+			})
+
+			rules.EnableDomainFronting(test.insecureSNI)
+			serviceManager := service.NewManager(rtConf.Services, http.DefaultTransport, nil, nil)
+			middlewaresBuilder := middleware.NewBuilder(rtConf.Middlewares, serviceManager)
+			responseModifierFactory := responsemodifiers.NewBuilder(rtConf.Middlewares)
+			chainBuilder := middleware.NewChainBuilder(static.Configuration{}, nil, nil)
+
+			routerManager := NewManager(rtConf, serviceManager, middlewaresBuilder, responseModifierFactory, chainBuilder)
+
+			handlers := routerManager.BuildHandlers(context.Background(), []string{test.entryPoint}, test.entryPoint == "websecure")
+
+			w := httptest.NewRecorder()
+			req := testhelpers.MustNewRequest(http.MethodGet, "https://foo.bar/", nil)
+
+			if test.entryPoint == "websecure" {
+				req.TLS = &tls.ConnectionState{}
+
+				if test.sni != "" {
+					req.TLS.ServerName = test.sni
+				}
+			}
+
+			reqHost := requestdecorator.New(nil)
+			reqHost.ServeHTTP(w, req, handlers[test.entryPoint].ServeHTTP)
 
 			assert.Equal(t, test.expected.StatusCode, w.Code)
 
@@ -683,7 +903,7 @@ func TestRuntimeConfiguration(t *testing.T) {
 			chainBuilder := middleware.NewChainBuilder(static.Configuration{}, nil, nil)
 
 			routerManager := NewManager(rtConf, serviceManager, middlewaresBuilder, responseModifierFactory, chainBuilder)
-
+			// TODO
 			_ = routerManager.BuildHandlers(context.Background(), entryPoints, false)
 
 			// even though rtConf was passed by argument to the manager builders above,

--- a/pkg/server/router/router_test.go
+++ b/pkg/server/router/router_test.go
@@ -27,6 +27,8 @@ import (
 func TestRouterManager_Get(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 
+	t.Cleanup(func() { server.Close() })
+
 	type expectedResult struct {
 		StatusCode     int
 		RequestHeaders map[string]string
@@ -315,6 +317,8 @@ func TestRouterManager_Get(t *testing.T) {
 func TestRouterManager_SNI(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 
+	t.Cleanup(func() { server.Close() })
+
 	type expectedResult struct {
 		StatusCode     int
 		RequestHeaders map[string]string
@@ -531,6 +535,8 @@ func TestRouterManager_SNI(t *testing.T) {
 
 func TestAccessLog(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	t.Cleanup(func() { server.Close() })
 
 	testCases := []struct {
 		desc              string
@@ -1002,6 +1008,8 @@ func (t *staticTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
 
 func BenchmarkRouterServe(b *testing.B) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	b.Cleanup(func() { server.Close() })
 
 	res := &http.Response{
 		StatusCode: 200,

--- a/pkg/server/router/router_test.go
+++ b/pkg/server/router/router_test.go
@@ -9,14 +9,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/containous/traefik/v2/pkg/rules"
-
 	"github.com/containous/traefik/v2/pkg/config/dynamic"
 	"github.com/containous/traefik/v2/pkg/config/runtime"
 	"github.com/containous/traefik/v2/pkg/config/static"
 	"github.com/containous/traefik/v2/pkg/middlewares/accesslog"
 	"github.com/containous/traefik/v2/pkg/middlewares/requestdecorator"
 	"github.com/containous/traefik/v2/pkg/responsemodifiers"
+	"github.com/containous/traefik/v2/pkg/rules"
 	"github.com/containous/traefik/v2/pkg/server/middleware"
 	"github.com/containous/traefik/v2/pkg/server/service"
 	"github.com/containous/traefik/v2/pkg/testhelpers"
@@ -903,7 +902,6 @@ func TestRuntimeConfiguration(t *testing.T) {
 			chainBuilder := middleware.NewChainBuilder(static.Configuration{}, nil, nil)
 
 			routerManager := NewManager(rtConf, serviceManager, middlewaresBuilder, responseModifierFactory, chainBuilder)
-			// TODO
 			_ = routerManager.BuildHandlers(context.Background(), entryPoints, false)
 
 			// even though rtConf was passed by argument to the manager builders above,
@@ -998,7 +996,7 @@ type staticTransport struct {
 	res *http.Response
 }
 
-func (t *staticTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+func (t *staticTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
 	return t.res, nil
 }
 

--- a/pkg/tcp/router.go
+++ b/pkg/tcp/router.go
@@ -102,7 +102,7 @@ func (r *Router) AddRouteTLS(sniHost string, target Handler, config *tls.Config)
 	})
 }
 
-// AddRouteHTTPTLS defines a handler for a given sniHost and sets the matching tlsConfig.
+// AddRouteHTTPTLS defines the matching tlsConfig for a given sniHost.
 func (r *Router) AddRouteHTTPTLS(sniHost string, config *tls.Config) {
 	if r.hostHTTPTLSConfig == nil {
 		r.hostHTTPTLSConfig = map[string]*tls.Config{}

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -12,6 +12,8 @@
 [global]
   checkNewVersion = true
   sendAnonymousUsage = true
+#  Enabling domain fronting
+#  insecureSNI = true
 
 ################################################################
 # Entrypoints configuration

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -12,8 +12,8 @@
 [global]
   checkNewVersion = true
   sendAnonymousUsage = true
-#  Enabling domain fronting
-#  insecureSNI = true
+  # Enabling domain fronting
+  # insecureSNI = true
 
 ################################################################
 # Entrypoints configuration


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR introduces a new default behavior to prevent domain fronting, at the router's level.

With this new behavior, all `Host` rules matchers will try to match **both** the `Host header` value **and** the `Server Name Indication` value from the TLS negotiation.

To fallback to the previous insecure behavior, a global configuration flag has been added: `InsecureSNI` (false by default).
When set to true it enables all `Host` rules matchers to match **only** the `Host header` value.

Furthermore, new rules matcher have been added: 
- `HostHeader` tries to match the `Host header` value
- `HostSNI` tries to match the `Server Name Indication` value from the TLS negotiation

Those new matchers can be used as an advanced feature to fine grain control routing.

<!-- A brief description of the change being made with this pull request. -->


### Motivation

Disabling domain fronting capability by default, to fix the [CVE-2019-20894](https://nvd.nist.gov/vuln/detail/CVE-2019-20894).
Fixes #5312
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Co-authored-by: jbdoumenjou <jb.doumenjou@gmail.com>