### PR TITLE
Make RouterName and ServiceName uniquely identifiable in k8s Ingress provider

### DIFF
--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -278,10 +278,10 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 					continue
 				}
 
-				serviceName := provider.Normalize(ingress.Namespace + "-" + pa.Backend.ServiceName + "-" + pa.Backend.ServicePort.String())
+				serviceName := provider.Normalize(ingress.Namespace) + "." + provider.Normalize(pa.Backend.ServiceName) + "." + provider.Normalize(pa.Backend.ServicePort.String())
 				conf.HTTP.Services[serviceName] = service
 
-				routerKey := strings.TrimPrefix(provider.Normalize(ingress.Name+"-"+ingress.Namespace+"-"+rule.Host+pa.Path), "-")
+				routerKey := strings.TrimPrefix(provider.Normalize(ingress.Namespace)+"."+provider.Normalize(ingress.Name)+"."+provider.Normalize(rule.Host+pa.Path), "-")
 				routers[routerKey] = append(routers[routerKey], loadRouter(rule, pa, rtConfig, serviceName))
 			}
 		}


### PR DESCRIPTION
### What does this PR do?

Since namespaces and service names are allowed to contain `-` in them, current RouterName and ServiceName do not uniquely identify the underlying resource. This PR tries to address that by using `.` instead of `-` as a separator, resulting in a unique mapping.

### Motivation

Currently, there is no clean way to identify the actual Ingress/Service an access log line belongs to.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
