### PR TITLE
Add ability to pass headers to plugin fetch action

### DIFF
--- a/pkg/plugins/client.go
+++ b/pkg/plugins/client.go
@@ -127,7 +127,7 @@ func ReadManifest(goPath, moduleName string) (*Manifest, error) {
 }
 
 // Download downloads a plugin archive.
-func (c *Client) Download(ctx context.Context, pName, pVersion string) (string, error) {
+func (c *Client) Download(ctx context.Context, pName, pVersion string, headers map[string]string) (string, error) {
 	filename := c.buildArchivePath(pName, pVersion)
 
 	var hash string
@@ -151,6 +151,12 @@ func (c *Client) Download(ctx context.Context, pName, pVersion string) (string, 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	if len(headers) > 0 {
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
 	}
 
 	if hash != "" {

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -29,7 +29,7 @@ func SetupRemotePlugins(client *Client, plugins map[string]Descriptor) error {
 	for pAlias, desc := range plugins {
 		log.Ctx(ctx).Debug().Msgf("Loading of plugin: %s: %s@%s", pAlias, desc.ModuleName, desc.Version)
 
-		hash, err := client.Download(ctx, desc.ModuleName, desc.Version)
+		hash, err := client.Download(ctx, desc.ModuleName, desc.Version, desc.Headers)
 		if err != nil {
 			_ = client.ResetAll()
 			return fmt.Errorf("unable to download plugin %s: %w", desc.ModuleName, err)

--- a/pkg/plugins/types.go
+++ b/pkg/plugins/types.go
@@ -25,6 +25,9 @@ type Descriptor struct {
 
 	// Settings (optional)
 	Settings Settings `description:"Plugin's settings (works only for wasm plugins)." json:"settings,omitempty" toml:"settings,omitempty" yaml:"settings,omitempty" export:"true"`
+
+	// Headers (optional)
+	Headers map[string]string `description:"HTTP headers to forward to the http client to fetch package." json:"headers,omitempty" toml:"headers,omitempty" yaml:"headers,omitempty" export:"true"`
 }
 
 // LocalDescriptor The static part of a local plugin configuration.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Adds headers support for plugins fetching action 

### Motivation

<!-- What inspired you to submit this pull request? -->
As a user I would like Traefik to be able to load plugins from my private repository

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
The question is, should we add support for managing headers in general, or should we only support this for auth headers?  Should we have a general headers section that sets headers for all the download calls?