### PR TITLE
feat(mirroring): default percent to 100 when unset + unit test

### DIFF
--- a/pkg/api/handler_http_test.go
+++ b/pkg/api/handler_http_test.go
@@ -467,15 +467,15 @@ func TestHandler_HTTP(t *testing.T) {
 								Mirrors: []dynamic.MirrorService{
 									{
 										Name:    "two@myprovider",
-										Percent: 10,
+										Percent: pointer(10),
 									},
 									{
 										Name:    "three@myprovider",
-										Percent: 15,
+										Percent: pointer(15),
 									},
 									{
 										Name:    "four@myprovider",
-										Percent: 80,
+										Percent: pointer(80),
 									},
 								},
 							},

--- a/pkg/config/dynamic/http_config.go
+++ b/pkg/config/dynamic/http_config.go
@@ -26,6 +26,9 @@ const (
 	MirroringDefaultMirrorBody = true
 	// MirroringDefaultMaxBodySize is the Mirroring.MaxBodySize option default value.
 	MirroringDefaultMaxBodySize int64 = -1
+
+	// MirroringServiceDefaultPercent is the default value for the MirrorService.Percent.
+	MirroringServiceDefaultPercent = 100
 )
 
 // +k8s:deepcopy-gen=true
@@ -126,10 +129,19 @@ type Failover struct {
 // MirrorService holds the MirrorService configuration.
 type MirrorService struct {
 	Name    string `json:"name,omitempty" toml:"name,omitempty" yaml:"name,omitempty" export:"true"`
-	Percent int    `json:"percent,omitempty" toml:"percent,omitempty" yaml:"percent,omitempty" export:"true"`
+	Percent *int   `json:"percent,omitempty" toml:"percent,omitempty" yaml:"percent,omitempty" export:"true"`
 }
 
 // +k8s:deepcopy-gen=true
+
+// SetDefaults sets the default values for a MirrorService.
+func (ms *MirrorService) SetDefaults() {
+	// If Percent is not provided, default to mirroring 100 % of the traffic.
+	if ms.Percent == nil {
+		defaultPercent := MirroringServiceDefaultPercent
+		ms.Percent = &defaultPercent
+	}
+}
 
 // WeightedRoundRobin is a weighted round robin load-balancer of services.
 type WeightedRoundRobin struct {

--- a/pkg/config/dynamic/http_config_test.go
+++ b/pkg/config/dynamic/http_config_test.go
@@ -1,0 +1,39 @@
+package dynamic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func pointer[T any](v T) *T { return &v }
+
+func TestMirrorService_SetDefaults(t *testing.T) {
+	const dflt = MirroringServiceDefaultPercent // 100
+
+	t.Run("unset ⇒ default", func(t *testing.T) {
+		ms := MirrorService{}
+		ms.SetDefaults()
+
+		require.NotNil(t, ms.Percent)
+		require.Equal(t, dflt, *ms.Percent)
+	})
+
+	t.Run("explicit 0 ⇒ keep 0", func(t *testing.T) {
+		zero := 0
+		ms := MirrorService{Percent: pointer(zero)}
+		ms.SetDefaults()
+
+		require.NotNil(t, ms.Percent)
+		require.Equal(t, 0, *ms.Percent)
+	})
+
+	t.Run("explicit 42 ⇒ keep 42", func(t *testing.T) {
+		v := 42
+		ms := MirrorService{Percent: pointer(v)}
+		ms.SetDefaults()
+
+		require.NotNil(t, ms.Percent)
+		require.Equal(t, 42, *ms.Percent)
+	})
+}

--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -304,7 +304,7 @@ func (c configBuilder) buildMirroring(ctx context.Context, tService *traefikv1al
 
 		mirrorServices = append(mirrorServices, dynamic.MirrorService{
 			Name:    mirroredName,
-			Percent: mirror.Percent,
+			Percent: &mirror.Percent,
 		})
 	}
 

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -2565,7 +2565,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 							Mirroring: &dynamic.Mirroring{
 								Service: "default-whoami5-8080",
 								Mirrors: []dynamic.MirrorService{
-									{Name: "default-whoami4-8080", Percent: 50},
+									{Name: "default-whoami4-8080", Percent: pointer(50)},
 								},
 							},
 						},
@@ -2932,7 +2932,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 							Mirroring: &dynamic.Mirroring{
 								Service: "baz-whoami6-8080",
 								Mirrors: []dynamic.MirrorService{
-									{Name: "foo-whoami4-8080", Percent: 50},
+									{Name: "foo-whoami4-8080", Percent: pointer(50)},
 								},
 							},
 						},
@@ -3014,7 +3014,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 							Mirroring: &dynamic.Mirroring{
 								Service: "default-whoami5-8080",
 								Mirrors: []dynamic.MirrorService{
-									{Name: "default-whoami4-8080", Percent: 50},
+									{Name: "default-whoami4-8080", Percent: pointer(50)},
 								},
 							},
 						},
@@ -3087,7 +3087,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 							Mirroring: &dynamic.Mirroring{
 								Service: "default-wrr1",
 								Mirrors: []dynamic.MirrorService{
-									{Name: "default-wrr2", Percent: 30},
+									{Name: "default-wrr2", Percent: pointer(30)},
 								},
 							},
 						},
@@ -6539,7 +6539,7 @@ func TestCrossNamespace(t *testing.T) {
 								Mirrors: []dynamic.MirrorService{
 									{
 										Name:    "cross-ns-whoami-svc-80",
-										Percent: 20,
+										Percent: pointer(20),
 									},
 								},
 							},
@@ -6550,7 +6550,7 @@ func TestCrossNamespace(t *testing.T) {
 								Mirrors: []dynamic.MirrorService{
 									{
 										Name:    "cross-ns-whoami-svc-80",
-										Percent: 20,
+										Percent: pointer(20),
 									},
 								},
 							},
@@ -6629,7 +6629,7 @@ func TestCrossNamespace(t *testing.T) {
 								Mirrors: []dynamic.MirrorService{
 									{
 										Name:    "cross-ns-whoami-svc-80",
-										Percent: 20,
+										Percent: pointer(20),
 									},
 								},
 							},

--- a/pkg/provider/kv/kv_test.go
+++ b/pkg/provider/kv/kv_test.go
@@ -693,11 +693,11 @@ func Test_buildConfiguration(t *testing.T) {
 						Mirrors: []dynamic.MirrorService{
 							{
 								Name:    "foobar",
-								Percent: 42,
+								Percent: pointer(42),
 							},
 							{
 								Name:    "foobar",
-								Percent: 42,
+								Percent: pointer(42),
 							},
 						},
 					},

--- a/pkg/redactor/redactor_config_test.go
+++ b/pkg/redactor/redactor_config_test.go
@@ -124,7 +124,7 @@ func init() {
 					Mirrors: []dynamic.MirrorService{
 						{
 							Name:    "foo",
-							Percent: 42,
+							Percent: pointer(42),
 						},
 					},
 				},

--- a/pkg/server/service/service.go
+++ b/pkg/server/service/service.go
@@ -232,7 +232,7 @@ func (m *Manager) getMirrorServiceHandler(ctx context.Context, config *dynamic.M
 			return nil, err
 		}
 
-		err = handler.AddMirror(mirrorHandler, mirrorConfig.Percent)
+		err = handler.AddMirror(mirrorHandler, *mirrorConfig.Percent)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.4

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.4

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

* Introduces `MirroringServiceDefaultPercent` (100).
* **Breaking change :** `Percent` field is now `*int`; `SetDefaults()` sets it to 100 when `nil`.
* Adds unit tests covering: default (`nil`) / explicit `0` / explicit custom value.


### Motivation

Implements the behavior discussed in #11818 and originally raised in #11781: mirrors should receive traffic by default when `percent` is not specified.

Fixes #11818 

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

<!--### Additional Notes-->

<!-- Anything else we should know when reviewing? -->
