### PR TITLE
Fix panic for empty defaultBackend and defaultBackend without resources

### DIFF
--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-defaultbackend-with-resource.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-defaultbackend-with-resource.yml
@@ -1,0 +1,12 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: defaultbackend
+  namespace: testing
+
+spec:
+  defaultBackend:
+    resource:
+      apiGroup: example.com
+      kind: SomeBackend
+      name: foo

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-empty-defaultbackend.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-empty-defaultbackend.yml
@@ -1,0 +1,8 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: defaultbackend
+  namespace: testing
+
+spec:
+  defaultBackend: {}

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -269,6 +269,17 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 				continue
 			}
 
+			if ingress.Spec.DefaultBackend.Resource != nil {
+				// https://kubernetes.io/docs/concepts/services-networking/ingress/#resource-backend
+				logger.Error().Msg("Resource is not supported for default backend")
+				continue
+			}
+
+			if ingress.Spec.DefaultBackend.Service == nil {
+				logger.Error().Msg("Default backend is missing service definition")
+				continue
+			}
+
 			service, err := p.loadService(client, ingress.Namespace, *ingress.Spec.DefaultBackend)
 			if err != nil {
 				logger.Error().

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -551,6 +551,26 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 			},
 		},
 		{
+			desc: "Ingress with defaultbackend with resource",
+			expected: &dynamic.Configuration{
+				HTTP: &dynamic.HTTPConfiguration{
+					Middlewares: map[string]*dynamic.Middleware{},
+					Routers:     map[string]*dynamic.Router{},
+					Services:    map[string]*dynamic.Service{},
+				},
+			},
+		},
+		{
+			desc: "Ingress with empty defaultbackend",
+			expected: &dynamic.Configuration{
+				HTTP: &dynamic.HTTPConfiguration{
+					Middlewares: map[string]*dynamic.Middleware{},
+					Routers:     map[string]*dynamic.Router{},
+					Services:    map[string]*dynamic.Service{},
+				},
+			},
+		},
+		{
 			desc: "Ingress with one service without endpoint",
 			expected: &dynamic.Configuration{
 				HTTP: &dynamic.HTTPConfiguration{


### PR DESCRIPTION
### What does this PR do?

This PR fixes a panic that could be caused by an empty `defaultBackend` or a `defaultBackend` without resources in an Ingress definition.


### Motivation

As a follow up to [#11777](https://github.com/traefik/traefik/pull/11777).


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

