### PR TITLE
Add configuration transformer mechanism to the ConfigurationWatcher

### DIFF
--- a/pkg/server/configurationwatcher_test.go
+++ b/pkg/server/configurationwatcher_test.go
@@ -442,7 +442,8 @@ func TestListenProvidersDoesNotSkipFlappingConfiguration(t *testing.T) {
 	}
 
 	pvd := &mockProvider{
-		wait: 5 * time.Millisecond, // The last message needs to be received before the second has been fully processed
+		wait:             5 * time.Millisecond, // The last message needs to be received before the second has been fully processed
+		throttleDuration: 15 * time.Millisecond,
 		messages: []dynamic.Message{
 			{ProviderName: "mock", Configuration: configuration},
 			{ProviderName: "mock", Configuration: transientConfiguration},
@@ -932,32 +933,36 @@ func TestConfigurationWatcher_MultipleTransformers(t *testing.T) {
 
 	var callCount1, callCount2 int
 
-	watcher.AddTransformer(func(providerName string, configs dynamic.Configurations) dynamic.Configurations {
+	watcher.AddTransformer(func(_ context.Context, configs dynamic.Configurations) dynamic.Configurations {
 		callCount1++
 
 		callOrder = append(callOrder, "transformer1")
 
-		if config := configs[providerName]; config != nil && config.HTTP != nil {
-			config.HTTP.Routers["from-transformer1"] = &dynamic.Router{
-				EntryPoints: []string{"e"},
-				Service:     "svc1",
+		for _, config := range configs {
+			if config != nil && config.HTTP != nil {
+				config.HTTP.Routers["from-transformer1"] = &dynamic.Router{
+					EntryPoints: []string{"e"},
+					Service:     "svc1",
+				}
 			}
 		}
 
 		return configs
 	})
 
-	watcher.AddTransformer(func(providerName string, configs dynamic.Configurations) dynamic.Configurations {
+	watcher.AddTransformer(func(_ context.Context, configs dynamic.Configurations) dynamic.Configurations {
 		callCount2++
 
 		callOrder = append(callOrder, "transformer2")
 
 		// Verify that transformer1's changes are visible.
-		if config := configs[providerName]; config != nil && config.HTTP != nil {
-			assert.Contains(t, config.HTTP.Routers, "from-transformer1")
-			config.HTTP.Routers["from-transformer2"] = &dynamic.Router{
-				EntryPoints: []string{"e"},
-				Service:     "svc2",
+		for _, config := range configs {
+			if config != nil && config.HTTP != nil {
+				assert.Contains(t, config.HTTP.Routers, "from-transformer1")
+				config.HTTP.Routers["from-transformer2"] = &dynamic.Router{
+					EntryPoints: []string{"e"},
+					Service:     "svc2",
+				}
 			}
 		}
 
@@ -986,78 +991,4 @@ func TestConfigurationWatcher_MultipleTransformers(t *testing.T) {
 	assert.Equal(t, []string{"transformer1", "transformer2"}, callOrder)
 	assert.Equal(t, 1, callCount1)
 	assert.Equal(t, 1, callCount2)
-}
-
-func TestConfigurationWatcher_CrossProviderTransformer(t *testing.T) {
-	routinesPool := safe.NewPool(t.Context())
-	t.Cleanup(routinesPool.Stop)
-
-	watcher := NewConfigurationWatcher(routinesPool, &mockProvider{}, []string{}, "")
-	watcher.allProvidersConfigs = make(chan dynamic.Message)
-
-	// Transformer that adds a router to provider-a when provider-b triggers.
-	watcher.AddTransformer(func(providerName string, configs dynamic.Configurations) dynamic.Configurations {
-		if providerName == "provider-b" {
-			if configA := configs["provider-a"]; configA != nil && configA.HTTP != nil {
-				configA.HTTP.Routers["added-by-b"] = &dynamic.Router{
-					EntryPoints: []string{"ep"},
-					Service:     "svc",
-				}
-			}
-		}
-
-		return configs
-	})
-
-	var lastConfig dynamic.Configuration
-
-	configCount := 0
-	configReceived := make(chan struct{})
-
-	watcher.AddListener(func(conf dynamic.Configuration) {
-		lastConfig = conf
-
-		configCount++
-
-		if configCount == 2 {
-			close(configReceived)
-		}
-	})
-
-	watcher.Start()
-	t.Cleanup(watcher.Stop)
-
-	// Send provider-a config.
-	watcher.allProvidersConfigs <- dynamic.Message{
-		ProviderName: "provider-a",
-		Configuration: &dynamic.Configuration{
-			HTTP: th.BuildConfiguration(
-				th.WithRouters(th.WithRouter("original-a", th.WithEntryPoints("ep"))),
-			),
-		},
-	}
-
-	// Wait a bit for the first config to be processed.
-	time.Sleep(50 * time.Millisecond)
-
-	// Send provider-b config, which should trigger modification of provider-a.
-	watcher.allProvidersConfigs <- dynamic.Message{
-		ProviderName: "provider-b",
-		Configuration: &dynamic.Configuration{
-			HTTP: th.BuildConfiguration(
-				th.WithRouters(th.WithRouter("original-b", th.WithEntryPoints("ep"))),
-			),
-		},
-	}
-
-	select {
-	case <-configReceived:
-	case <-time.After(5 * time.Second):
-		t.Fatal("Timeout waiting for configurations")
-	}
-
-	// Verify that provider-a's config was modified by the transformer.
-	assert.Contains(t, lastConfig.HTTP.Routers, "original-a@provider-a")
-	assert.Contains(t, lastConfig.HTTP.Routers, "added-by-b@provider-a")
-	assert.Contains(t, lastConfig.HTTP.Routers, "original-b@provider-b")
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Adds a configuration transformer mechanism to the ConfigurationWatcher that allows modifying dynamic configurations before they are applied. Transformers receive the triggering provider name and the full set of configurations from all providers.


### Motivation

This mechanism complements #12562  (dynamic config extension) by providing a way to compute and populate extended dynamic configuration fields. While #12562 allows extending configuration structures with custom fields, this PR provides the hook to compute and populate those fields based on provider configurations.

This enables dynamic configuration transformations from external components without requiring changes to individual providers. 


### More

- [x] Added/updated tests
- [ ] ~Added/updated documentation~

