### PR TITLE
Correct documentation for Digest auth

### DIFF
--- a/docs/content/reference/routing-configuration/http/middlewares/digestauth.md
+++ b/docs/content/reference/routing-configuration/http/middlewares/digestauth.md
@@ -67,8 +67,7 @@ spec:
 
 ### Passwords format
 
-Passwords must be hashed using MD5, SHA1, or BCrypt.
-Use `htpasswd` to generate the passwords.
+Use `htdigest` to generate the passwords.
 
 ### users & usersFile
 


### PR DESCRIPTION


<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Corrects the documentation. The `htpasswd` doesn't create password files suitable for Digest auth. An Internet search pointed to the `htdigest` tool.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

Noticed a mistake in the documentation.

Fixes #12750 

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

This is MD5-based authentication. What year is it? 😬 

I'm not sure what branch to target for documentation fixes, please correct if wrong.

<!-- Anything else we should know when reviewing? -->
