### PR TITLE
Add Scarf Analytics to documentation

### DIFF
--- a/docs/content/assets/js/extra.js
+++ b/docs/content/assets/js/extra.js
@@ -2,3 +2,13 @@
 (function(hljs) {
     hljs.initHighlightingOnLoad();
 })(hljs);
+
+/* Scarf Analytics - cookieless, anonymous company-level intelligence */
+(function() {
+    var img = document.createElement('img');
+    img.src = 'https://static.scarf.sh/a.png?x-pxid=1a49232a-b165-4015-8ed2-a1092f1f0d83';
+    img.referrerPolicy = 'no-referrer-when-downgrade';
+    img.loading = 'eager';
+    img.style.cssText = 'visibility:hidden;position:absolute;width:1px;height:1px;';
+    document.body.appendChild(img);
+})();


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Adds Scarf.sh analytics pixel to the documentation for anonymous, cookieless company-level traffic intelligence.

I evaluated three options:
- Template override (custom_dir) — Would require copying the theme's entire main.html and maintaining it separately. Rejected because the traefik-labs theme already has a complex main.html, and local overrides would break on theme updates.

- Adding to the theme repo (traefik/mkdocs-material) — The theme is open source and shared. Adding a Proxy-specific tracking ID there doesn't make sense since the theme itself isn't what gets deployed.

- JavaScript injection via extra.js — Adds the pixel through the existing script infrastructure. No theme modifications needed, survives theme upgrades, and keeps the tracking scoped to Proxy docs only.

Option 3 is the most maintainable solution.
