### PR TITLE
feat: allows to change the Pilot URL in the web UI in dev mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ DOCKER_RUN_TRAEFIK_NOTTY := docker run $(INTEGRATION_OPTS) $(if $(DOCKER_NON_INT
 
 PRE_TARGET ?= build-dev-image
 
+PLATFORM_URL := $(if $(PLATFORM_URL),$(PLATFORM_URL),"https://pilot.traefik.io")
+
 default: binary
 
 ## Build Dev Docker image
@@ -53,7 +55,7 @@ dist:
 
 ## Build WebUI Docker image
 build-webui-image:
-	docker build -t traefik-webui -f webui/Dockerfile webui
+	docker build -t traefik-webui --build-arg ARG_PLATFORM_URL=$(PLATFORM_URL) -f webui/Dockerfile webui
 
 ## Generate WebUI
 generate-webui: build-webui-image

--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:12.18
 
 ENV WEBUI_DIR /src/webui
+ARG ARG_PLATFORM_URL=https://pilot.traefik.io
+ENV PLATFORM_URL=${ARG_PLATFORM_URL}
 RUN mkdir -p $WEBUI_DIR
 
 COPY package.json $WEBUI_DIR/


### PR DESCRIPTION
### What does this PR do?

Expose the PLATFORM_URL environment variable that was already used to configure the build of the webUI.
Now, a user can set it to target another Pilot environnement.

```sh
export PLATFORM_URL=https://pilot.traefik.io
```

Then compile as usual.

### Motivation

That helps debugging previews of the next Pilot version.