### PR TITLE
Add missing reference docs for statusRewrites in errors middleware

### DIFF
--- a/docs/content/reference/routing-configuration/http/middlewares/errorpages.md
+++ b/docs/content/reference/routing-configuration/http/middlewares/errorpages.md
@@ -111,9 +111,11 @@ the [`passHostHeader`](../../../../routing/services/index.md#pass-host-header) o
 
 ### statusRewrites
 
-An optional mapping of status codes to be rewritten.
+`statusRewrites` is an optional mapping of status codes to be rewritten.
+
 For example, if a service returns a 418, you might want to rewrite it to a 404.
 You can map individual status codes or even ranges to a different status code.
+
 The syntax for ranges follows the same rules as the <a href="#opt-status">`status`</a> option.
 
 ### query


### PR DESCRIPTION
### What does this PR do?

This PR adds the original documentation for the statusRewrites option in the error pages middleware, originally introduced with PR #11520 and closes #12169.

### Motivation

The documentation got lost somehow.

Fixes #12169

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

