### PR TITLE
Additional reserved characters

### DIFF
--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -264,6 +264,9 @@ Subject alternative names.
 `--entrypoints.<name>.http.tls.options`:  
 Default TLS options for the routers linked to the entry point.
 
+`--entrypoints.<name>.http.additionalReservedCharacters`:  
+Add new valid encoded chars.
+
 `--entrypoints.<name>.http2.maxconcurrentstreams`:  
 Specifies the number of concurrent streams per connection that each client is allowed to initiate. (Default: ```250```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -273,6 +273,9 @@ Subject alternative names.
 `TRAEFIK_ENTRYPOINTS_<NAME>_HTTP_TLS_OPTIONS`:  
 Default TLS options for the routers linked to the entry point.
 
+`TRAEFIK_ENTRYPOINTS_<NAME>_HTTP_ADDITIONALRESERVEDCHARACTERS`:  
+Add new valid encoded chars, map of encoded caracter and decoded caracter.
+
 `TRAEFIK_ENTRYPOINTS_<NAME>_OBSERVABILITY_ACCESSLOGS`:  
  (Default: ```true```)
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -55,6 +55,8 @@
       encodeQuerySemicolons = true
       sanitizePath = true
       maxHeaderBytes = 42
+      [entryPoints.EntryPoint0.http.additionalReservedCharacters]
+        "%2E" = "."
       [entryPoints.EntryPoint0.http.redirections]
         [entryPoints.EntryPoint0.http.redirections.entryPoint]
           to = "foobar"

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -86,6 +86,8 @@ entryPoints:
       encodeQuerySemicolons: true
       sanitizePath: true
       maxHeaderBytes: 42
+      additionalReservedCharacters:
+        "%2E" : "."
     http2:
       maxConcurrentStreams: 42
     http3:

--- a/pkg/config/static/entrypoints.go
+++ b/pkg/config/static/entrypoints.go
@@ -64,12 +64,13 @@ func (ep *EntryPoint) SetDefaults() {
 
 // HTTPConfig is the HTTP configuration of an entry point.
 type HTTPConfig struct {
-	Redirections          *Redirections `description:"Set of redirection" json:"redirections,omitempty" toml:"redirections,omitempty" yaml:"redirections,omitempty" export:"true"`
-	Middlewares           []string      `description:"Default middlewares for the routers linked to the entry point." json:"middlewares,omitempty" toml:"middlewares,omitempty" yaml:"middlewares,omitempty" export:"true"`
-	TLS                   *TLSConfig    `description:"Default TLS configuration for the routers linked to the entry point." json:"tls,omitempty" toml:"tls,omitempty" yaml:"tls,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
-	EncodeQuerySemicolons bool          `description:"Defines whether request query semicolons should be URLEncoded." json:"encodeQuerySemicolons,omitempty" toml:"encodeQuerySemicolons,omitempty" yaml:"encodeQuerySemicolons,omitempty"`
-	SanitizePath          *bool         `description:"Defines whether to enable request path sanitization (removal of /./, /../ and multiple slash sequences)." json:"sanitizePath,omitempty" toml:"sanitizePath,omitempty" yaml:"sanitizePath,omitempty" export:"true"`
-	MaxHeaderBytes        int           `description:"Maximum size of request headers in bytes." json:"maxHeaderBytes,omitempty" toml:"maxHeaderBytes,omitempty" yaml:"maxHeaderBytes,omitempty" export:"true"`
+	Redirections                 *Redirections     `description:"Set of redirection" json:"redirections,omitempty" toml:"redirections,omitempty" yaml:"redirections,omitempty" export:"true"`
+	Middlewares                  []string          `description:"Default middlewares for the routers linked to the entry point." json:"middlewares,omitempty" toml:"middlewares,omitempty" yaml:"middlewares,omitempty" export:"true"`
+	TLS                          *TLSConfig        `description:"Default TLS configuration for the routers linked to the entry point." json:"tls,omitempty" toml:"tls,omitempty" yaml:"tls,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
+	EncodeQuerySemicolons        bool              `description:"Defines whether request query semicolons should be URLEncoded." json:"encodeQuerySemicolons,omitempty" toml:"encodeQuerySemicolons,omitempty" yaml:"encodeQuerySemicolons,omitempty"`
+	SanitizePath                 *bool             `description:"Defines whether to enable request path sanitization (removal of /./, /../ and multiple slash sequences)." json:"sanitizePath,omitempty" toml:"sanitizePath,omitempty" yaml:"sanitizePath,omitempty" export:"true"`
+	MaxHeaderBytes               int               `description:"Maximum size of request headers in bytes." json:"maxHeaderBytes,omitempty" toml:"maxHeaderBytes,omitempty" yaml:"maxHeaderBytes,omitempty" export:"true"`
+	AdditionalReservedCharacters map[string]string `description:"Add new valid encoded chars." json:"additionalReservedCharacters,omitempty" toml:"additionalReservedCharacters,omitempty" yaml:"additionalReservedCharacters,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values.

--- a/pkg/muxer/http/mux.go
+++ b/pkg/muxer/http/mux.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog/log"
 	"github.com/traefik/traefik/v3/pkg/rules"
+	"github.com/traefik/traefik/v3/pkg/types"
 )
 
 type matcherBuilderFuncs map[string]matcherBuilderFunc
@@ -87,32 +88,6 @@ func (m *Muxer) AddRoute(rule string, syntax string, priority int, handler http.
 	return nil
 }
 
-// reservedCharacters contains the mapping of the percent-encoded form to the ASCII form
-// of the reserved characters according to https://datatracker.ietf.org/doc/html/rfc3986#section-2.2.
-// By extension to https://datatracker.ietf.org/doc/html/rfc3986#section-2.1 the percent character is also considered a reserved character.
-// Because decoding the percent character would change the meaning of the URL.
-var reservedCharacters = map[string]rune{
-	"%3A": ':',
-	"%2F": '/',
-	"%3F": '?',
-	"%23": '#',
-	"%5B": '[',
-	"%5D": ']',
-	"%40": '@',
-	"%21": '!',
-	"%24": '$',
-	"%26": '&',
-	"%27": '\'',
-	"%28": '(',
-	"%29": ')',
-	"%2A": '*',
-	"%2B": '+',
-	"%2C": ',',
-	"%3B": ';',
-	"%3D": '=',
-	"%25": '%',
-}
-
 // getRoutingPath retrieves the routing path from the request context.
 // It returns nil if the routing path is not set in the context.
 func getRoutingPath(req *http.Request) *string {
@@ -144,7 +119,7 @@ func withRoutingPath(req *http.Request) (*http.Request, error) {
 		}
 
 		encodedCharacter := escapedPath[i : i+3]
-		if _, reserved := reservedCharacters[encodedCharacter]; reserved {
+		if _, reserved := types.ReservedCharacters[encodedCharacter]; reserved {
 			routingPathBuilder.WriteString(encodedCharacter)
 		} else {
 			// This should never happen as the standard library will reject requests containing invalid percent-encodings.

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"syscall"
 	"time"
+	"unicode/utf8"
 
 	"github.com/containous/alice"
 	gokitmetrics "github.com/go-kit/kit/metrics"
@@ -619,6 +620,24 @@ func createHTTPServer(ctx context.Context, ln net.Listener, configuration *stati
 		handler = h2c.NewHandler(handler, &http2.Server{
 			MaxConcurrentStreams: uint32(configuration.HTTP2.MaxConcurrentStreams),
 		})
+	}
+
+	if len(configuration.HTTP.AdditionalReservedCharacters) > 0 {
+		for key, value := range configuration.HTTP.AdditionalReservedCharacters {
+			if _, exists := types.ReservedCharacters[key]; !exists {
+				runes := []rune(value)
+				if len(runes) != 1 {
+					return nil, errors.New("AdditionalReservedCharacters value must be a single valid rune")
+				}
+				if runes[0] == '\uFFFD' {
+					return nil, errors.New("AdditionalReservedCharacters value contains an invalid rune")
+				}
+				if runes[0] < 0 || runes[0] > utf8.MaxRune {
+					return nil, errors.New("AdditionalReservedCharacters value is out of valid Unicode range")
+				}
+				types.ReservedCharacters[key] = runes[0]
+			}
+		}
 	}
 
 	handler = contenttype.DisableAutoDetection(handler)

--- a/pkg/types/reserved_characters.go
+++ b/pkg/types/reserved_characters.go
@@ -1,0 +1,25 @@
+package types
+
+// ReservedCharacters contains the mapping of the percent-encoded form to the ASCII
+// form of the reserved characters according to RFC 3986 §2.2 (plus ‘%’ itself).
+var ReservedCharacters = map[string]rune{
+	"%3A": ':',
+	"%2F": '/',
+	"%3F": '?',
+	"%23": '#',
+	"%5B": '[',
+	"%5D": ']',
+	"%40": '@',
+	"%21": '!',
+	"%24": '$',
+	"%26": '&',
+	"%27": '\'',
+	"%28": '(',
+	"%29": ')',
+	"%2A": '*',
+	"%2B": '+',
+	"%2C": ',',
+	"%3B": ';',
+	"%3D": '=',
+	"%25": '%',
+}


### PR DESCRIPTION
### What does this PR do?

Add the possibility of more reserved  encoded characters.  

### Motivation

With this pull request: https://github.com/traefik/traefik/pull/11790  its not possible to have dots as encoded characters in the path. For us is necessary to have them in some paths.  We need to add  more encoded characters and that is why I have added this new variable in the endpoint for this.  

### More
- [x] Added/updated tests
- [ ] Added/updated documentation
