### PR TITLE
Fix anchors in basic auth configuration options

### DIFF
--- a/docs/content/reference/routing-configuration/http/middlewares/basicauth.md
+++ b/docs/content/reference/routing-configuration/http/middlewares/basicauth.md
@@ -64,8 +64,8 @@ spec:
 
 | Field      | Description                                                                                                                                                                                 | Default | Required |
 |:-----------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------|:---------|
-| <a id="opt-users" href="#opt-users" title="#opt-users">`users`</a> | Array of authorized users. Each user must be declared using the `name:hashed-password` format. (More information [here](#users))| ""      | No      |
-| <a id="opt-usersFile" href="#opt-usersFile" title="#opt-usersFile">`usersFile`</a> | Path to an external file that contains the authorized users for the middleware. <br />The file content is a list of `name:hashed-password`. (More information [here](#usersfile)) | ""      | No      |
+| <a id="opt-users" href="#opt-users" title="#opt-users">`users`</a> | Array of authorized users. Each user must be declared using the `name:hashed-password` format. (More information [here](#users-usersfile))| ""      | No      |
+| <a id="opt-usersFile" href="#opt-usersFile" title="#opt-usersFile">`usersFile`</a> | Path to an external file that contains the authorized users for the middleware. <br />The file content is a list of `name:hashed-password`. (More information [here](#users-usersfile)) | ""      | No      |
 | <a id="opt-realm" href="#opt-realm" title="#opt-realm">`realm`</a> | Allow customizing the realm for the authentication.| "traefik"      | No      |
 | <a id="opt-headerField" href="#opt-headerField" title="#opt-headerField">`headerField`</a> | Allow defining a header field to store the authenticated user.| ""      | No      |
 | <a id="opt-removeHeader" href="#opt-removeHeader" title="#opt-removeHeader">`removeHeader`</a> | Allow removing the authorization header before forwarding the request to your service. | false      | No      |


### PR DESCRIPTION
### What does this PR do?

Fix anchors in basic auth configuration options

### Motivation

Clicking on the link lead to nothing which is confusing for the user

### More

- [-] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Looks like they were incorrect since the beginning in b7170df2c3a37caaf8e68de5919a2013d9c7b928
