### PR TITLE
Make the aggregator compute provider namespace for router's parentRefs

### DIFF
--- a/integration/fixtures/routing/multi_layer_auth.toml
+++ b/integration/fixtures/routing/multi_layer_auth.toml
@@ -42,10 +42,10 @@
   [http.routers.admin-router]
     rule = "Header(`X-User-Role`, `admin`)"
     service = "admin-service"
-    parentRefs = ["parent-router@file"]
+    parentRefs = ["parent-router"]
 
   # Child router for developer role
   [http.routers.developer-router]
     rule = "Header(`X-User-Role`, `developer`)"
     service = "developer-service"
-    parentRefs = ["parent-router@file"]
+    parentRefs = ["parent-router"]

--- a/pkg/server/aggregator.go
+++ b/pkg/server/aggregator.go
@@ -65,6 +65,16 @@ func mergeConfiguration(configurations dynamic.Configurations, defaultEntryPoint
 						Msg("Router's `ruleSyntax` option is deprecated, please remove any usage of this option.")
 				}
 
+				var qualifiedParentRefs []string
+				for _, parentRef := range router.ParentRefs {
+					if parts := strings.Split(parentRef, "@"); len(parts) == 1 {
+						parentRef = provider.MakeQualifiedName(pvd, parentRef)
+					}
+
+					qualifiedParentRefs = append(qualifiedParentRefs, parentRef)
+				}
+				router.ParentRefs = qualifiedParentRefs
+
 				conf.HTTP.Routers[provider.MakeQualifiedName(pvd, routerName)] = router
 			}
 			for middlewareName, middleware := range configuration.HTTP.Middlewares {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.5

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.5

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes the multilayer routing by making the aggregator compute provider namespace for router's parentRefs.
Previously, multilayer routing would only work for qualified parentRefs with the provider namespace.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

To have the multilayer routing working when parentRefs are provided without the provider namespace.
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Kevin Pollet <pollet.kevin@gmail.com>
<!-- Anything else we should know when reviewing? -->
