### PR TITLE
Reorder migrations for v2 minor upgrades

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -1,16 +1,77 @@
 # Migration: Steps needed between the versions
 
-## v2.2.2 to v2.2.5
+## v2.0 to v2.1
 
-### InsecureSNI removal
+### Kubernetes CRD
 
-In `v2.2.2` we introduced a new flag (`insecureSNI`) which was available as a global option to disable domain fronting.
-Since `v2.2.5` this global option has been removed, and you should not use it anymore.
+In v2.1, a new Kubernetes CRD called `TraefikService` was added.
+While updating an installation to v2.1,
+one should apply that CRD, and update the existing `ClusterRole` definition to allow Traefik to use that CRD.
 
-### HostSNI rule matcher removal
+To add that CRD and enhance the permissions, following definitions need to be applied to the cluster.
 
-In `v2.2.2` we introduced a new rule matcher (`HostSNI`) which was allowing to match the Server Name Indication at the router level.
-Since `v2.2.5` this rule has been removed, and you should not use it anymore.
+```yaml tab="TraefikService"
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: traefikservices.traefik.containo.us
+
+spec:
+  group: traefik.containo.us
+  version: v1alpha1
+  names:
+    kind: TraefikService
+    plural: traefikservices
+    singular: traefikservice
+  scope: Namespaced
+```
+
+```yaml tab="ClusterRole"
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: traefik-ingress-controller
+
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+  - apiGroups:
+      - traefik.containo.us
+    resources:
+      - middlewares
+      - ingressroutes
+      - traefikservices
+      - ingressroutetcps
+      - tlsoptions
+    verbs:
+      - get
+      - list
+      - watch
+```
+
+After having both resources applied, Traefik will work properly.
 
 ## v2.1 to v2.2
 
@@ -242,75 +303,14 @@ providers:
 --providers.kubernetesIngress=true
 ```
 
-## v2.0 to v2.1
+## v2.2.2 to v2.2.5
 
-### Kubernetes CRD
+### InsecureSNI removal
 
-In v2.1, a new Kubernetes CRD called `TraefikService` was added.
-While updating an installation to v2.1,
-one should apply that CRD, and update the existing `ClusterRole` definition to allow Traefik to use that CRD.
+In `v2.2.2` we introduced a new flag (`insecureSNI`) which was available as a global option to disable domain fronting.
+Since `v2.2.5` this global option has been removed, and you should not use it anymore.
 
-To add that CRD and enhance the permissions, following definitions need to be applied to the cluster.
+### HostSNI rule matcher removal
 
-```yaml tab="TraefikService"
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: traefikservices.traefik.containo.us
-
-spec:
-  group: traefik.containo.us
-  version: v1alpha1
-  names:
-    kind: TraefikService
-    plural: traefikservices
-    singular: traefikservice
-  scope: Namespaced
-```
-
-```yaml tab="ClusterRole"
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: traefik-ingress-controller
-
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - services
-      - endpoints
-      - secrets
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses/status
-    verbs:
-      - update
-  - apiGroups:
-      - traefik.containo.us
-    resources:
-      - middlewares
-      - ingressroutes
-      - traefikservices
-      - ingressroutetcps
-      - tlsoptions
-    verbs:
-      - get
-      - list
-      - watch
-```
-
-After having both resources applied, Traefik will work properly.
+In `v2.2.2` we introduced a new rule matcher (`HostSNI`) which was allowing to match the Server Name Indication at the router level.
+Since `v2.2.5` this rule has been removed, and you should not use it anymore.

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -12,79 +12,6 @@ Since `v2.2.5` this global option has been removed, and you should not use it an
 In `v2.2.2` we introduced a new rule matcher (`HostSNI`) which was allowing to match the Server Name Indication at the router level.
 Since `v2.2.5` this rule has been removed, and you should not use it anymore.
 
-## v2.0 to v2.1
-
-### Kubernetes CRD
-
-In v2.1, a new Kubernetes CRD called `TraefikService` was added.
-While updating an installation to v2.1,
-one should apply that CRD, and update the existing `ClusterRole` definition to allow Traefik to use that CRD.
-
-To add that CRD and enhance the permissions, following definitions need to be applied to the cluster.
-
-```yaml tab="TraefikService"
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: traefikservices.traefik.containo.us
-
-spec:
-  group: traefik.containo.us
-  version: v1alpha1
-  names:
-    kind: TraefikService
-    plural: traefikservices
-    singular: traefikservice
-  scope: Namespaced
-```
-
-```yaml tab="ClusterRole"
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: traefik-ingress-controller
-
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - services
-      - endpoints
-      - secrets
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses/status
-    verbs:
-      - update
-  - apiGroups:
-      - traefik.containo.us
-    resources:
-      - middlewares
-      - ingressroutes
-      - traefikservices
-      - ingressroutetcps
-      - tlsoptions
-    verbs:
-      - get
-      - list
-      - watch
-```
-
-After having both resources applied, Traefik will work properly.
-
 ## v2.1 to v2.2
 
 ### Headers middleware: accessControlAllowOrigin
@@ -314,3 +241,76 @@ providers:
 --entryPoints.websecure.address=:443
 --providers.kubernetesIngress=true
 ```
+
+## v2.0 to v2.1
+
+### Kubernetes CRD
+
+In v2.1, a new Kubernetes CRD called `TraefikService` was added.
+While updating an installation to v2.1,
+one should apply that CRD, and update the existing `ClusterRole` definition to allow Traefik to use that CRD.
+
+To add that CRD and enhance the permissions, following definitions need to be applied to the cluster.
+
+```yaml tab="TraefikService"
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: traefikservices.traefik.containo.us
+
+spec:
+  group: traefik.containo.us
+  version: v1alpha1
+  names:
+    kind: TraefikService
+    plural: traefikservices
+    singular: traefikservice
+  scope: Namespaced
+```
+
+```yaml tab="ClusterRole"
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: traefik-ingress-controller
+
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+  - apiGroups:
+      - traefik.containo.us
+    resources:
+      - middlewares
+      - ingressroutes
+      - traefikservices
+      - ingressroutetcps
+      - tlsoptions
+    verbs:
+      - get
+      - list
+      - watch
+```
+
+After having both resources applied, Traefik will work properly.


### PR DESCRIPTION
### What does this PR do?

This change reorders the migrations for v2 to follow the releases from bottom to top. (Oldest migrations at the bottom, newer ones at the top.)

### Motivation

Currently, the order of migrations is: `2.2.2 -> 2.2.5`.  `2.0 -> 2.1`, `2.1 -> 2.2`
As someone wo is upgrading from 2.0 to 2.2, I can now follow the migrations one by one without checking the whole document, if there are other changes that might be important for the version skips I try to do.


### More

- [x] Updated documentation

