### PR TITLE
Fix kubernetes.md with correct http redirections

### DIFF
--- a/docs/content/setup/kubernetes.md
+++ b/docs/content/setup/kubernetes.md
@@ -101,11 +101,12 @@ ports:
     port: 80
     nodePort: 30000
     # Instructs this entry point to redirect all traffic to the 'websecure' entry point
-    redirections:
-      entryPoint:
-        to: websecure
-        scheme: https
-        permanent: true
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
+          permanent: true
 
   # Defines the HTTPS entry point named 'websecure'
   websecure:


### PR DESCRIPTION
Was setting up my locak k8s cluster using Talos and Metallb. Noticed that this configuration item is not quite right in the docs.
The correct, more updated values were here: https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#configuration-example

Without this change the helm values.yaml is invalid.


### What does this PR do?
Fix the docs :)

### Motivation
Well, I had to do it my self. Might as well have others enjoy it!

### Additional Notes
Not really, but for the couple of people reading this. I hope you have a wonderful day.
