### PR TITLE
Forward the correct status code when compression is disabled within the Brotli handler

### DIFF
--- a/pkg/middlewares/compress/brotli/brotli.go
+++ b/pkg/middlewares/compress/brotli/brotli.go
@@ -160,6 +160,7 @@ func (r *responseWriter) Write(p []byte) (int, error) {
 			}
 			if !found {
 				r.compressionDisabled = true
+				r.rw.WriteHeader(r.statusCode)
 				return r.rw.Write(p)
 			}
 		}
@@ -167,6 +168,7 @@ func (r *responseWriter) Write(p []byte) (int, error) {
 		for _, excludedContentType := range r.excludedContentTypes {
 			if excludedContentType.equals(mediaType, params) {
 				r.compressionDisabled = true
+				r.rw.WriteHeader(r.statusCode)
 				return r.rw.Write(p)
 			}
 		}

--- a/pkg/middlewares/compress/brotli/brotli_test.go
+++ b/pkg/middlewares/compress/brotli/brotli_test.go
@@ -356,7 +356,7 @@ func Test_ExcludedContentTypes(t *testing.T) {
 			h := mustNewWrapper(t, cfg)(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				rw.Header().Set(contentType, test.contentType)
 
-				rw.WriteHeader(http.StatusOK)
+				rw.WriteHeader(http.StatusAccepted)
 
 				_, err := rw.Write(bigTestBody)
 				require.NoError(t, err)
@@ -368,7 +368,7 @@ func Test_ExcludedContentTypes(t *testing.T) {
 			rw := httptest.NewRecorder()
 			h.ServeHTTP(rw, req)
 
-			assert.Equal(t, http.StatusOK, rw.Code)
+			assert.Equal(t, http.StatusAccepted, rw.Code)
 
 			if test.expCompression {
 				assert.Equal(t, "br", rw.Header().Get(contentEncoding))
@@ -460,7 +460,7 @@ func Test_IncludedContentTypes(t *testing.T) {
 			h := mustNewWrapper(t, cfg)(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				rw.Header().Set(contentType, test.contentType)
 
-				rw.WriteHeader(http.StatusOK)
+				rw.WriteHeader(http.StatusAccepted)
 
 				_, err := rw.Write(bigTestBody)
 				require.NoError(t, err)
@@ -472,7 +472,7 @@ func Test_IncludedContentTypes(t *testing.T) {
 			rw := httptest.NewRecorder()
 			h.ServeHTTP(rw, req)
 
-			assert.Equal(t, http.StatusOK, rw.Code)
+			assert.Equal(t, http.StatusAccepted, rw.Code)
 
 			if test.expCompression {
 				assert.Equal(t, "br", rw.Header().Get(contentEncoding))


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR makes the compress middleware pass the correct status code when compression is disabled within the Brotli handler.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

Fixes #10683 
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Kevin Pollet <pollet.kevin@gmail.com>
<!-- Anything else we should know when reviewing? -->
