### PR TITLE
fix: redirection to entrypoint doesn't work when using socket activation: missing port in address

### DIFF
--- a/pkg/provider/traefik/fixtures/redirection_empty_address.json
+++ b/pkg/provider/traefik/fixtures/redirection_empty_address.json
@@ -1,0 +1,30 @@
+{
+  "http": {
+    "routers": {
+      "web-to-websecure": {
+        "entryPoints": [
+          "web"
+        ],
+        "middlewares": [
+          "redirect-web-to-websecure"
+        ],
+        "service": "noop@internal",
+        "rule": "HostRegexp(`^.+$`)",
+        "ruleSyntax": "default"
+      }
+    },
+    "services": {
+      "noop": {}
+    },
+    "middlewares": {
+      "redirect-web-to-websecure": {
+        "redirectScheme": {
+          "scheme": "https",
+          "permanent": true
+        }
+      }
+    }
+  },
+  "tcp": {},
+  "tls": {}
+}

--- a/pkg/provider/traefik/internal.go
+++ b/pkg/provider/traefik/internal.go
@@ -209,7 +209,14 @@ func (i *Provider) getEntryPointPort(name string, def *static.Redirections) (str
 		return "", fmt.Errorf("'to' entry point field references a non-existing entry point: %s", def.EntryPoint.To)
 	}
 
-	_, port, err := net.SplitHostPort(dst.GetAddress())
+	address := dst.GetAddress()
+	if address == "" {
+		// When address is empty (e.g., socket activation), return empty port.
+		// The redirect middleware will use the scheme's default port.
+		return "", nil
+	}
+
+	_, port, err := net.SplitHostPort(address)
 	if err != nil {
 		return "", fmt.Errorf("invalid entry point %q address %q: %w",
 			name, i.staticCfg.EntryPoints[def.EntryPoint.To].Address, err)

--- a/pkg/provider/traefik/internal_test.go
+++ b/pkg/provider/traefik/internal_test.go
@@ -261,6 +261,28 @@ func Test_createConfiguration(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "redirection_empty_address.json",
+			staticCfg: static.Configuration{
+				EntryPoints: map[string]*static.EntryPoint{
+					"web": {
+						Address: "",
+						HTTP: static.HTTPConfig{
+							Redirections: &static.Redirections{
+								EntryPoint: &static.RedirectEntryPoint{
+									To:        "websecure",
+									Scheme:    "https",
+									Permanent: true,
+								},
+							},
+						},
+					},
+					"websecure": {
+						Address: "",
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
Fixes #12469

## Changes
- Handle empty address in entrypoint redirection for socket activation
- When the destination entrypoint's address is empty, return empty port to let redirect middleware use scheme's default port (443 for https)
- Added test case for redirection with empty address