### PR TITLE
Do not display RemoveHeader option when not defined

### DIFF
--- a/webui/src/components/_commons/PanelMiddlewares.vue
+++ b/webui/src/components/_commons/PanelMiddlewares.vue
@@ -153,7 +153,7 @@
             </div>
           </q-card-section>
           <!-- EXTRA FIELDS FROM MIDDLEWARES - [basicAuth & digestAuth] - removeHeader -->
-          <q-card-section v-if="middleware.basicAuth || middleware.digestAuth">
+          <q-card-section v-if="exData(middleware).removeHeader">
             <div class="row items-start no-wrap">
               <div class="col">
                 <div class="text-subtitle2">


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.4

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.4

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request fixes the dashboard, which displays the `RemoveHeader` option in the dashboard even if it is not defined in the configuration.

### Motivation

Fixes #11780

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Romain <rtribotte@users.noreply.github.com>
