### PR TITLE
Clarifies that retry middleware uses TCP, not HTTP status codes

### DIFF
--- a/docs/content/middlewares/http/retry.md
+++ b/docs/content/middlewares/http/retry.md
@@ -12,8 +12,11 @@ Retrying until it Succeeds
 TODO: add schema
 -->
 
-The Retry middleware reissues requests a given number of times to a backend server if that server does not reply.
-As soon as the server answers, the middleware stops retrying, regardless of the response status.
+The Retry middleware reissues requests a given number of times when it cannot contact the backend service. 
+This applies at the transport level (TCP). 
+If the service does not respond to the initial connection attempt, the middleware retries.
+However, once the service responds, regardless of the HTTP status code, the middleware considers it operational and stops retrying.
+This means that the retry mechanism does not handle HTTP errors; it only retries when there is no response at the TCP level.
 The Retry middleware has an optional configuration to enable an exponential backoff.
 
 ## Configuration Examples


### PR DESCRIPTION
### What does this PR do?

Clarifies that the Retry middleware only retries on TCP connection failures and does not consider HTTP status codes.

### Motivation

Improve clarity of the documentation