### PR TITLE
Fix HTTPRoute use of backendRefs

### DIFF
--- a/docs/content/routing/providers/kubernetes-gateway.md
+++ b/docs/content/routing/providers/kubernetes-gateway.md
@@ -233,7 +233,7 @@ Kubernetes cluster before creating `HTTPRoute` objects.
             - headers:                          # [11]
                 name: foo                       # [12]
                 value: bar                      # [13]
-        - backendRefs:                          # [14]
+          backendRefs:                          # [14]
             - name: whoamitcp                   # [15]
               weight: 1                         # [16]
               port: 8080                        # [17]


### PR DESCRIPTION
### What does this PR do?

Fix yaml error in the documentation for creating an HTTPRoute resource. Specifically making `backendRefs` part of the same object containing `matches`, not a second object.


### Motivation

I closely followed the documentation and did not get the desired result.

Specifically, if creating a (slightly abbreviated) version of the documented resource, then fetching it back we can see that it doesn't create what one may expect:
```yaml
# manifest from documentation with dash before backendRefs
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: HTTPRoute
metadata:
  name: http-app
spec:
  parentRefs:
    - name: my-tcp-gateway
  rules:
    - matches:
        - path:
            type: Exact
            value: /bar
    - backendRefs:
        - name: whoamitcp
```
```yaml
# kubectl get httproutes http-app -o yaml  | yq .spec
parentRefs:
  - group: gateway.networking.k8s.io
    kind: Gateway
    name: my-tcp-gateway
rules:
  - matches:
      - path:
          type: Exact
          value: /bar
  - backendRefs:
      - group: ""
        kind: Service
        name: whoamitcp
        weight: 1
    matches:
      - path:
          type: PathPrefix
          value: /
```

It created two items under the `rules` block. The first with `Exact /bar` with no defined backend and the second with the (default) `PathPrefix /` and the whoamitcp service.

However after remove the extraneous `-`:
```yaml
# kubectl get httproutes http-app -o yaml  | yq .spec
parentRefs:
  - group: gateway.networking.k8s.io
    kind: Gateway
    name: my-tcp-gateway
rules:
  - backendRefs:
      - group: ""
        kind: Service
        name: whoamitcp
        weight: 1
    matches:
      - path:
          type: Exact
          value: /bar
```

Now there is a single `rules` entry with the expected `matches` filter and `backendRefs`

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
