### PR TITLE
Support file path for metrics.influxdb2.token option

### DIFF
--- a/docs/content/observability/metrics/influxdb2.md
+++ b/docs/content/observability/metrics/influxdb2.md
@@ -42,7 +42,7 @@ metrics:
 
 _Required, Default=""_
 
-Token with which to connect to InfluxDB v2.
+Token with which to connect to InfluxDB v2. It accepts either a token value or a file path to the token.
 
 ```yaml tab="File (YAML)"
 metrics:

--- a/docs/content/reference/install-configuration/configuration-options.md
+++ b/docs/content/reference/install-configuration/configuration-options.md
@@ -202,7 +202,7 @@ THIS FILE MUST NOT BE EDITED BY HAND
 | <a id="opt-metrics-influxdb2-bucket" href="#opt-metrics-influxdb2-bucket" title="#opt-metrics-influxdb2-bucket">metrics.influxdb2.bucket</a> | InfluxDB v2 bucket ID. | |
 | <a id="opt-metrics-influxdb2-org" href="#opt-metrics-influxdb2-org" title="#opt-metrics-influxdb2-org">metrics.influxdb2.org</a> | InfluxDB v2 org ID. | |
 | <a id="opt-metrics-influxdb2-pushinterval" href="#opt-metrics-influxdb2-pushinterval" title="#opt-metrics-influxdb2-pushinterval">metrics.influxdb2.pushinterval</a> | InfluxDB v2 push interval. | 10 |
-| <a id="opt-metrics-influxdb2-token" href="#opt-metrics-influxdb2-token" title="#opt-metrics-influxdb2-token">metrics.influxdb2.token</a> | InfluxDB v2 access token. | |
+| <a id="opt-metrics-influxdb2-token" href="#opt-metrics-influxdb2-token" title="#opt-metrics-influxdb2-token">metrics.influxdb2.token</a> | InfluxDB v2 access token. It accepts either a token value or a file path to the token. | |
 | <a id="opt-metrics-otlp" href="#opt-metrics-otlp" title="#opt-metrics-otlp">metrics.otlp</a> | OpenTelemetry metrics exporter type. | false |
 | <a id="opt-metrics-otlp-addentrypointslabels" href="#opt-metrics-otlp-addentrypointslabels" title="#opt-metrics-otlp-addentrypointslabels">metrics.otlp.addentrypointslabels</a> | Enable metrics on entry points. | true |
 | <a id="opt-metrics-otlp-addrouterslabels" href="#opt-metrics-otlp-addrouterslabels" title="#opt-metrics-otlp-addrouterslabels">metrics.otlp.addrouterslabels</a> | Enable metrics on routers. | false |

--- a/pkg/observability/metrics/influxdb2.go
+++ b/pkg/observability/metrics/influxdb2.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/go-kit/kit/metrics/influx"
@@ -138,11 +139,16 @@ func newInfluxDB2Client(config *otypes.InfluxDB2) (influxdb2.Client, error) {
 		return nil, errors.New("token, org or bucket property is missing")
 	}
 
+	token, err := config.Token.Read()
+	if err != nil {
+		return nil, err
+	}
+
 	// Disable InfluxDB2 logs.
 	// See https://github.com/influxdata/influxdb-client-go/blob/v2.7.0/options.go#L128
 	influxdb2log.Log = nil
 
-	return influxdb2.NewClient(config.Address, config.Token), nil
+	return influxdb2.NewClient(config.Address, strings.TrimSpace(string(token))), nil
 }
 
 type influxDB2Writer struct {

--- a/pkg/observability/types/metrics.go
+++ b/pkg/observability/types/metrics.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/traefik/paerser/types"
+	tTypes "github.com/traefik/traefik/v3/pkg/types"
 )
 
 // Metrics provides options to expose and send Traefik metrics to different third party monitoring systems.
@@ -87,15 +88,15 @@ func (s *Statsd) SetDefaults() {
 
 // InfluxDB2 contains address, token and metrics pushing interval configuration.
 type InfluxDB2 struct {
-	Address              string            `description:"InfluxDB v2 address." json:"address,omitempty" toml:"address,omitempty" yaml:"address,omitempty"`
-	Token                string            `description:"InfluxDB v2 access token." json:"token,omitempty" toml:"token,omitempty" yaml:"token,omitempty" loggable:"false"`
-	PushInterval         types.Duration    `description:"InfluxDB v2 push interval." json:"pushInterval,omitempty" toml:"pushInterval,omitempty" yaml:"pushInterval,omitempty" export:"true"`
-	Org                  string            `description:"InfluxDB v2 org ID." json:"org,omitempty" toml:"org,omitempty" yaml:"org,omitempty" export:"true"`
-	Bucket               string            `description:"InfluxDB v2 bucket ID." json:"bucket,omitempty" toml:"bucket,omitempty" yaml:"bucket,omitempty" export:"true"`
-	AddEntryPointsLabels bool              `description:"Enable metrics on entry points." json:"addEntryPointsLabels,omitempty" toml:"addEntryPointsLabels,omitempty" yaml:"addEntryPointsLabels,omitempty" export:"true"`
-	AddRoutersLabels     bool              `description:"Enable metrics on routers." json:"addRoutersLabels,omitempty" toml:"addRoutersLabels,omitempty" yaml:"addRoutersLabels,omitempty" export:"true"`
-	AddServicesLabels    bool              `description:"Enable metrics on services." json:"addServicesLabels,omitempty" toml:"addServicesLabels,omitempty" yaml:"addServicesLabels,omitempty" export:"true"`
-	AdditionalLabels     map[string]string `description:"Additional labels (influxdb tags) on all metrics" json:"additionalLabels,omitempty" toml:"additionalLabels,omitempty" yaml:"additionalLabels,omitempty" export:"true"`
+	Address              string               `description:"InfluxDB v2 address." json:"address,omitempty" toml:"address,omitempty" yaml:"address,omitempty"`
+	Token                tTypes.FileOrContent `description:"InfluxDB v2 access token. It accepts either a token value or a file path to the token." json:"token,omitempty" toml:"token,omitempty" yaml:"token,omitempty" loggable:"false"`
+	PushInterval         types.Duration       `description:"InfluxDB v2 push interval." json:"pushInterval,omitempty" toml:"pushInterval,omitempty" yaml:"pushInterval,omitempty" export:"true"`
+	Org                  string               `description:"InfluxDB v2 org ID." json:"org,omitempty" toml:"org,omitempty" yaml:"org,omitempty" export:"true"`
+	Bucket               string               `description:"InfluxDB v2 bucket ID." json:"bucket,omitempty" toml:"bucket,omitempty" yaml:"bucket,omitempty" export:"true"`
+	AddEntryPointsLabels bool                 `description:"Enable metrics on entry points." json:"addEntryPointsLabels,omitempty" toml:"addEntryPointsLabels,omitempty" yaml:"addEntryPointsLabels,omitempty" export:"true"`
+	AddRoutersLabels     bool                 `description:"Enable metrics on routers." json:"addRoutersLabels,omitempty" toml:"addRoutersLabels,omitempty" yaml:"addRoutersLabels,omitempty" export:"true"`
+	AddServicesLabels    bool                 `description:"Enable metrics on services." json:"addServicesLabels,omitempty" toml:"addServicesLabels,omitempty" yaml:"addServicesLabels,omitempty" export:"true"`
+	AdditionalLabels     map[string]string    `description:"Additional labels (influxdb tags) on all metrics" json:"additionalLabels,omitempty" toml:"additionalLabels,omitempty" yaml:"additionalLabels,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR enhances the option `metrics.influxdb2.token` in order to allow the user to provide a token as the path to a secret file.


### Motivation

See the issue #12450


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
