### PR TITLE
Fix the errors middleware's document for Kubernetes CRD

### DIFF
--- a/docs/content/reference/routing-configuration/http/middlewares/errorpages.md
+++ b/docs/content/reference/routing-configuration/http/middlewares/errorpages.md
@@ -19,8 +19,8 @@ http:
           - "503"
           - "505-599"
         statusRewrites:
-          "418": "404"
-          "502-504": "500"
+          "418": 404
+          "502-504": 500
         service: error-handler-service
         query: "/{status}.html"
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Fixes a syntax error in the documentation for the errors middleware configuration that caused validation failures when applying the manifest.

### Motivation

<!-- What inspired you to submit this pull request? -->
While following the documentation, the provided example caused a Kubernetes validation error when running:

```bash
kubectl apply -f traefik/error.yaml
```

The error message was:

```
The Middleware "custom-error-page" is invalid: 
* spec.errors.statusRewrites.418: Invalid value: "string": spec.errors.statusRewrites.418 in body must be of type integer: "string"
* <nil>: Invalid value: null: some validation rules were not checked because the object was invalid; correct the existing errors to complete validation
```

This PR corrects the configuration example so that it uses the proper data types and no longer produces a syntax error.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

This change only affects the documentation example and does not modify runtime behavior.
