### PR TITLE
Fix invalid links in documentation

### DIFF
--- a/docs/content/https/tls.md
+++ b/docs/content/https/tls.md
@@ -242,7 +242,7 @@ The TLS options allow one to configure some parameters of the TLS connection.
 
 !!! important "TLSOption in Kubernetes"
 
-    When using the [TLSOption resource](../../routing/providers/kubernetes-crd#kind-tlsoption) in Kubernetes, one might setup a default set of options that,
+    When using the [TLSOption resource](../../routing/providers/kubernetes-crd/#kind-tlsoption) in Kubernetes, one might setup a default set of options that,
     if not explicitly overwritten, should apply to all ingresses.  
     To achieve that, you'll have to create a TLSOption resource with the name `default`.
     There may exist only one TLSOption with the name `default` (across all namespaces) - otherwise they will be dropped.  

--- a/docs/content/operations/api.md
+++ b/docs/content/operations/api.md
@@ -46,7 +46,7 @@ And then define a routing configuration on Traefik itself with the
 
 --8<-- "content/operations/include-api-examples.md"
 
-??? warning "The router's [rule](../../routing/routers#rule) must catch requests for the URI path `/api`"
+??? warning "The router's [rule](../../routing/routers/#rule) must catch requests for the URI path `/api`"
     Using an "Host" rule is recommended, by catching all the incoming traffic on this host domain to the API.
     However, you can also use "path prefix" rule or any combination or rules.
 

--- a/docs/content/routing/overview.md
+++ b/docs/content/routing/overview.md
@@ -10,8 +10,8 @@ What's Happening to the Requests?
 
 Let's zoom in on Traefik's architecture and talk about the components that enable the routes to be created.
 
-First, when you start Traefik, you define [entrypoints](../entrypoints) (in their most basic forms, they are port numbers).
-Then, connected to these entrypoints, [routers](../routers) analyze the incoming requests to see if they match a set of [rules](../routers#rule).
+First, when you start Traefik, you define [entrypoints](../entrypoints/) (in their most basic forms, they are port numbers).
+Then, connected to these entrypoints, [routers](../routers/) analyze the incoming requests to see if they match a set of [rules](../routers/#rule).
 If they do, the router might transform the request using pieces of [middleware](../middlewares/overview.md) before forwarding them to your [services](./services/index.md).
 
 ![Architecture](../assets/img/architecture-overview.png)

--- a/docs/content/routing/providers/kubernetes-ingress.md
+++ b/docs/content/routing/providers/kubernetes-ingress.md
@@ -907,7 +907,7 @@ TLS certificates can be managed in Secrets objects.
     whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
 
     One alternative is to use an `ExternalName` service to forward requests to the Kubernetes service through DNS.
-    To do so, one must [allow external name services](https://doc.traefik.io/traefik/providers/kubernetes-ingress/#allowexternalnameservices "Link to docs about allowing external name services").
+    To do so, one must [allow external name services](../../../providers/kubernetes-ingress/#allowexternalnameservices "Link to docs about allowing external name services").
 
 Traefik automatically requests endpoint information based on the service provided in the ingress spec.
 Although Traefik will connect directly to the endpoints (pods),

--- a/docs/content/user-guides/docker-compose/acme-dns/index.md
+++ b/docs/content/user-guides/docker-compose/acme-dns/index.md
@@ -6,7 +6,7 @@ description: "Learn how to create a certificate with the Let's Encrypt DNS chall
 # Docker-compose with Let's Encrypt: DNS Challenge
 
 This guide aims to demonstrate how to create a certificate with the Let's Encrypt DNS challenge to use https on a simple service exposed with Traefik.  
-Please also read the [basic example](../basic-example) for details on how to expose such a service.  
+Please also read the [basic example](../basic-example/) for details on how to expose such a service.  
 
 ## Prerequisite
 


### PR DESCRIPTION
### What does this PR do?

Fix invalid links (404 or 301) as detected with this command:

```
docker run  --rm -u $(id -u):$(id -g) ghcr.io/linkchecker/linkchecker:latest --ignore-url=github.com -o html https://doc.traefik.io > linkcheck.html
```

[current report](https://github.com/user-attachments/files/21526467/linkcheck.html.zip)

### Motivation

Improve userXP and SEO

### More

- [x] Added/updated documentation

