### PR TITLE
docs: clarify usage for cross provider references in Kubernetes ingress annotations

### DIFF
--- a/docs/content/routing/providers/kubernetes-ingress.md
+++ b/docs/content/routing/providers/kubernetes-ingress.md
@@ -209,6 +209,11 @@ which in turn will create the resulting routers, services, handlers, etc.
 
 ## Annotations
 
+!!! warning "Referencing resources in annotations"
+    
+    In an annotation, when referencing a resource defined by another provider,
+    the [provider namespace syntax](../../providers/overview.md#provider-namespace) must be used.
+
 #### On Ingress
 
 ??? info "`traefik.ingress.kubernetes.io/router.entrypoints`"
@@ -224,7 +229,7 @@ which in turn will create the resulting routers, services, handlers, etc.
     See [middlewares](../routers/index.md#middlewares) and [middlewares overview](../../middlewares/overview.md) for more information.
 
     ```yaml
-    traefik.ingress.kubernetes.io/router.middlewares: auth@file,prefix@kubernetescrd,cb@file
+    traefik.ingress.kubernetes.io/router.middlewares: auth@file,default-prefix@kubernetescrd
     ```
 
 ??? info "`traefik.ingress.kubernetes.io/router.priority`"
@@ -283,7 +288,7 @@ which in turn will create the resulting routers, services, handlers, etc.
     See [options](../routers/index.md#options) for more information.
 
     ```yaml
-    traefik.ingress.kubernetes.io/router.tls.options: foobar
+    traefik.ingress.kubernetes.io/router.tls.options: foobar@file
     ```
 
 #### On Service


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR clarifies the usage for cross-provider references in Kubernetes ingress annotations.

<!-- A brief description of the change being made with this pull request. -->


### Motivation

<!-- What inspired you to submit this pull request? -->
fixes #8534

### More

- [ ] ~Added/updated tests~
- [x] Added/updated documentation

