### PR TITLE
Add configmaps right to Ingress NGINX RBAC

### DIFF
--- a/docs/content/migrate/v3.md
+++ b/docs/content/migrate/v3.md
@@ -576,3 +576,25 @@ Here is the list of the encoded characters that are rejected by default, along w
 | `%23`             | `#` (hash)              | `entryPoints.<name>.`<br/>`.http.encodedCharacters`<br/>`.allowEncodedHash`          |
 
 Please check out the entrypoint [encodedCharacters option](../reference/install-configuration/entrypoints.md#opt-http-encodedCharacters) documentation for more details.
+
+## v3.7.0
+
+### Ingress NGINX Provider
+
+Starting with `v3.7.0`, the Ingress NGINX provider now supports the `nginx.ingress.kubernetes.io/custom-headers` annotation to add custom headers to the response forwarded to the client.
+
+Therefore, in the corresponding RBACs (see [KubernetesIngressNGINX](../reference/dynamic-configuration/kubernetes-ingress-nginx-rbac.yml) provider RBACs) the `configmaps` right has been added.
+
+**Required RBAC Updates:**
+
+```yaml
+  ...
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - list
+      - watch  
+  ...
+```

--- a/docs/content/reference/dynamic-configuration/kubernetes-ingress-nginx-rbac.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-ingress-nginx-rbac.yml
@@ -8,6 +8,7 @@ rules:
     resources:
       - services
       - secrets
+      - configmaps
     verbs:
       - list
       - watch


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request updates the Ingress NGINX provider RBACs to add the `configmaps` resource introduced by https://github.com/traefik/traefik/pull/12414. It also adds a note to the migration guide.


### Motivation

This is a follow up to https://github.com/traefik/traefik/pull/12414


### More

- [ ] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
