### PR TITLE
Add support multiple tls certificate stores

### DIFF
--- a/docs/content/https/tls.md
+++ b/docs/content/https/tls.md
@@ -57,6 +57,7 @@ In Traefik, certificates are grouped together in certificates stores, which are 
 tls:
   stores:
     default: {}
+    mystore: {}
 ```
 
 ```toml tab="File (TOML)"
@@ -64,12 +65,8 @@ tls:
 
 [tls.stores]
   [tls.stores.default]
+  [tls.stores.mystore]
 ```
-
-!!! important "Restriction"
-
-    Any store definition other than the default one (named `default`) will be ignored,
-    and there is therefore only one globally available TLS store.
 
 In the `tls.certificates` section, a list of stores can then be specified to indicate where the certificates should be stored:
 
@@ -82,6 +79,10 @@ tls:
       keyFile: /path/to/domain.key
       stores:
         - default
+    - certFile: /path/to/second-domain.cert
+      keyFile: /path/to/second-domain.key
+      stores:
+        - mystore
     # Note that since no store is defined,
     # the certificate below will be stored in the `default` store.
     - certFile: /path/to/other-domain.cert
@@ -97,15 +98,16 @@ tls:
   stores = ["default"]
 
 [[tls.certificates]]
+  certFile = "/path/to/second-domain.cert"
+  keyFile = "/path/to/second-domain.key"
+  stores = ["mystore"]
+
+[[tls.certificates]]
   # Note that since no store is defined,
   # the certificate below will be stored in the `default` store.
   certFile = "/path/to/other-domain.cert"
   keyFile = "/path/to/other-domain.key"
 ```
-
-!!! important "Restriction"
-
-    The `stores` list will actually be ignored and automatically set to `["default"]`.
 
 ### Default Certificate
 

--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -918,7 +918,7 @@ tls:
 
 !!! warning "Selecting a certificate for a wildcard domain from a specific store"
 
-If your rule uses a regular expression with `HostRegexp()`, for example, for wildcard domains, to correctly select the certificate in your `store`, you should specify the correct SNI in the `Host()` rule using the OR operator `||`.
+If your rule uses a regular expression with `HostRegexp()` for example for wildcard domains to correctly select the certificate in your `store` you should specify the correct SNI in the `Host()` rule using the OR operator `||`.
 
 ```yaml tab="File (YAML)"
 ## Dynamic configuration

--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -877,6 +877,69 @@ The [supported `provider` table](../../https/acme.md#providers) indicates if the
 !!! warning "Double Wildcard Certificates"
     It is not possible to request a double wildcard certificate for a domain (for example `*.*.local.com`).
 
+#### `store`
+
+You can specify the `store` for a particular [tls.stores](../../https/tls#certificates-stores) where the certificate will be searched. If not specified, `default` is used.
+
+```yaml tab="File (YAML)"
+## Dynamic configuration
+http:
+  routers:
+    routerbar:
+      rule: "Host(`www.example.com`)"
+      tls:
+        store: mystore
+tls:
+  stores:
+    mystore: {}
+  certificates:
+    - certFile: /path/to/www.example.com.cert
+      keyFile: /path/to/www.example.com.key
+      stores:
+        - mystore
+```
+
+```toml tab="File (TOML)"
+## Dynamic configuration
+[http.routers]
+  [http.routers.routerbar]
+    rule = "Host(`www.example.com`)" 
+  [http.routers.routerbar.tls]
+    store = "mystore"
+
+[tls.stores]
+  [tls.stores.mystore]
+  [[tls.certificates]]
+    certFile = "/path/to/domain.cert"
+    keyFile = "/path/to/domain.key"
+    stores = ["default"]
+
+```
+
+!!! warning "Selecting a certificate for a wildcard domain from a specific store"
+
+If your rule uses a regular expression with `HostRegexp()`, for example, for wildcard domains, to correctly select the certificate in your `store`, you should specify the correct SNI in the `Host()` rule using the OR operator `||`.
+
+```yaml tab="File (YAML)"
+## Dynamic configuration
+http:
+  routers:
+    routerbar:
+      rule: "HostRegexp(`^.+\.example\.com$`) || Host(`*.example.com`)"
+      tls:
+        store: mystore
+```
+
+```toml tab="File (TOML)"
+## Dynamic configuration
+[http.routers]
+  [http.routers.routerbar]
+    rule = "HostRegexp(`^.+\.example\.com$`) || Host(`*.example.com`)"
+  [http.routers.routerbar.tls]
+    store = "mystore"
+
+```
+
 ### Observability
 
 The Observability section defines a per router behavior regarding access-logs, metrics or tracing.

--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -918,7 +918,7 @@ tls:
 
 !!! warning "Selecting a certificate for a wildcard domain from a specific store"
 
-If your rule uses a regular expression with `HostRegexp()` for example for wildcard domains to correctly select the certificate in your `store` you should specify the correct SNI in the `Host()` rule using the OR operator `||`.
+If your rule uses a regular expression with `HostRegexp()` for example for wildcard domains to correctly select the certificate in your `store` you should specify the correct DNS Name in certificate for `Host()` rule using the OR operator `||`.
 
 ```yaml tab="File (YAML)"
 ## Dynamic configuration

--- a/pkg/config/dynamic/http_config.go
+++ b/pkg/config/dynamic/http_config.go
@@ -81,6 +81,7 @@ type RouterTLSConfig struct {
 	Options      string         `json:"options,omitempty" toml:"options,omitempty" yaml:"options,omitempty" export:"true"`
 	CertResolver string         `json:"certResolver,omitempty" toml:"certResolver,omitempty" yaml:"certResolver,omitempty" export:"true"`
 	Domains      []types.Domain `json:"domains,omitempty" toml:"domains,omitempty" yaml:"domains,omitempty" export:"true"`
+	Store        string         `json:"store,omitempty" toml:"store,omitempty" yaml:"store,omitempty" export:"true"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/config/dynamic/tcp_config.go
+++ b/pkg/config/dynamic/tcp_config.go
@@ -77,6 +77,7 @@ type RouterTCPTLSConfig struct {
 	Options      string         `json:"options,omitempty" toml:"options,omitempty" yaml:"options,omitempty" export:"true"`
 	CertResolver string         `json:"certResolver,omitempty" toml:"certResolver,omitempty" yaml:"certResolver,omitempty" export:"true"`
 	Domains      []types.Domain `json:"domains,omitempty" toml:"domains,omitempty" yaml:"domains,omitempty" export:"true"`
+	Store        string         `json:"store,omitempty" toml:"store,omitempty" yaml:"store,omitempty" export:"true"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -508,6 +508,11 @@ func (p *Provider) watchNewDomains(ctx context.Context) {
 						logger := rootLogger.With().Str(logs.RouterName, routerName).Str(logs.Rule, route.Rule).Logger()
 						ctxRouter := logger.WithContext(ctx)
 
+						if len(route.TLS.Store) > 0 && route.TLS.Store != traefiktls.DefaultTLSStoreName {
+							logger.Error().Msg("Router with certificate resolver can only use default store.")
+							continue
+						}
+
 						if len(route.TLS.Domains) > 0 {
 							domains := deleteUnnecessaryDomains(ctxRouter, route.TLS.Domains)
 							for _, domain := range domains {
@@ -543,6 +548,11 @@ func (p *Provider) watchNewDomains(ctx context.Context) {
 
 						logger := rootLogger.With().Str(logs.RouterName, routerName).Str(logs.Rule, route.Rule).Logger()
 						ctxRouter := logger.WithContext(ctx)
+
+						if len(route.TLS.Store) > 0 && route.TLS.Store != traefiktls.DefaultTLSStoreName {
+							logger.Error().Msg("Router with certificate resolver can only use default store.")
+							continue
+						}
 
 						if len(route.TLS.Domains) > 0 {
 							domains := deleteUnnecessaryDomains(ctxRouter, route.TLS.Domains)

--- a/pkg/server/router/router.go
+++ b/pkg/server/router/router.go
@@ -171,7 +171,11 @@ func (m *Manager) buildRouterHandler(ctx context.Context, routerName string, rou
 		if len(routerConfig.TLS.Options) > 0 && routerConfig.TLS.Options != tls.DefaultTLSConfigName {
 			tlsOptionsName = provider.GetQualifiedName(ctx, routerConfig.TLS.Options)
 		}
-		if _, err := m.tlsManager.Get(tls.DefaultTLSStoreName, tlsOptionsName); err != nil {
+		tlsStoreName := tls.DefaultTLSStoreName
+		if len(routerConfig.TLS.Store) > 0 && routerConfig.TLS.Store != tls.DefaultTLSStoreName {
+			tlsStoreName = routerConfig.TLS.Store
+		}
+		if _, err := m.tlsManager.Get(tlsStoreName, tlsOptionsName); err != nil {
 			return nil, fmt.Errorf("building router handler: %w", err)
 		}
 	}

--- a/pkg/server/router/tcp/manager.go
+++ b/pkg/server/router/tcp/manager.go
@@ -140,6 +140,11 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 			tlsOptionsName = provider.GetQualifiedName(ctxRouter, routerHTTPConfig.TLS.Options)
 		}
 
+		tlsStoreName := traefiktls.DefaultTLSStoreName
+		if len(routerHTTPConfig.TLS.Store) > 0 && routerHTTPConfig.TLS.Store != traefiktls.DefaultTLSStoreName {
+			tlsStoreName = routerHTTPConfig.TLS.Store
+		}
+
 		domains, err := httpmuxer.ParseDomains(routerHTTPConfig.Rule)
 		if err != nil {
 			routerErr := fmt.Errorf("invalid rule %s, error: %w", routerHTTPConfig.Rule, err)
@@ -185,7 +190,7 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 		// Even though the error is seemingly ignored (aside from logging it),
 		// we actually rely later on the fact that a tls config is nil (which happens when an error is returned) to take special steps
 		// when assigning a handler to a route.
-		tlsConf, tlsConfErr := m.tlsManager.Get(traefiktls.DefaultTLSStoreName, tlsOptionsName)
+		tlsConf, tlsConfErr := m.tlsManager.Get(tlsStoreName, tlsOptionsName)
 		if tlsConfErr != nil {
 			// Note: we do not call AddError here because we already did so when buildRouterHandler errored for the same reason.
 			logger.Error().Err(tlsConfErr).Send()

--- a/pkg/server/router/tcp/manager_test.go
+++ b/pkg/server/router/tcp/manager_test.go
@@ -3,7 +3,10 @@ package tcp
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
+	"fmt"
 	"math"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -16,7 +19,105 @@ import (
 	"github.com/traefik/traefik/v3/pkg/server/service/tcp"
 	tcp2 "github.com/traefik/traefik/v3/pkg/tcp"
 	traefiktls "github.com/traefik/traefik/v3/pkg/tls"
+	"github.com/traefik/traefik/v3/pkg/types"
 )
+
+// go run $GOROOT/src/crypto/tls/generate_cert.go --rsa-bits 1024 --host host1.localhost --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+var cert_host1 = `-----BEGIN CERTIFICATE-----
+MIIB/TCCAWagAwIBAgIRAOhIR/mwfLj9ddC2KoBFaOEwDQYJKoZIhvcNAQELBQAw
+EjEQMA4GA1UEChMHQWNtZSBDbzAgFw03MDAxMDEwMDAwMDBaGA8yMDg0MDEyOTE2
+MDAwMFowEjEQMA4GA1UEChMHQWNtZSBDbzCBnzANBgkqhkiG9w0BAQEFAAOBjQAw
+gYkCgYEA7erdwU+ofPewrmC7OYdDQhjkHVRiVtc+4kds4TGQ2CmAVyQrdc7nIQpg
+MbZNsmJdYic+FuVREl737h/pp7iXWvlQgSyvgJAQmEK8qeDoweHFrDocNEmgM+oJ
+O+Ca5tGjxGVEZxevT7QwEStuuQdEnj7/nMvU7ZDBk4Z/LpOaan0CAwEAAaNRME8w
+DgYDVR0PAQH/BAQDAgWgMBMGA1UdJQQMMAoGCCsGAQUFBwMBMAwGA1UdEwEB/wQC
+MAAwGgYDVR0RBBMwEYIPaG9zdDEubG9jYWxob3N0MA0GCSqGSIb3DQEBCwUAA4GB
+AGBlOAqoIdA0G80YXuIawkCTk1W+nB0sT7HYKp2v1xxMBsmYnHbYjNlL9hpXEoLw
+rMwASUy4Db0Xt20jd6ewQNR+VENQqo6wiqKlwWt6kunuPNfWseuKo2rcDTLwyb5R
+jSvmExRD+lBfoZgKa7PUvhUDEvf3jSycHpPqf7MeNq8e
+-----END CERTIFICATE-----`
+
+var key_host1 = `-----BEGIN PRIVATE KEY-----
+MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAO3q3cFPqHz3sK5g
+uzmHQ0IY5B1UYlbXPuJHbOExkNgpgFckK3XO5yEKYDG2TbJiXWInPhblURJe9+4f
+6ae4l1r5UIEsr4CQEJhCvKng6MHhxaw6HDRJoDPqCTvgmubRo8RlRGcXr0+0MBEr
+brkHRJ4+/5zL1O2QwZOGfy6Tmmp9AgMBAAECgYEAgVX7hTozovPXlYQ6Y3S3yHfV
+kmgsKX9LzSD8/JLAZfJxtW2RPrLijOCiGIQ9SqsUjuY8Z5/z6aO87jNlButfQ2X/
+apMydU/hkJJp1/My+Qls/gaU7x46cSE/J28juMrHdTZiQFDMrrlnmwdmKDTcfbOJ
+S1hXeasQMJkTN6IpXlUCQQDxdtiDyUggglQR5QnYFLa88fd2lEkNiI/eVZ3WHZMa
+E2GFcXYZTNztf++dSdMqbedIpFxK0rLfj8UcmV1fLIz/AkEA/D1cj20eV7GASKb5
+7PESThQ+WyHXy++i3piHsu6v2plYwEEmA/1DwqeQEbQHqdSiT5KJ3SwI6B8763KR
+8L28gwJBAJ+KrQh2aAfC1RV1xglVtmAlaCKbW6Frh9OZsk4VAGsMPzVSgHu7A4aR
+L5s3eiTgtR6UKr7tdG6uqch5tO37m7UCQBTeRsAe+PmsV76rAdZWg3suNZJ4lE/s
+/X6JBAELukTNlwgg27JMy8RY9JRiXpfwXZVTvFAuCnaZzu1Fx0kxiV0CQDyixsfy
+jNmT8Q7KRHpXoB6sY9wZ0AarhK7IosYLIUQrhJqSXJghKicbwLh9OUVHTeKxqZfy
+hM9atiJV5XjK1pk=
+-----END PRIVATE KEY-----`
+
+// go run $GOROOT/src/crypto/tls/generate_cert.go --rsa-bits 1024 --host host2.localhost --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+var cert_host2 = `-----BEGIN CERTIFICATE-----
+MIIB/DCCAWWgAwIBAgIQRVKz4/fbzTfCSgVlA3lCTzANBgkqhkiG9w0BAQsFADAS
+MRAwDgYDVQQKEwdBY21lIENvMCAXDTcwMDEwMTAwMDAwMFoYDzIwODQwMTI5MTYw
+MDAwWjASMRAwDgYDVQQKEwdBY21lIENvMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCB
+iQKBgQCjUNtZ2XWn0hx5E/MKeeG8a1pflbk2Ht323PFRTUd51UqyIEqX5hwOTZVO
+o2a+ngldDb/4JpYIICwZPnqzxy4OslhRJ9rxQsD0RbHhZKll+xtcjk+R4x1qFQ0b
+vFORIyMIn0NJcmQcurjaogf2pDxktEtAt6x1JVs5umz8BGJyCwIDAQABo1EwTzAO
+BgNVHQ8BAf8EBAMCBaAwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIw
+ADAaBgNVHREEEzARgg9ob3N0Mi5sb2NhbGhvc3QwDQYJKoZIhvcNAQELBQADgYEA
+ZXUUsRK3TlbqR0fgSr21PE0haDQ2LFIluoYDHfrVpa5mpZ4wQOGbBZ43dW1PCJiA
+lK12aFpXfGR4Rgq0Sbt5sInic8wCxmDetty5/V2nOoZszPMPjAcZy2fPm1pBtMzG
+suN1vhy3dlbA8erx5KooqRWhuyKEYm/TEYotf3TG9ig=
+-----END CERTIFICATE-----`
+
+var key_host2 = `-----BEGIN PRIVATE KEY-----
+MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAKNQ21nZdafSHHkT
+8wp54bxrWl+VuTYe3fbc8VFNR3nVSrIgSpfmHA5NlU6jZr6eCV0Nv/gmlgggLBk+
+erPHLg6yWFEn2vFCwPRFseFkqWX7G1yOT5HjHWoVDRu8U5EjIwifQ0lyZBy6uNqi
+B/akPGS0S0C3rHUlWzm6bPwEYnILAgMBAAECgYBkD/R1lpFJ46hiXuC4eHjgkv3q
+Nrgl+r+Qs0p/v9OdSBveC37olqp18P8cEW2wOPAPvY7zIeEm1V9vkCJp6A3FJGbJ
+49G4GDuQAdsD/HQvGuf7OdUnnF6/eybePMFmJP626QPyJBAM7T0ZZz8i0MQZf7qH
+zat6tXSwTN2d9s5o8QJBAMBt+5KU0STodm9oF/NfEKRSKZa2f4ARFhI+NAvFP943
+XI8QdfVYcwjrSXj3r2OWsY2pDz6awBJtXZICV44SYR8CQQDZRK9127G07vHCYKZ4
+XbRtp3WXhHUH7Ykhw+Rju+iyTh9b1Nt4cPZolkztlwRMUj5Qv+fmHpiYXwnirrBR
+W7WVAkEAnxJMBMBAo+IHBdFm+yh6+VtyRcRXYea9+Bazr4c/ZNMfEKTq3gZgEd9u
+vTEDK7BG1nQKxhXm8VS3JRwKhMdswQJBAI8xhpadwcRmyu15951S3Mx8VrMSuHMO
+KZgYXFkjCl0hwecrJa5+fNg3XuIj6tBGUA22PSdcOOQLlx9QVKJ6V/UCQFlzbeqy
+uQIoOEjHGc2A0hMdC3/sNbFjMYdLqQq6qVDg8qlUMCG6u/SYPhHKk5SaXSKYwyd3
+X6QbEQfMGrSqyQE=
+-----END PRIVATE KEY-----
+`
+
+// go run $GOROOT/src/crypto/tls/generate_cert.go --rsa-bits 1024 --host default.localhost --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+var cert_default = `-----BEGIN CERTIFICATE-----
+MIIB/zCCAWigAwIBAgIRAKJPixo/MCa37PCn2PW3bP8wDQYJKoZIhvcNAQELBQAw
+EjEQMA4GA1UEChMHQWNtZSBDbzAgFw03MDAxMDEwMDAwMDBaGA8yMDg0MDEyOTE2
+MDAwMFowEjEQMA4GA1UEChMHQWNtZSBDbzCBnzANBgkqhkiG9w0BAQEFAAOBjQAw
+gYkCgYEApWTEUs2fepJFD87OzdiBRg77S0vkWYs5xIOjfmFVfxd3td5e/qfJc30S
+P9al4+dlXFZJtTWn2sZnlKegufjz1X/MXQaT2PkO/rWsqtqyLOT8wzSxkmrr+cU1
+sM26wssYq3ppKBi5O7zSCDCfGlqh6eOq3FamPVa8jN+xypq8TgsCAwEAAaNTMFEw
+DgYDVR0PAQH/BAQDAgWgMBMGA1UdJQQMMAoGCCsGAQUFBwMBMAwGA1UdEwEB/wQC
+MAAwHAYDVR0RBBUwE4IRZGVmYXVsdC5sb2NhbGhvc3QwDQYJKoZIhvcNAQELBQAD
+gYEAeaOBAwzoxeG40zz1dYS/pUZNkMXY5gumfU6PqfDZXghptNxHCAM+9cs3Gdlm
+cQZt66pzcrzcMP4v2qWAFanm39FKi2p16cyWkL8/DZvD0bBhVdevTuv6KmwJ18e7
+qtWRP0kBW4sPZNJInIpPIcg4cwSs2XYCkE8X4GbJCU+Nwqo=
+-----END CERTIFICATE-----`
+
+var key_default = `-----BEGIN PRIVATE KEY-----
+MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAKVkxFLNn3qSRQ/O
+zs3YgUYO+0tL5FmLOcSDo35hVX8Xd7XeXv6nyXN9Ej/WpePnZVxWSbU1p9rGZ5Sn
+oLn489V/zF0Gk9j5Dv61rKrasizk/MM0sZJq6/nFNbDNusLLGKt6aSgYuTu80ggw
+nxpaoenjqtxWpj1WvIzfscqavE4LAgMBAAECgYBa1PRc5UBoeFwlSlaZBgY5C5FG
+0O8fni6jlgf8KEhj++dqoi1ZfZxNKKsVFDUW7MXl6B2iv0zoAX5xTX4fpHGENR9K
+xUvgcB+3VMm/1bavssAYpyWp6yJ/MOLu3GtCfYj9w/DWiQMf6DMZnNdWlUtqgUvs
+GrwYDf1rz0DuIuwEwQJBAMzfu9d1GtYu28HhcaGfws/N023eCIfTwct44FI9ibMV
+NChj2DGylbzBRjLOsaLRikHIcaCx3W6bRK+jad1qGLcCQQDOqtoqsP7rKvdG3MXx
+ullmf0HkFe9kzHdW++uD5T8tNopKWVaL+MIHcPcjTjGpSjOACgnuSSNZRKl0wm7S
+3xlNAkEAtk28a7vz1nU57as7nxN3mcxQgGpb8umWgAWeru+9cVLD59D41zhPj/f4
+DEvqu7Rzr5e6rMC5Bqw5kYT7NiArvwJBAJWMjNLXwZ/rN4TPvW1uq8K/0655MQJ/
+8tu+8G5BNbZCAVBL1ZT0LXO1CyFBNC6MwzekDAuiYTH3vagACrINPwECQEkqiEQz
+HB04vhQ+KbcUCS7W5bS0Lod9Sdp9YkBDM+ckE5JHmlaWQNhZ1f+91biazFPhBew2
+KaX80/KYL8o/4Jo=
+-----END PRIVATE KEY-----`
 
 func TestRuntimeConfiguration(t *testing.T) {
 	testCases := []struct {
@@ -142,6 +243,52 @@ func TestRuntimeConfiguration(t *testing.T) {
 						Rule:        "Host(`bar.foo`) && PathPrefix(`/path`)",
 						TLS: &dynamic.RouterTLSConfig{
 							Options: "bar",
+						},
+					},
+				},
+			},
+			expectedError: 2,
+		},
+		{
+			desc: "HTTP routers with same domain but different TLS store",
+			httpServiceConfig: map[string]*runtime.ServiceInfo{
+				"foo-service": {
+					Service: &dynamic.Service{
+						LoadBalancer: &dynamic.ServersLoadBalancer{
+							Servers: []dynamic.Server{
+								{
+									Port: "8085",
+									URL:  "127.0.0.1:8085",
+								},
+								{
+									URL:  "127.0.0.1:8086",
+									Port: "8086",
+								},
+							},
+						},
+					},
+				},
+			},
+			httpRouterConfig: map[string]*runtime.RouterInfo{
+				"foo": {
+					Router: &dynamic.Router{
+						EntryPoints: []string{"web"},
+						Service:     "foo-service",
+						Rule:        "Host(`bar.foo`)",
+						TLS: &dynamic.RouterTLSConfig{
+							Options: "foo",
+							Store:   "foo",
+						},
+					},
+				},
+				"bar": {
+					Router: &dynamic.Router{
+						EntryPoints: []string{"web"},
+						Service:     "foo-service",
+						Rule:        "Host(`bar.foo`) && PathPrefix(`/path`)",
+						TLS: &dynamic.RouterTLSConfig{
+							Options: "foo",
+							Store:   "bar",
 						},
 					},
 				},
@@ -687,6 +834,369 @@ func TestDomainFronting(t *testing.T) {
 			router.GetHTTPSHandler().ServeHTTP(rw, req)
 
 			assert.Equal(t, test.expectedStatus, rw.Code)
+		})
+	}
+}
+
+func TestStore(t *testing.T) {
+	entryPoints := []string{"web"}
+
+	mockBackend, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = mockBackend.Close()
+	})
+
+	go func() {
+		for {
+			conn, err := mockBackend.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}
+	}()
+
+	stores := map[string]traefiktls.Store{
+		"store1": {
+			DefaultCertificate: &traefiktls.Certificate{
+				CertFile: types.FileOrContent(cert_default),
+				KeyFile:  types.FileOrContent(key_default),
+			},
+		},
+		"store2": {
+			DefaultCertificate: &traefiktls.Certificate{
+				CertFile: types.FileOrContent(cert_default),
+				KeyFile:  types.FileOrContent(key_default),
+			},
+		},
+	}
+	certs := []*traefiktls.CertAndStores{
+		{
+			Stores: []string{"store1"},
+			Certificate: traefiktls.Certificate{
+				CertFile: types.FileOrContent(cert_host1),
+				KeyFile:  types.FileOrContent(key_host1),
+			},
+		},
+		{
+			Stores: []string{"store2"},
+			Certificate: traefiktls.Certificate{
+				CertFile: types.FileOrContent(cert_host2),
+				KeyFile:  types.FileOrContent(key_host2),
+			},
+		},
+	}
+
+	tests := []struct {
+		desc                      string
+		routers                   map[string]*runtime.RouterInfo
+		conf                      *runtime.Configuration
+		ServerName                string
+		expectedCertificateDomain string
+		expectedCommonName        string
+	}{
+		{
+			desc: "[HTTP] Use specific certificate store store1 with right certificate in it",
+			conf: &runtime.Configuration{
+				Routers: map[string]*runtime.RouterInfo{
+					"router-1@file": {
+						Router: &dynamic.Router{
+							EntryPoints: entryPoints,
+							Rule:        "Host(`host1.localhost`)",
+							TLS: &dynamic.RouterTLSConfig{
+								Store: "store1",
+							},
+						},
+					},
+					"router-2@file": {
+						Router: &dynamic.Router{
+							EntryPoints: entryPoints,
+							Rule:        "Host(`host2.localhost`)",
+							TLS: &dynamic.RouterTLSConfig{
+								Store: "store2",
+							},
+						},
+					},
+				},
+			},
+			ServerName:                "host1.localhost",
+			expectedCertificateDomain: "host1.localhost",
+		}, {
+			desc: "[HTTP] Use specific certificate store store2 with right certificate in it",
+			conf: &runtime.Configuration{
+				Routers: map[string]*runtime.RouterInfo{
+					"router-1@file": {
+						Router: &dynamic.Router{
+							EntryPoints: entryPoints,
+							Rule:        "Host(`host1.localhost`)",
+							TLS: &dynamic.RouterTLSConfig{
+								Store: "store1",
+							},
+						},
+					},
+					"router-2@file": {
+						Router: &dynamic.Router{
+							EntryPoints: entryPoints,
+							Rule:        "Host(`host2.localhost`)",
+							TLS: &dynamic.RouterTLSConfig{
+								Store: "store2",
+							},
+						},
+					},
+				},
+			},
+			ServerName:                "host2.localhost",
+			expectedCertificateDomain: "host2.localhost",
+		},
+		{
+			desc: "[HTTP] Use specific certificate store without right certificate in it",
+			conf: &runtime.Configuration{
+				Routers: map[string]*runtime.RouterInfo{
+					"router-1@file": {
+						Router: &dynamic.Router{
+							EntryPoints: entryPoints,
+							Rule:        "Host(`host1.localhost`)",
+							TLS: &dynamic.RouterTLSConfig{
+								Store: "store2",
+							},
+						},
+					},
+					"router-2@file": {
+						Router: &dynamic.Router{
+							EntryPoints: entryPoints,
+							Rule:        "Host(`host2.localhost`)",
+							TLS: &dynamic.RouterTLSConfig{
+								Store: "store2",
+							},
+						},
+					},
+				},
+			},
+			ServerName:                "host1.localhost",
+			expectedCertificateDomain: "default.localhost",
+		},
+		{
+			desc: "[HTTP] Multi-store on same SNI use default store.",
+			conf: &runtime.Configuration{
+				Routers: map[string]*runtime.RouterInfo{
+					"router-1@file": {
+						Router: &dynamic.Router{
+							EntryPoints: entryPoints,
+							Rule:        "Host(`host1.localhost`)",
+							TLS: &dynamic.RouterTLSConfig{
+								Store: "store1",
+							},
+						},
+					},
+					"router-2@file": {
+						Router: &dynamic.Router{
+							EntryPoints: entryPoints,
+							Rule:        "Host(`host1.localhost`)",
+							TLS: &dynamic.RouterTLSConfig{
+								Store: "store2",
+							},
+						},
+					},
+				},
+			},
+			ServerName:         "host1.localhost",
+			expectedCommonName: "TRAEFIK DEFAULT CERT",
+		},
+		{
+			desc: "[TCP] Use specific certificate store store1 with right certificate in it",
+			conf: &runtime.Configuration{
+				TCPServices: map[string]*runtime.TCPServiceInfo{
+					"mock@file": {
+						TCPService: &dynamic.TCPService{
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{{Address: mockBackend.Addr().String()}},
+							},
+						},
+					},
+				},
+				TCPRouters: map[string]*runtime.TCPRouterInfo{
+					"router-1@file": {
+						TCPRouter: &dynamic.TCPRouter{
+							EntryPoints: entryPoints,
+							Rule:        "HostSNI(`host1.localhost`)",
+							TLS: &dynamic.RouterTCPTLSConfig{
+								Store: "store1",
+							},
+							Service: "mock",
+						},
+					},
+					"router-2@file": {
+						TCPRouter: &dynamic.TCPRouter{
+							EntryPoints: entryPoints,
+							Rule:        "HostSNI(`host2.localhost`)",
+							TLS: &dynamic.RouterTCPTLSConfig{
+								Store: "store2",
+							},
+							Service: "mock",
+						},
+					},
+				},
+			},
+			ServerName:                "host1.localhost",
+			expectedCertificateDomain: "host1.localhost",
+		}, {
+			desc: "[TCP] Use specific certificate store store2 with right certificate in it",
+			conf: &runtime.Configuration{
+				TCPServices: map[string]*runtime.TCPServiceInfo{
+					"mock@file": {
+						TCPService: &dynamic.TCPService{
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{{Address: mockBackend.Addr().String()}},
+							},
+						},
+					},
+				},
+				TCPRouters: map[string]*runtime.TCPRouterInfo{
+					"router-1@file": {
+						TCPRouter: &dynamic.TCPRouter{
+							EntryPoints: entryPoints,
+							Rule:        "HostSNI(`host1.localhost`)",
+							TLS: &dynamic.RouterTCPTLSConfig{
+								Store: "store1",
+							},
+							Service: "mock",
+						},
+					},
+					"router-2@file": {
+						TCPRouter: &dynamic.TCPRouter{
+							EntryPoints: entryPoints,
+							Rule:        "HostSNI(`host2.localhost`)",
+							TLS: &dynamic.RouterTCPTLSConfig{
+								Store: "store2",
+							},
+							Service: "mock",
+						},
+					},
+				},
+			},
+			ServerName:                "host2.localhost",
+			expectedCertificateDomain: "host2.localhost",
+		},
+		{
+			desc: "[TCP] Use specific certificate store without right certificate in it",
+			conf: &runtime.Configuration{
+				TCPServices: map[string]*runtime.TCPServiceInfo{
+					"mock@file": {
+						TCPService: &dynamic.TCPService{
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{{Address: mockBackend.Addr().String()}},
+							},
+						},
+					},
+				},
+				TCPRouters: map[string]*runtime.TCPRouterInfo{
+					"router-1@file": {
+						TCPRouter: &dynamic.TCPRouter{
+							EntryPoints: entryPoints,
+							Rule:        "HostSNI(`host1.localhost`)",
+							TLS: &dynamic.RouterTCPTLSConfig{
+								Store: "store2",
+							},
+							Service: "mock",
+						},
+					},
+					"router-2@file": {
+						TCPRouter: &dynamic.TCPRouter{
+							EntryPoints: entryPoints,
+							Rule:        "HostSNI(`host2.localhost`)",
+							TLS: &dynamic.RouterTCPTLSConfig{
+								Store: "store2",
+							},
+							Service: "mock",
+						},
+					},
+				},
+			},
+			ServerName:                "host1.localhost",
+			expectedCertificateDomain: "default.localhost",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			dialerManager := tcp2.NewDialerManager(nil)
+			dialerManager.Update(map[string]*dynamic.TCPServersTransport{
+				"default@internal": &dynamic.TCPServersTransport{},
+			})
+			serviceManager := tcp.NewManager(test.conf, dialerManager)
+			tlsManager := traefiktls.NewManager()
+			tlsManager.UpdateConfigs(context.Background(), stores, map[string]traefiktls.Options{
+				"default": {
+					MinVersion: "VersionTLS13",
+				}}, certs)
+
+			httpsHandler := map[string]http.Handler{
+				"web": http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {}),
+			}
+
+			middlewaresBuilder := tcpmiddleware.NewBuilder(test.conf.TCPMiddlewares)
+
+			routerManager := NewManager(test.conf, serviceManager, middlewaresBuilder, nil, httpsHandler, tlsManager)
+
+			routers := routerManager.BuildHandlers(context.Background(), entryPoints)
+			router, ok := routers["web"]
+			require.True(t, ok)
+
+			// serverHTTP handler returns only the "HTTP" value as body for further checks.
+			serverHTTP := &http.Server{
+				Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				}),
+			}
+
+			ln, err := net.Listen("tcp", ":0")
+			require.NoError(t, err)
+
+			t.Cleanup(func() {
+				_ = ln.Close()
+			})
+
+			forwarder := newHTTPForwarder(ln)
+			go func() {
+				// defer close(stoppedHTTP)
+				_ = serverHTTP.Serve(forwarder)
+			}()
+
+			router.SetHTTPSForwarder(forwarder)
+
+			go func() {
+				for {
+					conn, err := ln.Accept()
+					if err != nil {
+						return
+					}
+
+					tcpConn, ok := conn.(*net.TCPConn)
+					if !ok {
+						t.Error("not a write closer")
+					}
+
+					router.ServeTCP(tcpConn)
+				}
+			}()
+
+			_, port, err := net.SplitHostPort(ln.Addr().String())
+			require.NoError(t, err)
+
+			pool := x509.NewCertPool()
+			pool.AppendCertsFromPEM([]byte(cert_host1))
+			pool.AppendCertsFromPEM([]byte(cert_host2))
+			pool.AppendCertsFromPEM([]byte(cert_default))
+
+			conn, err := tls.Dial("tcp", fmt.Sprintf("127.0.0.1:%s", port), &tls.Config{ServerName: test.ServerName, RootCAs: pool, InsecureSkipVerify: true})
+			require.NoError(t, err)
+
+			if len(test.expectedCertificateDomain) > 0 {
+				require.Equal(t, test.expectedCertificateDomain, conn.ConnectionState().PeerCertificates[0].DNSNames[0])
+			}
+			if len(test.expectedCommonName) > 0 {
+				require.Equal(t, test.expectedCommonName, conn.ConnectionState().PeerCertificates[0].Subject.CommonName)
+			}
 		})
 	}
 }

--- a/pkg/server/router/tcp/router.go
+++ b/pkg/server/router/tcp/router.go
@@ -5,10 +5,13 @@ import (
 	"bytes"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"regexp"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/go-acme/lego/v4/challenge/tlsalpn01"
@@ -292,6 +295,10 @@ func (r *Router) SetHTTPSForwarder(handler tcp.Handler) {
 		}
 
 		rule := "HostSNI(`" + sniHost + "`)"
+		if sniHost != "*" && strings.Count(sniHost, "*") > 0 {
+			sniHost = strings.Replace(regexp.QuoteMeta(sniHost), `\*\.`, `[a-z0-9-\.]+\.`, 1)
+			rule = fmt.Sprintf("HostSNIRegexp(`^%s$`)", sniHost)
+		}
 		if err := r.muxerHTTPS.AddRoute(rule, "", tcpmuxer.GetRulePriority(rule), tcpHandler); err != nil {
 			log.Error().Err(err).Msg("Error while adding route for host")
 		}


### PR DESCRIPTION
### What does this PR do?

Resolve https://github.com/traefik/traefik/issues/4756

### Motivation

The current functionality does not satisfy our requirements. We use traefik on nodes where clients can upload their certificates, if all certificates are in 1 namespace, then 1 client can spoil the environment of another by uploading a certificate with the same CN.


### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
