### PR TITLE
Added ARM64 job in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ dist: trusty
 
 git:
   depth: false
-
+arch:
+    - amd64
+    - arm64
 services:
   - docker
 


### PR DESCRIPTION
Travis-CI has added support for ARM64. Added ARM64 job in Travis-CI.

Signed-off-by: odidev <odidev@puresoftware.com>