### PR TITLE
Add missing IPStrategy struct tag for YAML

### DIFF
--- a/docs/content/reference/dynamic-configuration/file.yaml
+++ b/docs/content/reference/dynamic-configuration/file.yaml
@@ -222,7 +222,7 @@ http:
       inFlightReq:
         amount: 42
         sourceCriterion:
-          ipstrategy:
+          ipStrategy:
             depth: 42
             excludedIPs:
             - foobar
@@ -259,7 +259,7 @@ http:
         period: 42
         burst: 42
         sourceCriterion:
-          ipstrategy:
+          ipStrategy:
             depth: 42
             excludedIPs:
             - foobar

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -300,7 +300,7 @@ type PassTLSClientCert struct {
 // If none are set, the default is to use the request's remote address field.
 // All fields are mutually exclusive.
 type SourceCriterion struct {
-	IPStrategy        *IPStrategy `json:"ipStrategy" toml:"ipStrategy, omitempty"`
+	IPStrategy        *IPStrategy `json:"ipStrategy,omitempty" toml:"ipStrategy,omitempty" yaml:"ipStrategy,omitempty"`
 	RequestHeaderName string      `json:"requestHeaderName,omitempty" toml:"requestHeaderName,omitempty" yaml:"requestHeaderName,omitempty"`
 	RequestHost       bool        `json:"requestHost,omitempty" toml:"requestHost,omitempty" yaml:"requestHost,omitempty"`
 }


### PR DESCRIPTION
### What does this PR do?

This PR:

- Adds a struct tag to the `IPStrategy` option for YAML. Without this tag, the deserialized option name must be `ipstrategy` which is not consistent with TOML, JSON and the documentation.

- Fixes the `IPStrategy` option name case in the file reference documentation.

### Motivation

Fixes #7129 

### More

- ~[ ] Added/updated tests~
- [x] Added/updated documentation
