### PR TITLE
Restrict regex validation of HTTP status codes for Ingress CRD resources

### DIFF
--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
@@ -1250,7 +1250,7 @@ spec:
                       as ranges by separating two codes with a dash (500-599),
                       or a combination of the two (404,418,500-599).
                     items:
-                      pattern: ^([0-5][0-9]{2}[,-]?)+$
+                      pattern: ^([1-5][0-9]{2}[,-]?)+$
                       type: string
                     type: array
                   statusRewrites:

--- a/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
@@ -481,7 +481,7 @@ spec:
                       as ranges by separating two codes with a dash (500-599),
                       or a combination of the two (404,418,500-599).
                     items:
-                      pattern: ^([0-5][0-9]{2}[,-]?)+$
+                      pattern: ^([1-5][0-9]{2}[,-]?)+$
                       type: string
                     type: array
                   statusRewrites:

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -1250,7 +1250,7 @@ spec:
                       as ranges by separating two codes with a dash (500-599),
                       or a combination of the two (404,418,500-599).
                     items:
-                      pattern: ^([0-5][0-9]{2}[,-]?)+$
+                      pattern: ^([1-5][0-9]{2}[,-]?)+$
                       type: string
                     type: array
                   statusRewrites:

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/middleware.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/middleware.go
@@ -67,7 +67,7 @@ type ErrorPage struct {
 	// as multiple comma-separated numbers (500,502),
 	// as ranges by separating two codes with a dash (500-599),
 	// or a combination of the two (404,418,500-599).
-	// +kubebuilder:validation:items:Pattern=`^([0-5][0-9]{2}[,-]?)+$`
+	// +kubebuilder:validation:items:Pattern=`^([1-5][0-9]{2}[,-]?)+$`
 	Status []string `json:"status,omitempty"`
 	// StatusRewrites defines a mapping of status codes that should be returned instead of the original error status codes.
 	// For example: "418": 404 or "410-418": 404


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

In #11311 various validations for CRD attributes were added (great change!), to provide for better user experience when creating and/or updating CRD resources. This included various regex expressions, including one for HTTP Status codes (used by the error code middleware).

Given that the RFC only allows for codes >= 100 (["Values outside the range 100..599 are invalid."](https://httpwg.org/specs/rfc9110.html#rfc.section.15)), this MR further restricts the first digit in the regex expression.


### Motivation

<!-- What inspired you to submit this pull request? -->
Reviewing changes to prepare for using v3.4 (rc) on my Kubernetes cluster.


### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

- I've targetted `v3.4` as this further enhances a change that is part of the 3.4 rc. If it's too late to make it in, then I'll retarget this on `master`.
- A similar change may be considered for the time pattern, which can be changed from `^([0-9]+(ns|us|µs|ms|s|m|h)?)+$` to `^([1-9][0-9]*(ns|us|µs|ms|s|m|h)?)+$` to disallow leading zeros, however that might be slight over-engineering and moreover would disallow a time of 0, which might be viable for some purposes
