### PR TITLE
Improve documentation for usage of Kubernetes Ingress

### DIFF
--- a/docs/content/https/tls.md
+++ b/docs/content/https/tls.md
@@ -138,8 +138,9 @@ The TLS options allow one to configure some parameters of the TLS connection.
 
     When using the TLSOptions-CRD in Kubernetes, one might setup a default set of options that,
     if not explicitly overwritten, should apply to all ingresses. To achieve that, you'll have to
-    create a TLSOptions CR with the name `default` in the namespace `default`.
-    To explicitly use a different TLSOptions CR (and using the Kubernetes Ingress resources) you'll 
+    create a TLSOptions CR with the name `default`. There may exist only one TLSOption with the 
+    name `default` (across all namespaces) - otherwise they will be dropped.  
+    To explicitly use a different TLSOption (and using the Kubernetes Ingress resources) you'll 
     have to add an annotation to the Ingress in the following form:
     `traefik.ingress.kubernetes.io/router.tls.options: <resource-namespace>-<resource-name>@kubernetescrd`
 

--- a/docs/content/https/tls.md
+++ b/docs/content/https/tls.md
@@ -134,6 +134,15 @@ If no default certificate is provided, Traefik generates and uses a self-signed 
 
 The TLS options allow one to configure some parameters of the TLS connection.
 
+!!! important "TLSOptions in Kubernetes"
+
+    When using the TLSOptions-CRD in Kubernetes, one might setup a default set of options that,
+    if not explicitly overwritten, should apply to all ingresses. To achieve that, you'll have to
+    create a TLSOptions CR with the name `default` in the namespace `default`.
+    To explicitly use a different TLSOptions CR (and using the Kubernetes Ingress resources) you'll 
+    have to add an annotation to the Ingress in the following form:
+    "traefik.ingress.kubernetes.io/router.tls.options: <namespace-of-CR>-<name-of-CR>@kubernetescrd"
+
 ### Minimum TLS Version
 
 ```toml tab="File (TOML)"

--- a/docs/content/https/tls.md
+++ b/docs/content/https/tls.md
@@ -141,7 +141,7 @@ The TLS options allow one to configure some parameters of the TLS connection.
     create a TLSOptions CR with the name `default` in the namespace `default`.
     To explicitly use a different TLSOptions CR (and using the Kubernetes Ingress resources) you'll 
     have to add an annotation to the Ingress in the following form:
-    "traefik.ingress.kubernetes.io/router.tls.options: <namespace-of-CR>-<name-of-CR>@kubernetescrd"
+    `traefik.ingress.kubernetes.io/router.tls.options: <resource-namespace>-<resource-name>@kubernetescrd`
 
 ### Minimum TLS Version
 

--- a/docs/content/middlewares/overview.md
+++ b/docs/content/middlewares/overview.md
@@ -63,45 +63,6 @@ spec:
       - name: stripprefix
 ```
 
-```yaml tab="Kubernetes Ingress"
-# As a Kubernetes Ingress
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: middlewares.traefik.containo.us
-spec:
-  group: traefik.containo.us 
-  version: v1alpha1
-  names:
-    kind: Middleware
-    plural: middlewares
-    singular: middleware
-  scope: Namespaced
-
----
-apiVersion: traefik.containo.us/v1alpha1
-kind: Middleware
-metadata:
-  name: stripprefix
-  namespace: appspace
-spec:
-  stripPrefix:
-    prefixes:
-      - /stripit
-
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: ingress
-  namespace: appspace
-  annotations:
-    # annotation the form <middleware-k8s-namespace>-<middleware-name>@kubernetescrd
-    "traefik.ingress.kubernetes.io/router.middlewares": appspace-stripprefix@kubernetescrd
-spec:
-  # ... regular ingress definition
-```
-
 ```yaml tab="Consul Catalog"
 # Create a middleware named `foo-add-prefix`
 - "traefik.http.middlewares.foo-add-prefix.addprefix.prefix=/foo"
@@ -187,9 +148,9 @@ then you'll have to append to the middleware name, the `@` separator, followed b
     In this case, since the definition of the middleware is not in kubernetes,
     specifying a "kubernetes namespace" when referring to the resource does not make any sense,
     and therefore this specification would be ignored even if present.
-    On the other hand, if you declare the middleware as a CRD in Kubernetes and use the non-crd Ingress 
-    objects, you'll have to add the kubernetes namespace, the middleware lives in, to the annotation like
-    this `<middleware-namespace>-<middleware-name>@kubernetescrd`.
+    On the other hand, if you declare the middleware as a Custom Resource in Kubernetes and use the 
+    non-crd Ingress objects, you'll have to add the kubernetes namespace of the middleware to the 
+    annotation like this `<middleware-namespace>-<middleware-name>@kubernetescrd`.
 
 !!! abstract "Referencing a Middleware from Another Provider"
 
@@ -220,7 +181,7 @@ then you'll have to append to the middleware name, the `@` separator, followed b
         - "traefik.http.routers.my-container.middlewares=add-foo-prefix@file"
     ```
 
-    ```yaml tab="Kubernetes"
+    ```yaml tab="Kubernetes Ingress Route"
     apiVersion: traefik.containo.us/v1alpha1
     kind: IngressRoute
     metadata:
@@ -240,6 +201,31 @@ then you'll have to append to the middleware name, the `@` separator, followed b
             # namespace: bar
             # A namespace specification such as above is ignored
             # when the cross-provider syntax is used.
+    ```
+    
+    ```yaml tab="Kubernetes Ingress"
+    apiVersion: traefik.containo.us/v1alpha1
+    kind: Middleware
+    metadata:
+      name: stripprefix
+      namespace: appspace
+    spec:
+      stripPrefix:
+        prefixes:
+          - /stripit
+    
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: ingress
+      namespace: appspace
+      annotations:
+        # referencing a middleware from Kubernetes CRD provider: 
+        # <middleware-namespace>-<middleware-name>@kubernetescrd
+        "traefik.ingress.kubernetes.io/router.middlewares": appspace-stripprefix@kubernetescrd
+    spec:
+      # ... regular ingress definition
     ```
 
 ## Available Middlewares

--- a/docs/content/middlewares/overview.md
+++ b/docs/content/middlewares/overview.md
@@ -63,7 +63,7 @@ spec:
       - name: stripprefix
 ```
 
-```yaml tab="Kubernetes Ingress
+```yaml tab="Kubernetes Ingress"
 # As a Kubernetes Ingress
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -189,7 +189,7 @@ then you'll have to append to the middleware name, the `@` separator, followed b
     and therefore this specification would be ignored even if present.
     On the other hand, if you declare the middleware as a CRD in Kubernetes and use the non-crd Ingress 
     objects, you'll have to add the kubernetes namespace, the middleware lives in, to the annotation like
-    this "<middleware-namespace>-<middleware-name>@kubernetescrd".
+    this `<middleware-namespace>-<middleware-name>@kubernetescrd`.
 
 !!! abstract "Referencing a Middleware from Another Provider"
 


### PR DESCRIPTION
### What does this PR do?

Provide an example for the usage of a Middleware with Kubernetes Ingress, include the requirements for the annotations in these scenarios, and improve the documentation for the setup of default TLSOptions in k8s.

### Motivation

We had a hard time figuring out, how to setup Middlewares / TLSOptions with the "old" style Kubernetes Ingress after upgrading to v2.x.
As we do have a lot of projects in our clusters, we didn't want to force an update to CRD to function correctly. Therefore we needed the correct annotation-format and a default TLSOption working for all ingresses.  

### More

- [x] Added/updated documentation