### PR TITLE
Auto-negotiate Docker API Version

### DIFF
--- a/pkg/provider/docker/pdocker.go
+++ b/pkg/provider/docker/pdocker.go
@@ -21,9 +21,6 @@ import (
 	"github.com/traefik/traefik/v3/pkg/safe"
 )
 
-// DockerAPIVersion is a constant holding the version of the Provider API traefik will use.
-const DockerAPIVersion = "1.24"
-
 const dockerName = "docker"
 
 var _ provider.Provider = (*Provider)(nil)
@@ -54,7 +51,6 @@ func (p *Provider) Init() error {
 }
 
 func (p *Provider) createClient(ctx context.Context) (*client.Client, error) {
-	p.ClientConfig.apiVersion = DockerAPIVersion
 	return createClient(ctx, p.ClientConfig)
 }
 

--- a/pkg/provider/docker/pswarm.go
+++ b/pkg/provider/docker/pswarm.go
@@ -22,9 +22,6 @@ import (
 	"github.com/traefik/traefik/v3/pkg/safe"
 )
 
-// SwarmAPIVersion is a constant holding the version of the Provider API traefik will use.
-const SwarmAPIVersion = "1.24"
-
 const swarmName = "swarm"
 
 var _ provider.Provider = (*SwarmProvider)(nil)
@@ -58,7 +55,6 @@ func (p *SwarmProvider) Init() error {
 }
 
 func (p *SwarmProvider) createClient(ctx context.Context) (*client.Client, error) {
-	p.ClientConfig.apiVersion = SwarmAPIVersion
 	return createClient(ctx, p.ClientConfig)
 }
 

--- a/pkg/provider/docker/shared.go
+++ b/pkg/provider/docker/shared.go
@@ -100,8 +100,6 @@ func parseContainer(container containertypes.InspectResponse) dockerData {
 }
 
 type ClientConfig struct {
-	apiVersion string
-
 	Username          string           `description:"Username for Basic HTTP authentication." json:"username,omitempty" toml:"username,omitempty" yaml:"username,omitempty"`
 	Password          string           `description:"Password for Basic HTTP authentication." json:"password,omitempty" toml:"password,omitempty" yaml:"password,omitempty"`
 	Endpoint          string           `description:"Docker server endpoint. Can be a TCP or a Unix socket endpoint." json:"endpoint,omitempty" toml:"endpoint,omitempty" yaml:"endpoint,omitempty"`
@@ -124,7 +122,7 @@ func createClient(ctx context.Context, cfg ClientConfig) (*client.Client, error)
 
 	opts = append(opts,
 		client.WithHTTPHeaders(httpHeaders),
-		client.WithVersion(cfg.apiVersion))
+		client.WithAPIVersionNegotiation())
 
 	return client.NewClientWithOpts(opts...)
 }


### PR DESCRIPTION
### What does this PR do?

This PR fixes #12253 by removing the hardcoded docker api version and relying on auto-negotiation between the docker client (sdk) and server using [WithAPIVersionNegotiation()](https://github.com/moby/moby/blob/v28.5.2/client/options.go#L221).

### Motivation

Traefik currently fails to work with Docker v29 with the following errors:

```
2025-11-10T23:03:43Z ERR Failed to retrieve information of the docker client and server host error="Error response from daemon: client version 1.24 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version" providerName=docker
2025-11-10T23:03:43Z ERR Provider error, retrying in 2.356192979s error="Error response from daemon: client version 1.24 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version" providerName=docker
```

Fixes #12253

### Additional Notes

- Tested on production servers with Docker 29.0.0.
- Test docker image available with tag `felixbuenemann/traefik:v3.6` on docker hub (created with `make build-image`)
