### PR TITLE
Fix typo when comparing exported data

### DIFF
--- a/docs/content/contributing/data-collection.md
+++ b/docs/content/contributing/data-collection.md
@@ -85,7 +85,7 @@ Once a day (the first call begins 10 minutes after the start of Traefik), we col
     ca = "xxxx"
     cert = "xxxx"
     key = "xxxx"
-    insecureSkipVerify = false
+    insecureSkipVerify = true
 ```
 
 ## The Code for Data Collection


### PR DESCRIPTION
### What does this PR do?

Fix a typo in the documentation for what data is requested.

The diff for this PR isn't the best, but the default screen for this page (https://docs.traefik.io/contributing/data-collection/#example-of-collected-data) shows `insecureSkipVerify = true` in the original code, but `false` for the obfuscated. Looking at `anonymize.go`, I can't see anything which would result in a boolean flip, so I'm assuming this is a typo.

### Motivation

Typos = bad