### PR TITLE
Introduce X25519MLKEM768 for Post-Quantum-Secure TLS

### DIFF
--- a/pkg/tls/certificate.go
+++ b/pkg/tls/certificate.go
@@ -35,14 +35,15 @@ var (
 	// Available CurveIDs defined at https://godoc.org/crypto/tls#CurveID,
 	// also allowing rfc names defined at https://tools.ietf.org/html/rfc8446#section-4.2.7
 	CurveIDs = map[string]tls.CurveID{
-		`secp256r1`: tls.CurveP256,
-		`CurveP256`: tls.CurveP256,
-		`secp384r1`: tls.CurveP384,
-		`CurveP384`: tls.CurveP384,
-		`secp521r1`: tls.CurveP521,
-		`CurveP521`: tls.CurveP521,
-		`x25519`:    tls.X25519,
-		`X25519`:    tls.X25519,
+		`secp256r1`:      tls.CurveP256,
+		`CurveP256`:      tls.CurveP256,
+		`secp384r1`:      tls.CurveP384,
+		`CurveP384`:      tls.CurveP384,
+		`secp521r1`:      tls.CurveP521,
+		`CurveP521`:      tls.CurveP521,
+		`x25519`:         tls.X25519,
+		`X25519`:         tls.X25519,
+		`X25519MLKEM768`: tls.X25519MLKEM768,
 	}
 )
 

--- a/pkg/tls/certificate.go
+++ b/pkg/tls/certificate.go
@@ -43,6 +43,7 @@ var (
 		`CurveP521`:      tls.CurveP521,
 		`x25519`:         tls.X25519,
 		`X25519`:         tls.X25519,
+		`x25519mlkem768`: tls.X25519MLKEM768,
 		`X25519MLKEM768`: tls.X25519MLKEM768,
 	}
 )


### PR DESCRIPTION
### What does this PR do?

This pull request adds support for a post-quantum key‐encapsulation mechanism to Traefik’s TLS configuration. Specifically:

In `certificate.go`, the new curve mapping `X25519MLKEM768` is registered by mapping it to `tls.X25519MLKEM768`.

The Go toolchain version in go.mod has been bumped to **1.24.0** to ensure compatibility with the new KEM.

With these changes, users can now enable post-quantum‐secure encryption directly in their TLS config.


### Motivation

As quantum computing advances, traditional public-key algorithms (like X25519) may become vulnerable. By integrating a post-quantum KEM (X25519MLKEM768), Traefik can offer stronger, future-proof encryption. This aligns with our goal of keeping Traefik at the forefront of secure, high-performance edge routing.

Fixes https://github.com/traefik/traefik/issues/10755

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

- The Go version bump to 1.24.0 in `go.mod` was necessary to pick up the new `tls.X25519MLKEM768` constants.
- No behavioral changes occur unless the new curve is explicitly configured in TLS.
