### PR TITLE
Remove deprecated swarm:1.0.0 image used in DockerSuite

### DIFF
--- a/integration/docker_test.go
+++ b/integration/docker_test.go
@@ -1,8 +1,6 @@
 package integration
 
 import (
-	"encoding/json"
-	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -75,16 +73,8 @@ func (s *DockerSuite) TestDefaultDockerContainers() {
 	require.NoError(s.T(), err)
 	req.Host = "simple.docker.localhost"
 
-	resp, err := try.ResponseUntilStatusCode(req, 3*time.Second, http.StatusOK)
+	_, err = try.ResponseUntilStatusCode(req, 3*time.Second, http.StatusOK)
 	require.NoError(s.T(), err)
-
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(s.T(), err)
-
-	var version map[string]any
-
-	assert.NoError(s.T(), json.Unmarshal(body, &version))
-	assert.Equal(s.T(), "swarm/1.0.0", version["Version"])
 }
 
 func (s *DockerSuite) TestDockerContainersWithTCPLabels() {
@@ -139,16 +129,8 @@ func (s *DockerSuite) TestDockerContainersWithLabels() {
 	require.NoError(s.T(), err)
 	req.Host = "my.super.host"
 
-	resp, err := try.ResponseUntilStatusCode(req, 3*time.Second, http.StatusOK)
+	_, err = try.ResponseUntilStatusCode(req, 3*time.Second, http.StatusOK)
 	require.NoError(s.T(), err)
-
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(s.T(), err)
-
-	var version map[string]any
-
-	assert.NoError(s.T(), json.Unmarshal(body, &version))
-	assert.Equal(s.T(), "swarm/1.0.0", version["Version"])
 }
 
 func (s *DockerSuite) TestDockerContainersWithOneMissingLabels() {
@@ -197,16 +179,8 @@ func (s *DockerSuite) TestRestartDockerContainers() {
 	req.Host = "my.super.host"
 
 	// TODO Need to wait than 500 milliseconds more (for swarm or traefik to boot up ?)
-	resp, err := try.ResponseUntilStatusCode(req, 1500*time.Millisecond, http.StatusOK)
+	_, err = try.ResponseUntilStatusCode(req, 1500*time.Millisecond, http.StatusOK)
 	require.NoError(s.T(), err)
-
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(s.T(), err)
-
-	var version map[string]any
-
-	assert.NoError(s.T(), json.Unmarshal(body, &version))
-	assert.Equal(s.T(), "swarm/1.0.0", version["Version"])
 
 	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 60*time.Second, try.BodyContains("powpow"))
 	require.NoError(s.T(), err)

--- a/integration/resources/compose/docker.yml
+++ b/integration/resources/compose/docker.yml
@@ -1,8 +1,7 @@
 version: "3.8"
 services:
   simple:
-    image: swarm:1.0.0
-    command: [ "manage", "token://blablabla" ]
+    image: traefik/whoami
 
   withtcplabels:
     image: traefik/whoamitcp
@@ -13,26 +12,24 @@ services:
       traefik.tcp.Services.Super.Loadbalancer.server.port: 8080
 
   withlabels1:
-    image: swarm:1.0.0
-    command: [ "manage", "token://blabla" ]
+    image: traefik/whoami
     labels:
       traefik.http.Routers.Super.Rule: Host(`my.super.host`)
 
   withlabels2:
-    image: swarm:1.0.0
-    command: [ "manage", "token://blablabla" ]
+    image: traefik/whoami
     labels:
       traefik.http.Routers.SuperHost.Rule: Host(`my-super.host`)
 
   withonelabelmissing:
-    image: swarm:1.0.0
-    command: [ "manage", "token://blabla" ]
+    image: traefik/whoami
     labels:
       traefik.random.value: my.super.host
 
   powpow:
-    image: swarm:1.0.0
-    command: [ "manage", "token://blabla" ]
+    image: traefik/whoami
+    command:
+      - --port=2375
     labels:
       traefik.http.Routers.Super.Rule: Host(`my.super.host`)
       traefik.http.Services.powpow.LoadBalancer.server.Port: 2375


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request updates the swarm image to 1.1.0.


### Motivation

To fix the integration tests.


### More

- [X] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
