### PR TITLE
Get Entrypoints Port Address without protocol for redirect

### DIFF
--- a/pkg/provider/traefik/fixtures/redirection_with_protocol.json
+++ b/pkg/provider/traefik/fixtures/redirection_with_protocol.json
@@ -1,0 +1,30 @@
+{
+  "http": {
+    "routers": {
+      "web-to-websecure": {
+        "entryPoints": [
+          "web"
+        ],
+        "middlewares": [
+          "redirect-web-to-websecure"
+        ],
+        "service": "noop@internal",
+        "rule": "HostRegexp(`{host:.+}`)"
+      }
+    },
+    "middlewares": {
+      "redirect-web-to-websecure": {
+        "redirectScheme": {
+          "scheme": "https",
+          "port": "443",
+          "permanent": true
+        }
+      }
+    },
+    "services": {
+      "noop": {}
+    }
+  },
+  "tcp": {},
+  "tls": {}
+}

--- a/pkg/provider/traefik/internal.go
+++ b/pkg/provider/traefik/internal.go
@@ -142,7 +142,7 @@ func (i *Provider) getEntryPointPort(name string, def *static.Redirections) (str
 		return "", fmt.Errorf("'to' entry point field references a non-existing entry point: %s", def.EntryPoint.To)
 	}
 
-	_, port, err := net.SplitHostPort(dst.Address)
+	_, port, err := net.SplitHostPort(dst.GetAddress())
 	if err != nil {
 		return "", fmt.Errorf("invalid entry point %q address %q: %w",
 			name, i.staticCfg.EntryPoints[def.EntryPoint.To].Address, err)

--- a/pkg/provider/traefik/internal_test.go
+++ b/pkg/provider/traefik/internal_test.go
@@ -205,7 +205,7 @@ func Test_createConfiguration(t *testing.T) {
 						},
 					},
 					"websecure": {
-						Address: ":443/tcp",
+						Address: ":443",
 					},
 				},
 			},
@@ -228,6 +228,28 @@ func Test_createConfiguration(t *testing.T) {
 					},
 					"websecure": {
 						Address: ":443",
+					},
+				},
+			},
+		},
+		{
+			desc: "redirection_with_protocol.json",
+			staticCfg: static.Configuration{
+				EntryPoints: map[string]*static.EntryPoint{
+					"web": {
+						Address: ":80",
+						HTTP: static.HTTPConfig{
+							Redirections: &static.Redirections{
+								EntryPoint: &static.RedirectEntryPoint{
+									To:        "websecure",
+									Scheme:    "https",
+									Permanent: true,
+								},
+							},
+						},
+					},
+					"websecure": {
+						Address: ":443/tcp",
 					},
 				},
 			},

--- a/pkg/provider/traefik/internal_test.go
+++ b/pkg/provider/traefik/internal_test.go
@@ -205,7 +205,7 @@ func Test_createConfiguration(t *testing.T) {
 						},
 					},
 					"websecure": {
-						Address: ":443",
+						Address: ":443/tcp",
 					},
 				},
 			},


### PR DESCRIPTION
### What does this PR do?

Takes the entrypoints address without the protocol for the entrypoint based redirection.

### Motivation

Fix https://github.com/containous/traefik-helm-chart/issues/208

### More

- [X] Added/updated tests
- ~~[ ] Added/updated documentation~~

### Additional Notes

