### PR TITLE
HTTP Healthcheck for TCP services

### DIFF
--- a/docs/content/reference/routing-configuration/tcp/service.md
+++ b/docs/content/reference/routing-configuration/tcp/service.md
@@ -73,6 +73,44 @@ labels:
 }
 ```
 
+#### HTTP Health Check Configuration Example
+
+You can also configure health checks using HTTP mode:
+
+```yaml tab="Structured (YAML)"
+tcp:
+  services:
+    my-service:
+      loadBalancer:
+        servers:
+        - address: "xx.xx.xx.xx:8080"
+        healthCheck:
+          mode: "HTTP"
+          httpHealthCheck:
+            path: "/health"
+            method: "GET"
+            status: 200
+          interval: "10s"
+          timeout: "3s"
+```
+
+```toml tab="Structured (TOML)"
+[tcp.services]
+  [tcp.services.my-service.loadBalancer]
+    [[tcp.services.my-service.loadBalancer.servers]]
+      address = "xx.xx.xx.xx:8080"
+
+    [tcp.services.my-service.loadBalancer.healthCheck]
+      mode = "HTTP"
+      interval = "10s"
+      timeout = "3s"
+
+      [tcp.services.my-service.loadBalancer.healthCheck.httpHealthCheck]
+        path = "/health"
+        method = "GET"
+        status = 200
+```
+
 ### Configuration Options
 
 | Field | Description                                 | Default |
@@ -101,6 +139,19 @@ Below are the available options for the health check mechanism:
 | <a id="opt-interval" href="#opt-interval" title="#opt-interval">`interval`</a> | Defines the frequency of the health check calls for healthy targets. | 30s | No |
 | <a id="opt-unhealthyInterval" href="#opt-unhealthyInterval" title="#opt-unhealthyInterval">`unhealthyInterval`</a> | Defines the frequency of the health check calls for unhealthy targets. When not defined, it defaults to the `interval` value. | 30s | No |
 | <a id="opt-timeout" href="#opt-timeout" title="#opt-timeout">`timeout`</a> | Defines the maximum duration Traefik will wait for a health check connection before considering the server unhealthy. | 5s | No |
+| <a id="opt-mode" href="#opt-mode" title="#opt-mode">`mode`</a> | Defines the health check mode. Can be `TCP` (default) for TCP payload exchange, or `HTTP` for HTTP health checks. | TCP | No |
+
+#### HTTP Mode
+
+When the health check `mode` is set to `HTTP`, you can configure HTTP-specific parameters using the `httpHealthCheck` field:
+
+| Field | Description | Default | Required |
+|-------|-------------|---------|----------|
+| <a id="opt-httpHealthCheck" href="#opt-httpHealthCheck" title="#opt-httpHealthCheck">`httpHealthCheck`</a> | Configures HTTP health check options. Required when mode is set to `http`. | | No |
+| <a id="opt-httpHealthCheck-path" href="#opt-httpHealthCheck-path" title="#opt-httpHealthCheck-path">`httpHealthCheck.path`</a> | Defines the HTTP request path for the health check. | / | No |
+| <a id="opt-httpHealthCheck-port" href="#opt-httpHealthCheck-port" title="#opt-httpHealthCheck-port">`httpHealthCheck.port`</a> | Overrides the server address port for the HTTP health check endpoint. | | No |
+| <a id="opt-httpHealthCheck-method" href="#opt-httpHealthCheck-method" title="#opt-httpHealthCheck-method">`httpHealthCheck.method`</a> | Defines the HTTP method used for the health check request. | GET | No |
+| <a id="opt-httpHealthCheck-status" href="#opt-httpHealthCheck-status" title="#opt-httpHealthCheck-status">`httpHealthCheck.status`</a> | Defines the expected HTTP status code for a successful health check. | 200 | No |
 
 ## Weighted Round Robin
 

--- a/pkg/config/dynamic/tcp_config.go
+++ b/pkg/config/dynamic/tcp_config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	ptypes "github.com/traefik/paerser/types"
+	"github.com/traefik/traefik/v3/pkg/healthcheck/tcphealthcheckmode"
 	traefiktls "github.com/traefik/traefik/v3/pkg/tls"
 	"github.com/traefik/traefik/v3/pkg/types"
 )
@@ -181,15 +182,26 @@ type TLSClientConfig struct {
 }
 
 // +k8s:deepcopy-gen=true
+// TCPHTTPHealthCheck holds the HTTP health check configuration for TCP services.
+type TCPHTTPHealthCheck struct {
+	Port   int    `json:"port,omitempty" toml:"port,omitempty,omitzero" yaml:"port,omitempty" export:"true"`
+	Path   string `json:"path,omitempty" toml:"path,omitempty" yaml:"path,omitempty" export:"true"`
+	Method string `json:"method,omitempty" toml:"method,omitempty" yaml:"method,omitempty" export:"true"`
+	Status int    `json:"status,omitempty" toml:"status,omitempty" yaml:"status,omitempty" export:"true"`
+}
+
+// +k8s:deepcopy-gen=true
 
 // TCPServerHealthCheck holds the HealthCheck configuration.
 type TCPServerHealthCheck struct {
-	Port              int              `json:"port,omitempty" toml:"port,omitempty,omitzero" yaml:"port,omitempty" export:"true"`
-	Send              string           `json:"send,omitempty" toml:"send,omitempty" yaml:"send,omitempty" export:"true"`
-	Expect            string           `json:"expect,omitempty" toml:"expect,omitempty" yaml:"expect,omitempty" export:"true"`
-	Interval          ptypes.Duration  `json:"interval,omitempty" toml:"interval,omitempty" yaml:"interval,omitempty" export:"true"`
-	UnhealthyInterval *ptypes.Duration `json:"unhealthyInterval,omitempty" toml:"unhealthyInterval,omitempty" yaml:"unhealthyInterval,omitempty" export:"true"`
-	Timeout           ptypes.Duration  `json:"timeout,omitempty" toml:"timeout,omitempty" yaml:"timeout,omitempty" export:"true"`
+	Port              int                                   `json:"port,omitempty" toml:"port,omitempty,omitzero" yaml:"port,omitempty" export:"true"`
+	Send              string                                `json:"send,omitempty" toml:"send,omitempty" yaml:"send,omitempty" export:"true"`
+	Expect            string                                `json:"expect,omitempty" toml:"expect,omitempty" yaml:"expect,omitempty" export:"true"`
+	Interval          ptypes.Duration                       `json:"interval,omitempty" toml:"interval,omitempty" yaml:"interval,omitempty" export:"true"`
+	UnhealthyInterval *ptypes.Duration                      `json:"unhealthyInterval,omitempty" toml:"unhealthyInterval,omitempty" yaml:"unhealthyInterval,omitempty" export:"true"`
+	Timeout           ptypes.Duration                       `json:"timeout,omitempty" toml:"timeout,omitempty" yaml:"timeout,omitempty" export:"true"`
+	HttpHealthCheck   *TCPHTTPHealthCheck                   `json:"httpHealthCheck,omitempty" toml:"httpHealthCheck,omitempty" yaml:"httpHealthCheck,omitempty" label:"allowEmpty" file:"allowEmpty" kv:"allowEmpty" export:"true"`
+	Mode              tcphealthcheckmode.TCPHealthCheckMode `json:"mode,omitempty" toml:"mode,omitempty" yaml:"mode,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values for a TCPServerHealthCheck.

--- a/pkg/healthcheck/tcphealthcheckmode/tcphealthcheckmode.go
+++ b/pkg/healthcheck/tcphealthcheckmode/tcphealthcheckmode.go
@@ -1,0 +1,8 @@
+package tcphealthcheckmode
+
+type TCPHealthCheckMode string
+
+const (
+	ModeTcp  TCPHealthCheckMode = "TCP"
+	ModeHttp TCPHealthCheckMode = "HTTP"
+)

--- a/pkg/server/service/tcp/service.go
+++ b/pkg/server/service/tcp/service.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"math/rand"
 	"net"
+	"net/http"
 	"slices"
 	"time"
 
@@ -114,7 +115,8 @@ func (m *Manager) BuildTCP(rootCtx context.Context, serviceName string) (tcp.Han
 				loadBalancer,
 				conf,
 				slices.Collect(maps.Values(uniqHealthCheckTargets)),
-				serviceQualifiedName)
+				serviceQualifiedName,
+				&http.Client{Timeout: 10 * time.Second})
 		}
 
 		return loadBalancer, nil


### PR DESCRIPTION
### What does this PR do?

Adds support for performing HTTP health checks for TCP services in Traefik.
This allows TCP routing decisions to be based on the result of an HTTP endpoint rather than just a TCP-level check.

### Motivation

For clustered services such as Patroni, etcd, PostgreSQL, or similar setups, a simple TCP check is often insufficient.
These systems usually expose an HTTP API that indicates whether a node is healthy, functional, or currently the primary/leader.

This change enables Traefik to:

Poll an HTTP endpoint for health information

Route traffic only to nodes that are healthy or in the correct role (e.g. primary)

### More

- [x] Added/updated tests
- [x] Added/updated documentation


