### PR TITLE
Revert domain fronting fix

### DIFF
--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -20,7 +20,6 @@ func NewTraefikConfiguration() *TraefikCmdConfiguration {
 		Configuration: static.Configuration{
 			Global: &static.Global{
 				CheckNewVersion: true,
-				InsecureSNI:     true,
 			},
 			EntryPoints: make(static.EntryPoints),
 			Providers: &static.Providers{

--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -25,7 +25,6 @@ import (
 	"github.com/containous/traefik/v2/pkg/provider/acme"
 	"github.com/containous/traefik/v2/pkg/provider/aggregator"
 	"github.com/containous/traefik/v2/pkg/provider/traefik"
-	"github.com/containous/traefik/v2/pkg/rules"
 	"github.com/containous/traefik/v2/pkg/safe"
 	"github.com/containous/traefik/v2/pkg/server"
 	"github.com/containous/traefik/v2/pkg/server/middleware"
@@ -162,8 +161,6 @@ func runCmd(staticConfiguration *static.Configuration) error {
 }
 
 func setupServer(staticConfiguration *static.Configuration) (*server.Server, error) {
-	rules.EnableDomainFronting(staticConfiguration.Global.InsecureSNI)
-
 	providerAggregator := aggregator.NewProviderAggregator(*staticConfiguration.Providers)
 
 	// adds internal provider

--- a/docs/content/https/tls.md
+++ b/docs/content/https/tls.md
@@ -130,20 +130,6 @@ tls:
 
 If no default certificate is provided, Traefik generates and uses a self-signed certificate.
 
-## Domain fronting
-
-Basically, [domain fronting](https://en.wikipedia.org/wiki/Domain_fronting) is a technique that allows to open a 
-connection with a specific domain name, thanks to the 
-[Server Name Indication](https://en.wikipedia.org/wiki/Server_Name_Indication), then access a service with another 
-domain set in the HTTP `Host` header.
-
-Since the `v2.2.4`, Traefik has the option to avoid domain fronting thanks to the `insecureSNI` global flag.
-As it is valid for advanced use cases, the `HostHeader` and `HostSNI` [rules](../routing/routers/index.md#rule) allow 
-to fine tune the routing with the `Server Name Indication` and `Host header` value.
-
-If you encounter routing issues with a previously working configuration, please refer to the 
-[migration guide](../migration/v2.md) to update your configuration.
-
 ## TLS Options
 
 The TLS options allow one to configure some parameters of the TLS connection.

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -1,38 +1,5 @@
 # Migration: Steps needed between the versions
 
-## v2.x to v2.2.2
-
-### Domain fronting
-
-In `v2.2.2` we introduced the ability to avoid [Domain fronting](https://en.wikipedia.org/wiki/Domain_fronting) for [https routers](../routing/routers/index.md#rule) configured with ```Host(`something`)``` but we disabled it for compatibility reasons by default.
-
-Nothing special is required to keep the previous behavior.
-
-However, a new flag is available as a global option to disable domain fronting.
-
-!!! example "Disabling Domain Fronting for All Routers"
-    
-    ```toml tab="File (TOML)"
-    # Static configuration
-    [global]
-      # Disabling domain fronting
-      insecureSNI = false
-    ```
-    
-    ```yaml tab="File (YAML)"
-    # Static configuration
-    global:
-      # Disabling domain fronting
-      insecureSNI: false
-    ```
-    
-    ```bash tab="CLI"
-    # Disabling domain fronting
-    --global.insecureSNI=false
-    ```
-
-To fine tune the HTTPS routing with Domain Fronting disabled, two new HTTP rules `HostSNI` and `HostHeader` are available. 
-
 ## v2.0 to v2.1
 
 ### Kubernetes CRD

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -1,5 +1,17 @@
 # Migration: Steps needed between the versions
 
+## v2.2.2 to v2.2.5
+
+### InsecureSNI removal
+
+In `v2.2.2` we introduced a new flag (`insecureSNI`) which was available as a global option to disable domain fronting.
+Since `v2.2.5` this global option has been removed, and you should not use it anymore.
+
+### HostSNI rule matcher removal
+
+In `v2.2.2` we introduced a new rule matcher (`HostSNI`) which was allowing to match the Server Name Indication at the router level.
+Since `v2.2.5` this rule has been removed, and you should not use it anymore.
+
 ## v2.0 to v2.1
 
 ### Kubernetes CRD

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -162,9 +162,6 @@ WriteTimeout is the maximum duration before timing out writes of the response. I
 `--global.checknewversion`:  
 Periodically check if a new version has been released. (Default: ```false```)
 
-`--global.insecuresni`:  
-Allow domain fronting. If the option is not specified, it will be enabled by default. (Default: ```true```)
-
 `--global.sendanonymoususage`:  
 Periodically send anonymous usage statistics. If the option is not specified, it will be enabled by default. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -162,9 +162,6 @@ WriteTimeout is the maximum duration before timing out writes of the response. I
 `TRAEFIK_GLOBAL_CHECKNEWVERSION`:  
 Periodically check if a new version has been released. (Default: ```false```)
 
-`TRAEFIK_GLOBAL_INSECURESNI`:  
-Allow domain fronting. If the option is not specified, it will be enabled by default. (Default: ```true```)
-
 `TRAEFIK_GLOBAL_SENDANONYMOUSUSAGE`:  
 Periodically send anonymous usage statistics. If the option is not specified, it will be enabled by default. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -1,7 +1,6 @@
 [global]
   checkNewVersion = true
   sendAnonymousUsage = true
-  insecureSNI = false
 
 [serversTransport]
   insecureSkipVerify = true

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -1,8 +1,6 @@
 global:
   checkNewVersion: true
   sendAnonymousUsage: true
-  insecureSNI: false
-
 serversTransport:
   insecureSkipVerify: true
   rootCAs:

--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -232,7 +232,8 @@ The table below lists all the available matchers:
 |------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
 | ```Headers(`key`, `value`)```                                          | Check if there is a key `key`defined in the headers, with the value `value`                                    |
 | ```HeadersRegexp(`key`, `regexp`)```                                   | Check if there is a key `key`defined in the headers, with a value that matches the regular expression `regexp` |
-| ```Host(`example.com`, ...)```                                         | Check if the request domain targets one of the given `domains`.                                                |
+| ```Host(`example.com`, ...)```                                         | Check if the request domain (host header value) targets one of the given `domains`.                            |
+| ```HostHeader(`example.com`, ...)```                                   | Check if the request domain (host header value) targets one of the given `domains`.                            |
 | ```HostRegexp(`example.com`, `{subdomain:[a-z]+}.example.com`, ...)``` | Check if the request domain matches the given `regexp`.                                                        |
 | ```Method(`GET`, ...)```                                               | Check if the request method is one of the given `methods` (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`)            |
 | ```Path(`/path`, `/articles/{cat:[a-z]+}/{id:[0-9]+}`, ...)```         | Match exact request path. It accepts a sequence of literal and regular expression paths.                       |

--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -228,18 +228,16 @@ If the rule is verified, the router becomes active, calls middlewares, and then 
 
 The table below lists all the available matchers:
 
-| Rule                                                                   | Description                                                                                                                                                                                                     |
-|------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ```Headers(`key`, `value`)```                                          | Check if there is a key `key`defined in the headers, with the value `value`                                                                                                                                     |
-| ```HeadersRegexp(`key`, `regexp`)```                                   | Check if there is a key `key`defined in the headers, with a value that matches the regular expression `regexp`                                                                                                  |
-| ```Host(`example.com`, ...)```                                         | By default, is equivalent to `HostHeader` **AND** `HostSNI` rules. See [Domain Fronting](../../https/tls.md#domain-fronting) and the [migration guide](../../migration/v2.md#domain-fronting) for more details. |
-| ```HostHeader(`example.com`, ...)```                                   | Check if the request domain (host header value) targets one of the given `domains`.                                                                                                                             |
-| ```HostSNI(`example.com`, ...)```                                      | Check if the [Server Name Indication](https://en.wikipedia.org/wiki/Server_Name_Indication) corresponds to the given `domains`.                                                                                 |
-| ```HostRegexp(`example.com`, `{subdomain:[a-z]+}.example.com`, ...)``` | Check if the request domain matches the given `regexp`.                                                                                                                                                         |
-| ```Method(`GET`, ...)```                                               | Check if the request method is one of the given `methods` (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`)                                                                                                             |
-| ```Path(`/path`, `/articles/{cat:[a-z]+}/{id:[0-9]+}`, ...)```         | Match exact request path. It accepts a sequence of literal and regular expression paths.                                                                                                                        |
-| ```PathPrefix(`/products/`, `/articles/{cat:[a-z]+}/{id:[0-9]+}`)```   | Match request prefix path. It accepts a sequence of literal and regular expression prefix paths.                                                                                                                |
-| ```Query(`foo=bar`, `bar=baz`)```                                      | Match Query String parameters. It accepts a sequence of key=value pairs.                                                                                                                                        | 
+| Rule                                                                   | Description                                                                                                    |
+|------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
+| ```Headers(`key`, `value`)```                                          | Check if there is a key `key`defined in the headers, with the value `value`                                    |
+| ```HeadersRegexp(`key`, `regexp`)```                                   | Check if there is a key `key`defined in the headers, with a value that matches the regular expression `regexp` |
+| ```Host(`example.com`, ...)```                                         | Check if the request domain targets one of the given `domains`.                                                |
+| ```HostRegexp(`example.com`, `{subdomain:[a-z]+}.example.com`, ...)``` | Check if the request domain matches the given `regexp`.                                                        |
+| ```Method(`GET`, ...)```                                               | Check if the request method is one of the given `methods` (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`)            |
+| ```Path(`/path`, `/articles/{cat:[a-z]+}/{id:[0-9]+}`, ...)```         | Match exact request path. It accepts a sequence of literal and regular expression paths.                       |
+| ```PathPrefix(`/products/`, `/articles/{cat:[a-z]+}/{id:[0-9]+}`)```   | Match request prefix path. It accepts a sequence of literal and regular expression prefix paths.               |
+| ```Query(`foo=bar`, `bar=baz`)```                                      | Match Query String parameters. It accepts a sequence of key=value pairs.                                       |
 
 !!! important "Regexp Syntax"
 

--- a/integration/fixtures/grpc/config.toml
+++ b/integration/fixtures/grpc/config.toml
@@ -22,7 +22,7 @@
 
 [http.routers]
   [http.routers.router1]
-    rule = "Host(`localhost`)"
+    rule = "Host(`127.0.0.1`)"
     service = "service1"
     [http.routers.router1.tls]
 

--- a/integration/fixtures/grpc/config_h2c_termination.toml
+++ b/integration/fixtures/grpc/config_h2c_termination.toml
@@ -19,7 +19,7 @@
 
 [http.routers]
   [http.routers.router1]
-    rule = "Host(`localhost`)"
+    rule = "Host(`127.0.0.1`)"
     service = "service1"
     [http.routers.router1.tls]
 

--- a/integration/fixtures/grpc/config_insecure.toml
+++ b/integration/fixtures/grpc/config_insecure.toml
@@ -22,7 +22,7 @@
 
 [http.routers]
   [http.routers.router1]
-    rule = "Host(`localhost`)"
+    rule = "Host(`127.0.0.1`)"
     service = "service1"
     [http.routers.router1.tls]
 

--- a/integration/fixtures/grpc/config_retry.toml
+++ b/integration/fixtures/grpc/config_retry.toml
@@ -22,7 +22,7 @@
 
 [http.routers]
   [http.routers.router1]
-    rule = "Host(`localhost`)"
+    rule = "Host(`127.0.0.1`)"
     service = "service1"
     middlewares = ["retryer"]
     [http.routers.router1.tls]

--- a/integration/grpc_test.go
+++ b/integration/grpc_test.go
@@ -86,7 +86,7 @@ func starth2cGRPCServer(lis net.Listener, server *myserver) error {
 func getHelloClientGRPC() (helloworld.GreeterClient, func() error, error) {
 	roots := x509.NewCertPool()
 	roots.AppendCertsFromPEM(LocalhostCert)
-	credsClient := credentials.NewClientTLSFromCert(roots, "localhost")
+	credsClient := credentials.NewClientTLSFromCert(roots, "")
 	conn, err := grpc.Dial("127.0.0.1:4443", grpc.WithTransportCredentials(credsClient))
 	if err != nil {
 		return nil, func() error { return nil }, err
@@ -167,7 +167,7 @@ func (s *GRPCSuite) TestGRPC(c *check.C) {
 	defer cmd.Process.Kill()
 
 	// wait for Traefik
-	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("Host(`localhost`)"))
+	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("Host(`127.0.0.1`)"))
 	c.Assert(err, check.IsNil)
 
 	var response string
@@ -247,7 +247,7 @@ func (s *GRPCSuite) TestGRPCh2cTermination(c *check.C) {
 	defer cmd.Process.Kill()
 
 	// wait for Traefik
-	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("Host(`localhost`)"))
+	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("Host(`127.0.0.1`)"))
 	c.Assert(err, check.IsNil)
 
 	var response string
@@ -289,7 +289,7 @@ func (s *GRPCSuite) TestGRPCInsecure(c *check.C) {
 	defer cmd.Process.Kill()
 
 	// wait for Traefik
-	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("Host(`localhost`)"))
+	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("Host(`127.0.0.1`)"))
 	c.Assert(err, check.IsNil)
 
 	var response string
@@ -336,7 +336,7 @@ func (s *GRPCSuite) TestGRPCBuffer(c *check.C) {
 	defer cmd.Process.Kill()
 
 	// wait for Traefik
-	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("Host(`localhost`)"))
+	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("Host(`127.0.0.1`)"))
 	c.Assert(err, check.IsNil)
 	var client helloworld.Greeter_StreamExampleClient
 	client, closer, err := callStreamExampleClientGRPC()
@@ -395,7 +395,7 @@ func (s *GRPCSuite) TestGRPCBufferWithFlushInterval(c *check.C) {
 	defer cmd.Process.Kill()
 
 	// wait for Traefik
-	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("Host(`localhost`)"))
+	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("Host(`127.0.0.1`)"))
 	c.Assert(err, check.IsNil)
 
 	var client helloworld.Greeter_StreamExampleClient
@@ -453,7 +453,7 @@ func (s *GRPCSuite) TestGRPCWithRetry(c *check.C) {
 	defer cmd.Process.Kill()
 
 	// wait for Traefik
-	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("Host(`localhost`)"))
+	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("Host(`127.0.0.1`)"))
 	c.Assert(err, check.IsNil)
 
 	var response string

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -79,12 +79,6 @@ type CertificateResolver struct {
 type Global struct {
 	CheckNewVersion    bool `description:"Periodically check if a new version has been released." json:"checkNewVersion,omitempty" toml:"checkNewVersion,omitempty" yaml:"checkNewVersion,omitempty" label:"allowEmpty" export:"true"`
 	SendAnonymousUsage bool `description:"Periodically send anonymous usage statistics. If the option is not specified, it will be enabled by default." json:"sendAnonymousUsage,omitempty" toml:"sendAnonymousUsage,omitempty" yaml:"sendAnonymousUsage,omitempty" label:"allowEmpty" export:"true"`
-	InsecureSNI        bool `description:"Allow domain fronting. If the option is not specified, it will be enabled by default." json:"insecureSNI" toml:"insecureSNI" yaml:"insecureSNI" label:"allowEmpty" export:"true"`
-}
-
-// SetDefaults sets the default values.
-func (a *Global) SetDefaults() {
-	a.InsecureSNI = true
 }
 
 // ServersTransport options to configure communication between Traefik and the servers.

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -13,6 +13,7 @@ import (
 
 var funcs = map[string]func(*mux.Route, ...string) error{
 	"Host":          host,
+	"HostHeader":    host,
 	"HostRegexp":    hostRegexp,
 	"Path":          path,
 	"PathPrefix":    pathPrefix,

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -12,9 +12,7 @@ import (
 )
 
 var funcs = map[string]func(*mux.Route, ...string) error{
-	"Host":          hostSecure,
-	"HostHeader":    host,
-	"HostSNI":       hostSNI,
+	"Host":          host,
 	"HostRegexp":    hostRegexp,
 	"Path":          path,
 	"PathPrefix":    pathPrefix,
@@ -22,18 +20,6 @@ var funcs = map[string]func(*mux.Route, ...string) error{
 	"Headers":       headers,
 	"HeadersRegexp": headersRegexp,
 	"Query":         query,
-}
-
-// EnableDomainFronting initialize the matcher functions to used on routers.
-// InsecureSNI defines if the domain fronting is allowed.
-func EnableDomainFronting(ok bool) {
-	if ok {
-		log.WithoutContext().Warn("With insecureSNI enabled, router rules do not prevent domain fronting techniques. Please use `HostHeader` and `HostSNI` rules if domain fronting is not desired.")
-		funcs["Host"] = host
-		return
-	}
-
-	funcs["Host"] = hostSecure
 }
 
 // Router handle routing with rules.
@@ -112,125 +98,46 @@ func host(route *mux.Route, hosts ...string) error {
 	}
 
 	route.MatcherFunc(func(req *http.Request, _ *mux.RouteMatch) bool {
-		return matchHost(req, true, hosts...)
-	})
-	return nil
-}
+		reqHost := requestdecorator.GetCanonizedHost(req.Context())
+		if len(reqHost) == 0 {
+			log.FromContext(req.Context()).Warnf("Could not retrieve CanonizedHost, rejecting %s", req.Host)
+			return false
+		}
 
-func matchHost(req *http.Request, insecureSNI bool, hosts ...string) bool {
-	logger := log.FromContext(req.Context())
+		flatH := requestdecorator.GetCNAMEFlatten(req.Context())
+		if len(flatH) > 0 {
+			for _, host := range hosts {
+				if strings.EqualFold(reqHost, host) || strings.EqualFold(flatH, host) {
+					return true
+				}
+				log.FromContext(req.Context()).Debugf("CNAMEFlattening: request %s which resolved to %s, is not matched to route %s", reqHost, flatH, host)
+			}
+			return false
+		}
 
-	reqHost := requestdecorator.GetCanonizedHost(req.Context())
-	if len(reqHost) == 0 {
-		logger.Warnf("Could not retrieve CanonizedHost, rejecting %s", req.Host)
-		return false
-	}
-
-	flatH := requestdecorator.GetCNAMEFlatten(req.Context())
-	if len(flatH) > 0 {
 		for _, host := range hosts {
-			if strings.EqualFold(reqHost, host) || strings.EqualFold(flatH, host) {
+			if reqHost == host {
 				return true
 			}
-			logger.Debugf("CNAMEFlattening: request %s which resolved to %s, is not matched to route %s", reqHost, flatH, host)
-		}
-		return false
-	}
 
-	for _, host := range hosts {
-		if reqHost == host {
-			logHostSNI(insecureSNI, req, reqHost)
-			return true
-		}
+			// Check for match on trailing period on host
+			if last := len(host) - 1; last >= 0 && host[last] == '.' {
+				h := host[:last]
+				if reqHost == h {
+					return true
+				}
+			}
 
-		// Check for match on trailing period on host
-		if last := len(host) - 1; last >= 0 && host[last] == '.' {
-			h := host[:last]
-			if reqHost == h {
-				logHostSNI(insecureSNI, req, reqHost)
-				return true
+			// Check for match on trailing period on request
+			if last := len(reqHost) - 1; last >= 0 && reqHost[last] == '.' {
+				h := reqHost[:last]
+				if h == host {
+					return true
+				}
 			}
 		}
-
-		// Check for match on trailing period on request
-		if last := len(reqHost) - 1; last >= 0 && reqHost[last] == '.' {
-			h := reqHost[:last]
-			if h == host {
-				logHostSNI(insecureSNI, req, reqHost)
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func logHostSNI(insecureSNI bool, req *http.Request, reqHost string) {
-	if insecureSNI && req.TLS != nil && !strings.EqualFold(reqHost, req.TLS.ServerName) {
-		log.FromContext(req.Context()).Debugf("Router reached with Host(%q) different from SNI(%q)", reqHost, req.TLS.ServerName)
-	}
-}
-
-func hostSNI(route *mux.Route, hosts ...string) error {
-	for i, host := range hosts {
-		hosts[i] = strings.ToLower(host)
-	}
-
-	route.MatcherFunc(func(req *http.Request, _ *mux.RouteMatch) bool {
-		return matchSNI(req, hosts...)
-	})
-
-	return nil
-}
-
-func matchSNI(req *http.Request, hosts ...string) bool {
-	if req.TLS == nil {
-		return true
-	}
-
-	if req.TLS.ServerName == "" {
-		return false
-	}
-
-	for _, host := range hosts {
-		if strings.EqualFold(req.TLS.ServerName, host) {
-			return true
-		}
-
-		// Check for match on trailing period on host
-		if last := len(host) - 1; last >= 0 && host[last] == '.' {
-			h := host[:last]
-			if strings.EqualFold(req.TLS.ServerName, h) {
-				return true
-			}
-		}
-
-		// Check for match on trailing period on request
-		if last := len(req.TLS.ServerName) - 1; last >= 0 && req.TLS.ServerName[last] == '.' {
-			h := req.TLS.ServerName[:last]
-			if strings.EqualFold(h, host) {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
-func hostSecure(route *mux.Route, hosts ...string) error {
-	for i, host := range hosts {
-		hosts[i] = strings.ToLower(host)
-	}
-
-	route.MatcherFunc(func(req *http.Request, _ *mux.RouteMatch) bool {
-		for _, host := range hosts {
-			if matchSNI(req, host) && matchHost(req, false, host) {
-				return true
-			}
-		}
-
 		return false
 	})
-
 	return nil
 }
 

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -51,6 +51,14 @@ func Test_addRoute(t *testing.T) {
 			},
 		},
 		{
+			desc: "HostHeader equivalent to Host",
+			rule: "HostHeader(`localhost`)",
+			expected: map[string]int{
+				"http://localhost/foo": http.StatusOK,
+				"http://bar/foo":       http.StatusNotFound,
+			},
+		},
+		{
 			desc: "Host with trailing period in rule",
 			rule: "Host(`localhost.`)",
 			expected: map[string]int{
@@ -678,6 +686,18 @@ func TestParseDomains(t *testing.T) {
 		{
 			description:   "Many host rules",
 			expression:    "Host(`foo.bar`,`test.bar`)",
+			domain:        []string{"foo.bar", "test.bar"},
+			errorExpected: false,
+		},
+		{
+			description:   "Many host rules upper",
+			expression:    "HOST(`foo.bar`,`test.bar`)",
+			domain:        []string{"foo.bar", "test.bar"},
+			errorExpected: false,
+		},
+		{
+			description:   "Many host rules lower",
+			expression:    "host(`foo.bar`,`test.bar`)",
 			domain:        []string{"foo.bar", "test.bar"},
 			errorExpected: false,
 		},

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -682,18 +682,6 @@ func TestParseDomains(t *testing.T) {
 			errorExpected: false,
 		},
 		{
-			description:   "Many host rules upper",
-			expression:    "HOST(`foo.bar`,`test.bar`)",
-			domain:        []string{"foo.bar", "test.bar"},
-			errorExpected: false,
-		},
-		{
-			description:   "Many host rules lower",
-			expression:    "host(`foo.bar`,`test.bar`)",
-			domain:        []string{"foo.bar", "test.bar"},
-			errorExpected: false,
-		},
-		{
 			description:   "No host rule",
 			expression:    "Path(`/test`)",
 			errorExpected: false,

--- a/pkg/server/router/router_test.go
+++ b/pkg/server/router/router_test.go
@@ -25,6 +25,8 @@ import (
 func TestRouterManager_Get(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 
+	t.Cleanup(func() { server.Close() })
+
 	type expectedResult struct {
 		StatusCode     int
 		RequestHeaders map[string]string
@@ -312,6 +314,8 @@ func TestRouterManager_Get(t *testing.T) {
 
 func TestAccessLog(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	t.Cleanup(func() { server.Close() })
 
 	testCases := []struct {
 		desc              string
@@ -778,12 +782,14 @@ type staticTransport struct {
 	res *http.Response
 }
 
-func (t *staticTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+func (t *staticTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
 	return t.res, nil
 }
 
 func BenchmarkRouterServe(b *testing.B) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	b.Cleanup(func() { server.Close() })
 
 	res := &http.Response{
 		StatusCode: 200,

--- a/pkg/tcp/router.go
+++ b/pkg/tcp/router.go
@@ -102,7 +102,7 @@ func (r *Router) AddRouteTLS(sniHost string, target Handler, config *tls.Config)
 	})
 }
 
-// AddRouteHTTPTLS defines the matching tlsConfig for a given sniHost.
+// AddRouteHTTPTLS defines a handler for a given sniHost and sets the matching tlsConfig.
 func (r *Router) AddRouteHTTPTLS(sniHost string, config *tls.Config) {
 	if r.hostHTTPTLSConfig == nil {
 		r.hostHTTPTLSConfig = map[string]*tls.Config{}

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -12,8 +12,6 @@
 [global]
   checkNewVersion = true
   sendAnonymousUsage = true
-  # Enabling domain fronting
-  # insecureSNI = true
 
 ################################################################
 # Entrypoints configuration


### PR DESCRIPTION

### What does this PR do?

This PR:
- reverts the domain fronting fix (introduced in v2.2.2)
- keeps the HostHeader rule matcher for routers (introduced in v2.2.2)

### Motivation

<!-- What inspired you to submit this pull request? -->
This PR fallback to v2.2.1 behavior because of regression issues, notably in case of [connection reuse](https://httpwg.org/specs/rfc7540.html#reuse) with http2

Fixes #7020

### More

- [x] Added/updated tests
- [x] Added/updated documentation
