### PR TITLE
Fix invalid string(int) instead of fmt.Sprint(int)

### DIFF
--- a/pkg/metrics/statsd_test.go
+++ b/pkg/metrics/statsd_test.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -36,11 +37,11 @@ func TestStatsD(t *testing.T) {
 	}
 
 	udp.ShouldReceiveAll(t, expected, func() {
-		statsdRegistry.ServiceReqsCounter().With("service", "test", "code", string(http.StatusOK), "method", http.MethodGet).Add(1)
-		statsdRegistry.ServiceReqsCounter().With("service", "test", "code", string(http.StatusNotFound), "method", http.MethodGet).Add(1)
+		statsdRegistry.ServiceReqsCounter().With("service", "test", "code", fmt.Sprint(http.StatusOK), "method", http.MethodGet).Add(1)
+		statsdRegistry.ServiceReqsCounter().With("service", "test", "code", fmt.Sprint(http.StatusNotFound), "method", http.MethodGet).Add(1)
 		statsdRegistry.ServiceRetriesCounter().With("service", "test").Add(1)
 		statsdRegistry.ServiceRetriesCounter().With("service", "test").Add(1)
-		statsdRegistry.ServiceReqDurationHistogram().With("service", "test", "code", string(http.StatusOK)).Observe(10000)
+		statsdRegistry.ServiceReqDurationHistogram().With("service", "test", "code", fmt.Sprint(http.StatusOK)).Observe(10000)
 		statsdRegistry.ConfigReloadsCounter().Add(1)
 		statsdRegistry.ConfigReloadsFailureCounter().Add(1)
 		statsdRegistry.EntryPointReqsCounter().With("entrypoint", "test").Add(1)
@@ -76,11 +77,11 @@ func TestStatsDWithPrefix(t *testing.T) {
 	}
 
 	udp.ShouldReceiveAll(t, expected, func() {
-		statsdRegistry.ServiceReqsCounter().With("service", "test", "code", string(http.StatusOK), "method", http.MethodGet).Add(1)
-		statsdRegistry.ServiceReqsCounter().With("service", "test", "code", string(http.StatusNotFound), "method", http.MethodGet).Add(1)
+		statsdRegistry.ServiceReqsCounter().With("service", "test", "code", fmt.Sprint(http.StatusOK), "method", http.MethodGet).Add(1)
+		statsdRegistry.ServiceReqsCounter().With("service", "test", "code", fmt.Sprint(http.StatusNotFound), "method", http.MethodGet).Add(1)
 		statsdRegistry.ServiceRetriesCounter().With("service", "test").Add(1)
 		statsdRegistry.ServiceRetriesCounter().With("service", "test").Add(1)
-		statsdRegistry.ServiceReqDurationHistogram().With("service", "test", "code", string(http.StatusOK)).Observe(10000)
+		statsdRegistry.ServiceReqDurationHistogram().With("service", "test", "code", fmt.Sprint(http.StatusOK)).Observe(10000)
 		statsdRegistry.ConfigReloadsCounter().Add(1)
 		statsdRegistry.ConfigReloadsFailureCounter().Add(1)
 		statsdRegistry.EntryPointReqsCounter().With("entrypoint", "test").Add(1)


### PR DESCRIPTION
### What does this PR do?

Fix a go vet reported issue.


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
