### PR TITLE
fix: bug parsing weighted service provider name

### DIFF
--- a/webui/src/components/_commons/PanelWeightedServices.vue
+++ b/webui/src/components/_commons/PanelWeightedServices.vue
@@ -64,7 +64,7 @@ export default {
     },
     getProviderLogoPath (service) {
       const provider = this.getProvider(service)
-      const name = provider.name.toLowerCase()
+      const name = provider.toLowerCase()
 
       if (name.includes('plugin-')) {
         return 'statics/providers/plugin.svg'


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR handles the returned value from the `getProvider` function as a string instead of an object and now lists all services in an weighted service.

### Motivation

The weighted service list is currently empty empty due to the template trying to handle the value of the provider name as it was an object instead of an string. This throws an exception and therefore stops rendering the service and the list is never populated.


### Additional Notes

This bug only affects weighted services.