### PR TITLE
IPWhiteList middleware: add the ability to configure custom body

### DIFF
--- a/docs/content/middlewares/http/ipwhitelist.md
+++ b/docs/content/middlewares/http/ipwhitelist.md
@@ -73,6 +73,10 @@ http:
 
 The `sourceRange` option sets the allowed IPs (or ranges of allowed IPs by using CIDR notation).
 
+### `errorBody`
+
+The `errorBody` option allows you to configure the message to return when an IP is unallowed (default to `Forbidden`).
+
 ### `ipStrategy`
 
 The `ipStrategy` option defines two parameters that set how Traefik determines the client IP: `depth`, and `excludedIPs`.

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -288,6 +288,7 @@ func (s *IPStrategy) Get() (ip.Strategy, error) {
 
 // IPWhiteList holds the ip white list configuration.
 type IPWhiteList struct {
+	ErrorBody   string      `json:"errorBody,omitempty" toml:"errorBody,omitempty" yaml:"errorBody,omitempty"`
 	SourceRange []string    `json:"sourceRange,omitempty" toml:"sourceRange,omitempty" yaml:"sourceRange,omitempty"`
 	IPStrategy  *IPStrategy `json:"ipStrategy,omitempty" toml:"ipStrategy,omitempty" yaml:"ipStrategy,omitempty"  label:"allowEmpty" file:"allowEmpty" kv:"allowEmpty" export:"true"`
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This commit adds a new "ErrorBody" option to the IPWhiteList middleware
which can be used to return a custom message when a request is unallowed.
The default behavior is unchanged.

### Motivation

The IPWhiteList middleware currently always returns the "Forbidden"
string when a request is unallowed.
I have some use cases where I would like to customize this error message.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

I also tested the change locally (built traefik and tried the option).

## Additional Notes

I cannot find how to generate the related Kubernetes CRD in order to add to it the new option. 