### PR TITLE
docs: add missing apigroup to Kubernetes RBAC

### DIFF
--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-rbac.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-rbac.yml
@@ -16,6 +16,7 @@ rules:
       - watch
   - apiGroups:
       - extensions
+      - networking.k8s.io
     resources:
       - ingresses
       - ingressclasses


### PR DESCRIPTION
### What does this PR do?

This PR updates the documentation to add the missing `networking.k8s.io` `apiGroup` to the Kubernetes RBAC. This `apiGroup` is needed to work with the new `IngressClass` resource available since Kubernetes [v1.18](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/).

### Motivation

I've deployed Traefik `v2.3.0-rc3` on Kubernetes `v1.18` and the `Ingress` discovery was failing because of the missing `apiGroup`.

### More

- ~[ ] Added/updated tests~
- [X] Added/updated documentation