### PR TITLE
Remove hub configuration out of experimental

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -507,3 +507,7 @@ As the Kubernetes CRD provider still works with both API Versions (`traefik.io/v
 it means that for the same kind, namespace and name, the provider will only keep the `traefik.io/v1alpha1` resource.
 
 In addition, the Kubernetes CRDs API Version `traefik.io/v1alpha1` will not be supported in Traefik v3 itself.
+
+### Traefik Hub
+
+In `v2.10`, Traefik Hub is GA and the `experimental.hub` flag is deprecated.

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -452,7 +452,6 @@
 [experimental]
   kubernetesGateway = true
   http3 = true
-  hub = true
   [experimental.plugins]
     [experimental.plugins.Descriptor0]
       moduleName = "foobar"

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -476,7 +476,6 @@ hub:
 experimental:
   kubernetesGateway: true
   http3: true
-  hub: true
   plugins:
     Descriptor0:
       moduleName: foobar

--- a/docs/content/traefik-hub/index.md
+++ b/docs/content/traefik-hub/index.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Once the Traefik Hub Experimental feature is enabled in Traefik,
+Once the Traefik Hub feature is enabled in Traefik,
 Traefik and its local agent communicate together.
 
 This agent can:
@@ -27,7 +27,6 @@ This agent can:
 
     * Traefik Hub is compatible with Traefik Proxy 2.7 or later.
     * The Traefik Hub Agent must be installed to connect to the Traefik Hub platform.
-    * Activate this feature in the experimental section of the static configuration.
 
 !!! information "Configuration Discovery"
 
@@ -38,9 +37,6 @@ This agent can:
 !!! example "Minimal Static Configuration to Activate Traefik Hub for Docker"
 
     ```yaml tab="File (YAML)"
-    experimental:
-      hub: true
-
     hub:
       tls:
         insecure: true
@@ -51,9 +47,6 @@ This agent can:
     ```
 
     ```toml tab="File (TOML)"
-    [experimental]
-      hub = true
-
     [hub]
       [hub.tls]
         insecure = true
@@ -64,7 +57,6 @@ This agent can:
     ```
 
     ```bash tab="CLI"
-    --experimental.hub
     --hub.tls.insecure
     --metrics.prometheus.addrouterslabels
     ```
@@ -72,9 +64,6 @@ This agent can:
 !!! example "Minimal Static Configuration to Activate Traefik Hub for Kubernetes"
 
     ```yaml tab="File (YAML)"
-    experimental:
-      hub: true
-
     hub: {}
 
     metrics:
@@ -83,9 +72,6 @@ This agent can:
     ```
 
     ```toml tab="File (TOML)"
-    [experimental]
-      hub = true
-
     [hub]
 
     [metrics]
@@ -94,7 +80,6 @@ This agent can:
     ```
 
     ```bash tab="CLI"
-    --experimental.hub
     --hub
     --metrics.prometheus.addrouterslabels
     ```

--- a/pkg/config/static/experimental.go
+++ b/pkg/config/static/experimental.go
@@ -9,5 +9,6 @@ type Experimental struct {
 
 	KubernetesGateway bool `description:"Allow the Kubernetes gateway api provider usage." json:"kubernetesGateway,omitempty" toml:"kubernetesGateway,omitempty" yaml:"kubernetesGateway,omitempty" export:"true"`
 	HTTP3             bool `description:"Enable HTTP3." json:"http3,omitempty" toml:"http3,omitempty" yaml:"http3,omitempty" export:"true"`
-	Hub               bool `description:"Enable the Traefik Hub provider." json:"hub,omitempty" toml:"hub,omitempty" yaml:"hub,omitempty" export:"true"`
+	// Deprecated.
+	Hub bool `description:"Enable the Traefik Hub provider." json:"hub,omitempty" toml:"hub,omitempty" yaml:"hub,omitempty" export:"true"`
 }

--- a/pkg/config/static/hub.go
+++ b/pkg/config/static/hub.go
@@ -8,9 +8,8 @@ import (
 )
 
 func (c *Configuration) initHubProvider() error {
-	// Hub provider is an experimental feature. It requires the experimental flag to be enabled before continuing.
-	if c.Experimental == nil || !c.Experimental.Hub {
-		return errors.New("the experimental flag for Hub is not set")
+	if c.Experimental != nil && c.Experimental.Hub {
+		log.WithoutContext().Warn("Experimental flag for Traefik Hub is deprecated, because Traefik Hub is now GA.")
 	}
 
 	if _, ok := c.EntryPoints[hub.TunnelEntrypoint]; !ok {

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -229,7 +229,7 @@ func (c *Configuration) SetEffectiveConfiguration() {
 			c.Hub = nil
 			log.WithoutContext().Errorf("Unable to activate the Hub provider: %v", err)
 		} else {
-			log.WithoutContext().Debugf("Experimental Hub provider has been activated.")
+			log.WithoutContext().Debugf("Hub provider has been activated.")
 		}
 	}
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.9
- for Traefik v3: use branch master

Bug fixes:
- for Traefik v2: use branch v2.9
- for Traefik v3: use branch master

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fully moves Hub out of experimental, and therefore depreciates the `experimental.hub` option.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

Hub is now GA.
<!-- What inspired you to submit this pull request? -->

### More

~- [ ] Added/updated tests~
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Fixes #9769 

Co-authored-by: Romain <rtribotte@users.noreply.github.com>

