### PR TITLE
feat(middleware): add generic OR-chain support (resolves #12249)

### DIFF
--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -23,6 +23,7 @@ type Middleware struct {
 	ReplacePath      *ReplacePath      `json:"replacePath,omitempty" toml:"replacePath,omitempty" yaml:"replacePath,omitempty" export:"true"`
 	ReplacePathRegex *ReplacePathRegex `json:"replacePathRegex,omitempty" toml:"replacePathRegex,omitempty" yaml:"replacePathRegex,omitempty" export:"true"`
 	Chain            *Chain            `json:"chain,omitempty" toml:"chain,omitempty" yaml:"chain,omitempty" export:"true"`
+	OrGroup 		  string		   `json:"orGroup,omitempty" yaml:"orGroup,omitempty"`
 	// Deprecated: please use IPAllowList instead.
 	IPWhiteList       *IPWhiteList       `json:"ipWhiteList,omitempty" toml:"ipWhiteList,omitempty" yaml:"ipWhiteList,omitempty" export:"true"`
 	IPAllowList       *IPAllowList       `json:"ipAllowList,omitempty" toml:"ipAllowList,omitempty" yaml:"ipAllowList,omitempty" export:"true"`


### PR DESCRIPTION
### What does this PR do?

This PR introduces a new optional orGroup` label in the middleware configuration.

Middlewares that share the same `orGroup`  name are evaluated using OR logic.
Different OR-chain groups are then combined using the existing AND-chain behavior.

This mechanism is generic and applies to all middleware types, not only `ipAllowList`.

If the `orGroup` label is not defined, the behavior remains fully backward-compatible and follows the original AND-chain implementation.

Multiple independent OR-chain groups are supported.

This PR also resolves the long-standing limitations described in:
- #12249 (ipAllowList OR behavior)

---

### Motivation

Currently, Traefik only supports strict AND behavior when chaining multiple middlewares.
This makes it impossible to express common access control patterns such as:

- Allow access if **IP is in group A OR IP is in group B**
- Combine multiple independent OR groups with AND logic
- Maybe other features (not tested)

For `ipAllowList`, this limitation forces users to duplicate shared IP ranges
(e.g. management IPs) across multiple routers.

By introducing the `orGroup` chaining mechanism, users can:
- Group middlewares using OR logic
- Combine multiple OR groups with AND logic
- Avoid configuration duplication
- Build more expressive and maintainable security policies

---

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

---

### Additional Notes

This change is fully backward-compatible.
Existing configurations continue to work without any changes when `orGroup` is not used.

Example logic supported after this change:

routers:
    first-router:
      rule: Host(`domain.tld`)
      entryPoints:
        - web-secure
      middlewares:
        - security-headers
        - management-whitelist # <--------
        - first-whitelist # <-----------
      service: first

  middlewares:
    management-whitelist:
      ipAllowList:
        sourceRange:
          - "1.1.1.1" # mgmt IP 1
          - "2.2.2.2" # mgmt IP 2
          ...
        orGroup: allowip1

    first-whitelist:
      ipAllowList:
        sourceRange:
          - "3.3.3.3" # special use case IP 3 for "first" service
        ...
        orGroup: allowip1

Logic: (management-whitelist or first-whitelist) and security-headers