### PR TITLE
Add authSignInURL in forward auth middleware

### DIFF
--- a/docs/content/reference/routing-configuration/other-providers/file.toml
+++ b/docs/content/reference/routing-configuration/other-providers/file.toml
@@ -211,6 +211,7 @@
         maxBodySize = 42
         preserveLocationHeader = true
         preserveRequestMethod = true
+        authSigninURL = "foobar"
         [http.middlewares.Middleware10.forwardAuth.tls]
           ca = "foobar"
           cert = "foobar"

--- a/docs/content/reference/routing-configuration/other-providers/file.yaml
+++ b/docs/content/reference/routing-configuration/other-providers/file.yaml
@@ -239,6 +239,7 @@ http:
         maxBodySize: 42
         preserveLocationHeader: true
         preserveRequestMethod: true
+        authSigninURL: foobar
     Middleware11:
       grpcWeb:
         allowOrigins:

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -270,6 +270,9 @@ type ForwardAuth struct {
 	PreserveLocationHeader bool `json:"preserveLocationHeader,omitempty" toml:"preserveLocationHeader,omitempty" yaml:"preserveLocationHeader,omitempty" export:"true"`
 	// PreserveRequestMethod defines whether to preserve the original request method while forwarding the request to the authentication server.
 	PreserveRequestMethod bool `json:"preserveRequestMethod,omitempty" toml:"preserveRequestMethod,omitempty" yaml:"preserveRequestMethod,omitempty" export:"true"`
+	// AuthSigninURL specifies the URL to redirect to when the authentication server returns 401 Unauthorized.
+	// Supports nginx-compatible variable substitution: $scheme, $host, $request_uri, $escaped_request_uri.
+	AuthSigninURL string `json:"authSigninURL,omitempty" toml:"authSigninURL,omitempty" yaml:"authSigninURL,omitempty" export:"true"`
 }
 
 func (f *ForwardAuth) SetDefaults() {

--- a/pkg/middlewares/auth/forward_test.go
+++ b/pkg/middlewares/auth/forward_test.go
@@ -872,6 +872,133 @@ func TestForwardAuthPreserveRequestMethod(t *testing.T) {
 	}
 }
 
+func TestForwardAuthSigninRedirectOn401(t *testing.T) {
+	authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+	}))
+	t.Cleanup(authServer.Close)
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fail()
+	})
+
+	auth := dynamic.ForwardAuth{
+		Address:       authServer.URL,
+		AuthSigninURL: "https://auth.example.com/login",
+	}
+	middleware, err := NewForward(t.Context(), next, auth, "authTest")
+	require.NoError(t, err)
+
+	ts := httptest.NewServer(middleware)
+	t.Cleanup(ts.Close)
+
+	client := &http.Client{
+		CheckRedirect: func(r *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	req := testhelpers.MustNewRequest(http.MethodGet, ts.URL, nil)
+	res, err := client.Do(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusFound, res.StatusCode)
+
+	location, err := res.Location()
+	require.NoError(t, err)
+	assert.Equal(t, "https://auth.example.com/login", location.String())
+}
+
+func TestForwardAuthNoRedirectOn401WithoutSigninURL(t *testing.T) {
+	authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+	}))
+	t.Cleanup(authServer.Close)
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fail()
+	})
+
+	auth := dynamic.ForwardAuth{
+		Address: authServer.URL,
+	}
+	middleware, err := NewForward(t.Context(), next, auth, "authTest")
+	require.NoError(t, err)
+
+	ts := httptest.NewServer(middleware)
+	t.Cleanup(ts.Close)
+
+	req := testhelpers.MustNewRequest(http.MethodGet, ts.URL, nil)
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusUnauthorized, res.StatusCode)
+
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	err = res.Body.Close()
+	require.NoError(t, err)
+
+	assert.Equal(t, "Unauthorized\n", string(body))
+}
+
+func TestForwardAuthNoRedirectOnOtherErrors(t *testing.T) {
+	testCases := []struct {
+		name       string
+		statusCode int
+	}{
+		{
+			name:       "403 Forbidden",
+			statusCode: http.StatusForbidden,
+		},
+		{
+			name:       "500 Internal Server Error",
+			statusCode: http.StatusInternalServerError,
+		},
+		{
+			name:       "503 Service Unavailable",
+			statusCode: http.StatusServiceUnavailable,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, http.StatusText(test.statusCode), test.statusCode)
+			}))
+			t.Cleanup(authServer.Close)
+
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Fail()
+			})
+
+			// AuthSigninURL is configured but should NOT trigger redirect for non-401 errors.
+			auth := dynamic.ForwardAuth{
+				Address:       authServer.URL,
+				AuthSigninURL: "https://auth.example.com/login",
+			}
+			middleware, err := NewForward(t.Context(), next, auth, "authTest")
+			require.NoError(t, err)
+
+			ts := httptest.NewServer(middleware)
+			t.Cleanup(ts.Close)
+
+			client := &http.Client{
+				CheckRedirect: func(r *http.Request, via []*http.Request) error {
+					return http.ErrUseLastResponse
+				},
+			}
+
+			req := testhelpers.MustNewRequest(http.MethodGet, ts.URL, nil)
+			res, err := client.Do(req)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.statusCode, res.StatusCode)
+			assert.Empty(t, res.Header.Get("Location"))
+		})
+	}
+}
+
 type mockTracer struct {
 	embedded.Tracer
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This branch adds a new authSignInURL configuration option to ForwardAuth middleware.
When the ForwardAuth middleware receives a 401 Unauthorized response from the authentication server, it can now automatically redirect users to a configured sign-in URL instead of passing the 401 response through to the client.

### Motivation

### More

- [x] Added/updated tests
- [x] Added/updated documentation
