### PR TITLE
Change the default value of insecureSNI

### DIFF
--- a/docs/content/https/tls.md
+++ b/docs/content/https/tls.md
@@ -137,7 +137,7 @@ connection with a specific domain name, thanks to the
 [Server Name Indication](https://en.wikipedia.org/wiki/Server_Name_Indication), then access a service with another 
 domain set in the HTTP `Host` header.
 
-Since the `v2.2.2`, Traefik allows to avoid domain fronting thanks to the `insecureSNI` global flag.
+Since the `v2.2.4`, Traefik has the option to avoid domain fronting thanks to the `insecureSNI` global flag.
 As it is valid for advanced use cases, the `HostHeader` and `HostSNI` [rules](../routing/routers/index.md#rule) allow 
 to fine tune the routing with the `Server Name Indication` and `Host header` value.
 

--- a/docs/content/https/tls.md
+++ b/docs/content/https/tls.md
@@ -137,7 +137,7 @@ connection with a specific domain name, thanks to the
 [Server Name Indication](https://en.wikipedia.org/wiki/Server_Name_Indication), then access a service with another 
 domain set in the HTTP `Host` header.
 
-Since the `v2.2.2`, Traefik avoids (by default) using domain fronting.
+Since the `v2.2.2`, Traefik allows to avoid domain fronting thanks to the `insecureSNI` global flag.
 As it is valid for advanced use cases, the `HostHeader` and `HostSNI` [rules](../routing/routers/index.md#rule) allow 
 to fine tune the routing with the `Server Name Indication` and `Host header` value.
 

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -16,7 +16,7 @@ However, a new flag is available as a global option to disable domain fronting.
     # Static configuration
     [global]
       # Disabling domain fronting
-      insecureSNI = fase
+      insecureSNI = false
     ```
     
     ```yaml tab="File (YAML)"

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -4,8 +4,8 @@
 
 ### Domain fronting
 
-In `v2.2.2` we introduced the ability to avoid [Domain fronting](https://en.wikipedia.org/wiki/Domain_fronting), 
-and disabled it by default for [https routers](../routing/routers/index.md#rule) configured with ```Host(`something`)```.
+In `v2.2.2` we introduced the ability to avoid [Domain fronting](https://en.wikipedia.org/wiki/Domain_fronting) for [https routers](../routing/routers/index.md#rule) configured with ```Host(`something`)``` but we disabled it for compatibility reasons by default.
+
 Nothing special is required to keep the previous behavior.
 
 However, a new flag is available as a global option to disable domain fronting.

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -5,112 +5,33 @@
 ### Domain fronting
 
 In `v2.2.2` we introduced the ability to avoid [Domain fronting](https://en.wikipedia.org/wiki/Domain_fronting), 
-and enabled it by default for [https routers](../routing/routers/index.md#rule) configured with ```Host(`something`)```.
+and disabled it by default for [https routers](../routing/routers/index.md#rule) configured with ```Host(`something`)```.
+Nothing special is required to keep the previous behavior.
 
-!!! example "Allow Domain Fronting on a Specific Router"
-    
-    !!! info "Before v2.2.2"
-    
-    ```yaml tab="Docker"
-    labels:
-      - "traefik.http.routers.router0.rule=Host(`test.localhost`)"
-    ```
-    
-    ```yaml tab="K8s Ingress"
-    apiVersion: traefik.containo.us/v1alpha1
-    kind: IngressRoute
-    metadata:
-      name: ingressroutebar
-    
-    spec:
-      entryPoints:
-        - http
-      routes:
-      - match: Host(`test.localhost`)
-        kind: Rule
-        services:
-        - name: server0
-          port: 80
-        - name: server1
-          port: 80
-    ```
-        
-    ```toml tab="File (TOML)"
-    [http.routers.router0]
-        rule = "Host(`test.localhost`)"
-        service = "my-service"
-    ```
-    
-    ```toml tab="File (YAML)"
-    http:
-      routers:
-        router0:
-          rule: "Host(`test.localhost`)"
-          service: my-service
-    ```
+However, a new flag is available as a global option to disable domain fronting.
 
-    !!! info "v2.2.2"
-    
-    ```yaml tab="Docker"
-    labels:
-      - "traefik.http.routers.router0.rule=HostHeader(`test.localhost`)"
-    ```
-    
-    ```yaml tab="K8s Ingress"
-    apiVersion: traefik.containo.us/v1alpha1
-    kind: IngressRoute
-    metadata:
-      name: ingressroutebar
-    
-    spec:
-      entryPoints:
-        - http
-      routes:
-      - match: HostHeader(`test.localhost`)
-        kind: Rule
-        services:
-        - name: server0
-          port: 80
-        - name: server1
-          port: 80
-    ```
-        
-    ```toml tab="File (TOML)"
-    [http.routers.router0]
-        rule = "HostHeader(`test.localhost`)"
-        service = "my-service"
-    ```
-    
-    ```toml tab="File (YAML)"
-    http:
-      routers:
-        router0:
-          rule: "HostHeader(`test.localhost`)"
-          service: my-service
-    ```
-
-As a fallback, a new flag is available as a global option:
-
-!!! example "Enabling Domain Fronting for All Routers"
+!!! example "Disabling Domain Fronting for All Routers"
     
     ```toml tab="File (TOML)"
     # Static configuration
     [global]
-      # Enabling domain fronting
-      insecureSNI = true
+      # Disabling domain fronting
+      insecureSNI = fase
     ```
     
     ```yaml tab="File (YAML)"
     # Static configuration
     global:
-      # Enabling domain fronting
-      insecureSNI: true
+      # Disabling domain fronting
+      insecureSNI: false
     ```
     
     ```bash tab="CLI"
-    # Enabling domain fronting
-    --global.insecureSNI
+    # Disabling domain fronting
+    --global.insecureSNI=false
     ```
+
+To fine tune the HTTPS routing with Domain Fronting disabled, two new HTTP rules `HostSNI` and `HostHeader` are available. 
 
 ## v2.0 to v2.1
 

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -163,7 +163,7 @@ WriteTimeout is the maximum duration before timing out writes of the response. I
 Periodically check if a new version has been released. (Default: ```false```)
 
 `--global.insecuresni`:  
-Allow domain fronting. If the option is not specified, it will be disabled by default. (Default: ```false```)
+Allow domain fronting. If the option is not specified, it will be enabled by default. (Default: ```true```)
 
 `--global.sendanonymoususage`:  
 Periodically send anonymous usage statistics. If the option is not specified, it will be enabled by default. (Default: ```false```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -163,7 +163,7 @@ WriteTimeout is the maximum duration before timing out writes of the response. I
 Periodically check if a new version has been released. (Default: ```false```)
 
 `TRAEFIK_GLOBAL_INSECURESNI`:  
-Allow domain fronting. If the option is not specified, it will be disabled by default. (Default: ```false```)
+Allow domain fronting. If the option is not specified, it will be enabled by default. (Default: ```true```)
 
 `TRAEFIK_GLOBAL_SENDANONYMOUSUSAGE`:  
 Periodically send anonymous usage statistics. If the option is not specified, it will be enabled by default. (Default: ```false```)

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -79,7 +79,12 @@ type CertificateResolver struct {
 type Global struct {
 	CheckNewVersion    bool `description:"Periodically check if a new version has been released." json:"checkNewVersion,omitempty" toml:"checkNewVersion,omitempty" yaml:"checkNewVersion,omitempty" label:"allowEmpty" export:"true"`
 	SendAnonymousUsage bool `description:"Periodically send anonymous usage statistics. If the option is not specified, it will be enabled by default." json:"sendAnonymousUsage,omitempty" toml:"sendAnonymousUsage,omitempty" yaml:"sendAnonymousUsage,omitempty" label:"allowEmpty" export:"true"`
-	InsecureSNI        bool `description:"Allow domain fronting. If the option is not specified, it will be disabled by default." json:"insecureSNI,omitempty" toml:"insecureSNI,omitempty" yaml:"insecureSNI,omitempty" label:"allowEmpty" export:"true"`
+	InsecureSNI        bool `description:"Allow domain fronting. If the option is not specified, it will be enabled by default." json:"insecureSNI,omitempty" toml:"insecureSNI,omitempty" yaml:"insecureSNI,omitempty" label:"allowEmpty" export:"true"`
+}
+
+// SetDefaults sets the default values.
+func (a *Global) SetDefaults() {
+	a.InsecureSNI = true
 }
 
 // ServersTransport options to configure communication between Traefik and the servers.


### PR DESCRIPTION
### What does this PR do?

insecureSNI is `true` by default.

### Motivation

related to #7020 

### More

- [ ] ~Added/updated tests~
- [x] Added/updated documentation
