### PR TITLE
make docker socket read only in quick-start

### DIFF
--- a/docs/content/getting-started/quick-start.md
+++ b/docs/content/getting-started/quick-start.md
@@ -25,7 +25,7 @@ services:
       - "8080:8080"
     volumes:
       # So that Traefik can listen to the Docker events
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock:ro
 ```
 
 **That's it. Now you can launch Traefik!**


### PR DESCRIPTION
Having write access to the host machine's docker.sock from inside a container can be used for privilege escalation and container outbreaks and should be avoided.

<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

It makes the docker socket read only from within traefiks container.


### Motivation

<!-- What inspired you to submit this pull request? -->
Security should matter :)


### More

- [ ] Added/updated tests
- [X ] Added/updated documentation

