### PR TITLE
Improve region resolution for ECS provider

### DIFF
--- a/docs/content/providers/ecs.md
+++ b/docs/content/providers/ecs.md
@@ -213,7 +213,10 @@ providers:
 # ...
 ```
 
-If `accessKeyID` / `secretAccessKey` is not provided credentials will be resolved in the following order:
+If `region` is not provided, it will be resolved from the EC2 metadata endpoint for EC2 tasks. 
+In a FARGATE context it will be resolved from the `AWS_REGION` env variable.
+
+If `accessKeyID` / `secretAccessKey` are not provided, credentials will be resolved in the following order:
 
 - From environment variables `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN`.
 - Shared credentials, determined by `AWS_PROFILE` and `AWS_SHARED_CREDENTIALS_FILE`, defaults to default and `~/.aws/credentials`.

--- a/pkg/provider/ecs/ecs.go
+++ b/pkg/provider/ecs/ecs.go
@@ -14,15 +14,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ecs"
-
 	"github.com/cenkalti/backoff/v4"
-	"github.com/patrickmn/go-cache"
-
 	"github.com/containous/traefik/v2/pkg/config/dynamic"
 	"github.com/containous/traefik/v2/pkg/job"
 	"github.com/containous/traefik/v2/pkg/log"
 	"github.com/containous/traefik/v2/pkg/provider"
 	"github.com/containous/traefik/v2/pkg/safe"
+	"github.com/patrickmn/go-cache"
 )
 
 // Provider holds configurations of the provider.
@@ -97,14 +95,16 @@ func (p *Provider) Init() error {
 }
 
 func (p *Provider) createClient(logger log.Logger) (*awsClient, error) {
-	sess, err := session.NewSession()
+	sess, err := session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	})
 	if err != nil {
 		return nil, err
 	}
 
 	ec2meta := ec2metadata.New(sess)
-	if p.Region == "" {
-		logger.Infoln("No EC2 region provided, querying instance metadata endpoint...")
+	if p.Region == "" && ec2meta.Available() {
+		logger.Infoln("No region provided, querying instance metadata endpoint...")
 		identity, err := ec2meta.GetInstanceIdentityDocument()
 		if err != nil {
 			return nil, err
@@ -113,7 +113,6 @@ func (p *Provider) createClient(logger log.Logger) (*awsClient, error) {
 	}
 
 	cfg := &aws.Config{
-		Region: &p.Region,
 		Credentials: credentials.NewChainCredentials(
 			[]credentials.Provider{
 				&credentials.StaticProvider{
@@ -126,6 +125,11 @@ func (p *Provider) createClient(logger log.Logger) (*awsClient, error) {
 				&credentials.SharedCredentialsProvider{},
 				defaults.RemoteCredProvider(*(defaults.Config()), defaults.Handlers()),
 			}),
+	}
+
+	// Set the region if it is defined by the user or resolved from the EC2 metadata.
+	if p.Region != "" {
+		cfg.Region = &p.Region
 	}
 
 	cfg.WithLogger(aws.LoggerFunc(func(args ...interface{}) {


### PR DESCRIPTION
### What does this PR do?

This PR improves the automatic `Region` resolution by:

- Querying the EC2 instance metadata only in an EC2 context.
- Using the `AWS_REGION` environment variable added by AWS to the FARGATE container.

### Motivation

Fixes #7096

### More

- [ ] ~Added/updated tests~
- [X] Added/updated documentation

### Additional Notes

Co-authored-by: Romain <rtribotte@users.noreply.github.com>
