### PR TITLE
acme: fix non-cluster mode

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -452,18 +452,19 @@ func (gc *GlobalConfiguration) InitACMEProvider() (*acmeprovider.Provider, error
 		if gc.Cluster == nil {
 			provider := &acmeprovider.Provider{}
 			provider.Configuration = &acmeprovider.Configuration{
-				KeyType:       gc.ACME.KeyType,
-				OnHostRule:    gc.ACME.OnHostRule,
-				OnDemand:      gc.ACME.OnDemand,
-				Email:         gc.ACME.Email,
-				Storage:       gc.ACME.Storage,
-				HTTPChallenge: gc.ACME.HTTPChallenge,
-				DNSChallenge:  gc.ACME.DNSChallenge,
-				TLSChallenge:  gc.ACME.TLSChallenge,
-				Domains:       gc.ACME.Domains,
-				ACMELogging:   gc.ACME.ACMELogging,
-				CAServer:      gc.ACME.CAServer,
-				EntryPoint:    gc.ACME.EntryPoint,
+				KeyType:        gc.ACME.KeyType,
+				OnHostRule:     gc.ACME.OnHostRule,
+				OnDemand:       gc.ACME.OnDemand,
+				Email:          gc.ACME.Email,
+				PreferredChain: gc.ACME.PreferredChain,
+				Storage:        gc.ACME.Storage,
+				HTTPChallenge:  gc.ACME.HTTPChallenge,
+				DNSChallenge:   gc.ACME.DNSChallenge,
+				TLSChallenge:   gc.ACME.TLSChallenge,
+				Domains:        gc.ACME.Domains,
+				ACMELogging:    gc.ACME.ACMELogging,
+				CAServer:       gc.ACME.CAServer,
+				EntryPoint:     gc.ACME.EntryPoint,
 			}
 
 			store := acmeprovider.NewLocalStore(provider.Storage)


### PR DESCRIPTION
### What does this PR do?

acme: fix non-cluster mode

### Motivation

Fixes #8500

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

```
Version:          3 (0x02)
Serial number:    xxx (0xXXXX)
Algorithm ID:     SHA256withRSA
Validity
  Not Before:     04/09/2020 00:00:00 (dd-mm-yyyy hh:mm:ss) (200904000000Z)
  Not After:      15/09/2025 16:00:00 (dd-mm-yyyy hh:mm:ss) (250915160000Z)
Issuer
  C  = US
  O  = Internet Security Research Group
  CN = ISRG Root X1
Subject
  C  = US
  O  = Let's Encrypt
  CN = R3
Public Key
  Algorithm:      RSA
  Length:         2048 bits
  Modulus:        xxxx
  Exponent:       65537 (0x10001)
Certificate Signature
  Algorithm:      SHA256withRSA
  Signature:      xxxx

Extensions
  keyUsage CRITICAL:
    digitalSignature,keyCertSign,cRLSign
  extKeyUsage :
    clientAuth, serverAuth
  basicConstraints CRITICAL:
    cA=true, pathLen=0
  subjectKeyIdentifier :
    xxxx
  authorityKeyIdentifier :
    kid=xxx
  authorityInfoAccess :
    caissuer: http://x1.i.lencr.org/
  cRLDistributionPoints :
    http://x1.c.lencr.org/
  certificatePolicies :
    policy oid: 2.23.140.1.2.1
    policy oid: 1.3.6.1.4.1.44947.1.1.1
```