### PR TITLE
Remove listener name in backendtls ancestor refs

### DIFF
--- a/pkg/provider/kubernetes/gateway/httproute.go
+++ b/pkg/provider/kubernetes/gateway/httproute.go
@@ -445,7 +445,6 @@ func (p *Provider) loadHTTPServers(ctx context.Context, namespace string, route 
 					Kind:        ptr.To(gatev1.Kind(kindGateway)),
 					Namespace:   ptr.To(gatev1.Namespace(namespace)),
 					Name:        gatev1.ObjectName(listener.GWName),
-					SectionName: ptr.To(gatev1.SectionName(listener.Name)),
 				},
 				ControllerName: controllerName,
 			}


### PR DESCRIPTION
### What does this PR do?

Prevents a BackendTLSPolicy.status.ancestors.ancestorRef.sectionName from being overwritten by every listener.

### Motivation

There is a bug that will cause the controller to repeatedly update BackendTLSPolicy for each gateway listener.

See: https://github.com/traefik/traefik/issues/12511

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Fwiw I'm not sure this is the best way to handle this but the right way may require a large rewrite of the original implementation.  My thought process is that the listener isn't specific to a backendtlspolicy.  A backendtlspolicy typically targets a kubernetes Service and tells a gateway controller when sending to that service use TLS for the connection.

In the current code implementation all listeners are getting looped through and added as the ancestor to the policy regardless of if that policy has any association whatsoever with the listener.  It makes sense to me that the Gateway itself would be the ancestor rather than a specific listener as everything passing through the gateway will already adhere to the backendtlspolicy rule.