### PR TITLE
log mTLS failures and other http errors in zerolog.ErrorLevel

### DIFF
--- a/pkg/logs/log.go
+++ b/pkg/logs/log.go
@@ -2,6 +2,7 @@ package logs
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/rs/zerolog"
 )
@@ -32,4 +33,18 @@ func (n NoLevelHook) Run(e *zerolog.Event, level zerolog.Level, _ string) {
 
 func msgFunc(i ...any) func() string {
 	return func() string { return fmt.Sprint(i...) }
+}
+
+func TLSErrors(logger zerolog.Logger) zerolog.Logger {
+	return logger.Hook(
+		zerolog.HookFunc(func(e *zerolog.Event, level zerolog.Level, message string) {
+			if !strings.HasPrefix(message, "http: TLS handshake error from") {
+				e.Discard()
+				return
+			}
+
+			if level == zerolog.NoLevel {
+				e.Str("level", zerolog.ErrorLevel.String())
+			}
+		}))
 }

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -647,7 +647,7 @@ func createHTTPServer(ctx context.Context, ln net.Listener, configuration *stati
 	serverHTTP := &http.Server{
 		Protocols:      &protocols,
 		Handler:        handler,
-		ErrorLog:       stdlog.New(logs.NoLevel(log.Logger, zerolog.DebugLevel), "", 0),
+		ErrorLog:       stdlog.New(logs.NoLevel(log.Logger, zerolog.ErrorLevel), "", 0),
 		ReadTimeout:    time.Duration(configuration.Transport.RespondingTimeouts.ReadTimeout),
 		WriteTimeout:   time.Duration(configuration.Transport.RespondingTimeouts.WriteTimeout),
 		IdleTimeout:    time.Duration(configuration.Transport.RespondingTimeouts.IdleTimeout),

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -18,7 +18,6 @@ import (
 	"github.com/containous/alice"
 	gokitmetrics "github.com/go-kit/kit/metrics"
 	"github.com/pires/go-proxyproto"
-	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/traefik/traefik/v3/pkg/config/static"
 	"github.com/traefik/traefik/v3/pkg/ip"
@@ -647,7 +646,7 @@ func createHTTPServer(ctx context.Context, ln net.Listener, configuration *stati
 	serverHTTP := &http.Server{
 		Protocols:      &protocols,
 		Handler:        handler,
-		ErrorLog:       stdlog.New(logs.NoLevel(log.Logger, zerolog.ErrorLevel), "", 0),
+		ErrorLog:       stdlog.New(logs.TLSErrors(log.Logger), "", 0),
 		ReadTimeout:    time.Duration(configuration.Transport.RespondingTimeouts.ReadTimeout),
 		WriteTimeout:   time.Duration(configuration.Transport.RespondingTimeouts.WriteTimeout),
 		IdleTimeout:    time.Duration(configuration.Transport.RespondingTimeouts.IdleTimeout),


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.5

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.5

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/
-->

### What does this PR do?
Fixes #11955 


### Motivation
When using traefix as a reverse proxy, it was surprising to see it not log mTLS connection failures as errors.
I think that's probably a bug.


Before:
```
2025-08-03T16:37:35+05:30 DBG ../../../../../opt/homebrew/Cellar/go/1.24.5/libexec/src/log/log.go:245 > http: TLS handshake error from [::1]:50461: tls: failed to verify certificate: x509: certificate signed by unknown authority
2025-08-03T16:37:43+05:30 DBG ../../../../../opt/homebrew/Cellar/go/1.24.5/libexec/src/log/log.go:245 > http: TLS handshake error from [::1]:50471: tls: client didn't provide a certificate
```

After:
```
2025-08-03T16:39:11+05:30 ERR ../../../../../opt/homebrew/Cellar/go/1.24.5/libexec/src/log/log.go:245 > http: TLS handshake error from [::1]:50526: tls: failed to verify certificate: x509: certificate signed by unknown authority
2025-08-03T16:39:21+05:30 ERR ../../../../../opt/homebrew/Cellar/go/1.24.5/libexec/src/log/log.go:245 > http: TLS handshake error from [::1]:50533: tls: client didn't provide a certificate
```
### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
