### PR TITLE
Use client conn to build the proxy protocol header

### DIFF
--- a/pkg/tcp/dialer.go
+++ b/pkg/tcp/dialer.go
@@ -19,12 +19,20 @@ import (
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
 	traefiktls "github.com/traefik/traefik/v3/pkg/tls"
 	"github.com/traefik/traefik/v3/pkg/types"
-	"golang.org/x/net/proxy"
 )
 
-type Dialer interface {
-	proxy.Dialer
+// ClientConn is the interface that provides information about the client connection.
+type ClientConn interface {
+	// LocalAddr returns the local network address, if known.
+	LocalAddr() net.Addr
 
+	// RemoteAddr returns the remote network address, if known.
+	RemoteAddr() net.Addr
+}
+
+// Dialer is an interface to dial a network connection, with support for PROXY protocol and termination delay.
+type Dialer interface {
+	Dial(network, addr string, clientConn ClientConn) (c net.Conn, err error)
 	TerminationDelay() time.Duration
 }
 
@@ -34,18 +42,20 @@ type tcpDialer struct {
 	proxyProtocol    *dynamic.ProxyProtocol
 }
 
+// TerminationDelay returns the termination delay duration.
 func (d tcpDialer) TerminationDelay() time.Duration {
 	return d.terminationDelay
 }
 
-func (d tcpDialer) Dial(network, addr string) (net.Conn, error) {
+// Dial dials a network connection and optionally sends a PROXY protocol header.
+func (d tcpDialer) Dial(network, addr string, clientConn ClientConn) (net.Conn, error) {
 	conn, err := d.dialer.Dial(network, addr)
 	if err != nil {
 		return nil, err
 	}
 
-	if d.proxyProtocol != nil && d.proxyProtocol.Version > 0 && d.proxyProtocol.Version < 3 {
-		header := proxyproto.HeaderProxyFromAddrs(byte(d.proxyProtocol.Version), conn.RemoteAddr(), conn.LocalAddr())
+	if d.proxyProtocol != nil && clientConn != nil && d.proxyProtocol.Version > 0 && d.proxyProtocol.Version < 3 {
+		header := proxyproto.HeaderProxyFromAddrs(byte(d.proxyProtocol.Version), clientConn.RemoteAddr(), clientConn.LocalAddr())
 		if _, err := header.WriteTo(conn); err != nil {
 			_ = conn.Close()
 			return nil, fmt.Errorf("writing PROXY Protocol header: %w", err)
@@ -60,8 +70,9 @@ type tcpTLSDialer struct {
 	tlsConfig *tls.Config
 }
 
-func (d tcpTLSDialer) Dial(network, addr string) (net.Conn, error) {
-	conn, err := d.tcpDialer.Dial(network, addr)
+// Dial dials a network connection with the wrapped tcpDialer and performs a TLS handshake.
+func (d tcpTLSDialer) Dial(network, addr string, clientConn ClientConn) (net.Conn, error) {
+	conn, err := d.tcpDialer.Dial(network, addr, clientConn)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tcp/proxy.go
+++ b/pkg/tcp/proxy.go
@@ -34,7 +34,7 @@ func (p *Proxy) ServeTCP(conn WriteCloser) {
 	// needed because of e.g. server.trackedConnection
 	defer conn.Close()
 
-	connBackend, err := p.dialBackend()
+	connBackend, err := p.dialBackend(conn)
 	if err != nil {
 		log.Error().Err(err).Msg("Error while dialing backend")
 		return
@@ -62,8 +62,10 @@ func (p *Proxy) ServeTCP(conn WriteCloser) {
 	<-errChan
 }
 
-func (p *Proxy) dialBackend() (WriteCloser, error) {
-	conn, err := p.dialer.Dial("tcp", p.address)
+func (p *Proxy) dialBackend(clientConn net.Conn) (WriteCloser, error) {
+	// The clientConn is passed to the dialer so that it can use information from it if needed,
+	// to build a PROXY protocol header.
+	conn, err := p.dialer.Dial("tcp", p.address, clientConn)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.5

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.5

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes the Proxy Protocol communication with backends by using the client connection to build the proxy protocol header instead of the backend connection.
<!-- A brief description of the change being made with this pull request. -->

### Motivation

Fixes #12055
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Additional work on the dialer rewrite is needed to better integrate the proxy protocol responsibilities.

Co-authored-by: Simon Delicata <simon.delicata@free.fr>
<!-- Anything else we should know when reviewing? -->


