### PR TITLE
Fix invalid version in docs about Gateway API on Traefik v3

### DIFF
--- a/docs/content/providers/kubernetes-gateway.md
+++ b/docs/content/providers/kubernetes-gateway.md
@@ -14,7 +14,7 @@ The Gateway API project is part of Kubernetes, working under SIG-NETWORK.
 The Kubernetes Gateway provider is a Traefik implementation of the [Gateway API](https://gateway-api.sigs.k8s.io/)
 specifications from the Kubernetes Special Interest Groups (SIGs).
 
-This provider is proposed as an experimental feature and partially supports the Gateway API [v0.4.0](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v0.4.0) specification.
+This provider is proposed as an experimental feature and partially supports Gateway API [v1.0.0](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.0.0) specification.
 
 !!! warning "Enabling The Experimental Kubernetes Gateway Provider"
 

--- a/docs/content/routing/providers/kubernetes-gateway.md
+++ b/docs/content/routing/providers/kubernetes-gateway.md
@@ -5,7 +5,8 @@ description: "The Kubernetes Gateway API can be used as a provider for routing a
 
 # Traefik & Kubernetes
 
-The Kubernetes Gateway API, The Experimental Way. {: .subtitle }
+The Kubernetes Gateway API, The Experimental Way.
+{: .subtitle }
 
 ## Configuration Examples
 


### PR DESCRIPTION
### What does this PR do?

Precise supported version of Gateway API in Traefik v3.

### Motivation

Up to date documentation.

### More

- [x] Added/updated documentation
