### PR TITLE
Close listener at last sequence to avoid flakiness

### DIFF
--- a/pkg/healthcheck/healthcheck_tcp_test.go
+++ b/pkg/healthcheck/healthcheck_tcp_test.go
@@ -481,7 +481,7 @@ func TestServiceTCPHealthChecker_Launch(t *testing.T) {
 			}
 
 			// Wait for all health checks to complete deterministically
-			for range test.server.StatusSequence {
+			for i := range test.server.StatusSequence {
 				test.server.Next()
 
 				initialUpserted := lb.numUpsertedServers
@@ -490,6 +490,11 @@ func TestServiceTCPHealthChecker_Launch(t *testing.T) {
 				for time.Now().Before(deadline) {
 					time.Sleep(5 * time.Millisecond)
 					if lb.numUpsertedServers > initialUpserted || lb.numRemovedServers > initialRemoved {
+						// Stop the health checker immediately after the last expected sequence completes
+						// to prevent extra health checks from firing and modifying the counters.
+						if i == len(test.server.StatusSequence)-1 {
+							cancel()
+						}
 						break
 					}
 				}
@@ -700,12 +705,6 @@ func (s *sequencedTCPServer) Start(t *testing.T) {
 					t.Errorf("failed to write payload: %v", err)
 				}
 			}
-		}
-
-		// Close the final listener to prevent health checks from succeeding
-		// after all test sequences are exhausted, which would cause flaky test failures.
-		if listener != nil {
-			listener.Close()
 		}
 
 		defer close(s.release)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Fixes a flaky test in the TCP health check by stopping the healthcheck, preventing the health check goroutine from calling the listener after the `statusSequence` is completed.


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [ ] ~Added/updated documentation~
 
