### PR TITLE
Update docker in-depth setup guide

### DIFF
--- a/docs/content/setup/docker.md
+++ b/docs/content/setup/docker.md
@@ -64,7 +64,7 @@ In the same folder as the `dynamic/tls.yaml` file, create a `docker-compose.yaml
 ```yaml
 services:
   traefik:
-    image: traefik:v3.4
+    image: traefik:v3.6
     container_name: traefik
     restart: unless-stopped
     security_opt:
@@ -77,7 +77,6 @@ services:
     ports:
       - "80:80"
       - "443:443"
-      - "8080:8080"
 
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This PR adds minor updates to the docker in-depth setup guide:
* Updates traefik docker image version from 3.4 to 3.6.
* Removes unnecessary exposure of port 8080. 

### Motivation

<!-- What inspired you to submit this pull request? -->

As a newcomer to Traefik, I was going through the Docker in-depth setup guide and wanted to make a small contribution.
My understanding is that, since the guide talks about securely exposing the dashboard behind TLS, it seems to me that exposing port 8080 in the compose file is unnecessary.

I also updated the traefik container image version from 3.4 to 3.6.

I've followed through the guide and everything worked as expected. Please let me know what/if evidence is necessary to support this.


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
