### PR TITLE
Support HostRegexp as basis for TLSOptions

### DIFF
--- a/pkg/middlewares/snicheck/snicheck.go
+++ b/pkg/middlewares/snicheck/snicheck.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"github.com/traefik/traefik/v3/pkg/middlewares/requestdecorator"
-	"github.com/traefik/traefik/v3/pkg/muxer/tcp"
 	traefiktls "github.com/traefik/traefik/v3/pkg/tls"
 )
 
@@ -23,14 +22,9 @@ type SNICheck struct {
 func New(tlsOptionsForHost map[string]string, tlsOptionsForHostRegexp map[string]string, next http.Handler) *SNICheck {
 	tlsOptionsForHostRegex := make(map[*regexp.Regexp]string)
 	for hostRegexp, tlsOptions := range tlsOptionsForHostRegexp {
-		preparePattern, err := tcp.PreparePattern(hostRegexp)
+		re, err := regexp.Compile(hostRegexp)
 		if err != nil {
-			log.Error().Err(err).Str("hostRegexp", hostRegexp).Msg("Failed to prepare pattern")
-			continue
-		}
-		re, err := regexp.Compile(preparePattern)
-		if err != nil {
-			log.Error().Err(err).Str("host", hostRegexp).Str("pattern", preparePattern).Msg("Failed to compile regex")
+			log.Error().Err(err).Str("hostRegexp", hostRegexp).Msg("Failed to compile regex")
 			continue
 		}
 		tlsOptionsForHostRegex[re] = tlsOptions

--- a/pkg/middlewares/snicheck/snicheck.go
+++ b/pkg/middlewares/snicheck/snicheck.go
@@ -1,7 +1,6 @@
 package snicheck
 
 import (
-	"github.com/traefik/traefik/v3/pkg/muxer/tcp"
 	"net"
 	"net/http"
 	"regexp"
@@ -9,6 +8,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"github.com/traefik/traefik/v3/pkg/middlewares/requestdecorator"
+	"github.com/traefik/traefik/v3/pkg/muxer/tcp"
 	traefiktls "github.com/traefik/traefik/v3/pkg/tls"
 )
 

--- a/pkg/middlewares/snicheck/snicheck.go
+++ b/pkg/middlewares/snicheck/snicheck.go
@@ -1,8 +1,10 @@
 package snicheck
 
 import (
+	"github.com/traefik/traefik/v3/pkg/muxer/tcp"
 	"net"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -12,13 +14,28 @@ import (
 
 // SNICheck is an HTTP handler that checks whether the TLS configuration for the server name is the same as for the host header.
 type SNICheck struct {
-	next              http.Handler
-	tlsOptionsForHost map[string]string
+	next                   http.Handler
+	tlsOptionsForHost      map[string]string
+	tlsOptionsForHostRegex map[*regexp.Regexp]string
 }
 
 // New creates a new SNICheck.
-func New(tlsOptionsForHost map[string]string, next http.Handler) *SNICheck {
-	return &SNICheck{next: next, tlsOptionsForHost: tlsOptionsForHost}
+func New(tlsOptionsForHost map[string]string, tlsOptionsForHostRegexp map[string]string, next http.Handler) *SNICheck {
+	tlsOptionsForHostRegex := make(map[*regexp.Regexp]string)
+	for hostRegexp, tlsOptions := range tlsOptionsForHostRegexp {
+		preparePattern, err := tcp.PreparePattern(hostRegexp)
+		if err != nil {
+			log.Error().Err(err).Str("hostRegexp", hostRegexp).Msg("Failed to prepare pattern")
+			continue
+		}
+		re, err := regexp.Compile(preparePattern)
+		if err != nil {
+			log.Error().Err(err).Str("host", hostRegexp).Str("pattern", preparePattern).Msg("Failed to compile regex")
+			continue
+		}
+		tlsOptionsForHostRegex[re] = tlsOptions
+	}
+	return &SNICheck{next: next, tlsOptionsForHost: tlsOptionsForHost, tlsOptionsForHostRegex: tlsOptionsForHostRegex}
 }
 
 func (s SNICheck) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
@@ -32,8 +49,8 @@ func (s SNICheck) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	// Domain Fronting
 	if !strings.EqualFold(host, serverName) {
-		tlsOptionHeader := findTLSOptionName(s.tlsOptionsForHost, host, true)
-		tlsOptionSNI := findTLSOptionName(s.tlsOptionsForHost, serverName, false)
+		tlsOptionHeader := s.findTLSOptionName(host, true)
+		tlsOptionSNI := s.findTLSOptionName(serverName, false)
 
 		if tlsOptionHeader != tlsOptionSNI {
 			log.Debug().
@@ -68,13 +85,13 @@ func getHost(req *http.Request) string {
 	return strings.TrimSpace(host)
 }
 
-func findTLSOptionName(tlsOptionsForHost map[string]string, host string, fqdn bool) string {
-	name := findTLSOptName(tlsOptionsForHost, host, fqdn)
+func (s SNICheck) findTLSOptionName(host string, fqdn bool) string {
+	name := s.findTLSOptName(host, fqdn)
 	if name != "" {
 		return name
 	}
 
-	name = findTLSOptName(tlsOptionsForHost, strings.ToLower(host), fqdn)
+	name = s.findTLSOptName(strings.ToLower(host), fqdn)
 	if name != "" {
 		return name
 	}
@@ -82,9 +99,15 @@ func findTLSOptionName(tlsOptionsForHost map[string]string, host string, fqdn bo
 	return traefiktls.DefaultTLSConfigName
 }
 
-func findTLSOptName(tlsOptionsForHost map[string]string, host string, fqdn bool) string {
-	if tlsOptions, ok := tlsOptionsForHost[host]; ok {
+func (s SNICheck) findTLSOptName(host string, fqdn bool) string {
+	if tlsOptions, ok := s.tlsOptionsForHost[host]; ok {
 		return tlsOptions
+	}
+
+	for regexp, tlsOptions := range s.tlsOptionsForHostRegex {
+		if regexp.MatchString(host) {
+			return tlsOptions
+		}
 	}
 
 	if !fqdn {
@@ -92,15 +115,28 @@ func findTLSOptName(tlsOptionsForHost map[string]string, host string, fqdn bool)
 	}
 
 	if last := len(host) - 1; last >= 0 && host[last] == '.' {
-		if tlsOptions, ok := tlsOptionsForHost[host[:last]]; ok {
+		if tlsOptions, ok := s.tlsOptionsForHost[host[:last]]; ok {
 			return tlsOptions
+		}
+
+		for regexp, tlsOptions := range s.tlsOptionsForHostRegex {
+			if regexp.MatchString(host[:last]) {
+				return tlsOptions
+			}
 		}
 
 		return ""
 	}
 
-	if tlsOptions, ok := tlsOptionsForHost[host+"."]; ok {
+	hostFqdn := host + "."
+	if tlsOptions, ok := s.tlsOptionsForHost[hostFqdn]; ok {
 		return tlsOptions
+	}
+
+	for regexp, tlsOptions := range s.tlsOptionsForHostRegex {
+		if regexp.MatchString(hostFqdn) {
+			return tlsOptions
+		}
 	}
 
 	return ""

--- a/pkg/muxer/tcp/matcher_v2.go
+++ b/pkg/muxer/tcp/matcher_v2.go
@@ -132,7 +132,7 @@ func hostSNIRegexpV2(tree *matchersTree, templates ...string) error {
 	var regexps []*regexp.Regexp
 
 	for _, template := range templates {
-		preparedPattern, err := PreparePattern(template)
+		preparedPattern, err := preparePattern(template)
 		if err != nil {
 			return fmt.Errorf("invalid pattern value for \"HostSNIRegexp\" matcher, %q is not a valid pattern: %w", template, err)
 		}
@@ -158,10 +158,10 @@ func hostSNIRegexpV2(tree *matchersTree, templates ...string) error {
 	return nil
 }
 
-// PreparePattern builds a regexp pattern from the initial user defined expression.
+// preparePattern builds a regexp pattern from the initial user defined expression.
 // This function reuses the code dedicated to host matching of the newRouteRegexp func from the gorilla/mux library.
 // https://github.com/containous/mux/tree/8ffa4f6d063c1e2b834a73be6a1515cca3992618.
-func PreparePattern(template string) (string, error) {
+func preparePattern(template string) (string, error) {
 	// Check if it is well-formed.
 	idxs, errBraces := braceIndices(template)
 	if errBraces != nil {

--- a/pkg/muxer/tcp/matcher_v2.go
+++ b/pkg/muxer/tcp/matcher_v2.go
@@ -132,7 +132,7 @@ func hostSNIRegexpV2(tree *matchersTree, templates ...string) error {
 	var regexps []*regexp.Regexp
 
 	for _, template := range templates {
-		preparedPattern, err := preparePattern(template)
+		preparedPattern, err := PreparePattern(template)
 		if err != nil {
 			return fmt.Errorf("invalid pattern value for \"HostSNIRegexp\" matcher, %q is not a valid pattern: %w", template, err)
 		}
@@ -158,10 +158,10 @@ func hostSNIRegexpV2(tree *matchersTree, templates ...string) error {
 	return nil
 }
 
-// preparePattern builds a regexp pattern from the initial user defined expression.
+// PreparePattern builds a regexp pattern from the initial user defined expression.
 // This function reuses the code dedicated to host matching of the newRouteRegexp func from the gorilla/mux library.
 // https://github.com/containous/mux/tree/8ffa4f6d063c1e2b834a73be6a1515cca3992618.
-func preparePattern(template string) (string, error) {
+func PreparePattern(template string) (string, error) {
 	// Check if it is well-formed.
 	idxs, errBraces := braceIndices(template)
 	if errBraces != nil {

--- a/pkg/server/router/tcp/manager_test.go
+++ b/pkg/server/router/tcp/manager_test.go
@@ -603,6 +603,33 @@ func TestDomainFronting(t *testing.T) {
 			expectedStatus: http.StatusOK,
 		},
 		{
+			desc: "Request is OK when Host is matched by HostRegexp and TLS options are different",
+			routers: map[string]*runtime.RouterInfo{
+				"router-1@file": {
+					Router: &dynamic.Router{
+						EntryPoints: entryPoints,
+						Rule:        "HostRegexp(`.*.local`)",
+						TLS: &dynamic.RouterTLSConfig{
+							Options: "host1@file",
+						},
+					},
+				},
+				"router-2@crd": {
+					Router: &dynamic.Router{
+						EntryPoints: entryPoints,
+						Rule:        "Host(`host2.local`)",
+						TLS: &dynamic.RouterTLSConfig{
+							Options: "host1@crd",
+						},
+					},
+				},
+			},
+			tlsOptions:     tlsOptionsBase,
+			host:           "other.local",
+			ServerName:     "other.local",
+			expectedStatus: http.StatusOK,
+		},
+		{
 			desc: "Request is misdirected when server name is empty and the host name is an FQDN, but router's rule is not",
 			routers: map[string]*runtime.RouterInfo{
 				"router-1@file": {

--- a/pkg/server/router/tcp/router.go
+++ b/pkg/server/router/tcp/router.go
@@ -249,15 +249,9 @@ func (r *Router) AddHTTPTLSConfig(sniHost string, config *tls.Config) {
 }
 
 func (r *Router) AddHTTPRegexpTLSConfig(hostRegexp string, config *tls.Config) {
-	preparePattern, err := tcpmuxer.PreparePattern(hostRegexp)
+	re, err := regexp.Compile(hostRegexp)
 	if err != nil {
-		log.Error().Err(err).Str("hostRegexp", hostRegexp).Msg("Failed to prepare pattern")
-		return
-	}
-
-	re, err := regexp.Compile(preparePattern)
-	if err != nil {
-		log.Error().Err(err).Str("host", hostRegexp).Str("pattern", preparePattern).Msg("Failed to compile regex")
+		log.Error().Err(err).Str("host", hostRegexp).Msg("Failed to compile regex")
 		return
 	}
 

--- a/pkg/server/router/tcp/router.go
+++ b/pkg/server/router/tcp/router.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"regexp"
 	"slices"
 	"time"
 
@@ -45,7 +46,8 @@ type Router struct {
 	httpsTLSConfig *tls.Config // default TLS config
 	// hostHTTPTLSConfig contains TLS configs keyed by SNI.
 	// A nil config is the hint to set up a brokenTLSRouter.
-	hostHTTPTLSConfig map[string]*tls.Config // TLS configs keyed by SNI
+	hostHTTPTLSConfig       map[string]*tls.Config         // TLS configs keyed by SNI
+	hostHTTPRegexpTLSConfig map[*regexp.Regexp]*tls.Config // TLS configs keyed by regexp
 }
 
 // NewRouter returns a new TCP router.
@@ -77,6 +79,12 @@ func (r *Router) GetTLSGetClientInfo() func(info *tls.ClientHelloInfo) (*tls.Con
 	return func(info *tls.ClientHelloInfo) (*tls.Config, error) {
 		if tlsConfig, ok := r.hostHTTPTLSConfig[info.ServerName]; ok {
 			return tlsConfig, nil
+		}
+
+		for re, tlsConfig := range r.hostHTTPRegexpTLSConfig {
+			if re.MatchString(info.ServerName) {
+				return tlsConfig, nil
+			}
 		}
 
 		return r.httpsTLSConfig, nil
@@ -240,6 +248,26 @@ func (r *Router) AddHTTPTLSConfig(sniHost string, config *tls.Config) {
 	r.hostHTTPTLSConfig[sniHost] = config
 }
 
+func (r *Router) AddHTTPRegexpTLSConfig(hostRegexp string, config *tls.Config) {
+	preparePattern, err := tcpmuxer.PreparePattern(hostRegexp)
+	if err != nil {
+		log.Error().Err(err).Str("hostRegexp", hostRegexp).Msg("Failed to prepare pattern")
+		return
+	}
+
+	re, err := regexp.Compile(preparePattern)
+	if err != nil {
+		log.Error().Err(err).Str("host", hostRegexp).Str("pattern", preparePattern).Msg("Failed to compile regex")
+		return
+	}
+
+	if r.hostHTTPRegexpTLSConfig == nil {
+		r.hostHTTPRegexpTLSConfig = map[*regexp.Regexp]*tls.Config{}
+	}
+
+	r.hostHTTPRegexpTLSConfig[re] = config
+}
+
 // GetConn creates a connection proxy with a peeked string.
 func (r *Router) GetConn(conn tcp.WriteCloser, peeked string) tcp.WriteCloser {
 	// TODO should it really be on Router ?
@@ -292,6 +320,23 @@ func (r *Router) SetHTTPSForwarder(handler tcp.Handler) {
 		}
 
 		rule := "HostSNI(`" + sniHost + "`)"
+		if err := r.muxerHTTPS.AddRoute(rule, "", tcpmuxer.GetRulePriority(rule), tcpHandler); err != nil {
+			log.Error().Err(err).Msg("Error while adding route for host")
+		}
+	}
+
+	for sniHostRegex, tlsConf := range r.hostHTTPRegexpTLSConfig {
+		var tcpHandler tcp.Handler
+		if tlsConf == nil {
+			tcpHandler = &brokenTLSRouter{}
+		} else {
+			tcpHandler = &tcp.TLSHandler{
+				Next:   handler,
+				Config: tlsConf,
+			}
+		}
+
+		rule := "HostSNIRegexp(`" + sniHostRegex.String() + "`)"
 		if err := r.muxerHTTPS.AddRoute(rule, "", tcpmuxer.GetRulePriority(rule), tcpHandler); err != nil {
 			log.Error().Err(err).Msg("Error while adding route for host")
 		}


### PR DESCRIPTION
### What does this PR do?

This implements https://github.com/traefik/traefik/issues/11375. It allows different TLSOptions for wildcard domains by parsing HostRegExp() in addition to Host() expressions.


### Motivation

This feature was still missing and my use case requires it, as I want to host some wildcard domains with no mTLS requirement, while the default TLSOptions require it. This was not possible at all before this change. Also see the other mentioned issues other users are facing.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

-
