### PR TITLE
added mention of target address for prometheus

### DIFF
--- a/docs/content/observability/metrics/prometheus.md
+++ b/docs/content/observability/metrics/prometheus.md
@@ -16,6 +16,28 @@ metrics:
 --metrics.prometheus=true
 ```
 
+#### `address`
+
+_Required, Default="localhost:9090"_
+
+Address instructs exporter to send metrics to Prometheus at this address.
+
+```toml tab="File (TOML)"
+[metrics]
+  [metrics.prometheus]
+    address = "localhost:9090"
+```
+
+```yaml tab="File (YAML)"
+metrics:
+  prometheus:
+    address: localhost:9090
+```
+
+```bash tab="CLI"
+--metrics.prometheus.address=localhost:9090
+```
+
 #### `buckets`
 
 _Optional, Default="0.100000, 0.300000, 1.200000, 5.000000"_


### PR DESCRIPTION
there's no trace of a target address for the prometheus observable

not sure of that is by design by here's my proposed change of the documentation

<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes a "missing-documentation" occurence under the Prometheus Observability Tool
There is no mention of the target prometheus server (or port)


### Motivation

Missing/incorrect documentation should always be adressed


### More

- [x] Added/updated documentation

### Additional Notes

If there's something I'm missing in my PR I'm more than happy to fix it
