### PR TITLE
Remove extraneous dots in migration guide

### DIFF
--- a/docs/content/migrate/v3.md
+++ b/docs/content/migrate/v3.md
@@ -568,12 +568,12 @@ Here is the list of the encoded characters that are rejected by default, along w
 | Encoded Character | Character               | Config option to allow the encoded character                                         |
 |-------------------|-------------------------|--------------------------------------------------------------------------------------|
 | `%2f` or `%2F`    | `/` (slash)             | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedSlash`          |
-| `%5c` or `%5C`    | `\` (backslash)         | `entryPoints.<name>.`<br/>`.http.encodedCharacters`<br/>`.allowEncodedBackSlash`     |
-| `%00`             | `NULL` (null character) | `entryPoints.<name>.`<br/>`.http.encodedCharacters`<br/>`.allowEncodedNullCharacter` |
-| `%3b` or `%3B`    | `;` (semicolon)         | `entryPoints.<name>.`<br/>`.http.encodedCharacters`<br/>`.allowEncodedSemicolon`     |
-| `%25`             | `%` (percent)           | `entryPoints.<name>.`<br/>`.http.encodedCharacters`<br/>`.allowEncodedPercent`       |
-| `%3f` or `%3F`    | `?` (question mark)     | `entryPoints.<name>.`<br/>`.http.encodedCharacters`<br/>`.allowEncodedQuestionMark`  |
-| `%23`             | `#` (hash)              | `entryPoints.<name>.`<br/>`.http.encodedCharacters`<br/>`.allowEncodedHash`          |
+| `%5c` or `%5C`    | `\` (backslash)         | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedBackSlash`      |
+| `%00`             | `NULL` (null character) | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedNullCharacter`  |
+| `%3b` or `%3B`    | `;` (semicolon)         | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedSemicolon`      |
+| `%25`             | `%` (percent)           | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedPercent`        |
+| `%3f` or `%3F`    | `?` (question mark)     | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedQuestionMark`   |
+| `%23`             | `#` (hash)              | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedHash`           |
 
 Please check out the entrypoint [encodedCharacters option](../reference/install-configuration/entrypoints.md#opt-http-encodedCharacters) documentation for more details.
 
@@ -590,12 +590,12 @@ Here is the list of the encoded characters that can be configured to `false` to 
 | Encoded Character | Character               | Config options                                                                       | Default value |
 |-------------------|-------------------------|--------------------------------------------------------------------------------------|---------------|
 | `%2f` or `%2F`    | `/` (slash)             | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedSlash`          | `true`        |
-| `%5c` or `%5C`    | `\` (backslash)         | `entryPoints.<name>.`<br/>`.http.encodedCharacters`<br/>`.allowEncodedBackSlash`     | `true`        |
-| `%00`             | `NULL` (null character) | `entryPoints.<name>.`<br/>`.http.encodedCharacters`<br/>`.allowEncodedNullCharacter` | `true`        |
-| `%3b` or `%3B`    | `;` (semicolon)         | `entryPoints.<name>.`<br/>`.http.encodedCharacters`<br/>`.allowEncodedSemicolon`     | `true`        |
-| `%25`             | `%` (percent)           | `entryPoints.<name>.`<br/>`.http.encodedCharacters`<br/>`.allowEncodedPercent`       | `true`        |
-| `%3f` or `%3F`    | `?` (question mark)     | `entryPoints.<name>.`<br/>`.http.encodedCharacters`<br/>`.allowEncodedQuestionMark`  | `true`        |
-| `%23`             | `#` (hash)              | `entryPoints.<name>.`<br/>`.http.encodedCharacters`<br/>`.allowEncodedHash`          | `true`        |
+| `%5c` or `%5C`    | `\` (backslash)         | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedBackSlash`      | `true`        |
+| `%00`             | `NULL` (null character) | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedNullCharacter`  | `true`        |
+| `%3b` or `%3B`    | `;` (semicolon)         | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedSemicolon`      | `true`        |
+| `%25`             | `%` (percent)           | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedPercent`        | `true`        |
+| `%3f` or `%3F`    | `?` (question mark)     | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedQuestionMark`   | `true`        |
+| `%23`             | `#` (hash)              | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedHash`           | `true`        |
 
 Note: This check is not done against query parameters,
 but only against the request path as defined


### PR DESCRIPTION
This is #12565 with the change made against the v3.6 branch.  Removes extraneous `.` from documentation.
