### PR TITLE
Add Traefik ingress class annotation to IngressRoute

### DIFF
--- a/docs/content/getting-started/kubernetes.md
+++ b/docs/content/getting-started/kubernetes.md
@@ -190,6 +190,8 @@ apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: whoami
+  annotations:
+    kubernetes.io/ingress.class: traefik
 spec:
   entryPoints:
     - web


### PR DESCRIPTION
Traefik will not pick up the ingressRoute if not annotated properly

### What does this PR do?
Small documantion fix :: Demo Deployment (of _traefik/whoami_) will need an **ingressRoute with a traefik ingress class annotation**, otherwise Traefik will not pick up the ingressRoute and the user may be confused on the root cause.


### Motivation
Was confused by current docs, unable to deploy a demo poc deployment with traefik.

