### PR TITLE
Remove max-width constraint to use full screen width

### DIFF
--- a/webui/src/components/resources/UsedByRoutersSection.tsx
+++ b/webui/src/components/resources/UsedByRoutersSection.tsx
@@ -1,4 +1,4 @@
-import { Flex } from '@traefiklabs/faency'
+import { AriaTable, AriaTbody, AriaThead, AriaTr, Flex } from '@traefiklabs/faency'
 import { orderBy } from 'lodash'
 import { useContext, useEffect, useMemo } from 'react'
 import { useSearchParams } from 'react-router-dom'
@@ -6,7 +6,7 @@ import { useSearchParams } from 'react-router-dom'
 import { SectionTitle } from './DetailsCard'
 
 import AriaTableSkeleton from 'components/tables/AriaTableSkeleton'
-import PaginatedTable from 'components/tables/PaginatedTable'
+import SortableTh from 'components/tables/SortableTh'
 import { ToastContext } from 'contexts/toasts'
 import { makeRowRender } from 'pages/http/HttpRouters'
 
@@ -46,38 +46,29 @@ export const UsedByRoutersSection = ({ data, protocol = 'http' }: UsedByRoutersS
     )
   }, [addToast, routersNotFound])
 
-  const columns = useMemo((): Array<{
-    key: keyof Router.DetailsData
-    header: string
-    sortable?: boolean
-    width?: string
-  }> => {
-    return [
-      { key: 'status', header: 'Status', sortable: true, width: '36px' },
-      ...(protocol !== 'udp' ? [{ key: 'tls' as keyof Router.DetailsData, header: 'TLS', width: '24px' }] : []),
-      ...(protocol !== 'udp' ? [{ key: 'rule' as keyof Router.DetailsData, header: 'Rule', sortable: true }] : []),
-      { key: 'using', header: 'Entrypoints', sortable: true },
-      { key: 'name', header: 'Name', sortable: true },
-      { key: 'service', header: 'Service', sortable: true },
-      { key: 'provider', header: 'Provider', sortable: true, width: '40px' },
-      { key: 'priority', header: 'Priority', sortable: true },
-    ]
-  }, [protocol])
-
   if (!routersFound || routersFound.length <= 0) {
     return null
   }
 
   return (
-    <Flex gap={2} css={{ flexDirection: 'column' }}>
-      <SectionTitle title="Used by routers" />
-      <PaginatedTable
-        data={routersFound}
-        columns={columns}
-        itemsPerPage={10}
-        testId="routers-table"
-        renderRow={renderRow}
-      />
+    <Flex css={{ flexDirection: 'column', mt: '$5' }}>
+      <SectionTitle title="Used by Routers" />
+
+      <AriaTable data-testid="routers-table" css={{ tableLayout: 'auto' }}>
+        <AriaThead>
+          <AriaTr>
+            <SortableTh label="Status" css={{ width: '40px' }} isSortable sortByValue="status" />
+            {protocol !== 'udp' ? <SortableTh css={{ width: '40px' }} label="TLS" /> : null}
+            {protocol !== 'udp' ? <SortableTh label="Rule" isSortable sortByValue="rule" /> : null}
+            <SortableTh label="Entrypoints" isSortable sortByValue="entryPoints" />
+            <SortableTh label="Name" isSortable sortByValue="name" />
+            <SortableTh label="Service" isSortable sortByValue="service" />
+            <SortableTh label="Provider" css={{ width: '40px' }} isSortable sortByValue="provider" />
+            <SortableTh label="Priority" isSortable sortByValue="priority" />
+          </AriaTr>
+        </AriaThead>
+        <AriaTbody>{routersFound.map(renderRow)}</AriaTbody>
+      </AriaTable>
     </Flex>
   )
 }

--- a/webui/src/pages/http/HttpMiddlewares.tsx
+++ b/webui/src/pages/http/HttpMiddlewares.tsx
@@ -57,7 +57,7 @@ export const HttpMiddlewaresRender = ({
 
   return (
     <>
-      <AriaTable>
+      <AriaTable css={{ tableLayout: 'auto' }}>
         <AriaThead>
           <AriaTr>
             <SortableTh label="Status" css={{ width: '36px' }} isSortable sortByValue="status" />

--- a/webui/src/pages/http/HttpRouters.tsx
+++ b/webui/src/pages/http/HttpRouters.tsx
@@ -86,7 +86,7 @@ export const HttpRoutersRender = ({
 
   return (
     <>
-      <AriaTable>
+      <AriaTable css={{ tableLayout: 'auto' }}>
         <AriaThead>
           <AriaTr>
             <SortableTh label="Status" css={{ width: '36px' }} isSortable sortByValue="status" />

--- a/webui/src/pages/http/HttpServices.tsx
+++ b/webui/src/pages/http/HttpServices.tsx
@@ -55,7 +55,7 @@ export const HttpServicesRender = ({
 
   return (
     <>
-      <AriaTable>
+      <AriaTable css={{ tableLayout: 'auto' }}>
         <AriaThead>
           <AriaTr>
             <SortableTh label="Status" css={{ width: '36px' }} isSortable sortByValue="status" />

--- a/webui/src/pages/tcp/TcpMiddlewares.tsx
+++ b/webui/src/pages/tcp/TcpMiddlewares.tsx
@@ -57,7 +57,7 @@ export const TcpMiddlewaresRender = ({
 
   return (
     <>
-      <AriaTable>
+      <AriaTable css={{ tableLayout: 'auto' }}>
         <AriaThead>
           <AriaTr>
             <SortableTh label="Status" css={{ width: '36px' }} isSortable sortByValue="status" />

--- a/webui/src/pages/tcp/TcpRouters.tsx
+++ b/webui/src/pages/tcp/TcpRouters.tsx
@@ -71,7 +71,7 @@ export const TcpRoutersRender = ({
 
   return (
     <>
-      <AriaTable>
+      <AriaTable css={{ tableLayout: 'auto' }}>
         <AriaThead>
           <AriaTr>
             <SortableTh label="Status" css={{ width: '36px' }} isSortable sortByValue="status" />

--- a/webui/src/pages/tcp/TcpServices.tsx
+++ b/webui/src/pages/tcp/TcpServices.tsx
@@ -55,7 +55,7 @@ export const TcpServicesRender = ({
 
   return (
     <>
-      <AriaTable>
+      <AriaTable css={{ tableLayout: 'auto' }}>
         <AriaThead>
           <AriaTr>
             <SortableTh label="Status" css={{ width: '36px' }} isSortable sortByValue="status" />

--- a/webui/src/pages/udp/UdpRouters.tsx
+++ b/webui/src/pages/udp/UdpRouters.tsx
@@ -57,7 +57,7 @@ export const UdpRoutersRender = ({
 
   return (
     <>
-      <AriaTable>
+      <AriaTable css={{ tableLayout: 'auto' }}>
         <AriaThead>
           <AriaTr>
             <SortableTh label="Status" css={{ width: '36px' }} isSortable sortByValue="status" />

--- a/webui/src/pages/udp/UdpServices.tsx
+++ b/webui/src/pages/udp/UdpServices.tsx
@@ -55,7 +55,7 @@ export const UdpServicesRender = ({
 
   return (
     <>
-      <AriaTable>
+      <AriaTable css={{ tableLayout: 'auto' }}>
         <AriaThead>
           <AriaTr>
             <SortableTh label="Status" css={{ width: '36px' }} isSortable sortByValue="status" />


### PR DESCRIPTION
## What does this PR do?

Removes the `maxWidth` CSS constraint on the Container component that was limiting the table width on large screens (>1440px).

## Motivation

As reported in #12312, tables don't use the full screen width, which results in truncated content (especially router rules). Users with large monitors couldn't benefit from the extra screen real estate.

## Changes

Removed the media query in `webui/src/layout/Container.tsx` that was setting:
```css
@media (min-width: 1440px) {
  max-width: calc(1440px - 96px);
  margin: 0 auto;
}
```

### Before
Tables were capped at ~1344px width, causing content truncation on large screens.

### After
Tables now expand to use the full available width, making long content like router rules more readable.

Fixes #12312