### PR TITLE
Validate plugin module name

### DIFF
--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/traefik/traefik/v2/pkg/log"
+	"golang.org/x/mod/module"
 )
 
 const localGoPath = "./plugins-local/"
@@ -68,24 +69,18 @@ func checkRemotePluginsConfiguration(plugins map[string]Descriptor) error {
 
 	var errs []string
 	for pAlias, descriptor := range plugins {
-		if descriptor.ModuleName == "" {
-			errs = append(errs, fmt.Sprintf("%s: plugin name is missing", pAlias))
+		if err := module.CheckPath(descriptor.ModuleName); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: malformed plugin module name is missing: %s", pAlias, err))
 		}
 
 		if descriptor.Version == "" {
 			errs = append(errs, fmt.Sprintf("%s: plugin version is missing", pAlias))
 		}
 
-		if strings.HasPrefix(descriptor.ModuleName, "/") || strings.HasSuffix(descriptor.ModuleName, "/") {
-			errs = append(errs, fmt.Sprintf("%s: plugin name should not start or end with a /", pAlias))
-			continue
-		}
-
 		if _, ok := uniq[descriptor.ModuleName]; ok {
 			errs = append(errs, fmt.Sprintf("only one version of a plugin is allowed, there is a duplicate of %s", descriptor.ModuleName))
 			continue
 		}
-
 		uniq[descriptor.ModuleName] = struct{}{}
 	}
 

--- a/pkg/plugins/plugins_test.go
+++ b/pkg/plugins/plugins_test.go
@@ -1,0 +1,85 @@
+package plugins
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_checkRemotePluginsConfiguration(t *testing.T) {
+	testCases := []struct {
+		name    string
+		plugins map[string]Descriptor
+		wantErr bool
+	}{
+		{
+			name:    "nil plugins configuration returns no error",
+			plugins: nil,
+			wantErr: false,
+		},
+		{
+			name: "malformed module name returns error",
+			plugins: map[string]Descriptor{
+				"plugin1": {ModuleName: "invalid/module/name", Version: "v1.0.0"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "malformed module name with path traversal returns error",
+			plugins: map[string]Descriptor{
+				"plugin1": {ModuleName: "github.com/module/../name", Version: "v1.0.0"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "malformed module name with encoded path traversal returns error",
+			plugins: map[string]Descriptor{
+				"plugin1": {ModuleName: "github.com/module%2F%2E%2E%2Fname", Version: "v1.0.0"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "malformed module name returns error",
+			plugins: map[string]Descriptor{
+				"plugin1": {ModuleName: "invalid/module/name", Version: "v1.0.0"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing plugin version returns error",
+			plugins: map[string]Descriptor{
+				"plugin1": {ModuleName: "github.com/module/name", Version: ""},
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplicate plugin module name returns error",
+			plugins: map[string]Descriptor{
+				"plugin1": {ModuleName: "github.com/module/name", Version: "v1.0.0"},
+				"plugin2": {ModuleName: "github.com/module/name", Version: "v1.1.0"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid plugins configuration returns no error",
+			plugins: map[string]Descriptor{
+				"plugin1": {ModuleName: "github.com/module/name1", Version: "v1.0.0"},
+				"plugin2": {ModuleName: "github.com/module/name2", Version: "v1.1.0"},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := checkRemotePluginsConfiguration(test.plugins)
+			if test.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request validates that the plugin name is well-formed cause we were missing some validation. Before, a non-valid plugin module name would have led to an error when retrieving it from the registry.

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Romain <rtribotte@users.noreply.github.com>
