### PR TITLE
Replace Split in loops with more efficient SplitSeq

### DIFF
--- a/integration/access_log_test.go
+++ b/integration/access_log_test.go
@@ -245,8 +245,8 @@ func digestParts(resp *http.Response) map[string]string {
 	result := map[string]string{}
 	if len(resp.Header["Www-Authenticate"]) > 0 {
 		wantedHeaders := []string{"nonce", "realm", "qop", "opaque"}
-		responseHeaders := strings.Split(resp.Header["Www-Authenticate"][0], ",")
-		for _, r := range responseHeaders {
+		responseHeaders := strings.SplitSeq(resp.Header["Www-Authenticate"][0], ",")
+		for r := range responseHeaders {
 			for _, w := range wantedHeaders {
 				if strings.Contains(r, w) {
 					result[w] = strings.Split(r, `"`)[1]

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -409,7 +409,7 @@ func (s *BaseSuite) displayTraefikLog(output *bytes.Buffer) {
 	if output == nil || output.Len() == 0 {
 		log.Info().Msg("No Traefik logs.")
 	} else {
-		for _, line := range strings.Split(output.String(), "\n") {
+		for line := range strings.SplitSeq(output.String(), "\n") {
 			log.Info().Msg(line)
 		}
 	}

--- a/pkg/middlewares/accesslog/logger_test.go
+++ b/pkg/middlewares/accesslog/logger_test.go
@@ -325,7 +325,7 @@ func lineCount(t *testing.T, fileName string) int {
 	}
 
 	count := 0
-	for _, line := range strings.Split(string(fileContents), "\n") {
+	for line := range strings.SplitSeq(string(fileContents), "\n") {
 		if strings.TrimSpace(line) == "" {
 			continue
 		}

--- a/pkg/middlewares/auth/connectionheader.go
+++ b/pkg/middlewares/auth/connectionheader.go
@@ -22,7 +22,7 @@ func RemoveConnectionHeaders(req *http.Request) {
 	}
 
 	for _, f := range req.Header[connectionHeader] {
-		for _, sf := range strings.Split(f, ",") {
+		for sf := range strings.SplitSeq(f, ",") {
 			if sf = textproto.TrimString(sf); sf != "" {
 				req.Header.Del(sf)
 			}

--- a/pkg/middlewares/compress/acceptencoding.go
+++ b/pkg/middlewares/compress/acceptencoding.go
@@ -63,7 +63,7 @@ func parseAcceptableEncodings(acceptEncoding []string, supportedEncodings map[st
 	var encodings []Encoding
 
 	for _, line := range acceptEncoding {
-		for _, item := range strings.Split(strings.ReplaceAll(line, " ", ""), ",") {
+		for item := range strings.SplitSeq(strings.ReplaceAll(line, " ", ""), ",") {
 			parsed := strings.SplitN(item, ";", 2)
 			if len(parsed) == 0 {
 				continue

--- a/pkg/middlewares/forwardedheaders/forwarded_header.go
+++ b/pkg/middlewares/forwardedheaders/forwarded_header.go
@@ -216,7 +216,7 @@ func (x *XForwarded) removeConnectionHeaders(req *http.Request) {
 
 	var connectionHopByHopHeaders []string
 	for _, f := range req.Header[connection] {
-		for _, sf := range strings.Split(f, ",") {
+		for sf := range strings.SplitSeq(f, ",") {
 			if sf = textproto.TrimString(sf); sf != "" {
 				// Connection header cannot dictate to remove X- headers managed by Traefik,
 				// as per rfc7230 https://datatracker.ietf.org/doc/html/rfc7230#section-6.1,

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -1088,7 +1088,7 @@ func (p *Provider) certExists(validDomains []string) bool {
 
 func isDomainAlreadyChecked(domainToCheck string, existentDomains []string) bool {
 	for _, certDomains := range existentDomains {
-		for _, certDomain := range strings.Split(certDomains, ",") {
+		for certDomain := range strings.SplitSeq(certDomains, ",") {
 			if types.MatchDomain(domainToCheck, certDomain) {
 				return true
 			}

--- a/pkg/provider/kubernetes/ingress-nginx/annotations.go
+++ b/pkg/provider/kubernetes/ingress-nginx/annotations.go
@@ -92,8 +92,8 @@ func parseIngressConfig(ing *netv1.Ingress) (ingressConfig, error) {
 			if field.Type.Elem().Elem().Kind() == reflect.String {
 				// Handle slice of strings
 				var slice []string
-				elements := strings.Split(val, ",")
-				for _, elt := range elements {
+				elements := strings.SplitSeq(val, ",")
+				for elt := range elements {
 					slice = append(slice, strings.TrimSpace(elt))
 				}
 				cfgValue.Field(i).Set(reflect.ValueOf(&slice))

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
@@ -1128,8 +1128,8 @@ func basicAuthUsers(secret *corev1.Secret, authSecretType string) (dynamic.Users
 	}
 
 	// Trim lines and filter out blanks
-	rawLines := strings.Split(string(authFileContent), "\n")
-	for _, rawLine := range rawLines {
+	rawLines := strings.SplitSeq(string(authFileContent), "\n")
+	for rawLine := range rawLines {
 		line := strings.TrimSpace(rawLine)
 		if line != "" && !strings.HasPrefix(line, "#") {
 			users = append(users, line)

--- a/pkg/proxy/fast/proxy.go
+++ b/pkg/proxy/fast/proxy.go
@@ -364,7 +364,7 @@ type fasthttpHeader interface {
 // See RFC 7230, section 6.1.
 func removeConnectionHeaders(h fasthttpHeader) {
 	f := h.Peek(fasthttp.HeaderConnection)
-	for _, sf := range bytes.Split(f, []byte{','}) {
+	for sf := range bytes.SplitSeq(f, []byte{','}) {
 		if sf = bytes.TrimSpace(sf); len(sf) > 0 {
 			h.DelBytes(sf)
 		}

--- a/pkg/tls/certificate_store.go
+++ b/pkg/tls/certificate_store.go
@@ -102,7 +102,7 @@ func (c *CertificateStore) GetBestCertificate(clientHello *tls.ClientHelloInfo) 
 	matchedCerts := map[string]*CertificateData{}
 	if c.DynamicCerts != nil && c.DynamicCerts.Get() != nil {
 		for domains, cert := range c.DynamicCerts.Get().(map[string]*CertificateData) {
-			for _, certDomain := range strings.Split(domains, ",") {
+			for certDomain := range strings.SplitSeq(domains, ",") {
 				if matchDomain(serverName, certDomain) {
 					matchedCerts[certDomain] = cert
 				}
@@ -157,7 +157,7 @@ func (c *CertificateStore) GetCertificate(domains []string) *CertificateData {
 			}
 
 			var matchedDomains []string
-			for _, certDomain := range strings.Split(certDomains, ",") {
+			for certDomain := range strings.SplitSeq(certDomains, ",") {
 				for _, checkDomain := range domains {
 					if certDomain == checkDomain {
 						matchedDomains = append(matchedDomains, certDomain)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?



strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

It significantly reduces memory allocations and can improve performance for long strings.

More info: https://github.com/golang/go/issues/61901



### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
