### PR TITLE
Make TLSStore gracefully handle missing secrets

### DIFF
--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -1439,7 +1439,7 @@ func buildTLSStores(ctx context.Context, client Client) (map[string]tls.Store, m
 
 // buildCertificates loads TLSStore certificates from secrets and sets them into tlsConfigs.
 // It continues processing other certificates even if one fails, making the TLS store resilient
-// to missing or invalid secrets. Missing secrets are logged as warnings but don't prevent
+// to missing or invalid secrets. Missing secrets are logged as errors but don't prevent
 // the TLS store from being created with the certificates that are available.
 func buildCertificates(ctx context.Context, client Client, tlsStore, namespace string, certificates []traefikv1alpha1.Certificate, tlsConfigs map[string]*tls.CertAndStores) {
 	logger := log.Ctx(ctx).With().Str("TLSStore", tlsStore).Str("namespace", namespace).Logger()


### PR DESCRIPTION
### What does this PR do?

Currently, when loading certificates from TlsStore if there is an issue reading one of the secrets the whole TlsStore is not loaded.

It might be possible that you configure the TlsStore with a secret that does not already exist (i.e. you provision a certificate with cert-manager that is new, and it takes a while to provision or fails to do so).

This pull request allows the TlsStore to work even if there is an issue loading one of the certificates.

Fixes #12523

### Motivation

It's easy to overlook this existing implementation detail, preventing all your certificates from being loaded. I'd rather classify this as a bug, but it is subject to interpretation on how this is currently built and the potential impact of using broken or not yet available secrets in TlsStore.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
