### PR TITLE
Add option metrics.influxdb2.tokenfile

### DIFF
--- a/docs/content/observability/metrics/influxdb2.md
+++ b/docs/content/observability/metrics/influxdb2.md
@@ -42,6 +42,8 @@ metrics:
 
 _Required, Default=""_
 
+##### Either `token` or `tokenFile` is required. If both are provided, `token` is used.
+
 Token with which to connect to InfluxDB v2.
 
 ```yaml tab="File (YAML)"
@@ -59,6 +61,29 @@ metrics:
 ```bash tab="CLI"
 --metrics.influxdb2.token=secret
 ```
+
+#### `tokenFile`
+
+Default=""_
+
+The path to an external file that contains the token with which to connect to InfluxDB v2.
+
+```yaml tab="File (YAML)"
+metrics:
+  influxDB2:
+    tokenFile: /secrets/influxdb2_token
+```
+
+```toml tab="File (TOML)"
+[metrics]
+  [metrics.influxDB2]
+    tokenFile = "/secrets/influxdb2_token"
+```
+
+```bash tab="CLI"
+--metrics.influxdb2.tokenfile=/secrets/influxdb2_token
+```
+
 
 #### `org`
 

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -543,6 +543,9 @@ InfluxDB v2 push interval. (Default: ```10```)
 `--metrics.influxdb2.token`:  
 InfluxDB v2 access token.
 
+`--metrics.influxdb2.tokenfile`:  
+InfluxDB v2 access token file.
+
 `--metrics.otlp`:  
 OpenTelemetry metrics exporter type. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -543,6 +543,9 @@ InfluxDB v2 push interval. (Default: ```10```)
 `TRAEFIK_METRICS_INFLUXDB2_TOKEN`:  
 InfluxDB v2 access token.
 
+`TRAEFIK_METRICS_INFLUXDB2_TOKENFILE`:  
+InfluxDB v2 access token file.
+
 `TRAEFIK_METRICS_OTLP`:  
 OpenTelemetry metrics exporter type. (Default: ```false```)
 

--- a/pkg/observability/types/metrics.go
+++ b/pkg/observability/types/metrics.go
@@ -89,6 +89,7 @@ func (s *Statsd) SetDefaults() {
 type InfluxDB2 struct {
 	Address              string            `description:"InfluxDB v2 address." json:"address,omitempty" toml:"address,omitempty" yaml:"address,omitempty"`
 	Token                string            `description:"InfluxDB v2 access token." json:"token,omitempty" toml:"token,omitempty" yaml:"token,omitempty" loggable:"false"`
+	TokenFile            string            `description:"InfluxDB v2 access token file." json:"tokenFile,omitempty" toml:"tokenFile,omitempty" yaml:"tokenFile,omitempty"`
 	PushInterval         types.Duration    `description:"InfluxDB v2 push interval." json:"pushInterval,omitempty" toml:"pushInterval,omitempty" yaml:"pushInterval,omitempty" export:"true"`
 	Org                  string            `description:"InfluxDB v2 org ID." json:"org,omitempty" toml:"org,omitempty" yaml:"org,omitempty" export:"true"`
 	Bucket               string            `description:"InfluxDB v2 bucket ID." json:"bucket,omitempty" toml:"bucket,omitempty" yaml:"bucket,omitempty" export:"true"`


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adds the option `metrics.influxdb2.tokenfile` that allows a user to provide a token as the path to a secret file.


### Motivation

See the issue #12450 


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
