### PR TITLE
doc: add name of used key for kubernetes client auth

### DIFF
--- a/docs/content/https/tls.md
+++ b/docs/content/https/tls.md
@@ -428,6 +428,7 @@ metadata:
 
 spec:
   clientAuth:
+    # the CA certificate is extracted from key `tls.ca` of the given secrets.
     secretNames:
       - secretCA
     clientAuthType: RequireAndVerifyClientCert


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

Document which key of the Kubernetes secret is used to retrieve the CA certificate from for client auth.
<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
I had a secret with key `ca.crt` which did not work. Instead of getting this information from the docs, I only saw it in the logs of traefik:

```
the tls.ca entry is missing from secret traefik/client-ca
```
