### PR TITLE
Fix version display regression

### DIFF
--- a/webui/src/contexts/version.tsx
+++ b/webui/src/contexts/version.tsx
@@ -1,5 +1,7 @@
 import { createContext, ReactNode, useEffect, useState } from 'react'
 
+import { BASE_PATH } from 'libs/utils'
+
 type VersionContextProps = {
   showHubButton: boolean
   version: string
@@ -21,7 +23,7 @@ export const VersionProvider = ({ children }: VersionProviderProps) => {
   useEffect(() => {
     const fetchVersion = async () => {
       try {
-        const response = await fetch('/api/version')
+        const response = await fetch(`${BASE_PATH}/version`)
         if (!response.ok) {
           throw new Error(`Network error: ${response.status}`)
         }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.5

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.5

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

In v3.5.3, the application version is no longer displayed next to the logo due to a regression in the version retrieval API call.
The API request to fetch the version information is not accounting for the `basePath` configuration value, causing the request to target an incorrect endpoint.

### Motivation

Fix a regression in v3.5.3 where the application version is not displayed next to the logo.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
Fixes https://github.com/traefik/traefik/issues/12110
