### PR TITLE
Fix HTTPRoute path type

### DIFF
--- a/docs/content/routing/providers/kubernetes-gateway.md
+++ b/docs/content/routing/providers/kubernetes-gateway.md
@@ -252,7 +252,7 @@ Kubernetes cluster before creating `HTTPRoute` objects.
 | [6]  | `rules`       | A list of HTTP matchers, filters and actions.                                                                                                                               |
 | [7]  | `matches`     | Conditions used for matching the rule against incoming HTTP requests. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. |
 | [8]  | `path`        | An HTTP request path matcher. If this field is not specified, a default prefix match on the "/" path is provided.                                                           |
-| [9]  | `type`        | Type of match against the path Value (supported types: `Exact`, `PathPrefix`, `RegularExpression`).                                                                         |
+| [9]  | `type`        | Type of match against the path Value (supported types: `Exact`, `PathPrefix`).                                                                                              |
 | [10] | `value`       | The value of the HTTP path to match against.                                                                                                                                |
 | [11] | `headers`     | Conditions to select a HTTP route by matching HTTP request headers.                                                                                                         |
 | [12] | `type`        | Type of match for the HTTP request header match against the `values` (supported types: `Exact`).                                                                            |


### PR DESCRIPTION
### What does this PR do?

Fix typo in the HTTPRoute documentation. Instead of valid path types being `Exact`, `Path`, the valid types are `Exact`, `PathPrefix`.


### Motivation

I got an error when following the documentation:
```
The HTTPRoute "http-app" is invalid: spec.rules[0].matches[0].path.type: Unsupported value: "Prefix": supported values: "Exact", "PathPrefix", "RegularExpression"
```


### More

- [ ] Added/updated tests
- [x] Added/updated documentation


### Additional Notes

`PathPrefix` matches the docs here: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/. So indeed it's the docs that were wrong, not the code.