### PR TITLE
Fix encoded characters entryPoint option documentation

### DIFF
--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -127,14 +127,15 @@ They can be defined by using a file (YAML or TOML) or CLI arguments.
           trustedIPs:
             - "127.0.0.1"
             - "192.168.0.1"
-        encodedCharacters:
-          allowEncodedSlash: true
-          allowEncodedBackSlash: true
-          allowEncodedNullCharacter: true
-          allowEncodedSemicolon: true
-          allowEncodedPercent: true
-          allowEncodedQuestionMark: true
-          allowEncodedHash: true
+        http:
+          encodedCharacters:
+            allowEncodedSlash: true
+            allowEncodedBackSlash: true
+            allowEncodedNullCharacter: true
+            allowEncodedSemicolon: true
+            allowEncodedPercent: true
+            allowEncodedQuestionMark: true
+            allowEncodedHash: true
     ```
 
     ```toml tab="File (TOML)"
@@ -160,7 +161,7 @@ They can be defined by using a file (YAML or TOML) or CLI arguments.
         [entryPoints.name.forwardedHeaders]
           insecure = true
           trustedIPs = ["127.0.0.1", "192.168.0.1"]
-        [entryPoints.name.encodedCharacters]
+        [entryPoints.name.http.encodedCharacters]
           allowEncodedSlash = true
           allowEncodedBackSlash = true
           allowEncodedNullCharacter = true
@@ -184,13 +185,13 @@ They can be defined by using a file (YAML or TOML) or CLI arguments.
     --entryPoints.name.proxyProtocol.trustedIPs=127.0.0.1,192.168.0.1
     --entryPoints.name.forwardedHeaders.insecure=true
     --entryPoints.name.forwardedHeaders.trustedIPs=127.0.0.1,192.168.0.1
-    --entryPoints.name.encodedCharacters.allowEncodedSlash=true
-    --entryPoints.name.encodedCharacters.allowEncodedBackSlash=true
-    --entryPoints.name.encodedCharacters.allowEncodedNullCharacter=true
-    --entryPoints.name.encodedCharacters.allowEncodedSemicolon=true
-    --entryPoints.name.encodedCharacters.allowEncodedPercent=true
-    --entryPoints.name.encodedCharacters.allowEncodedQuestionMark=true
-    --entryPoints.name.encodedCharacters.allowEncodedHash=true
+    --entryPoints.name.http.encodedCharacters.allowEncodedSlash=true
+    --entryPoints.name.http.encodedCharacters.allowEncodedBackSlash=true
+    --entryPoints.name.http.encodedCharacters.allowEncodedNullCharacter=true
+    --entryPoints.name.http.encodedCharacters.allowEncodedSemicolon=true
+    --entryPoints.name.http.encodedCharacters.allowEncodedPercent=true
+    --entryPoints.name.http.encodedCharacters.allowEncodedQuestionMark=true
+    --entryPoints.name.http.encodedCharacters.allowEncodedHash=true
     ```
 
 ### Address

--- a/docs/content/security/request-path.md
+++ b/docs/content/security/request-path.md
@@ -93,21 +93,22 @@ All encoded character filtering is enabled by default (`false` means encoded cha
 entryPoints:
   websecure:
     address: ":443"
-    encodedCharacters:
-      allowEncodedSlash: false          # %2F - Default: false (RECOMMENDED)
-      allowEncodedBackSlash: false      # %5C - Default: false (RECOMMENDED)
-      allowEncodedNullCharacter: false  # %00 - Default: false (RECOMMENDED)
-      allowEncodedSemicolon: false      # %3B - Default: false (RECOMMENDED)
-      allowEncodedPercent: false        # %25 - Default: false (RECOMMENDED)
-      allowEncodedQuestionMark: false   # %3F - Default: false (RECOMMENDED)
-      allowEncodedHash: false           # %23 - Default: false (RECOMMENDED)
+    http:
+      encodedCharacters:
+        allowEncodedSlash: false          # %2F - Default: false (RECOMMENDED)
+        allowEncodedBackSlash: false      # %5C - Default: false (RECOMMENDED)
+        allowEncodedNullCharacter: false  # %00 - Default: false (RECOMMENDED)
+        allowEncodedSemicolon: false      # %3B - Default: false (RECOMMENDED)
+        allowEncodedPercent: false        # %25 - Default: false (RECOMMENDED)
+        allowEncodedQuestionMark: false   # %3F - Default: false (RECOMMENDED)
+        allowEncodedHash: false           # %23 - Default: false (RECOMMENDED)
 ```
 
 ```toml tab="File (TOML)"
 [entryPoints.websecure]
   address = ":443"
 
-  [entryPoints.websecure.encodedCharacters]
+  [entryPoints.websecure.http.encodedCharacters]
     allowEncodedSlash = false
     allowEncodedBackSlash = false
     allowEncodedNullCharacter = false
@@ -119,11 +120,11 @@ entryPoints:
 
 ```bash tab="CLI"
 --entryPoints.websecure.address=:443
---entryPoints.websecure.encodedCharacters.allowEncodedSlash=false
---entryPoints.websecure.encodedCharacters.allowEncodedBackSlash=false
---entryPoints.websecure.encodedCharacters.allowEncodedNullCharacter=false
---entryPoints.websecure.encodedCharacters.allowEncodedSemicolon=false
---entryPoints.websecure.encodedCharacters.allowEncodedPercent=false
---entryPoints.websecure.encodedCharacters.allowEncodedQuestionMark=false
---entryPoints.websecure.encodedCharacters.allowEncodedHash=false
+--entryPoints.websecure.http.encodedCharacters.allowEncodedSlash=false
+--entryPoints.websecure.http.encodedCharacters.allowEncodedBackSlash=false
+--entryPoints.websecure.http.encodedCharacters.allowEncodedNullCharacter=false
+--entryPoints.websecure.http.encodedCharacters.allowEncodedSemicolon=false
+--entryPoints.websecure.http.encodedCharacters.allowEncodedPercent=false
+--entryPoints.websecure.http.encodedCharacters.allowEncodedQuestionMark=false
+--entryPoints.websecure.http.encodedCharacters.allowEncodedHash=false
 ```


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes the encodedCharacters entryPoint option documentation by adding the missing `http` configuration node to which it belong.
<!-- A brief description of the change being made with this pull request. -->

### Motivation

Fixes #12380
<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
