### PR TITLE
Fix concurrent access to balancer status map in WRR and P2C strategies

### DIFF
--- a/pkg/server/service/loadbalancer/wrr/wrr.go
+++ b/pkg/server/service/loadbalancer/wrr/wrr.go
@@ -27,6 +27,7 @@ type namedHandler struct {
 type Balancer struct {
 	wantsHealthCheck bool
 
+	// handlersMu is a mutex to protect the handlers slice, the status and the fenced maps.
 	handlersMu sync.RWMutex
 	handlers   []*namedHandler
 	// status is a record of which child services of the Balancer are healthy, keyed
@@ -34,11 +35,12 @@ type Balancer struct {
 	// created via Add, and it is later removed or added to the map as needed,
 	// through the SetStatus method.
 	status map[string]struct{}
+	// fenced is the list of terminating yet still serving child services.
+	fenced map[string]struct{}
+
 	// updaters is the list of hooks that are run (to update the Balancer
 	// parent(s)), whenever the Balancer status changes.
 	updaters []func(bool)
-	// fenced is the list of terminating yet still serving child services.
-	fenced map[string]struct{}
 
 	sticky *loadbalancer.Sticky
 
@@ -180,7 +182,10 @@ func (b *Balancer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		if err != nil {
 			log.Error().Err(err).Msg("Error while getting sticky handler")
 		} else if h != nil {
-			if _, ok := b.status[h.Name]; ok {
+			b.handlersMu.RLock()
+			_, ok := b.status[h.Name]
+			b.handlersMu.RUnlock()
+			if ok {
 				if rewrite {
 					if err := b.sticky.WriteStickyCookie(rw, h.Name); err != nil {
 						log.Error().Err(err).Msg("Writing sticky cookie")


### PR DESCRIPTION
### What does this PR do?

This pull request resolves an issue where a panic occurred due to concurrent access to the balancer status map in the WRR and P2C strategies.

The handlers mutex call was removed in #11547.

### Motivation

Fixes #11877

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
