### PR TITLE
Updates Docker Client API version 1.24 -> 1.44

### DIFF
--- a/pkg/provider/docker/pdocker.go
+++ b/pkg/provider/docker/pdocker.go
@@ -22,7 +22,7 @@ import (
 )
 
 // DockerAPIVersion is a constant holding the version of the Provider API traefik will use.
-const DockerAPIVersion = "1.24"
+const DockerAPIVersion = "1.44"
 
 const dockerName = "docker"
 


### PR DESCRIPTION
Oldest supported version [as of Docker 29.0](https://docs.docker.com/engine/release-notes/29/#breaking-changes) is 1.44. Fixes #12253, but in a manner that introduces backward incompatibilities.

<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.5

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.5

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Updates Docker Client API to the minimum version to be compatible with the latest released version of Docker CE (v1.24 -> v1.44).

### Motivation

Am also suffering from shared issue with #12253.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
