### PR TITLE
Document Path matcher placeholder removal in v3 migration guide

### DIFF
--- a/docs/content/migrate/v2-to-v3-details.md
+++ b/docs/content/migrate/v2-to-v3-details.md
@@ -750,7 +750,8 @@ In v3, this is no longer supported and `PathRegexp` should be used instead.
     v3 syntax:
 
     ```yaml
-    match: Host(`example.com`) && PathRegexp(`^/users/[^/]+/orders/[^/]+$`)
+    match: Host(`example.com`) && PathRegexp(`^/users/[^/]+/orders/[^/]+$`) ## matches any non-slash characters
+    match: Host(`example.com`) && PathRegexp(`^/users/[a-zA-Z0-9_-]+/orders/[a-zA-Z0-9_-]+$`) ## restricts to alphanumeric, hyphens, and underscores
     ```
 
 ### IPWhiteList


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

- Documents that `Path` and `PathPrefix` matchers no longer support path parameter placeholders (e.g., `{id}`, `{name}`) in v3 syntax
- Adds migration examples showing how to convert placeholder-based routes to `PathRegexp`

Fix https://github.com/traefik/traefik/issues/12409


### More

- [x] Added/updated documentation

