### PR TITLE
Remove flaky TestReadLoopMaxDataSize

### DIFF
--- a/pkg/udp/conn_test.go
+++ b/pkg/udp/conn_test.go
@@ -1,11 +1,9 @@
 package udp
 
 import (
-	"crypto/rand"
 	"errors"
 	"io"
 	"net"
-	"runtime"
 	"testing"
 	"time"
 
@@ -300,58 +298,6 @@ func TestShutdown(t *testing.T) {
 	case <-time.Tick(5 * time.Second):
 		// In case we introduce a regression that would make the test wait forever.
 		t.Fatal("Timeout during shutdown")
-	}
-}
-
-func TestReadLoopMaxDataSize(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		// sudo sysctl -w net.inet.udp.maxdgram=65507
-		t.Skip("Skip test on darwin as the maximum dgram size is set to 9216 bytes by default")
-	}
-
-	// Theoretical maximum size of data in a UDP datagram.
-	// 65535 − 8 (UDP header) − 20 (IP header).
-	dataSize := 65507
-
-	doneCh := make(chan struct{})
-
-	l, err := Listen(net.ListenConfig{}, "udp", ":0", 3*time.Second)
-	require.NoError(t, err)
-
-	defer func() {
-		err := l.Close()
-		require.NoError(t, err)
-	}()
-
-	go func() {
-		defer close(doneCh)
-
-		conn, err := l.Accept()
-		require.NoError(t, err)
-
-		buffer := make([]byte, dataSize)
-
-		n, err := conn.Read(buffer)
-		require.NoError(t, err)
-
-		assert.Equal(t, dataSize, n)
-	}()
-
-	c, err := net.Dial("udp", l.Addr().String())
-	require.NoError(t, err)
-
-	data := make([]byte, dataSize)
-
-	_, err = rand.Read(data)
-	require.NoError(t, err)
-
-	_, err = c.Write(data)
-	require.NoError(t, err)
-
-	select {
-	case <-doneCh:
-	case <-time.Tick(5 * time.Second):
-		t.Fatal("Timeout waiting for datagram read")
 	}
 }
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.5

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.5

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

This PR removes `TestReadLoopMaxDataSize`. Using the maximum size in `c.write` doesn’t work because it is platform-dependent, making the test flaky and providing little meaningful coverage.


### Motivation

<!-- What inspired you to submit this pull request? -->

Make CI more effective


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
