### PR TITLE
Fix migration guide indentation

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -717,7 +717,7 @@ However, it can be re-enabled by setting the `multipathtcp` variable in the GODE
 
 ## v2.11.32
 
-## Encoded Characters in Request Path
+### Encoded Characters in Request Path
 
 Since `v2.11.32`, for security reasons Traefik now rejects requests with a path containing a specific set of encoded characters by default.
 When such a request is received, Traefik responds with a `400 Bad Request` status code.

--- a/docs/content/security/request-path.md
+++ b/docs/content/security/request-path.md
@@ -1,5 +1,5 @@
 ---
-title: "Request Path Security"
+title: "Request Path"
 description: "Learn how Traefik processes and secures request paths through sanitization and encoded character filtering to protect against path traversal and injection attacks."
 ---
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request fixes the migration guide indentation.


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
