### PR TITLE
kubernetes-crd: fix whitespace in configuration examples

### DIFF
--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -108,16 +108,16 @@ The Kubernetes Ingress Controller, The Custom Resource Way.
       name: myingressroute
       namespace: default
     
-      spec:
-        entryPoints:
-          - web
+    spec:
+      entryPoints:
+        - web
     
-        routes:
-          - match: Host(`foo`) && PathPrefix(`/bar`)
-            kind: Rule
-            services:
-            - name: whoami
-              port: 80
+      routes:
+      - match: Host(`foo`) && PathPrefix(`/bar`)
+        kind: Rule
+        services:
+        - name: whoami
+          port: 80
     
     ---
     apiVersion: traefik.containo.us/v1alpha1
@@ -126,15 +126,15 @@ The Kubernetes Ingress Controller, The Custom Resource Way.
       name: ingressroute.tcp
       namespace: default
     
-      spec:
-        entryPoints:
-          - tcpep
-        routes:
-          - match: HostSNI(`bar`)
-            kind: Rule
-            services:
-              - name: whoamitcp
-                port: 8080
+    spec:
+      entryPoints:
+        - tcpep
+      routes:
+      - match: HostSNI(`bar`)
+        kind: Rule
+        services:
+          - name: whoamitcp
+            port: 8080
     
     ---
     apiVersion: traefik.containo.us/v1alpha1
@@ -143,14 +143,14 @@ The Kubernetes Ingress Controller, The Custom Resource Way.
       name: ingressroute.udp
       namespace: default
     
-      spec:
-        entryPoints:
-          - fooudp
-        routes:
-          - kind: Rule
-            services:
-              - name: whoamiudp
-                port: 8080
+    spec:
+      entryPoints:
+        - fooudp
+      routes:
+      - kind: Rule
+        services:
+          - name: whoamiudp
+            port: 8080
     ```
     
     ```yaml tab="Whoami"


### PR DESCRIPTION
With the whitespace as it was the whole spec would be part of the
resource metadata which obviously won't yield the desired results.

### What does this PR do?

The configuration examples in the kubernetes-crd part contain erroneous whitespace, making the whole spec part of the resource metadata. As such, these examples cannot be used as-is as the desired rules never become effective.

This PR fixes the whitespace so the examples can be used.

### Motivation

Low-hanging fruit to help others taking their first steps with kubernetes-crd.

### More

- [ ] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

None.
