### PR TITLE
Add migration documentation for IngressClass

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -323,5 +323,5 @@ The file parser has been changed, since v2.3 the unknown options/fields in a dyn
 
 ### IngressClass
 
-In `v2.3`, we support the newly introduced `IngressClass` available since Kubernetes version `1.18`.
-In order to be able to use this resource you have to update the [Kubernetes RBAC](../reference/dynamic-configuration/kubernetes-crd.md#rbac). 
+In `v2.3`, the support of `IngressClass`, which is available since Kubernetes version `1.18`, has been introduced.
+In order to be able to use this new resource the [Kubernetes RBAC](../reference/dynamic-configuration/kubernetes-crd.md#rbac) must be updated. 

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -320,3 +320,8 @@ Since `v2.2.5` this rule has been removed, and you should not use it anymore.
 ### File Provider
 
 The file parser has been changed, since v2.3 the unknown options/fields in a dynamic configuration file are treated as errors.
+
+### IngressClass
+
+In `v2.3`, we support the newly introduced `IngressClass` available since Kubernetes version `1.18`.
+In order to be able to use this resource you have to update the [Kubernetes RBAC](../reference/dynamic-configuration/kubernetes-crd.md#rbac). 

--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-rbac.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-rbac.yml
@@ -18,6 +18,7 @@ rules:
       - extensions
     resources:
       - ingresses
+      - ingressclasses
     verbs:
       - get
       - list

--- a/pkg/tls/certificate_store.go
+++ b/pkg/tls/certificate_store.go
@@ -13,14 +13,14 @@ import (
 	"github.com/patrickmn/go-cache"
 )
 
-// CertificateStore store for dynamic and static certificates.
+// CertificateStore store for dynamic certificates.
 type CertificateStore struct {
 	DynamicCerts       *safe.Safe
 	DefaultCertificate *tls.Certificate
 	CertCache          *cache.Cache
 }
 
-// NewCertificateStore create a store for dynamic and static certificates.
+// NewCertificateStore create a store for dynamic certificates.
 func NewCertificateStore() *CertificateStore {
 	return &CertificateStore{
 		DynamicCerts: &safe.Safe{},
@@ -37,7 +37,7 @@ func (c CertificateStore) getDefaultCertificateDomains() []string {
 
 	x509Cert, err := x509.ParseCertificate(c.DefaultCertificate.Certificate[0])
 	if err != nil {
-		log.WithoutContext().Errorf("Could not parse default certicate: %v", err)
+		log.WithoutContext().Errorf("Could not parse default certificate: %v", err)
 		return allCerts
 	}
 


### PR DESCRIPTION
### What does this PR do?

This PR:

- Adds a migration documentation and updates the Kubernetes RBAC to support the newly introduced `IngressClass`.
- Fix some typos in the certificate store code.

### Motivation

Improve the `IngressClass` documentation.

### More

- [ ] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
