### PR TITLE
Fix code copy button positioning

### DIFF
--- a/docs/content/assets/css/code-copy.css
+++ b/docs/content/assets/css/code-copy.css
@@ -1,0 +1,18 @@
+/* Fix positioning of the built-in clipboard button for code blocks.
+ * In this theme, the button can end up positioned relative to <body>,
+ * so anchor it to the code block container instead.
+ */
+
+.md-typeset pre.highlight {
+  position: relative;
+}
+
+.md-typeset pre.highlight > button.md-clipboard {
+  position: absolute;
+  top: .25rem;
+  right: .25rem;
+  z-index: 10;
+  opacity: 1;
+  visibility: visible;
+}
+

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -20,6 +20,8 @@ theme:
   logo: assets/img/traefikproxy-vertical-logo-color.svg
   feature:
     tabs: false
+  features:
+    - content.code.copy
   palette:
     primary: 'cyan'
     accent: 'cyan'
@@ -35,6 +37,7 @@ extra_javascript:
 
 extra_css:
   - assets/css/menu-icons.css
+  - assets/css/code-copy.css
 
 plugins:
   - search


### PR DESCRIPTION
### What does this PR do?

To enhance the documentation and usability ( UX), this PR fixes the visibility/placement of the “copy to clipboard” button on code blocks.

This PR enables the theme’s built-in clipboard feature and adds a small CSS override so the injected button is anchored to the actual code block container.

### Motivation

Issue #12498 reports that the docs don’t show a copy button on code snippets. The author of the issue requests for that feature so that UX would be greatly enhanced.

Fixes #12498.

### More

- [ ] Added/updated tests (not applicable for a small docs/theme change)
- [x] Added/updated CSS

### Additional Notes

Changes are intentionally minimal:
- enable the built-in clipboard feature via `theme.features`
- add a dedicated CSS file to anchor `button.md-clipboard` to `pre.highlight`
- include it via `extra_css` in `docs/mkdocs.yml`
- No custom JS was added.

### Tests
```
docker run --rm -v /Users/anurag/workspace/github/traefik-repo/traefik-docs/docs:/app traefik-docs-check /verify.sh
=== Checking HTML content...
= Documentation checked successfully.
```

### Use of AI
- Used AI to explore the best way popular docs provide this feature.

### Screenshots
<img width="1500" height="727" alt="Screenshot 2026-01-06 at 7 40 12 PM" src="https://github.com/user-attachments/assets/6553f236-2d66-4612-88d4-ffa59c14baed" />
<img width="1487" height="639" alt="Screenshot 2026-01-06 at 7 39 54 PM" src="https://github.com/user-attachments/assets/c6f3f567-f7e4-4338-b8d2-87ab54e76b35" />
<img width="1494" height="561" alt="Screenshot 2026-01-06 at 7 40 04 PM" src="https://github.com/user-attachments/assets/ad8daba1-7126-499e-8836-29649741d9d2" />
<img width="1499" height="892" alt="Screenshot 2026-01-06 at 7 40 21 PM" src="https://github.com/user-attachments/assets/d647ab43-cf5d-4cfe-b1c8-b252c3620909" />

