### PR TITLE
Fix KV key name used to check if connection is alive

### DIFF
--- a/pkg/provider/kv/kv.go
+++ b/pkg/provider/kv/kv.go
@@ -54,7 +54,7 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 	logger := log.FromContext(ctx)
 
 	operation := func() error {
-		if _, err := p.kvClient.Exists(ctx, path.Join(p.RootKey, "qmslkjdfmqlskdjfmqlksjazçueznbvbwzlkajzebvkwjdcqmlsfj"), nil); err != nil {
+		if _, err := p.kvClient.Exists(ctx, path.Join(p.RootKey, "qmslkjdfmqlskdjfmqlksjazcueznbvbwzlkajzebvkwjdcqmlsfj"), nil); err != nil {
 			return fmt.Errorf("KV store connection error: %w", err)
 		}
 		return nil


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.5

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.5

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request fixes the value of the KV key name used to check if the connection is alive.
The previous key name value breaks the update to Consul 1.21.5 due to key validation.

### Motivation

Fixes #12092


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
