### PR TITLE
Enable Prometheus provider cleanup when only the router's metrics level is activated

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -298,7 +298,7 @@ func setupServer(staticConfiguration *static.Configuration) (*server.Server, err
 	watcher.AddListener(switchRouter(routerFactory, serverEntryPointsTCP, serverEntryPointsUDP))
 
 	// Metrics
-	if metricsRegistry.IsEpEnabled() || metricsRegistry.IsSvcEnabled() {
+	if metricsRegistry.IsEpEnabled() || metricsRegistry.IsRouterEnabled() || metricsRegistry.IsSvcEnabled() {
 		var eps []string
 		for key := range serverEntryPointsTCP {
 			eps = append(eps, key)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes the Prometheus provider cleanup mechanism by enabling it also when the router metrics level is activated.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

To enable Prometheus provider cleanup when only the router's metrics level is activated.
<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
Co-authored-by: Kevin Pollet <pollet.kevin@gmail.com>