### PR TITLE
fix: do not validate shell script in node-modules folder

### DIFF
--- a/script/validate-shell-script.sh
+++ b/script/validate-shell-script.sh
@@ -12,10 +12,10 @@ then
         # The shellcheck command are run in background, to have an overview of the linter (instead of a fail at first issue)
         shellcheck "${script_to_check}" &
     done < <( # Search all the repository for sh and bash shebangs, excluding .js and .md files
-        # the folders ".git" and "vendor" are also ignored
+        # the folders ".git", "vendor" and "node_modules" are also ignored
         grep -rI '#!/' "${script_dir}"/.. \
         | grep 'sh' | grep -v '.js' | grep -v '.md' \
-        | grep -v '.git/' | grep -v 'vendor/' \
+        | grep -v '.git/' | grep -v 'vendor/'  | grep -v 'node_modules/' \
         | cut -d':' -f1
     )
     wait # Wait for all background command to be completed


### PR DESCRIPTION
### What does this PR do?

Ingnores the `node_modules` folder from `shellcheck` validation.

### Motivation

After installing node modules to build the web UI locally, `make validate` checks this folder for errors. As this is scripts that are not managed by this repo, these warning add noise when validating actual scripts.

### More

- ~~[ ] Added/updated tests~~
- ~~[ ] Added/updated documentation~~
