### PR TITLE
Update swarm.md traefik version

### DIFF
--- a/docs/content/setup/swarm.md
+++ b/docs/content/setup/swarm.md
@@ -61,7 +61,7 @@ In the same directory, create `docker‑compose‑swarm.yaml`:
 ```yaml
 services:
   traefik:
-    image: traefik:v3.4
+    image: traefik:v3.6
     
     networks:
     # Connect to the 'traefik_proxy' overlay network for inter-container communication across nodes


### PR DESCRIPTION
With the latest Docker version, Traefik 3.4 API is deprecated and does not work.
Works perfectly with Traefik 3.6 without any modification.

### What does this PR do?

Updates documentation and branch recommendations for Traefik v3 to reflect compatibility
with the latest Docker version. Specifies that v3.4 API is deprecated and v3.6 works without changes.

### Motivation

Users running the latest Docker version encounter errors with Traefik 3.4 API.
Updating the docs and branch references prevents confusion and directs users
to the compatible v3.6 branch.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

No code changes required; this PR is purely documentation and guidance updates.