### PR TITLE
Update jaeger-client-go dependency to v2.25.0

### DIFF
--- a/docs/content/observability/tracing/jaeger.md
+++ b/docs/content/observability/tracing/jaeger.md
@@ -185,6 +185,29 @@ tracing:
 --tracing.jaeger.traceContextHeaderName=uber-trace-id
 ```
 
+### disableAttemptReconnecting
+
+_Optional, Default=true_
+
+Disable the UDP connection helper that periodically re-resolves the agent's hostname and reconnects if there was a change.
+Enabling the re-resolving of UDP address make the client more robust in Kubernetes deployments.
+
+```toml tab="File (TOML)"
+[tracing]
+  [tracing.jaeger]
+    disableAttemptReconnecting = false
+```
+
+```yaml tab="File (YAML)"
+tracing:
+  jaeger:
+    disableAttemptReconnecting: false
+```
+
+```bash tab="CLI"
+--tracing.jaeger.disableAttemptReconnecting=false
+```
+
 ### `collector`
 #### `endpoint`
 

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -858,6 +858,9 @@ Password for basic http authentication when sending spans to jaeger-collector.
 `--tracing.jaeger.collector.user`:  
 User for basic http authentication when sending spans to jaeger-collector.
 
+`--tracing.jaeger.disableattemptreconnecting`:  
+Disable the periodic re-resolution of the agent's hostname and reconnection if there was a change. (Default: ```true```)
+
 `--tracing.jaeger.gen128bit`:  
 Generate 128 bit span IDs. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -858,6 +858,9 @@ Password for basic http authentication when sending spans to jaeger-collector.
 `TRAEFIK_TRACING_JAEGER_COLLECTOR_USER`:  
 User for basic http authentication when sending spans to jaeger-collector.
 
+`TRAEFIK_TRACING_JAEGER_DISABLEATTEMPTRECONNECTING`:  
+Disable the periodic re-resolution of the agent's hostname and reconnection if there was a change. (Default: ```true```)
+
 `TRAEFIK_TRACING_JAEGER_GEN128BIT`:  
 Generate 128 bit span IDs. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -290,6 +290,7 @@
     gen128Bit = true
     propagation = "foobar"
     traceContextHeaderName = "foobar"
+    disableAttemptReconnecting = true
     [tracing.jaeger.collector]
       endpoint = "foobar"
       user = "foobar"

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -308,6 +308,7 @@ tracing:
     gen128Bit: true
     propagation: foobar
     traceContextHeaderName: foobar
+    disableAttemptReconnecting: true
     collector:
       endpoint: foobar
       user: foobar

--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/stvp/go-udp-testing v0.0.0-20191102171040-06b61409b154
 	github.com/tinylib/msgp v1.0.2 // indirect
 	github.com/traefik/paerser v0.1.0
-	github.com/uber/jaeger-client-go v2.22.1+incompatible
+	github.com/uber/jaeger-client-go v2.25.0+incompatible
 	github.com/uber/jaeger-lib v2.2.0+incompatible
 	github.com/unrolled/render v1.0.2
 	github.com/unrolled/secure v1.0.7

--- a/go.sum
+++ b/go.sum
@@ -704,8 +704,8 @@ github.com/transip/gotransip/v6 v6.0.2/go.mod h1:pQZ36hWWRahCUXkFWlx9Hs711gLd8J4
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/uber-go/atomic v1.3.2 h1:Azu9lPBWRNKzYXSIwRfgRuDuS0YKsK4NFhiQv98gkxo=
 github.com/uber-go/atomic v1.3.2/go.mod h1:/Ct5t2lcmbJ4OSe/waGBoaVvVqtO0bmtfVNex1PFV8g=
-github.com/uber/jaeger-client-go v2.22.1+incompatible h1:NHcubEkVbahf9t3p75TOCR83gdUHXjRJvjoBh1yACsM=
-github.com/uber/jaeger-client-go v2.22.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
+github.com/uber/jaeger-client-go v2.25.0+incompatible h1:IxcNZ7WRY1Y3G4poYlx24szfsn/3LvK9QHCq9oQw8+U=
+github.com/uber/jaeger-client-go v2.25.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.2.0+incompatible h1:MxZXOiR2JuoANZ3J6DE/U0kSFv/eJ/GfSYVCjK7dyaw=
 github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/unrolled/render v1.0.2 h1:dGS3EmChQP3yOi1YeFNO/Dx+MbWZhdvhQJTXochM5bs=

--- a/pkg/tracing/jaeger/jaeger.go
+++ b/pkg/tracing/jaeger/jaeger.go
@@ -17,14 +17,15 @@ const Name = "jaeger"
 
 // Config provides configuration settings for a jaeger tracer.
 type Config struct {
-	SamplingServerURL      string     `description:"Set the sampling server url." json:"samplingServerURL,omitempty" toml:"samplingServerURL,omitempty" yaml:"samplingServerURL,omitempty"`
-	SamplingType           string     `description:"Set the sampling type." json:"samplingType,omitempty" toml:"samplingType,omitempty" yaml:"samplingType,omitempty" export:"true"`
-	SamplingParam          float64    `description:"Set the sampling parameter." json:"samplingParam,omitempty" toml:"samplingParam,omitempty" yaml:"samplingParam,omitempty" export:"true"`
-	LocalAgentHostPort     string     `description:"Set jaeger-agent's host:port that the reporter will used." json:"localAgentHostPort,omitempty" toml:"localAgentHostPort,omitempty" yaml:"localAgentHostPort,omitempty"`
-	Gen128Bit              bool       `description:"Generate 128 bit span IDs." json:"gen128Bit,omitempty" toml:"gen128Bit,omitempty" yaml:"gen128Bit,omitempty" export:"true"`
-	Propagation            string     `description:"Which propagation format to use (jaeger/b3)." json:"propagation,omitempty" toml:"propagation,omitempty" yaml:"propagation,omitempty" export:"true"`
-	TraceContextHeaderName string     `description:"Set the header to use for the trace-id." json:"traceContextHeaderName,omitempty" toml:"traceContextHeaderName,omitempty" yaml:"traceContextHeaderName,omitempty" export:"true"`
-	Collector              *Collector `description:"Define the collector information" json:"collector,omitempty" toml:"collector,omitempty" yaml:"collector,omitempty" export:"true"`
+	SamplingServerURL          string     `description:"Set the sampling server url." json:"samplingServerURL,omitempty" toml:"samplingServerURL,omitempty" yaml:"samplingServerURL,omitempty"`
+	SamplingType               string     `description:"Set the sampling type." json:"samplingType,omitempty" toml:"samplingType,omitempty" yaml:"samplingType,omitempty" export:"true"`
+	SamplingParam              float64    `description:"Set the sampling parameter." json:"samplingParam,omitempty" toml:"samplingParam,omitempty" yaml:"samplingParam,omitempty" export:"true"`
+	LocalAgentHostPort         string     `description:"Set jaeger-agent's host:port that the reporter will used." json:"localAgentHostPort,omitempty" toml:"localAgentHostPort,omitempty" yaml:"localAgentHostPort,omitempty"`
+	Gen128Bit                  bool       `description:"Generate 128 bit span IDs." json:"gen128Bit,omitempty" toml:"gen128Bit,omitempty" yaml:"gen128Bit,omitempty" export:"true"`
+	Propagation                string     `description:"Which propagation format to use (jaeger/b3)." json:"propagation,omitempty" toml:"propagation,omitempty" yaml:"propagation,omitempty" export:"true"`
+	TraceContextHeaderName     string     `description:"Set the header to use for the trace-id." json:"traceContextHeaderName,omitempty" toml:"traceContextHeaderName,omitempty" yaml:"traceContextHeaderName,omitempty" export:"true"`
+	Collector                  *Collector `description:"Define the collector information" json:"collector,omitempty" toml:"collector,omitempty" yaml:"collector,omitempty" export:"true"`
+	DisableAttemptReconnecting bool       `description:"Disable the periodic re-resolution of the agent's hostname and reconnection if there was a change." json:"disableAttemptReconnecting,omitempty" toml:"disableAttemptReconnecting,omitempty" yaml:"disableAttemptReconnecting,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values.
@@ -36,6 +37,7 @@ func (c *Config) SetDefaults() {
 	c.Propagation = "jaeger"
 	c.Gen128Bit = false
 	c.TraceContextHeaderName = jaegercli.TraceContextHeaderName
+	c.DisableAttemptReconnecting = true
 }
 
 // Collector provides configuration settings for jaeger collector.
@@ -55,8 +57,9 @@ func (c *Collector) SetDefaults() {
 // Setup sets up the tracer.
 func (c *Config) Setup(componentName string) (opentracing.Tracer, io.Closer, error) {
 	reporter := &jaegercfg.ReporterConfig{
-		LogSpans:           true,
-		LocalAgentHostPort: c.LocalAgentHostPort,
+		LogSpans:                   true,
+		LocalAgentHostPort:         c.LocalAgentHostPort,
+		DisableAttemptReconnecting: c.DisableAttemptReconnecting,
 	}
 
 	if c.Collector != nil {


### PR DESCRIPTION
### What does this PR do?

This PR updates the `jaeger-client-go` dependency version to `v2.25.0`. 

This update allows the reconnection to the `jaeger-agent` when the connection is lost. As this new behaviour is listed as breaking in [v2.25.0](https://github.com/jaegertracing/jaeger-client-go/releases/tag/v2.25.0) a new tracing option for jaeger named `DisableAttemptReconnecting` defaulting to `true` has been introduced to be backward compatible.

### Motivation

Fixes #6093.

### More

- ~[ ] Added/updated tests~
- [x] Added/updated documentation

### Additional Notes

- Diff of `jaeger-client-go` https://github.com/jaegertracing/jaeger-client-go/compare/v2.22.1...v2.25.0



