### PR TITLE
Fix verifyServerCertMatchesURI function behavior

### DIFF
--- a/pkg/provider/consulcatalog/connect_tls.go
+++ b/pkg/provider/consulcatalog/connect_tls.go
@@ -10,8 +10,9 @@ import (
 
 // connectCert holds our certificates as a client of the Consul Connect protocol.
 type connectCert struct {
-	root []string
-	leaf keyPair
+	trustDomain string
+	root        []string
+	leaf        keyPair
 }
 
 func (c *connectCert) getRoot() []types.FileOrContent {
@@ -52,7 +53,8 @@ func (c *connectCert) equals(other *connectCert) bool {
 }
 
 func (c *connectCert) serversTransport(item itemData) *dynamic.ServersTransport {
-	spiffeID := fmt.Sprintf("spiffe:///ns/%s/dc/%s/svc/%s",
+	spiffeID := fmt.Sprintf("spiffe://%s/ns/%s/dc/%s/svc/%s",
+		c.trustDomain,
 		item.Namespace,
 		item.Datacenter,
 		item.Name,
@@ -72,7 +74,8 @@ func (c *connectCert) serversTransport(item itemData) *dynamic.ServersTransport 
 }
 
 func (c *connectCert) tcpServersTransport(item itemData) *dynamic.TCPServersTransport {
-	spiffeID := fmt.Sprintf("spiffe:///ns/%s/dc/%s/svc/%s",
+	spiffeID := fmt.Sprintf("spiffe://%s/ns/%s/dc/%s/svc/%s",
+		c.trustDomain,
 		item.Namespace,
 		item.Datacenter,
 		item.Name,

--- a/pkg/tls/certificate_test.go
+++ b/pkg/tls/certificate_test.go
@@ -1,0 +1,64 @@
+package tls
+
+import (
+	"crypto/x509"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_verifyServerCertMatchesURI(t *testing.T) {
+	tests := []struct {
+		desc   string
+		uri    string
+		cert   *x509.Certificate
+		expErr require.ErrorAssertionFunc
+	}{
+		{
+			desc:   "returns error when certificate is nil",
+			uri:    "spiffe://foo.com",
+			expErr: require.Error,
+		},
+		{
+			desc:   "returns error when certificate has no URIs",
+			uri:    "spiffe://foo.com",
+			cert:   &x509.Certificate{URIs: nil},
+			expErr: require.Error,
+		},
+		{
+			desc: "returns error when no URI matches",
+			uri:  "spiffe://foo.com",
+			cert: &x509.Certificate{URIs: []*url.URL{
+				{Scheme: "spiffe", Host: "other.org"},
+			}},
+			expErr: require.Error,
+		},
+		{
+			desc: "returns nil when URI matches",
+			uri:  "spiffe://foo.com",
+			cert: &x509.Certificate{URIs: []*url.URL{
+				{Scheme: "spiffe", Host: "foo.com"},
+			}},
+			expErr: require.NoError,
+		},
+		{
+			desc: "returns nil when one of the URI matches",
+			uri:  "spiffe://foo.com",
+			cert: &x509.Certificate{URIs: []*url.URL{
+				{Scheme: "spiffe", Host: "example.org"},
+				{Scheme: "spiffe", Host: "foo.com"},
+			}},
+			expErr: require.NoError,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			err := verifyServerCertMatchesURI(test.uri, test.cert)
+			test.expErr(t, err)
+		})
+	}
+}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request fixes the `verifyServerCertMatchesURI` function used when the `PeerCertURI` is configured on a `ServersTransport`. Now, the whole SAN URI list is checked, and the comparison does not change the expected Host anymore. 


### Motivation

To fix an issue.


### More

- [X] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Mathis Urien <contact.lbf38@gmail.com>