### PR TITLE
Add blog post link into Nginx Provider reference documentation

### DIFF
--- a/docs/content/reference/routing-configuration/kubernetes/ingress-nginx.md
+++ b/docs/content/reference/routing-configuration/kubernetes/ingress-nginx.md
@@ -237,6 +237,8 @@ which in turn will create the resulting routers, services, handlers, etc.
                         number: 80
       ```
 
+See also this TraefikLabs [blog post](https://traefik.io/blog/transition-from-ingress-nginx-to-traefik).
+
 ## Annotations Support
 
 This section lists all known NGINX Ingress annotations, split between those currently implemented (with limitations if any) and those not implemented. 


### PR DESCRIPTION
### What does this PR do?

Add a link to traefik blog post in nginx provider reference documentation. 
This blog post give context and shows a step-by-step simple migration example.

### Motivation

FTM, there is only reference documentation about this provider. 

### More

- [x] Added/updated documentation