### PR TITLE
Add the ingressclass resource in the ingress RBAC documentation

### DIFF
--- a/docs/content/routing/providers/kubernetes-ingress.md
+++ b/docs/content/routing/providers/kubernetes-ingress.md
@@ -32,8 +32,10 @@ which in turn will create the resulting routers, services, handlers, etc.
           - watch
       - apiGroups:
           - extensions
+          - networking.k8s.io
         resources:
           - ingresses
+          - ingressclasses
         verbs:
           - get
           - list


### PR DESCRIPTION
### What does this PR do?

Add the ingressclass resource and the networking.k8s.io apiGroup to the RBAC.

### Motivation

Have an up to date documentation.

related to #7199 and #7083

### More

- [ ] ~Added/updated tests~
- [x] Added/updated documentation
