### PR TITLE
Include enabling traefik in example

### DIFF
--- a/docs/content/operations/include-dashboard-examples.md
+++ b/docs/content/operations/include-dashboard-examples.md
@@ -1,6 +1,7 @@
 ```yaml tab="Docker"
 # Dynamic Configuration
 labels:
+  - "traefik.enable=true"
   - "traefik.http.routers.dashboard.rule=Host(`traefik.example.com`) && (PathPrefix(`/api`) || PathPrefix(`/dashboard`))"
   - "traefik.http.routers.dashboard.service=api@internal"
   - "traefik.http.routers.dashboard.middlewares=auth"


### PR DESCRIPTION
You need to enable traefik on the default traefik service for the router rules to apply. (I'm too lazy to add this to every example, feel free to do that yourself.)

### What does this PR do?

Adds a label to the example which is required to make the example work in the first place.

### Motivation

Two hours of struggle.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

I only updated one example.
