### PR TITLE
Fix encodedCharacters entryPoint option documentation

### DIFF
--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -129,14 +129,15 @@ They can be defined by using a file (YAML or TOML) or CLI arguments.
           trustedIPs:
             - "127.0.0.1"
             - "192.168.0.1"
-        encodedCharacters:
-          allowEncodedSlash: true
-          allowEncodedBackSlash: true
-          allowEncodedNullCharacter: true
-          allowEncodedSemicolon: true
-          allowEncodedPercent: true
-          allowEncodedQuestionMark: true
-          allowEncodedHash: true
+        http:
+          encodedCharacters:
+            allowEncodedSlash: true
+            allowEncodedBackSlash: true
+            allowEncodedNullCharacter: true
+            allowEncodedSemicolon: true
+            allowEncodedPercent: true
+            allowEncodedQuestionMark: true
+            allowEncodedHash: true
     ```
 
     ```toml tab="File (TOML)"
@@ -164,7 +165,7 @@ They can be defined by using a file (YAML or TOML) or CLI arguments.
         [entryPoints.name.forwardedHeaders]
           insecure = true
           trustedIPs = ["127.0.0.1", "192.168.0.1"]
-        [entryPoints.name.encodedCharacters]
+        [entryPoints.name.http.encodedCharacters]
           allowEncodedSlash = true
           allowEncodedBackSlash = true
           allowEncodedNullCharacter = true
@@ -190,13 +191,13 @@ They can be defined by using a file (YAML or TOML) or CLI arguments.
     --entryPoints.name.proxyProtocol.trustedIPs=127.0.0.1,192.168.0.1
     --entryPoints.name.forwardedHeaders.insecure=true
     --entryPoints.name.forwardedHeaders.trustedIPs=127.0.0.1,192.168.0.1
-    --entryPoints.name.encodedCharacters.allowEncodedSlash=true
-    --entryPoints.name.encodedCharacters.allowEncodedBackSlash=true
-    --entryPoints.name.encodedCharacters.allowEncodedNullCharacter=true
-    --entryPoints.name.encodedCharacters.allowEncodedSemicolon=true
-    --entryPoints.name.encodedCharacters.allowEncodedPercent=true
-    --entryPoints.name.encodedCharacters.allowEncodedQuestionMark=true
-    --entryPoints.name.encodedCharacters.allowEncodedHash=true
+    --entryPoints.name.http.encodedCharacters.allowEncodedSlash=true
+    --entryPoints.name.http.encodedCharacters.allowEncodedBackSlash=true
+    --entryPoints.name.http.encodedCharacters.allowEncodedNullCharacter=true
+    --entryPoints.name.http.encodedCharacters.allowEncodedSemicolon=true
+    --entryPoints.name.http.encodedCharacters.allowEncodedPercent=true
+    --entryPoints.name.http.encodedCharacters.allowEncodedQuestionMark=true
+    --entryPoints.name.http.encodedCharacters.allowEncodedHash=true
     ```
 
 ### Address
@@ -657,8 +658,9 @@ By default, Traefik rejects requests containing certain encoded characters that 
     entryPoints:
       web:
         address: ":80"
-        encodedCharacters:
-          allowEncodedSlash: true
+        http:
+          encodedCharacters:
+            allowEncodedSlash: true
     ```
 
     ```toml tab="File (TOML)"
@@ -667,14 +669,14 @@ By default, Traefik rejects requests containing certain encoded characters that 
       [entryPoints.web]
         address = ":80"
 
-        [entryPoints.web.encodedCharacters]
+        [entryPoints.web.http.encodedCharacters]
           allowEncodedSlash = true
     ```
 
     ```bash tab="CLI"
     ## Static configuration
     --entryPoints.web.address=:80
-    --entryPoints.web.encodedCharacters.allowEncodedSlash=true
+    --entryPoints.web.http.encodedCharacters.allowEncodedSlash=true
     ```
 
 ??? info "`encodedCharacters.allowEncodedBackSlash`"
@@ -688,8 +690,9 @@ By default, Traefik rejects requests containing certain encoded characters that 
     entryPoints:
       web:
         address: ":80"
-        encodedCharacters:
-          allowEncodedBackSlash: true
+        http:
+          encodedCharacters:
+            allowEncodedBackSlash: true
     ```
 
     ```toml tab="File (TOML)"
@@ -698,14 +701,14 @@ By default, Traefik rejects requests containing certain encoded characters that 
       [entryPoints.web]
         address = ":80"
 
-        [entryPoints.web.encodedCharacters]
+        [entryPoints.web.http.encodedCharacters]
           allowEncodedBackSlash = true
     ```
 
     ```bash tab="CLI"
     ## Static configuration
     --entryPoints.web.address=:80
-    --entryPoints.web.encodedCharacters.allowEncodedBackSlash=true
+    --entryPoints.web.http.encodedCharacters.allowEncodedBackSlash=true
     ```
 
 ??? info "`encodedCharacters.allowEncodedNullCharacter`"
@@ -719,8 +722,9 @@ By default, Traefik rejects requests containing certain encoded characters that 
     entryPoints:
       web:
         address: ":80"
-        encodedCharacters:
-          allowEncodedNullCharacter: true
+        http:
+          encodedCharacters:
+            allowEncodedNullCharacter: true
     ```
 
     ```toml tab="File (TOML)"
@@ -729,14 +733,14 @@ By default, Traefik rejects requests containing certain encoded characters that 
       [entryPoints.web]
         address = ":80"
 
-        [entryPoints.web.encodedCharacters]
+        [entryPoints.web.http.encodedCharacters]
           allowEncodedNullCharacter = true
     ```
 
     ```bash tab="CLI"
     ## Static configuration
     --entryPoints.web.address=:80
-    --entryPoints.web.encodedCharacters.allowEncodedNullCharacter=true
+    --entryPoints.web.http.encodedCharacters.allowEncodedNullCharacter=true
     ```
 
 ??? info "`encodedCharacters.allowEncodedSemicolon`"
@@ -750,8 +754,9 @@ By default, Traefik rejects requests containing certain encoded characters that 
     entryPoints:
       web:
         address: ":80"
-        encodedCharacters:
-          allowEncodedSemicolon: true
+        http:
+          encodedCharacters:
+            allowEncodedSemicolon: true
     ```
 
     ```toml tab="File (TOML)"
@@ -760,14 +765,14 @@ By default, Traefik rejects requests containing certain encoded characters that 
       [entryPoints.web]
         address = ":80"
 
-        [entryPoints.web.encodedCharacters]
+        [entryPoints.web.http.encodedCharacters]
           allowEncodedSemicolon = true
     ```
 
     ```bash tab="CLI"
     ## Static configuration
     --entryPoints.web.address=:80
-    --entryPoints.web.encodedCharacters.allowEncodedSemicolon=true
+    --entryPoints.web.http.encodedCharacters.allowEncodedSemicolon=true
     ```
 
 ??? info "`encodedCharacters.allowEncodedPercent`"
@@ -781,8 +786,9 @@ By default, Traefik rejects requests containing certain encoded characters that 
     entryPoints:
       web:
         address: ":80"
-        encodedCharacters:
-          allowEncodedPercent: true
+        http:
+          encodedCharacters:
+            allowEncodedPercent: true
     ```
 
     ```toml tab="File (TOML)"
@@ -791,14 +797,14 @@ By default, Traefik rejects requests containing certain encoded characters that 
       [entryPoints.web]
         address = ":80"
 
-        [entryPoints.web.encodedCharacters]
+        [entryPoints.web.http.encodedCharacters]
           allowEncodedPercent = true
     ```
 
     ```bash tab="CLI"
     ## Static configuration
     --entryPoints.web.address=:80
-    --entryPoints.web.encodedCharacters.allowEncodedPercent=true
+    --entryPoints.web.http.encodedCharacters.allowEncodedPercent=true
     ```
 
 ??? info "`encodedCharacters.allowEncodedQuestionMark`"
@@ -812,8 +818,9 @@ By default, Traefik rejects requests containing certain encoded characters that 
     entryPoints:
       web:
         address: ":80"
-        encodedCharacters:
-          allowEncodedQuestionMark: true
+        http:
+          encodedCharacters:
+            allowEncodedQuestionMark: true
     ```
 
     ```toml tab="File (TOML)"
@@ -822,14 +829,14 @@ By default, Traefik rejects requests containing certain encoded characters that 
       [entryPoints.web]
         address = ":80"
 
-        [entryPoints.web.encodedCharacters]
+        [entryPoints.web.http.encodedCharacters]
           allowEncodedQuestionMark = true
     ```
 
     ```bash tab="CLI"
     ## Static configuration
     --entryPoints.web.address=:80
-    --entryPoints.web.encodedCharacters.allowEncodedQuestionMark=true
+    --entryPoints.web.http.encodedCharacters.allowEncodedQuestionMark=true
     ```
 
 ??? info "`encodedCharacters.allowEncodedHash`"
@@ -843,8 +850,9 @@ By default, Traefik rejects requests containing certain encoded characters that 
     entryPoints:
       web:
         address: ":80"
-        encodedCharacters:
-          allowEncodedHash: true
+        http:
+          encodedCharacters:
+            allowEncodedHash: true
     ```
 
     ```toml tab="File (TOML)"
@@ -853,14 +861,14 @@ By default, Traefik rejects requests containing certain encoded characters that 
       [entryPoints.web]
         address = ":80"
 
-        [entryPoints.web.encodedCharacters]
+        [entryPoints.web.http.encodedCharacters]
           allowEncodedHash = true
     ```
 
     ```bash tab="CLI"
     ## Static configuration
     --entryPoints.web.address=:80
-    --entryPoints.web.encodedCharacters.allowEncodedHash=true
+    --entryPoints.web.http.encodedCharacters.allowEncodedHash=true
     ```
 
 ### Transport

--- a/docs/content/security/request-path.md
+++ b/docs/content/security/request-path.md
@@ -93,21 +93,22 @@ All encoded character filtering is enabled by default (`false` means encoded cha
 entryPoints:
   websecure:
     address: ":443"
-    encodedCharacters:
-      allowEncodedSlash: false          # %2F - Default: false (RECOMMENDED)
-      allowEncodedBackSlash: false      # %5C - Default: false (RECOMMENDED)
-      allowEncodedNullCharacter: false  # %00 - Default: false (RECOMMENDED)
-      allowEncodedSemicolon: false      # %3B - Default: false (RECOMMENDED)
-      allowEncodedPercent: false        # %25 - Default: false (RECOMMENDED)
-      allowEncodedQuestionMark: false   # %3F - Default: false (RECOMMENDED)
-      allowEncodedHash: false           # %23 - Default: false (RECOMMENDED)
+    http:
+      encodedCharacters:
+        allowEncodedSlash: false          # %2F - Default: false (RECOMMENDED)
+        allowEncodedBackSlash: false      # %5C - Default: false (RECOMMENDED)
+        allowEncodedNullCharacter: false  # %00 - Default: false (RECOMMENDED)
+        allowEncodedSemicolon: false      # %3B - Default: false (RECOMMENDED)
+        allowEncodedPercent: false        # %25 - Default: false (RECOMMENDED)
+        allowEncodedQuestionMark: false   # %3F - Default: false (RECOMMENDED)
+        allowEncodedHash: false           # %23 - Default: false (RECOMMENDED)
 ```
 
 ```toml tab="File (TOML)"
 [entryPoints.websecure]
   address = ":443"
 
-  [entryPoints.websecure.encodedCharacters]
+  [entryPoints.websecure.http.encodedCharacters]
     allowEncodedSlash = false
     allowEncodedBackSlash = false
     allowEncodedNullCharacter = false
@@ -119,11 +120,11 @@ entryPoints:
 
 ```bash tab="CLI"
 --entryPoints.websecure.address=:443
---entryPoints.websecure.encodedCharacters.allowEncodedSlash=false
---entryPoints.websecure.encodedCharacters.allowEncodedBackSlash=false
---entryPoints.websecure.encodedCharacters.allowEncodedNullCharacter=false
---entryPoints.websecure.encodedCharacters.allowEncodedSemicolon=false
---entryPoints.websecure.encodedCharacters.allowEncodedPercent=false
---entryPoints.websecure.encodedCharacters.allowEncodedQuestionMark=false
---entryPoints.websecure.encodedCharacters.allowEncodedHash=false
+--entryPoints.websecure.http.encodedCharacters.allowEncodedSlash=false
+--entryPoints.websecure.http.encodedCharacters.allowEncodedBackSlash=false
+--entryPoints.websecure.http.encodedCharacters.allowEncodedNullCharacter=false
+--entryPoints.websecure.http.encodedCharacters.allowEncodedSemicolon=false
+--entryPoints.websecure.http.encodedCharacters.allowEncodedPercent=false
+--entryPoints.websecure.http.encodedCharacters.allowEncodedQuestionMark=false
+--entryPoints.websecure.http.encodedCharacters.allowEncodedHash=false
 ```


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes the encodedCharacters entryPoint option documentation by adding the missing `http` configuration node to which it belong.
<!-- A brief description of the change being made with this pull request. -->

### Motivation

Fixes #12380
<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
