### PR TITLE
Support configuring a HTTP client timeout in the Docker provider

### DIFF
--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -491,6 +491,30 @@ providers:
 
 Defines the polling interval (in seconds) in Swarm Mode.
 
+### `httpClientTimeout`
+
+_Optional, Default=32_
+
+```toml tab="File (TOML)"
+[providers.docker]
+  httpClientTimeout = 300
+  # ...
+```
+
+```yaml tab="File (YAML)"
+providers:
+  docker:
+    httpClientTimeout: 300
+    # ...
+```
+
+```bash tab="CLI"
+--providers.docker.httpClientTimeout=300
+# ...
+```
+
+Client timeout for HTTP connections (in seconds).
+
 ### `watch`
 
 _Optional, Default=true_

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -402,6 +402,9 @@ Docker server endpoint. Can be a tcp or a unix socket endpoint. (Default: ```uni
 `--providers.docker.exposedbydefault`:  
 Expose containers by default. (Default: ```true```)
 
+`--providers.docker.httpclienttimeout`:  
+Client timeout for HTTP connections. (Default: ```32```)
+
 `--providers.docker.network`:  
 Default Docker network used.
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -402,6 +402,9 @@ Docker server endpoint. Can be a tcp or a unix socket endpoint. (Default: ```uni
 `TRAEFIK_PROVIDERS_DOCKER_EXPOSEDBYDEFAULT`:  
 Expose containers by default. (Default: ```true```)
 
+`TRAEFIK_PROVIDERS_DOCKER_HTTPCLIENTTIMEOUT`:  
+Client timeout for HTTP connections. (Default: ```32```)
+
 `TRAEFIK_PROVIDERS_DOCKER_NETWORK`:  
 Default Docker network used.
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -60,6 +60,7 @@
     swarmMode = true
     network = "foobar"
     swarmModeRefreshSeconds = 42
+    httpClientTimeout = 42
     [providers.docker.tls]
       ca = "foobar"
       caOptional = true

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -72,6 +72,7 @@ providers:
     swarmMode: true
     network: foobar
     swarmModeRefreshSeconds: 42
+    httpClientTimeout: 42
   file:
     directory: foobar
     watch: true

--- a/pkg/anonymize/anonymize_config_test.go
+++ b/pkg/anonymize/anonymize_config_test.go
@@ -157,6 +157,7 @@ func TestDo_globalConfiguration(t *testing.T) {
 		SwarmMode:               true,
 		Network:                 "MyNetwork",
 		SwarmModeRefreshSeconds: 42,
+		HTTPClientTimeout:       42,
 	}
 
 	config.Providers.KubernetesIngress = &ingress.Provider{

--- a/pkg/config/dynamic/fixtures/sample.toml
+++ b/pkg/config/dynamic/fixtures/sample.toml
@@ -41,6 +41,7 @@
     swarmMode = true
     network = "foobar"
     swarmModeRefreshSeconds = 42
+    httpClientTimeout = 42
     [providers.docker.tls]
       ca = "foobar"
       caOptional = true

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -210,6 +210,10 @@ func (c *Configuration) SetEffectiveConfiguration() {
 		if c.Providers.Docker.SwarmModeRefreshSeconds <= 0 {
 			c.Providers.Docker.SwarmModeRefreshSeconds = ptypes.Duration(15 * time.Second)
 		}
+
+		if c.Providers.Docker.HTTPClientTimeout <= 0 {
+			c.Providers.Docker.HTTPClientTimeout = ptypes.Duration(32 * time.Second)
+		}
 	}
 
 	if c.Providers.Rancher != nil {

--- a/pkg/provider/docker/docker.go
+++ b/pkg/provider/docker/docker.go
@@ -57,6 +57,7 @@ type Provider struct {
 	SwarmMode               bool             `description:"Use Docker on Swarm Mode." json:"swarmMode,omitempty" toml:"swarmMode,omitempty" yaml:"swarmMode,omitempty" export:"true"`
 	Network                 string           `description:"Default Docker network used." json:"network,omitempty" toml:"network,omitempty" yaml:"network,omitempty" export:"true"`
 	SwarmModeRefreshSeconds ptypes.Duration  `description:"Polling interval for swarm mode." json:"swarmModeRefreshSeconds,omitempty" toml:"swarmModeRefreshSeconds,omitempty" yaml:"swarmModeRefreshSeconds,omitempty" export:"true"`
+	HTTPClientTimeout       ptypes.Duration  `description:"Client timeout for HTTP connections." json:"httpClientTimeout,omitempty" toml:"httpClientTimeout,omitempty" yaml:"httpClientTimeout,omitempty" export:"true"`
 	defaultRuleTpl          *template.Template
 }
 
@@ -67,6 +68,7 @@ func (p *Provider) SetDefaults() {
 	p.Endpoint = "unix:///var/run/docker.sock"
 	p.SwarmMode = false
 	p.SwarmModeRefreshSeconds = ptypes.Duration(15 * time.Second)
+	p.HTTPClientTimeout = ptypes.Duration(32 * time.Second)
 	p.DefaultRule = DefaultTemplateRule
 }
 
@@ -147,6 +149,7 @@ func (p *Provider) getClientOpts() ([]client.Opt, error) {
 
 		return []client.Opt{
 			client.WithHTTPClient(httpClient),
+			client.WithTimeout(time.Duration(p.HTTPClientTimeout)),
 			client.WithHost(helper.Host), // To avoid 400 Bad Request: malformed Host header daemon error
 			client.WithDialContext(helper.Dialer),
 		}, nil
@@ -154,6 +157,7 @@ func (p *Provider) getClientOpts() ([]client.Opt, error) {
 
 	opts := []client.Opt{
 		client.WithHost(p.Endpoint),
+		client.WithTimeout(time.Duration(p.HTTPClientTimeout)),
 	}
 
 	if p.TLS != nil {
@@ -177,7 +181,7 @@ func (p *Provider) getClientOpts() ([]client.Opt, error) {
 			return nil, err
 		}
 
-		opts = append(opts, client.WithHTTPClient(&http.Client{Transport: tr}))
+		opts = append(opts, client.WithHTTPClient(&http.Client{Transport: tr, Timeout: time.Duration(p.HTTPClientTimeout)}))
 	}
 
 	return opts, nil


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

This PR adds a new configuration option on the Docker provider setting the HTTP client timeout when a HTTP endpoint is used. It also sets a default of 1 hour, which should probably be debated as there is currently _no_ timeout by default.

### Motivation

<!-- What inspired you to submit this pull request? -->

Closes #7093.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Let's debate whether it's a good or a bad idea to set a default timeout of e.g. 1 hour.