### PR TITLE
prefer NoError/Error over Nil/NotNil

### DIFF
--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -448,9 +448,9 @@ func TestLBStatusUpdater(t *testing.T) {
 	svInfo := &runtime.ServiceInfo{}
 	lbsu := NewLBStatusUpdater(lb, svInfo)
 	newServer, err := url.Parse("http://foo.com")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = lbsu.UpsertServer(newServer, roundrobin.Weight(1))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, len(lbsu.Servers()), 1)
 	assert.Equal(t, len(lbsu.BalancerHandler.(*testLoadBalancer).Options()), 1)
 	statuses := svInfo.GetAllStatus()
@@ -461,7 +461,7 @@ func TestLBStatusUpdater(t *testing.T) {
 		break
 	}
 	err = lbsu.RemoveServer(newServer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, len(lbsu.Servers()), 0)
 	statuses = svInfo.GetAllStatus()
 	assert.Equal(t, len(statuses), 1)

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -1179,7 +1179,7 @@ func TestGetCertificates(t *testing.T) {
 			if test.errResult != "" {
 				assert.EqualError(t, err, test.errResult)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, test.result, tlsConfigs)
 			}
 		})

--- a/pkg/server/middleware/middlewares_test.go
+++ b/pkg/server/middleware/middlewares_test.go
@@ -276,7 +276,7 @@ func TestBuilder_BuildChainWithContext(t *testing.T) {
 
 			handlers, err := result.Then(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }))
 			if test.expectedError != nil {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				require.Equal(t, test.expectedError.Error(), err.Error())
 			} else {
 				require.NoError(t, err)

--- a/pkg/server/service/tcp/service_test.go
+++ b/pkg/server/service/tcp/service_test.go
@@ -193,7 +193,7 @@ func TestManager_BuildTCP(t *testing.T) {
 				assert.EqualError(t, err, test.expectedError)
 				require.Nil(t, handler)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				require.NotNil(t, handler)
 			}
 		})

--- a/pkg/server/service/udp/service_test.go
+++ b/pkg/server/service/udp/service_test.go
@@ -193,7 +193,7 @@ func TestManager_BuildUDP(t *testing.T) {
 				assert.EqualError(t, err, test.expectedError)
 				require.Nil(t, handler)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				require.NotNil(t, handler)
 			}
 		})


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?
replaces calls to require/assert Nil/NotNil to NoError/Error

[NoError](https://godoc.org/github.com/stretchr/testify/require#NoError) is for asserting no error was return
[Error](https://godoc.org/github.com/stretchr/testify/require#Error) is for asserting an error was returned

### Motivation

```golang
return Fail(t, fmt.Sprintf("Received unexpected error:\n%+v", err), msgAndArgs...)
```
```golang
return Fail(t, "An error is expected but got nil.", msgAndArgs...)
```
When these fail their message explicitly calls out that we were or were not expecting an error. This communicates the intent of the assertion.
