### PR TITLE
docs: remove quotes in certificatesresolvers CLI examples

### DIFF
--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -560,7 +560,7 @@ certificatesResolvers:
 
 ```bash tab="CLI"
 # ...
---certificatesresolvers.myresolver.acme.preferredChain="ISRG Root X1"
+--certificatesresolvers.myresolver.acme.preferredChain=ISRG Root X1
 # ...
 ```
 
@@ -588,7 +588,7 @@ certificatesResolvers:
 
 ```bash tab="CLI"
 # ...
---certificatesresolvers.myresolver.acme.keyType="RSA4096"
+--certificatesresolvers.myresolver.acme.keyType=RSA4096
 # ...
 ```
 


### PR DESCRIPTION
quoting here does not work with CLI

(https://community.traefik.io/t/traefik-serving-lets-encrypt-legacy-chain-instead-of-lets-encrypt-modern-chain/11933)