### PR TITLE
Auto-negotiate Docker API version

### DIFF
--- a/pkg/provider/docker/docker.go
+++ b/pkg/provider/docker/docker.go
@@ -33,14 +33,6 @@ import (
 	"github.com/traefik/traefik/v2/pkg/version"
 )
 
-const (
-	// DockerAPIVersion is a constant holding the version of the Provider API traefik will use.
-	DockerAPIVersion = "1.24"
-
-	// SwarmAPIVersion is a constant holding the version of the Provider API traefik will use.
-	SwarmAPIVersion = "1.24"
-)
-
 // DefaultTemplateRule The default template for the default rule.
 const DefaultTemplateRule = "Host(`{{ normalize .Name }}`)"
 
@@ -121,13 +113,10 @@ func (p *Provider) createClient() (client.APIClient, error) {
 	httpHeaders := map[string]string{
 		"User-Agent": "Traefik " + version.Version,
 	}
-	opts = append(opts, client.WithHTTPHeaders(httpHeaders))
-
-	apiVersion := DockerAPIVersion
-	if p.SwarmMode {
-		apiVersion = SwarmAPIVersion
-	}
-	opts = append(opts, client.WithVersion(apiVersion))
+	opts = append(opts,
+		client.FromEnv,
+		client.WithAPIVersionNegotiation(),
+		client.WithHTTPHeaders(httpHeaders))
 
 	return client.NewClientWithOpts(opts...)
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request avoids hardcoding the Docker API version.
Based on https://github.com/traefik/traefik/pull/12256


### Motivation

Related to https://github.com/traefik/traefik/issues/12253


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
