### PR TITLE
fix: clean X-Forwarded-Prefix header for the dashboard.

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"net/url"
 
 	"github.com/containous/traefik/v2/pkg/log"
 	assetfs "github.com/elazarl/go-bindata-assetfs"
@@ -23,11 +24,25 @@ func (g DashboardHandler) Append(router *mux.Router) {
 	// Expose dashboard
 	router.Methods(http.MethodGet).
 		Path("/").
-		HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
-			http.Redirect(response, request, request.Header.Get("X-Forwarded-Prefix")+"/dashboard/", http.StatusFound)
+		HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+			http.Redirect(resp, req, safePrefix(req)+"/dashboard/", http.StatusFound)
 		})
 
 	router.Methods(http.MethodGet).
 		PathPrefix("/dashboard/").
 		Handler(http.StripPrefix("/dashboard/", http.FileServer(g.Assets)))
+}
+
+func safePrefix(req *http.Request) string {
+	prefix := req.Header.Get("X-Forwarded-Prefix")
+	if prefix == "" {
+		return ""
+	}
+
+	parse, err := url.Parse(prefix)
+	if err != nil {
+		return ""
+	}
+
+	return parse.Path
 }

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -44,5 +44,9 @@ func safePrefix(req *http.Request) string {
 		return ""
 	}
 
+	if parse.Host != "" {
+		return ""
+	}
+
 	return parse.Path
 }

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -22,7 +22,7 @@ func Test_safePrefix(t *testing.T) {
 		{
 			desc:     "host with path",
 			value:    "https://example.com/foo/bar?test",
-			expected: "/foo/bar",
+			expected: "",
 		},
 		{
 			desc:     "path",

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -20,12 +20,17 @@ func Test_safePrefix(t *testing.T) {
 			expected: "",
 		},
 		{
+			desc:     "host with path",
+			value:    "https://example.com/foo/bar?test",
+			expected: "/foo/bar",
+		},
+		{
 			desc:     "path",
 			value:    "/foo/bar",
 			expected: "/foo/bar",
 		},
 		{
-			desc:     "path without trailing slash",
+			desc:     "path without leading slash",
 			value:    "foo/bar",
 			expected: "foo/bar",
 		},

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_safePrefix(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		value    string
+		expected string
+	}{
+		{
+			desc:     "host",
+			value:    "https://example.com",
+			expected: "",
+		},
+		{
+			desc:     "path",
+			value:    "/foo/bar",
+			expected: "/foo/bar",
+		},
+		{
+			desc:     "path without trailing slash",
+			value:    "foo/bar",
+			expected: "foo/bar",
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			req, err := http.NewRequest(http.MethodGet, "http://localhost", nil)
+			require.NoError(t, err)
+
+			req.Header.Set("X-Forwarded-Prefix", test.value)
+
+			prefix := safePrefix(req)
+
+			assert.Equal(t, test.expected, prefix)
+		})
+	}
+}


### PR DESCRIPTION

### What does this PR do?

Clean X-Forwarded-Prefix header for the dashboard.

### Motivation

Be safe.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation
