### PR TITLE
Use url.Parse to validate X-Forwarded-Prefix value

### DIFF
--- a/pkg/api/dashboard/dashboard.go
+++ b/pkg/api/dashboard/dashboard.go
@@ -82,9 +82,8 @@ func Append(router *mux.Router, basePath string, customAssets fs.FS) error {
 		HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 			xfPrefix := req.Header.Get("X-Forwarded-Prefix")
 
-			// Validates that the X-Forwarded-Prefix value contains a relative path.
-			u, err := url.Parse(xfPrefix)
-			if err != nil || u.Host != "" || u.Scheme != "" {
+			// Validates that the X-Forwarded-Prefix value contains a relative URL.
+			if u, err := url.Parse(xfPrefix); err != nil || u.Host != "" || u.Scheme != "" {
 				log.Error().Msgf("X-Forwarded-Prefix contains an invalid value: %s, defaulting to empty prefix", xfPrefix)
 				xfPrefix = ""
 			}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request fixes the X-Forwarded-Prefix validation to use url.Parse from the stdlib.


### Motivation

To use url.Parse for validation.


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
