### PR TITLE
Correct encoded characters allowance in entrypoints.md

### DIFF
--- a/docs/content/reference/install-configuration/entrypoints.md
+++ b/docs/content/reference/install-configuration/entrypoints.md
@@ -232,7 +232,7 @@ By default, Traefik do not reject requests with path containing certain encoded 
     When your backend is not fully compliant with [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) and notably decode encoded reserved characters in the requets path,
     it is recommended to set these options to `false` to avoid split-view situation and helps prevent path traversal attacks or other malicious attempts to bypass security controls.
 
-Here is the list of the encoded characters that are rejected by default:
+Here is the list of the encoded characters that are allowed by default:
 
 | Encoded Character                                                                  | Character               |
 |------------------------------------------------------------------------------------|-------------------------|


### PR DESCRIPTION
### What does this PR do?

After back an forth in the last versions they are allowed by default again?!


### Motivation

It confused me what the default is now. But a few lines above it is written: By default, Traefik do not reject requests with path containing certain encoded characters


### More

- [ ] Added/updated tests
- [x] Added/updated documentation
