### PR TITLE
docs: fix over-indented yaml configuration of access logs

### DIFF
--- a/docs/content/observability/access-logs.md
+++ b/docs/content/observability/access-logs.md
@@ -154,9 +154,9 @@ accessLog:
     headers:
       defaultMode: keep
       names:
-          User-Agent: redact
-          Authorization: drop
-          Content-Type: keep
+        User-Agent: redact
+        Authorization: drop
+        Content-Type: keep
 ```
 
 ```toml tab="File (TOML)"


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

The nested yaml is indented by 4 spaces instead of the standard 2 spaces

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
