### PR TITLE
Update mkdocs dependency to remove lock on jinja version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,6 @@
-mkdocs==1.2.2
+mkdocs==1.2.4
 pymdown-extensions==7.0
 mkdocs-bootswatch==1.0
 mkdocs-traefiklabs>=100.0.7
 markdown-include==0.5.1
 mkdocs-exclude==1.0.2
-Jinja2==3.0.0


### PR DESCRIPTION
### What does this PR do?

This PR updates the `mkdocs` version to fix the bug of `jinja` and remove the lock of `jinja` version.

### Motivation

Have a working doc and CI.

### More

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~

### Additional Notes

Follows https://github.com/mkdocs/mkdocs/pull/2800

There is no difference between assets generated by `mkdocs 1.2.2` and `mkdocs 1.2.4`.