### PR TITLE
Add documentation for loadbalancer.server.url in Docker and Swarm providers

### DIFF
--- a/docs/content/reference/routing-configuration/other-providers/docker.md
+++ b/docs/content/reference/routing-configuration/other-providers/docker.md
@@ -287,10 +287,11 @@ you'd add the label `traefik.http.services.<name-of-your-choice>.loadbalancer.pa
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.server.url`"
 
-    Specifies a URL to publish on the service, rather than just a port and scheme
+    Defines the service URL.
+    This option cannot be used in combination with `port` or `scheme` definition.
 
     ```yaml
-     "traefik.http.services.myservice.loadbalancer.server.url=http://container-name-here:8080"
+    traefik.http.services.<service_name>.loadbalancer.server.url=http://foobar:8080
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.serverstransport`"

--- a/docs/content/reference/routing-configuration/other-providers/swarm.md
+++ b/docs/content/reference/routing-configuration/other-providers/swarm.md
@@ -303,10 +303,11 @@ you'd add the label `traefik.http.services.<name-of-your-choice>.loadbalancer.pa
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.server.url`"
 
-    Specifies a URL to publish on the service, rather than just a port and scheme
+    Defines the service URL.
+    This option cannot be used in combination with `port` or `scheme` definition.
 
     ```yaml
-     "traefik.http.services.myservice.loadbalancer.server.url=http://container-name-here:8080"
+    traefik.http.services.<service_name>.loadbalancer.server.url=http://foobar:8080
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.server.weight`"


### PR DESCRIPTION
Added information about specifying a URL for the service in Docker configuration. This is per #11374 and #8753

<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.5

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.5

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Updates the documentation to specify that `loadbalancer.server.url` is available as a label option for the Docker provider.


### Motivation

It was added in #11374 but the documentation wasn't updated. What is confusing, is that [this page](https://doc.traefik.io/traefik/reference/routing-configuration/http/load-balancing/service/#configuration-example) documents `.loadbalancer.servers[0].url` as an option in the labels example, but that doesn't work (in Swarm, at least).


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
Replaces #12223 