### PR TITLE
Support Kubernetes Ingress pathType

### DIFF
--- a/docs/content/providers/kubernetes-ingress.md
+++ b/docs/content/providers/kubernetes-ingress.md
@@ -258,16 +258,13 @@ Value of `kubernetes.io/ingress.class` annotation that identifies Ingress object
 If the parameter is non-empty, only Ingresses containing an annotation with the same value are processed.
 Otherwise, Ingresses missing the annotation, having an empty value, or with the value `traefik` are processed.
 
-#### ingressClass on Kubernetes 1.18+
+!!! info "Kubernetes 1.18+"
 
-If you cluster is running kubernetes 1.18+,
-you can also leverage the newly Introduced `IngressClass` resource to define which Ingress Objects to handle.
-In that case, Traefik will look for an `IngressClass` in your cluster with the controller of *traefik.io/ingress-controller* inside the spec. 
-
-!!! note ""
-    Please note, the ingressClass configuration on the provider is not used then anymore.
-
-Please see [this article](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/) for more information.
+    If the Kubernetes cluster version is 1.18+,
+    the newly `IngressClass` resource can be leveraged to identify Ingress objects that should be processed.
+    In that case, Traefik will look for an `IngressClass` in the cluster with the controller value equal to *traefik.io/ingress-controller*. 
+    
+    Please see [this article](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/) for more information.
 
 ### `ingressEndpoint`
 

--- a/docs/content/providers/kubernetes-ingress.md
+++ b/docs/content/providers/kubernetes-ingress.md
@@ -261,7 +261,7 @@ Otherwise, Ingresses missing the annotation, having an empty value, or with the 
 !!! info "Kubernetes 1.18+"
 
     If the Kubernetes cluster version is 1.18+,
-    the newly `IngressClass` resource can be leveraged to identify Ingress objects that should be processed.
+    the new `IngressClass` resource can be leveraged to identify Ingress objects that should be processed.
     In that case, Traefik will look for an `IngressClass` in the cluster with the controller value equal to *traefik.io/ingress-controller*. 
     
     Please see [this article](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/) for more information.

--- a/docs/content/routing/providers/kubernetes-ingress.md
+++ b/docs/content/routing/providers/kubernetes-ingress.md
@@ -360,7 +360,7 @@ and will connect via TLS automatically.
     If this is not an option, you may need to skip TLS certificate verification.
     See the [insecureSkipVerify](../../routing/overview.md#insecureskipverify) setting for more details.
 
-#### Certificates Management
+### Certificates Management
 
 ??? example "Using a secret"
     

--- a/docs/content/routing/providers/kubernetes-ingress.md
+++ b/docs/content/routing/providers/kubernetes-ingress.md
@@ -322,9 +322,23 @@ which in turn will create the resulting routers, services, handlers, etc.
     traefik.ingress.kubernetes.io/service.sticky.cookie.httponly: "true"
     ```
 
-### TLS
+## Path Types on Kubernetes 1.18+
+              
+If the Kubernetes cluster version is 1.18+,
+the new `pathType` property can be leveraged to define the rules matchers:
 
-#### Communication Between Traefik and Pods
+- `Exact`: This path type forces the rule matcher to `Path`
+- `Prefix`: This path type forces the rule matcher to `PathPrefix`
+
+Please see [this documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types) for more information.
+
+!!! warning "Multiple Matches"
+    In the case of multiple matches, Traefik will not ensure the priority of a Path matcher over a PathPrefix matcher,
+    as stated in [this documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#multiple-matches).
+
+## TLS
+
+### Communication Between Traefik and Pods
 
 Traefik automatically requests endpoint information based on the service provided in the ingress spec.
 Although Traefik will connect directly to the endpoints (pods),

--- a/pkg/provider/kubernetes/ingress/client.go
+++ b/pkg/provider/kubernetes/ingress/client.go
@@ -341,7 +341,7 @@ func (c *clientWrapper) GetIngressClass() (*networkingv1beta1.IngressClass, erro
 
 	for _, ic := range ingressClasses {
 		if ic.Spec.Controller == traefikDefaultIngressClassController {
-			return ic, err
+			return ic, nil
 		}
 	}
 

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-empty-pathType_endpoint.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-empty-pathType_endpoint.yml
@@ -1,0 +1,11 @@
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+subsets:
+- addresses:
+  - ip: 10.10.0.1
+  ports:
+  - port: 8080

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-empty-pathType_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-empty-pathType_ingress.yml
@@ -1,0 +1,16 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1beta1
+metadata:
+  name: ""
+  namespace: testing
+  annotations:
+    traefik.ingress.kubernetes.io/router.pathmatcher: Path
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /bar
+        pathType: ""
+        backend:
+          serviceName: service1
+          servicePort: 80

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-empty-pathType_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-empty-pathType_service.yml
@@ -1,0 +1,10 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+spec:
+  ports:
+  - port: 80
+  clusterIp: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-exact-pathType_endpoint.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-exact-pathType_endpoint.yml
@@ -1,0 +1,11 @@
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+subsets:
+- addresses:
+  - ip: 10.10.0.1
+  ports:
+  - port: 8080

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-exact-pathType_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-exact-pathType_ingress.yml
@@ -1,0 +1,14 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1beta1
+metadata:
+  name: ""
+  namespace: testing
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /bar
+        pathType: Exact
+        backend:
+          serviceName: service1
+          servicePort: 80

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-exact-pathType_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-exact-pathType_service.yml
@@ -1,0 +1,10 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+spec:
+  ports:
+  - port: 80
+  clusterIp: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-implementationSpecific-pathType_endpoint.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-implementationSpecific-pathType_endpoint.yml
@@ -1,0 +1,11 @@
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+subsets:
+- addresses:
+  - ip: 10.10.0.1
+  ports:
+  - port: 8080

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-implementationSpecific-pathType_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-implementationSpecific-pathType_ingress.yml
@@ -1,0 +1,16 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1beta1
+metadata:
+  name: ""
+  namespace: testing
+  annotations:
+    traefik.ingress.kubernetes.io/router.pathmatcher: Path
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /bar
+        pathType: ImplementationSpecific
+        backend:
+          serviceName: service1
+          servicePort: 80

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-implementationSpecific-pathType_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-implementationSpecific-pathType_service.yml
@@ -1,0 +1,10 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+spec:
+  ports:
+  - port: 80
+  clusterIp: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-ingress-annotation_endpoint.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-ingress-annotation_endpoint.yml
@@ -1,0 +1,11 @@
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+subsets:
+- addresses:
+  - ip: 10.10.0.1
+  ports:
+  - port: 8080

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-ingress-annotation_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-ingress-annotation_ingress.yml
@@ -1,0 +1,15 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1beta1
+metadata:
+  name: ""
+  namespace: testing
+  annotations:
+    kubernetes.io/ingress.class: traefik
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /bar
+        backend:
+          serviceName: service1
+          servicePort: 80

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-ingress-annotation_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-ingress-annotation_service.yml
@@ -1,0 +1,10 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+spec:
+  ports:
+  - port: 80
+  clusterIp: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-no-pathType_endpoint.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-no-pathType_endpoint.yml
@@ -1,0 +1,11 @@
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+subsets:
+- addresses:
+  - ip: 10.10.0.1
+  ports:
+  - port: 8080

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-no-pathType_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-no-pathType_ingress.yml
@@ -1,0 +1,15 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1beta1
+metadata:
+  name: ""
+  namespace: testing
+  annotations:
+    traefik.ingress.kubernetes.io/router.pathmatcher: Path
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /bar
+        backend:
+          serviceName: service1
+          servicePort: 80

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-no-pathType_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-no-pathType_service.yml
@@ -1,0 +1,10 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+spec:
+  ports:
+  - port: 80
+  clusterIp: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-prefix-pathType_endpoint.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-prefix-pathType_endpoint.yml
@@ -1,0 +1,11 @@
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+subsets:
+- addresses:
+  - ip: 10.10.0.1
+  ports:
+  - port: 8080

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-prefix-pathType_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-prefix-pathType_ingress.yml
@@ -1,0 +1,14 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1beta1
+metadata:
+  name: ""
+  namespace: testing
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /bar
+        pathType: Prefix
+        backend:
+          serviceName: service1
+          servicePort: 80

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-prefix-pathType_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-prefix-pathType_service.yml
@@ -1,0 +1,10 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+spec:
+  ports:
+  - port: 80
+  clusterIp: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -549,11 +549,9 @@ func loadRouter(rule v1beta1.IngressRule, pa v1beta1.HTTPIngressPath, rtConfig *
 		matcher := defaultPathMatcher
 
 		if pa.PathType == nil || *pa.PathType == "" || *pa.PathType == v1beta1.PathTypeImplementationSpecific {
-
 			if rtConfig != nil && rtConfig.Router != nil && rtConfig.Router.PathMatcher != "" {
 				matcher = rtConfig.Router.PathMatcher
 			}
-
 		} else if *pa.PathType == v1beta1.PathTypeExact {
 			matcher = "Path"
 		}

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -953,6 +953,146 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 			},
 		},
 		{
+			desc:          "v18 Ingress with no pathType",
+			serverVersion: "v1.18",
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{},
+				HTTP: &dynamic.HTTPConfiguration{
+					Middlewares: map[string]*dynamic.Middleware{},
+					Routers: map[string]*dynamic.Router{
+						"testing-bar": {
+							Rule:    "Path(`/bar`)",
+							Service: "testing-service1-80",
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"testing-service1-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								PassHostHeader: Bool(true),
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:8080",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:          "v18 Ingress with empty pathType",
+			serverVersion: "v1.18",
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{},
+				HTTP: &dynamic.HTTPConfiguration{
+					Middlewares: map[string]*dynamic.Middleware{},
+					Routers: map[string]*dynamic.Router{
+						"testing-bar": {
+							Rule:    "Path(`/bar`)",
+							Service: "testing-service1-80",
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"testing-service1-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								PassHostHeader: Bool(true),
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:8080",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:          "v18 Ingress with implementationSpecific pathType",
+			serverVersion: "v1.18",
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{},
+				HTTP: &dynamic.HTTPConfiguration{
+					Middlewares: map[string]*dynamic.Middleware{},
+					Routers: map[string]*dynamic.Router{
+						"testing-bar": {
+							Rule:    "Path(`/bar`)",
+							Service: "testing-service1-80",
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"testing-service1-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								PassHostHeader: Bool(true),
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:8080",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:          "v18 Ingress with prefix pathType",
+			serverVersion: "v1.18",
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{},
+				HTTP: &dynamic.HTTPConfiguration{
+					Middlewares: map[string]*dynamic.Middleware{},
+					Routers: map[string]*dynamic.Router{
+						"testing-bar": {
+							Rule:    "PathPrefix(`/bar`)",
+							Service: "testing-service1-80",
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"testing-service1-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								PassHostHeader: Bool(true),
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:8080",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:          "v18 Ingress with exact pathType",
+			serverVersion: "v1.18",
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{},
+				HTTP: &dynamic.HTTPConfiguration{
+					Middlewares: map[string]*dynamic.Middleware{},
+					Routers: map[string]*dynamic.Router{
+						"testing-bar": {
+							Rule:    "Path(`/bar`)",
+							Service: "testing-service1-80",
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"testing-service1-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								PassHostHeader: Bool(true),
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:8080",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			desc:          "v18 Ingress with missing ingressClass",
 			serverVersion: "v1.18",
 			expected: &dynamic.Configuration{
@@ -964,12 +1104,43 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc:          "v18 Ingress with ingress annotation",
+			serverVersion: "v1.18",
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{},
+				HTTP: &dynamic.HTTPConfiguration{
+					Middlewares: map[string]*dynamic.Middleware{},
+					Routers: map[string]*dynamic.Router{
+						"testing-bar": {
+							Rule:    "PathPrefix(`/bar`)",
+							Service: "testing-service1-80",
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"testing-service1-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								PassHostHeader: Bool(true),
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:8080",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range testCases {
 		test := test
+
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
+
+			t.Log(generateTestFilename("_ingress", test.desc))
 
 			var paths []string
 			_, err := os.Stat(generateTestFilename("_ingress", test.desc))

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -1140,8 +1140,6 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			t.Log(generateTestFilename("_ingress", test.desc))
-
 			var paths []string
 			_, err := os.Stat(generateTestFilename("_ingress", test.desc))
 			if err == nil {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR introduces the support of the `pathType` property for the Kubernetes Ingress, which is available since version 1.18.

### Motivation

Introducing the support of the new `pathType` property.

fixes #6690
<!-- What inspired you to submit this pull request? -->

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

It also fixes the support for the new IngressClass, making not mandatory to use the new IngressClass in cluster of version 1.18+.

Co-authored-by: jbdoumenjou <jb.doumenjou@gmail.com>
Co-authored-by: kevinpollet <pollet.kevin@gmail.com>