### PR TITLE
docs: remove non-working kind config in IngressRouteTCP/UDP examples

### DIFF
--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -146,8 +146,7 @@ The Kubernetes Ingress Controller, The Custom Resource Way.
       entryPoints:
         - udpep
       routes:
-      - kind: Rule
-        services:
+      - services:
           - name: whoamiudp
             port: 8080
     ```


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request removes the non-working `kind: Rule` configuration from the `IngressRouteTCP` and `IngressRouteUDP` examples.

For both resources the `kind` configuration property does not exist:
- https://github.com/traefik/traefik/blob/v2.5/pkg/provider/kubernetes/crd/traefik/v1alpha1/ingressroutetcp.go#L18
- https://github.com/traefik/traefik/blob/v2.5/pkg/provider/kubernetes/crd/traefik/v1alpha1/ingressrouteudp.go#L15

### Motivation

Related to https://github.com/traefik/traefik/issues/8466#issuecomment-951447844

### More

- [ ] Added/updated tests
- [X] Added/updated documentation

