### PR TITLE
chore: pin GitHub Actions to SHA hashes for supply chain security

### DIFF
--- a/.github/workflows/sync-docker-images.yaml
+++ b/.github/workflows/sync-docker-images.yaml
@@ -14,9 +14,9 @@ jobs:
     if: github.repository == 'traefik/traefik'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: imjasonh/setup-crane@v0.4
+      - uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
       
       - name: Sync
         run: |

--- a/.github/workflows/test-gateway-api-conformance.yaml
+++ b/.github/workflows/test-gateway-api-conformance.yaml
@@ -22,12 +22,12 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Set up Go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ env.GO_VERSION }}
 

--- a/.github/workflows/test-knative-conformance.yaml
+++ b/.github/workflows/test-knative-conformance.yaml
@@ -22,17 +22,17 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Set up Go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Set up KO
-        uses: ko-build/setup-ko@v0.6
+        uses: ko-build/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa # v0.6
         env:
           KO_DOCKER_REPO: ko.local
 


### PR DESCRIPTION
## Summary
- Pin GitHub Actions to SHA hashes for supply chain security

## Test plan
- [ ] Verify CI workflows run correctly

cf. https://github.com/traefik/infra/issues/10113