### PR TITLE
Remove allocation with the use of the buffer pool

### DIFF
--- a/pkg/server/service/bufferpool.go
+++ b/pkg/server/service/bufferpool.go
@@ -23,5 +23,5 @@ func (b *bufferPool) Get() []byte {
 }
 
 func (b *bufferPool) Put(bytes []byte) {
-	b.pool.Put(bytes)
+	b.pool.Put(&bytes)
 }


### PR DESCRIPTION
More info: https://staticcheck.io/docs/checks#SA6002

### What does this PR do?
The current buffer pool is doing an unnecessary allocation. More info here: https://staticcheck.io/docs/checks#SA6002

### Motivation
Free performance improvement.