### PR TITLE
mitigate race against server readiness in test

### DIFF
--- a/pkg/server/server_entrypoint_tcp_http3_test.go
+++ b/pkg/server/server_entrypoint_tcp_http3_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -112,6 +113,9 @@ func TestHTTP3AdvertisedPort(t *testing.T) {
 		InsecureSkipVerify: true,
 	})
 	require.NoError(t, err)
+
+	// We are racing with the http3Server readiness happening in the goroutine starting the entrypoint
+	time.Sleep(time.Second)
 
 	request, err := http.NewRequest(http.MethodGet, "https://127.0.0.1:8090", nil)
 	require.NoError(t, err)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.9
- for Traefik v3: use branch master

Bug fixes:
- for Traefik v2: use branch v2.9
- for Traefik v3: use branch master

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adds a Sleep in TestHTTP3AdvertisedPort, in order to wait for the http3 server (started in a concurrent goroutine) readiness.

<!-- A brief description of the change being made with this pull request. -->


### Motivation

TestHTTP3AdvertisedPort failing fairly often on the CI.

<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
~- [ ] Added/updated documentation~

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Co-authored-by: Romain <rtribotte@users.noreply.github.com>
