### PR TITLE
Add a note to certificatesDuration

### DIFF
--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -767,6 +767,8 @@ docker run -v "/my/host/acme:/etc/traefik/acme" traefik
 
 _Optional, Default=2160_
 
+`certificatesDuration` specifies the duration (in hours) of the certificates issued by the CA server. It is used to determine when to renew the certificate, but it **doesn't** define the duration of the certificates, that is up to the CA server. 
+
 `certificatesDuration` is used to calculate two durations:
 
 - `Renew Period`: the period before the end of the certificate duration, during which the certificate should be renewed.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.4

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.4

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This PR adds a small note about who actually controls the duration of the issued certificate, because the property name is a little misleading and can invoke the assumption that Traefik controls the duration of the requested certificate, which is not the case.

Fixes #10847

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->