### PR TITLE
Avoid recursion with services

### DIFF
--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -451,13 +451,13 @@ func TestPrometheusMetricRemoval(t *testing.T) {
 				th.WithRouter("foo@providerName", th.WithServiceName("bar")),
 				th.WithRouter("router2", th.WithServiceName("bar@providerName")),
 			),
-			th.WithLoadBalancerServices(
-				th.WithService("bar@providerName", th.WithServers(
+			th.WithServices(
+				th.WithService("bar@providerName", th.WithServiceServersLoadBalancer(th.WithServers(
 					th.WithServer("http://localhost:9000"),
 					th.WithServer("http://localhost:9999"),
 					th.WithServer("http://localhost:9998"),
-				)),
-				th.WithService("service1", th.WithServers(th.WithServer("http://localhost:9000"))),
+				))),
+				th.WithService("service1", th.WithServiceServersLoadBalancer(th.WithServers(th.WithServer("http://localhost:9000")))),
 			),
 		),
 	}
@@ -467,8 +467,8 @@ func TestPrometheusMetricRemoval(t *testing.T) {
 			th.WithRouters(
 				th.WithRouter("foo@providerName", th.WithServiceName("bar")),
 			),
-			th.WithLoadBalancerServices(
-				th.WithService("bar@providerName", th.WithServers(th.WithServer("http://localhost:9000"))),
+			th.WithServices(
+				th.WithService("bar@providerName", th.WithServiceServersLoadBalancer(th.WithServers(th.WithServer("http://localhost:9000")))),
 			),
 		),
 	}
@@ -538,8 +538,8 @@ func TestPrometheusMetricRemoveEndpointForRecoveredService(t *testing.T) {
 
 	conf1 := dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
-			th.WithLoadBalancerServices(
-				th.WithService("service1", th.WithServers(th.WithServer("http://localhost:9000"))),
+			th.WithServices(
+				th.WithService("service1", th.WithServiceServersLoadBalancer(th.WithServers(th.WithServer("http://localhost:9000")))),
 			),
 		),
 	}
@@ -550,8 +550,8 @@ func TestPrometheusMetricRemoveEndpointForRecoveredService(t *testing.T) {
 
 	conf3 := dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
-			th.WithLoadBalancerServices(
-				th.WithService("service1", th.WithServers(th.WithServer("http://localhost:9001"))),
+			th.WithServices(
+				th.WithService("service1", th.WithServiceServersLoadBalancer(th.WithServers(th.WithServer("http://localhost:9001")))),
 			),
 		),
 	}
@@ -577,8 +577,8 @@ func TestPrometheusRemovedMetricsReset(t *testing.T) {
 
 	conf1 := dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
-			th.WithLoadBalancerServices(th.WithService("service",
-				th.WithServers(th.WithServer("http://localhost:9000"))),
+			th.WithServices(
+				th.WithService("service", th.WithServiceServersLoadBalancer(th.WithServers(th.WithServer("http://localhost:9000")))),
 			),
 		),
 	}

--- a/pkg/server/configurationwatcher_test.go
+++ b/pkg/server/configurationwatcher_test.go
@@ -86,7 +86,7 @@ func TestNewConfigurationWatcher(t *testing.T) {
 						th.WithEntryPoints("e"),
 						th.WithServiceName("scv"))),
 				th.WithMiddlewares(),
-				th.WithLoadBalancerServices(),
+				th.WithServices(),
 			),
 			TCP: &dynamic.TCPConfiguration{
 				Routers:     map[string]*dynamic.TCPRouter{},
@@ -123,7 +123,9 @@ func TestWaitForRequiredProvider(t *testing.T) {
 	config := &dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
 			th.WithRouters(th.WithRouter("foo", th.WithEntryPoints("ep"))),
-			th.WithLoadBalancerServices(th.WithService("bar")),
+			th.WithServices(
+				th.WithService("bar", th.WithServiceServersLoadBalancer()),
+			),
 		),
 	}
 
@@ -167,14 +169,18 @@ func TestIgnoreTransientConfiguration(t *testing.T) {
 	config := &dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
 			th.WithRouters(th.WithRouter("foo", th.WithEntryPoints("ep"))),
-			th.WithLoadBalancerServices(th.WithService("bar")),
+			th.WithServices(
+				th.WithService("bar", th.WithServiceServersLoadBalancer()),
+			),
 		),
 	}
 
 	expectedConfig := dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
 			th.WithRouters(th.WithRouter("foo@mock", th.WithEntryPoints("ep"))),
-			th.WithLoadBalancerServices(th.WithService("bar@mock")),
+			th.WithServices(
+				th.WithService("bar@mock", th.WithServiceServersLoadBalancer()),
+			),
 			th.WithMiddlewares(),
 		),
 		TCP: &dynamic.TCPConfiguration{
@@ -197,7 +203,9 @@ func TestIgnoreTransientConfiguration(t *testing.T) {
 	expectedConfig3 := dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
 			th.WithRouters(th.WithRouter("foo@mock", th.WithEntryPoints("ep"))),
-			th.WithLoadBalancerServices(th.WithService("bar-config3@mock")),
+			th.WithServices(
+				th.WithService("bar-config3@mock", th.WithServiceServersLoadBalancer()),
+			),
 			th.WithMiddlewares(),
 		),
 		TCP: &dynamic.TCPConfiguration{
@@ -220,14 +228,18 @@ func TestIgnoreTransientConfiguration(t *testing.T) {
 	config2 := &dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
 			th.WithRouters(th.WithRouter("baz", th.WithEntryPoints("ep"))),
-			th.WithLoadBalancerServices(th.WithService("toto")),
+			th.WithServices(
+				th.WithService("toto", th.WithServiceServersLoadBalancer()),
+			),
 		),
 	}
 
 	config3 := &dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
 			th.WithRouters(th.WithRouter("foo", th.WithEntryPoints("ep"))),
-			th.WithLoadBalancerServices(th.WithService("bar-config3")),
+			th.WithServices(
+				th.WithService("bar-config3", th.WithServiceServersLoadBalancer()),
+			),
 		),
 	}
 	watcher := NewConfigurationWatcher(routinesPool, &mockProvider{}, []string{}, "")
@@ -311,7 +323,9 @@ func TestListenProvidersThrottleProviderConfigReload(t *testing.T) {
 			Configuration: &dynamic.Configuration{
 				HTTP: th.BuildConfiguration(
 					th.WithRouters(th.WithRouter("foo"+strconv.Itoa(i), th.WithEntryPoints("ep"))),
-					th.WithLoadBalancerServices(th.WithService("bar")),
+					th.WithServices(
+						th.WithService("bar", th.WithServiceServersLoadBalancer()),
+					),
 				),
 			},
 		})
@@ -371,7 +385,9 @@ func TestListenProvidersSkipsSameConfigurationForProvider(t *testing.T) {
 		Configuration: &dynamic.Configuration{
 			HTTP: th.BuildConfiguration(
 				th.WithRouters(th.WithRouter("foo", th.WithEntryPoints("ep"))),
-				th.WithLoadBalancerServices(th.WithService("bar")),
+				th.WithServices(
+					th.WithService("bar", th.WithServiceServersLoadBalancer()),
+				),
 			),
 		},
 	}
@@ -403,14 +419,18 @@ func TestListenProvidersDoesNotSkipFlappingConfiguration(t *testing.T) {
 	configuration := &dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
 			th.WithRouters(th.WithRouter("foo", th.WithEntryPoints("ep"))),
-			th.WithLoadBalancerServices(th.WithService("bar")),
+			th.WithServices(
+				th.WithService("bar", th.WithServiceServersLoadBalancer()),
+			),
 		),
 	}
 
 	transientConfiguration := &dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
 			th.WithRouters(th.WithRouter("bad", th.WithEntryPoints("ep"))),
-			th.WithLoadBalancerServices(th.WithService("bad")),
+			th.WithServices(
+				th.WithService("bad", th.WithServiceServersLoadBalancer()),
+			),
 		),
 	}
 
@@ -442,7 +462,9 @@ func TestListenProvidersDoesNotSkipFlappingConfiguration(t *testing.T) {
 	expected := dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
 			th.WithRouters(th.WithRouter("foo@mock", th.WithEntryPoints("ep"))),
-			th.WithLoadBalancerServices(th.WithService("bar@mock")),
+			th.WithServices(
+				th.WithService("bar@mock", th.WithServiceServersLoadBalancer()),
+			),
 			th.WithMiddlewares(),
 		),
 		TCP: &dynamic.TCPConfiguration{
@@ -471,14 +493,18 @@ func TestListenProvidersIgnoreSameConfig(t *testing.T) {
 	configuration := &dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
 			th.WithRouters(th.WithRouter("foo", th.WithEntryPoints("ep"))),
-			th.WithLoadBalancerServices(th.WithService("bar")),
+			th.WithServices(
+				th.WithService("bar", th.WithServiceServersLoadBalancer()),
+			),
 		),
 	}
 
 	transientConfiguration := &dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
 			th.WithRouters(th.WithRouter("bad", th.WithEntryPoints("ep"))),
-			th.WithLoadBalancerServices(th.WithService("bad")),
+			th.WithServices(
+				th.WithService("bad", th.WithServiceServersLoadBalancer()),
+			),
 		),
 	}
 
@@ -531,7 +557,9 @@ func TestListenProvidersIgnoreSameConfig(t *testing.T) {
 	expected := dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
 			th.WithRouters(th.WithRouter("foo@mock", th.WithEntryPoints("ep"))),
-			th.WithLoadBalancerServices(th.WithService("bar@mock")),
+			th.WithServices(
+				th.WithService("bar@mock", th.WithServiceServersLoadBalancer()),
+			),
 			th.WithMiddlewares(),
 		),
 		TCP: &dynamic.TCPConfiguration{
@@ -570,7 +598,9 @@ func TestApplyConfigUnderStress(t *testing.T) {
 			case watcher.allProvidersConfigs <- dynamic.Message{ProviderName: "mock", Configuration: &dynamic.Configuration{
 				HTTP: th.BuildConfiguration(
 					th.WithRouters(th.WithRouter("foo"+strconv.Itoa(i), th.WithEntryPoints("ep"))),
-					th.WithLoadBalancerServices(th.WithService("bar")),
+					th.WithServices(
+						th.WithService("bar", th.WithServiceServersLoadBalancer()),
+					),
 				),
 			}}:
 			}
@@ -605,28 +635,36 @@ func TestListenProvidersIgnoreIntermediateConfigs(t *testing.T) {
 	configuration := &dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
 			th.WithRouters(th.WithRouter("foo", th.WithEntryPoints("ep"))),
-			th.WithLoadBalancerServices(th.WithService("bar")),
+			th.WithServices(
+				th.WithService("bar", th.WithServiceServersLoadBalancer()),
+			),
 		),
 	}
 
 	transientConfiguration := &dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
 			th.WithRouters(th.WithRouter("bad", th.WithEntryPoints("ep"))),
-			th.WithLoadBalancerServices(th.WithService("bad")),
+			th.WithServices(
+				th.WithService("bad", th.WithServiceServersLoadBalancer()),
+			),
 		),
 	}
 
 	transientConfiguration2 := &dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
 			th.WithRouters(th.WithRouter("bad2", th.WithEntryPoints("ep"))),
-			th.WithLoadBalancerServices(th.WithService("bad2")),
+			th.WithServices(
+				th.WithService("bad2", th.WithServiceServersLoadBalancer()),
+			),
 		),
 	}
 
 	finalConfiguration := &dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
 			th.WithRouters(th.WithRouter("final", th.WithEntryPoints("ep"))),
-			th.WithLoadBalancerServices(th.WithService("final")),
+			th.WithServices(
+				th.WithService("final", th.WithServiceServersLoadBalancer()),
+			),
 		),
 	}
 
@@ -665,7 +703,9 @@ func TestListenProvidersIgnoreIntermediateConfigs(t *testing.T) {
 	expected := dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
 			th.WithRouters(th.WithRouter("final@mock", th.WithEntryPoints("ep"))),
-			th.WithLoadBalancerServices(th.WithService("final@mock")),
+			th.WithServices(
+				th.WithService("final@mock", th.WithServiceServersLoadBalancer()),
+			),
 			th.WithMiddlewares(),
 		),
 		TCP: &dynamic.TCPConfiguration{
@@ -696,7 +736,9 @@ func TestListenProvidersPublishesConfigForEachProvider(t *testing.T) {
 	configuration := &dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
 			th.WithRouters(th.WithRouter("foo", th.WithEntryPoints("ep"))),
-			th.WithLoadBalancerServices(th.WithService("bar")),
+			th.WithServices(
+				th.WithService("bar", th.WithServiceServersLoadBalancer()),
+			),
 		),
 	}
 
@@ -729,9 +771,9 @@ func TestListenProvidersPublishesConfigForEachProvider(t *testing.T) {
 				th.WithRouter("foo@mock", th.WithEntryPoints("ep")),
 				th.WithRouter("foo@mock2", th.WithEntryPoints("ep")),
 			),
-			th.WithLoadBalancerServices(
-				th.WithService("bar@mock"),
-				th.WithService("bar@mock2"),
+			th.WithServices(
+				th.WithService("bar@mock", th.WithServiceServersLoadBalancer()),
+				th.WithService("bar@mock2", th.WithServiceServersLoadBalancer()),
 			),
 			th.WithMiddlewares(),
 		),

--- a/pkg/server/middleware/middlewares.go
+++ b/pkg/server/middleware/middlewares.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
-	"slices"
-	"strings"
 
 	"github.com/containous/alice"
 	"github.com/traefik/traefik/v2/pkg/config/runtime"
@@ -33,12 +31,7 @@ import (
 	"github.com/traefik/traefik/v2/pkg/middlewares/stripprefixregex"
 	"github.com/traefik/traefik/v2/pkg/middlewares/tracing"
 	"github.com/traefik/traefik/v2/pkg/server/provider"
-)
-
-type middlewareStackType int
-
-const (
-	middlewareStackKey middlewareStackType = iota
+	"github.com/traefik/traefik/v2/pkg/server/recursion"
 )
 
 // Builder the middleware builder.
@@ -70,7 +63,7 @@ func (b *Builder) BuildChain(ctx context.Context, middlewares []string) *alice.C
 			}
 
 			var err error
-			if constructorContext, err = checkRecursion(constructorContext, middlewareName); err != nil {
+			if constructorContext, err = recursion.CheckRecursion(constructorContext, "middleware", middlewareName); err != nil {
 				b.configs[middlewareName].AddError(err, true)
 				return nil, err
 			}
@@ -91,17 +84,6 @@ func (b *Builder) BuildChain(ctx context.Context, middlewares []string) *alice.C
 		})
 	}
 	return &chain
-}
-
-func checkRecursion(ctx context.Context, middlewareName string) (context.Context, error) {
-	currentStack, ok := ctx.Value(middlewareStackKey).([]string)
-	if !ok {
-		currentStack = []string{}
-	}
-	if slices.Contains(currentStack, middlewareName) {
-		return ctx, fmt.Errorf("could not instantiate middleware %s: recursion detected in %s", middlewareName, strings.Join(append(currentStack, middlewareName), "->"))
-	}
-	return context.WithValue(ctx, middlewareStackKey, append(currentStack, middlewareName)), nil
 }
 
 // it is the responsibility of the caller to make sure that b.configs[middlewareName].Middleware exists.

--- a/pkg/server/middleware/middlewares_test.go
+++ b/pkg/server/middleware/middlewares_test.go
@@ -172,7 +172,7 @@ func TestBuilder_BuildChainWithContext(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("could not instantiate middleware m1: recursion detected in m1->m2->m3->m1"),
+			expectedError: errors.New("could not instantiate middleware m1: recursion detected in middleware:m1->middleware:m2->middleware:m3->middleware:m1"),
 		},
 		{
 			desc:       "Detects recursion in Middleware chain",
@@ -197,9 +197,10 @@ func TestBuilder_BuildChainWithContext(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("could not instantiate middleware m1@provider: recursion detected in m1@provider->m2@provider2->m3@provider->m1@provider"),
+			expectedError: errors.New("could not instantiate middleware m1@provider: recursion detected in middleware:m1@provider->middleware:m2@provider2->middleware:m3@provider->middleware:m1@provider"),
 		},
 		{
+			desc:       "Detects recursion in Middleware chain",
 			buildChain: []string{"ok", "m0"},
 			configuration: map[string]*dynamic.Middleware{
 				"ok": {
@@ -211,7 +212,7 @@ func TestBuilder_BuildChainWithContext(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("could not instantiate middleware m0: recursion detected in m0->m0"),
+			expectedError: errors.New("could not instantiate middleware m0: recursion detected in middleware:m0->middleware:m0"),
 		},
 		{
 			desc:       "Detects MiddlewareChain that references a Chain that references a Chain with a missing middleware",
@@ -238,7 +239,7 @@ func TestBuilder_BuildChainWithContext(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("could not instantiate middleware m2: recursion detected in m0->m1->m2->m3->m2"),
+			expectedError: errors.New("could not instantiate middleware m2: recursion detected in middleware:m0->middleware:m1->middleware:m2->middleware:m3->middleware:m2"),
 		},
 		{
 			desc:       "--",
@@ -250,7 +251,7 @@ func TestBuilder_BuildChainWithContext(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("could not instantiate middleware m0: recursion detected in m0->m0"),
+			expectedError: errors.New("could not instantiate middleware m0: recursion detected in middleware:m0->middleware:m0"),
 		},
 	}
 

--- a/pkg/server/recursion/recursion.go
+++ b/pkg/server/recursion/recursion.go
@@ -1,0 +1,26 @@
+package recursion
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+type stackType int
+
+const (
+	stackKey stackType = iota
+)
+
+func CheckRecursion(ctx context.Context, itemType, itemName string) (context.Context, error) {
+	currentStack, ok := ctx.Value(stackKey).([]string)
+	if !ok {
+		currentStack = []string{}
+	}
+	name := itemType + ":" + itemName
+	if slices.Contains(currentStack, name) {
+		return ctx, fmt.Errorf("could not instantiate %s %s: recursion detected in %s", itemType, itemName, strings.Join(append(currentStack, name), "->"))
+	}
+	return context.WithValue(ctx, stackKey, append(currentStack, name)), nil
+}

--- a/pkg/server/service/service.go
+++ b/pkg/server/service/service.go
@@ -25,6 +25,7 @@ import (
 	"github.com/traefik/traefik/v2/pkg/safe"
 	"github.com/traefik/traefik/v2/pkg/server/cookie"
 	"github.com/traefik/traefik/v2/pkg/server/provider"
+	"github.com/traefik/traefik/v2/pkg/server/recursion"
 	"github.com/traefik/traefik/v2/pkg/server/service/loadbalancer/failover"
 	"github.com/traefik/traefik/v2/pkg/server/service/loadbalancer/mirror"
 	"github.com/traefik/traefik/v2/pkg/server/service/loadbalancer/wrr"
@@ -114,6 +115,12 @@ func (m *Manager) BuildHTTP(rootCtx context.Context, serviceName string) (http.H
 		err := errors.New("cannot create service: multi-types service not supported, consider declaring two different pieces of service instead")
 		conf.AddError(err, true)
 		return nil, err
+	}
+
+	var errRecursion error
+	if ctx, errRecursion = recursion.CheckRecursion(ctx, "service", serviceName); errRecursion != nil {
+		conf.AddError(errRecursion, true)
+		return nil, errRecursion
 	}
 
 	var lb http.Handler

--- a/pkg/testhelpers/config.go
+++ b/pkg/testhelpers/config.go
@@ -53,27 +53,72 @@ func WithServiceName(serviceName string) func(*dynamic.Router) {
 	}
 }
 
-// WithLoadBalancerServices is a helper to create a configuration.
-func WithLoadBalancerServices(opts ...func(service *dynamic.ServersLoadBalancer) string) func(*dynamic.HTTPConfiguration) {
+// WithServices is a helper to create a configuration.
+func WithServices(opts ...func(service *dynamic.Service) string) func(*dynamic.HTTPConfiguration) {
 	return func(c *dynamic.HTTPConfiguration) {
 		c.Services = make(map[string]*dynamic.Service)
 		for _, opt := range opts {
-			b := &dynamic.ServersLoadBalancer{}
+			b := &dynamic.Service{}
 			name := opt(b)
-			c.Services[name] = &dynamic.Service{
-				LoadBalancer: b,
-			}
+			c.Services[name] = b
 		}
 	}
 }
 
 // WithService is a helper to create a configuration.
-func WithService(name string, opts ...func(*dynamic.ServersLoadBalancer)) func(*dynamic.ServersLoadBalancer) string {
-	return func(r *dynamic.ServersLoadBalancer) string {
+func WithService(name string, opts ...func(*dynamic.Service)) func(*dynamic.Service) string {
+	return func(s *dynamic.Service) string {
 		for _, opt := range opts {
-			opt(r)
+			opt(s)
 		}
+
 		return name
+	}
+}
+
+func WithServiceServersLoadBalancer(opts ...func(*dynamic.ServersLoadBalancer)) func(*dynamic.Service) {
+	return func(s *dynamic.Service) {
+		b := &dynamic.ServersLoadBalancer{}
+		b.SetDefaults()
+
+		for _, opt := range opts {
+			opt(b)
+		}
+
+		s.LoadBalancer = b
+	}
+}
+
+func WithServiceWRR(opts ...func(*dynamic.WeightedRoundRobin)) func(*dynamic.Service) {
+	return func(s *dynamic.Service) {
+		b := &dynamic.WeightedRoundRobin{}
+
+		for _, opt := range opts {
+			opt(b)
+		}
+
+		s.Weighted = b
+	}
+}
+
+// WithWRRServices is a helper to create a configuration.
+func WithWRRServices(opts ...func(*dynamic.WRRService)) func(*dynamic.WeightedRoundRobin) {
+	return func(b *dynamic.WeightedRoundRobin) {
+		for _, opt := range opts {
+			service := dynamic.WRRService{}
+			opt(&service)
+			b.Services = append(b.Services, service)
+		}
+	}
+}
+
+// WithWRRService is a helper to create a configuration.
+func WithWRRService(name string, opts ...func(*dynamic.WRRService)) func(*dynamic.WRRService) {
+	return func(s *dynamic.WRRService) {
+		for _, opt := range opts {
+			opt(s)
+		}
+		s.Name = name
 	}
 }
 
@@ -103,6 +148,13 @@ func WithMiddleware(name string, opts ...func(*dynamic.Middleware)) func(*dynami
 func WithBasicAuth(auth *dynamic.BasicAuth) func(*dynamic.Middleware) {
 	return func(r *dynamic.Middleware) {
 		r.BasicAuth = auth
+	}
+}
+
+// WithErrorPage is a helper to create a configuration.
+func WithErrorPage(errorPage *dynamic.ErrorPage) func(*dynamic.Middleware) {
+	return func(r *dynamic.Middleware) {
+		r.Errors = errorPage
 	}
 }
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes a bug where you can have a recursion problem in the services configuration.
If a service referenced itself ( like WRR or Mirror ), we had a panic with recursion.

### Motivation

To fix the panic.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

