### PR TITLE
Reduce vertical padding in dashboard table rows for more compact layout

### DIFF
--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -1,4 +1,4 @@
-import { Box, darkTheme, FaencyProvider, lightTheme } from '@traefiklabs/faency'
+import { globalCss, Box, darkTheme, FaencyProvider, lightTheme } from '@traefiklabs/faency'
 import { Suspense, useEffect } from 'react'
 import { HelmetProvider } from 'react-helmet-async'
 import { HashRouter, Navigate, Route, Routes as RouterRoutes, useLocation } from 'react-router-dom'
@@ -71,6 +71,12 @@ export const Routes = () => {
 
 const isDev = import.meta.env.NODE_ENV === 'development'
 
+const customGlobalStyle = globalCss({
+  'span[role=cell]': {     // target the AriaTd component
+    p: '$2 $3'
+  },
+})
+
 const App = () => {
   const isDarkMode = useIsDarkMode()
 
@@ -95,6 +101,7 @@ const App = () => {
         >
           <VersionProvider>
             <HashRouter basename={import.meta.env.VITE_APP_BASE_URL || ''}>
+              {customGlobalStyle()}
               <ScrollToTop />
               <Routes />
             </HashRouter>


### PR DESCRIPTION
### What does this PR do?

This PR reduces the vertical padding on table cells on the router, middleware and services pages.

You can see before and after images on https://github.com/traefik/traefik/issues/12132

### Motivation

I raised in https://github.com/traefik/traefik/issues/12132 the fact that there is too much unused space which doesn't make good use of screen real estate. It was agreed this could be a sensible change.

### Other notes

The default styling seems to come from the Faency library here: https://github.com/traefik/faency/blob/2998bd08454a830f29e5c5d1feead56d994db960/components/Table/Table.tsx#L61

I couldn't see a more straightforward way to customise the padding across multiple pages than creating my own SlimmerAriaTd component. This may well not be the best approach! Happy to look at alternatives if required.