### PR TITLE
feat(tcp): allow configuring server address with label providers

### DIFF
--- a/pkg/config/dynamic/tcp_config.go
+++ b/pkg/config/dynamic/tcp_config.go
@@ -121,7 +121,7 @@ func (l *TCPServersLoadBalancer) Mergeable(loadBalancer *TCPServersLoadBalancer)
 
 // TCPServer holds a TCP Server configuration.
 type TCPServer struct {
-	Address string `json:"address,omitempty" toml:"address,omitempty" yaml:"address,omitempty" label:"-"`
+	Address string `json:"address,omitempty" toml:"address,omitempty" yaml:"address,omitempty" label:"address"`
 	Port    string `json:"-" toml:"-" yaml:"-"`
 	TLS     bool   `json:"tls,omitempty" toml:"tls,omitempty" yaml:"tls,omitempty"`
 }

--- a/pkg/provider/docker/config_test.go
+++ b/pkg/provider/docker/config_test.go
@@ -3903,6 +3903,60 @@ func TestDynConfBuilder_build(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "TCP service with explicit address label",
+			containers: []dockerData{
+				{
+					ServiceName: "test-service",
+					Name:        "test-container",
+					Labels: map[string]string{
+						"traefik.tcp.services.s1.loadbalancer.server.address": "1.2.3.4:5678",
+					},
+					NetworkSettings: networkSettings{
+						Ports: nat.PortMap{
+							"80/tcp": {},
+						},
+						Networks: map[string]*networkData{
+							"bridge": {
+								Name: "bridge",
+								Addr: "172.17.0.2",
+							},
+						},
+					},
+				},
+			},
+			expected: &dynamic.Configuration{
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services: map[string]*dynamic.TCPService{
+						"s1": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{
+										Address: "1.2.3.4:5678",
+									},
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.TCPServersTransport{},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TLS: &dynamic.TLSConfiguration{
+					Stores: map[string]tls.Store{},
+				},
+			},
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION


### What does this PR do?

This PR enables the configuration of TCP server addresses via labels, specifically for the Docker provider.

Previously, the Docker provider would always auto-detect the container's IP and port, ignoring any manual address configuration attempted via labels. This change set the TCP behavior with the existing HTTP behavior (where server.url can be manually set).

### More

Fixes #12386

- [x] Added/updated tests




