### PR TITLE
Fix default value for InsecureSNI when global is not set

### DIFF
--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -20,6 +20,7 @@ func NewTraefikConfiguration() *TraefikCmdConfiguration {
 		Configuration: static.Configuration{
 			Global: &static.Global{
 				CheckNewVersion: true,
+				InsecureSNI:     true,
 			},
 			EntryPoints: make(static.EntryPoints),
 			Providers: &static.Providers{

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -79,7 +79,7 @@ type CertificateResolver struct {
 type Global struct {
 	CheckNewVersion    bool `description:"Periodically check if a new version has been released." json:"checkNewVersion,omitempty" toml:"checkNewVersion,omitempty" yaml:"checkNewVersion,omitempty" label:"allowEmpty" export:"true"`
 	SendAnonymousUsage bool `description:"Periodically send anonymous usage statistics. If the option is not specified, it will be enabled by default." json:"sendAnonymousUsage,omitempty" toml:"sendAnonymousUsage,omitempty" yaml:"sendAnonymousUsage,omitempty" label:"allowEmpty" export:"true"`
-	InsecureSNI        bool `description:"Allow domain fronting. If the option is not specified, it will be enabled by default." json:"insecureSNI,omitempty" toml:"insecureSNI,omitempty" yaml:"insecureSNI,omitempty" label:"allowEmpty" export:"true"`
+	InsecureSNI        bool `description:"Allow domain fronting. If the option is not specified, it will be enabled by default." json:"insecureSNI" toml:"insecureSNI" yaml:"insecureSNI" label:"allowEmpty" export:"true"`
 }
 
 // SetDefaults sets the default values.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?
This PR fixes the `global.insecureSNI` default value when the `global` is not set.


### Motivation

Changes the default value for insecureSNI.

### Additional Notes
related to #7020 

<!-- Anything else we should know when reviewing? -->
