### PR TITLE
Use configured token in the Nomad client

### DIFF
--- a/docs/content/providers/nomad.md
+++ b/docs/content/providers/nomad.md
@@ -158,33 +158,6 @@ providers:
 # ...
 ```
 
-#### `datacenter`
-
-_Optional, Default=""_
-
-Defines the datacenter to use.
-If not provided in Traefik, Nomad uses the agent datacenter.
-
-```yaml tab="File (YAML)"
-providers:
-  nomad:
-    endpoint:
-      datacenter: dc1
-    # ...
-```
-
-```toml tab="File (TOML)"
-[providers.nomad]
-  [providers.nomad.endpoint]
-    datacenter = "dc1"
-    # ...
-```
-
-```bash tab="CLI"
---providers.nomad.endpoint.datacenter=dc1
-# ...
-```
-
 #### `token`
 
 _Optional, Default=""_
@@ -236,58 +209,6 @@ providers:
 ```bash tab="CLI"
 --providers.nomad.endpoint.endpointwaittime=15s
 # ...
-```
-
-#### `httpAuth`
-
-_Optional_
-
-Used to authenticate the HTTP client using HTTP Basic Authentication.
-
-##### `username`
-
-_Optional, Default=""_
-
-Username to use for HTTP Basic Authentication.
-
-```yaml tab="File (YAML)"
-providers:
-  nomad:
-    endpoint:
-      httpAuth:
-        username: admin
-```
-
-```toml tab="File (TOML)"
-[providers.nomad.endpoint.httpAuth]
-  username = "admin"
-```
-
-```bash tab="CLI"
---providers.nomad.endpoint.httpauth.username=admin
-```
-
-##### `password`
-
-_Optional, Default=""_
-
-Password to use for HTTP Basic Authentication.
-
-```yaml tab="File (YAML)"
-providers:
-  nomad:
-    endpoint:
-      httpAuth:
-        password: passw0rd
-```
-
-```toml tab="File (TOML)"
-[providers.nomad.endpoint.httpAuth]
-  password = "passw0rd"
-```
-
-```bash tab="CLI"
---providers.nomad.endpoint.httpauth.password=passw0rd
 ```
 
 #### `tls`

--- a/pkg/provider/nomad/nomad.go
+++ b/pkg/provider/nomad/nomad.go
@@ -164,9 +164,10 @@ func (p *Provider) loadConfiguration(ctx context.Context, configurationC chan<- 
 func createClient(namespace string, endpoint *EndpointConfig) (*api.Client, error) {
 	config := api.Config{
 		Address:   endpoint.Address,
-		Region:    endpoint.Region,
-		WaitTime:  time.Duration(endpoint.EndpointWaitTime),
 		Namespace: namespace,
+		Region:    endpoint.Region,
+		SecretID:  endpoint.Token,
+		WaitTime:  time.Duration(endpoint.EndpointWaitTime),
 	}
 
 	if endpoint.TLS != nil {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.7

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.7

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request fixes the non-working token configuration by configuring it as a `SecretID` in the Nomad API client. It also removes unexisting configuration options from the Nomad documentation (`datacenter` and `httpAuth`) 

### Motivation

To be able to use the `token` configuration option.

Fixes #9109

### More

- [ ] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
