### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/check_doc.yaml
+++ b/.github/workflows/check_doc.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -54,7 +54,7 @@ jobs:
 
       # Comes from https://github.com/gjtorikian/html-proofer?tab=readme-ov-file#caching-with-continuous-integration
       - name: Cache HTMLProofer
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: tmp/.htmlproofer
           key: ${{ runner.os }}-htmlproofer

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,7 @@ jobs:
           args: release --clean --timeout="90m" --config "${{ env.GORELEASER_CONFIG_FILE_PATH }}"
 
       - name: Artifact binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.os }}-binaries
           path: |

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -46,7 +46,7 @@ jobs:
           key: ${{ runner.os }}-go-build-cache-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}
 
       - name: Artifact traefik binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: traefik
           path: ./dist/linux/amd64/traefik

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -76,7 +76,7 @@ jobs:
         run: corepack enable
 
       - name: Set up Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: webui/.nvmrc
           cache: 'yarn'

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -29,7 +29,7 @@ jobs:
           check-latest: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           version: "${{ env.GOLANGCI_LINT_VERSION }}"
 


### PR DESCRIPTION
### What does this PR do?

This PR updates outdated GitHub Action versions to ensure compatibility with the latest workflows.

### Motivation

To maintain up-to-date and secure workflows by leveraging the latest GitHub Actions versions.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

The PR updates GitHub Action versions across multiple workflows, ensuring compatibility with the latest versions of the actions. The changes are made to support the latest Traefik versions, though the specific Traefik version is not directly tied to the GitHub Action versions in this PR.
