### PR TITLE
Change ForwardAuth error log level from DEBUG to ERROR

### DIFF
--- a/pkg/middlewares/auth/forward.go
+++ b/pkg/middlewares/auth/forward.go
@@ -195,7 +195,7 @@ func (fa *forwardAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	forwardResponse, forwardErr := fa.client.Do(forwardReq)
 	if forwardErr != nil {
-		logger.Debug().Err(forwardErr).Msgf("Error calling %s", fa.address)
+		logger.Error().Err(forwardErr).Msgf("Error calling %s", fa.address)
 		observability.SetStatusErrorf(req.Context(), "Error calling %s. Cause: %s", fa.address, forwardErr)
 
 		statusCode := http.StatusInternalServerError


### PR DESCRIPTION
## What does this PR do?

When the ForwardAuth middleware fails to reach the authentication server, it returns a 500 error but logs at DEBUG level, making it difficult to diagnose issues in production without enabling debug logging.

This change promotes the error log to ERROR level for better observability.

## Motivation

As reported in #12234, when the ForwardAuth middleware cannot reach the auth server (e.g., DNS resolution failure, network issues), users receive 500 errors with no indication in logs unless DEBUG level is enabled. This makes troubleshooting production issues very difficult.

### Example log before this change:
```
2025-11-04T11:22:57Z DBG github.com/traefik/traefik/v3/pkg/middlewares/auth/forward.go:196 > Error calling <host>:8080/v0/auth:check error="..." 
```

### Example log after this change:
```
2025-11-04T11:22:57Z ERR github.com/traefik/traefik/v3/pkg/middlewares/auth/forward.go:196 > Error calling <host>:8080/v0/auth:check error="..."
```

## Changes

- Changed log level from `Debug()` to `Error()` in `pkg/middlewares/auth/forward.go` line 198

Fixes #12234