### PR TITLE
Fix build only linux and darwin support wazergo

### DIFF
--- a/pkg/plugins/wasip.go
+++ b/pkg/plugins/wasip.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build linux || darwin
 
 package plugins
 

--- a/pkg/plugins/wasip_mock.go
+++ b/pkg/plugins/wasip_mock.go
@@ -1,4 +1,4 @@
-//go:build windows
+//go:build !linux && !darwin
 
 package plugins
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR changes build tags for the wazergo part of wasm because only darwin and linux support Wazergo.

### Motivation

Fix the build

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
