### PR TITLE
Add router-level open connections metric for TCP routers

### DIFF
--- a/pkg/observability/metrics/datadog.go
+++ b/pkg/observability/metrics/datadog.go
@@ -45,6 +45,7 @@ const (
 	ddRouterReqsDurationName = "router.request.duration"
 	ddRouterReqsBytesName    = "router.requests.bytes.total"
 	ddRouterRespsBytesName   = "router.responses.bytes.total"
+	ddRouterOpenConnsName    = "router.open.connections"
 
 	ddServiceReqsName         = "service.request.total"
 	ddServiceReqsTLSName      = "service.request.tls.total"
@@ -93,6 +94,7 @@ func RegisterDatadog(ctx context.Context, config *otypes.Datadog) Registry {
 		registry.routerReqDurationHistogram, _ = NewHistogramWithScale(datadogClient.NewHistogram(ddRouterReqsDurationName, 1.0), time.Second)
 		registry.routerReqsBytesCounter = datadogClient.NewCounter(ddRouterReqsBytesName, 1.0)
 		registry.routerRespsBytesCounter = datadogClient.NewCounter(ddRouterRespsBytesName, 1.0)
+		registry.routerOpenConnectionsGauge = datadogClient.NewGauge(ddRouterOpenConnsName)
 	}
 
 	if config.AddServicesLabels {

--- a/pkg/observability/metrics/influxdb2.go
+++ b/pkg/observability/metrics/influxdb2.go
@@ -42,6 +42,7 @@ const (
 	influxDBRouterReqsDurationName = "traefik.router.request.duration"
 	influxDBRouterReqsBytesName    = "traefik.router.requests.bytes.total"
 	influxDBRouterRespsBytesName   = "traefik.router.responses.bytes.total"
+	influxDBRouterOpenConnsName    = "traefik.router.open.connections"
 
 	influxDBServiceReqsName         = "traefik.service.requests.total"
 	influxDBServiceReqsTLSName      = "traefik.service.requests.tls.total"
@@ -102,6 +103,7 @@ func RegisterInfluxDB2(ctx context.Context, config *otypes.InfluxDB2) Registry {
 		registry.routerReqDurationHistogram, _ = NewHistogramWithScale(influxDB2Store.NewHistogram(influxDBRouterReqsDurationName), time.Second)
 		registry.routerReqsBytesCounter = influxDB2Store.NewCounter(influxDBRouterReqsBytesName)
 		registry.routerRespsBytesCounter = influxDB2Store.NewCounter(influxDBRouterRespsBytesName)
+		registry.routerOpenConnectionsGauge = influxDB2Store.NewGauge(influxDBRouterOpenConnsName)
 	}
 
 	if config.AddServicesLabels {

--- a/pkg/observability/metrics/metrics.go
+++ b/pkg/observability/metrics/metrics.go
@@ -44,6 +44,7 @@ type Registry interface {
 	RouterReqDurationHistogram() ScalableHistogram
 	RouterReqsBytesCounter() metrics.Counter
 	RouterRespsBytesCounter() metrics.Counter
+	RouterOpenConnectionsGauge() metrics.Gauge
 
 	// service metrics
 
@@ -80,6 +81,7 @@ func NewMultiRegistry(registries []Registry) Registry {
 	var routerReqDurationHistogram []ScalableHistogram
 	var routerReqsBytesCounter []metrics.Counter
 	var routerRespsBytesCounter []metrics.Counter
+	var routerOpenConnectionsGauge []metrics.Gauge
 	var serviceReqsCounter []CounterWithHeaders
 	var serviceReqsTLSCounter []metrics.Counter
 	var serviceReqDurationHistogram []ScalableHistogram
@@ -131,6 +133,9 @@ func NewMultiRegistry(registries []Registry) Registry {
 		if r.RouterRespsBytesCounter() != nil {
 			routerRespsBytesCounter = append(routerRespsBytesCounter, r.RouterRespsBytesCounter())
 		}
+		if r.RouterOpenConnectionsGauge() != nil {
+			routerOpenConnectionsGauge = append(routerOpenConnectionsGauge, r.RouterOpenConnectionsGauge())
+		}
 		if r.ServiceReqsCounter() != nil {
 			serviceReqsCounter = append(serviceReqsCounter, r.ServiceReqsCounter())
 		}
@@ -172,6 +177,7 @@ func NewMultiRegistry(registries []Registry) Registry {
 		routerReqDurationHistogram:     MultiHistogram(routerReqDurationHistogram),
 		routerReqsBytesCounter:         multi.NewCounter(routerReqsBytesCounter...),
 		routerRespsBytesCounter:        multi.NewCounter(routerRespsBytesCounter...),
+		routerOpenConnectionsGauge:     multi.NewGauge(routerOpenConnectionsGauge...),
 		serviceReqsCounter:             NewMultiCounterWithHeaders(serviceReqsCounter...),
 		serviceReqsTLSCounter:          multi.NewCounter(serviceReqsTLSCounter...),
 		serviceReqDurationHistogram:    MultiHistogram(serviceReqDurationHistogram),
@@ -200,6 +206,7 @@ type standardRegistry struct {
 	routerReqDurationHistogram     ScalableHistogram
 	routerReqsBytesCounter         metrics.Counter
 	routerRespsBytesCounter        metrics.Counter
+	routerOpenConnectionsGauge     metrics.Gauge
 	serviceReqsCounter             CounterWithHeaders
 	serviceReqsTLSCounter          metrics.Counter
 	serviceReqDurationHistogram    ScalableHistogram
@@ -275,6 +282,10 @@ func (r *standardRegistry) RouterReqsBytesCounter() metrics.Counter {
 
 func (r *standardRegistry) RouterRespsBytesCounter() metrics.Counter {
 	return r.routerRespsBytesCounter
+}
+
+func (r *standardRegistry) RouterOpenConnectionsGauge() metrics.Gauge {
+	return r.routerOpenConnectionsGauge
 }
 
 func (r *standardRegistry) ServiceReqsCounter() CounterWithHeaders {

--- a/pkg/observability/metrics/otel.go
+++ b/pkg/observability/metrics/otel.go
@@ -154,6 +154,9 @@ func RegisterOpenTelemetry(ctx context.Context, config *otypes.OTLP) Registry {
 			"The total size of requests in bytes handled by a router, partitioned by status code, protocol, and method.")
 		reg.routerRespsBytesCounter = newOTLPCounterFrom(meter, routerRespsBytesTotalName,
 			"The total size of responses in bytes handled by a router, partitioned by status code, protocol, and method.")
+		reg.routerOpenConnectionsGauge = newOTLPGaugeFrom(meter, routerOpenConnectionsName,
+			"How many open connections exist on a router, partitioned by service.",
+			"1")
 	}
 
 	if config.AddServicesLabels {

--- a/pkg/observability/metrics/prometheus.go
+++ b/pkg/observability/metrics/prometheus.go
@@ -44,7 +44,8 @@ const (
 	routerReqsTLSTotalName    = metricRouterPrefix + "requests_tls_total"
 	routerReqDurationName     = metricRouterPrefix + "request_duration_seconds"
 	routerReqsBytesTotalName  = metricRouterPrefix + "requests_bytes_total"
-	routerRespsBytesTotalName = metricRouterPrefix + "responses_bytes_total"
+	routerRespsBytesTotalName  = metricRouterPrefix + "responses_bytes_total"
+	routerOpenConnectionsName = metricRouterPrefix + "open_connections"
 
 	// service level.
 	metricServicePrefix        = MetricNamePrefix + "service_"
@@ -204,6 +205,10 @@ func initStandardRegistry(config *otypes.Prometheus) Registry {
 			Name: routerRespsBytesTotalName,
 			Help: "The total size of responses in bytes handled by a router, partitioned by service, status code, protocol, and method.",
 		}, []string{"code", "method", "protocol", "router", "service"})
+		routerOpenConns := newGaugeFrom(stdprometheus.GaugeOpts{
+			Name: routerOpenConnectionsName,
+			Help: "How many open connections exist on a router, partitioned by service.",
+		}, []string{"router", "service"})
 
 		promState.vectors = append(promState.vectors,
 			routerReqs.cv,
@@ -211,12 +216,14 @@ func initStandardRegistry(config *otypes.Prometheus) Registry {
 			routerReqDurations.hv,
 			routerReqsBytesTotal.cv,
 			routerRespsBytesTotal.cv,
+			routerOpenConns.gv,
 		)
 		reg.routerReqsCounter = routerReqs
 		reg.routerReqsTLSCounter = routerReqsTLS
 		reg.routerReqDurationHistogram, _ = NewHistogramWithScale(routerReqDurations, time.Second)
 		reg.routerReqsBytesCounter = routerReqsBytesTotal
 		reg.routerRespsBytesCounter = routerRespsBytesTotal
+		reg.routerOpenConnectionsGauge = routerOpenConns
 	}
 
 	if config.AddServicesLabels {

--- a/pkg/observability/metrics/prometheus_test.go
+++ b/pkg/observability/metrics/prometheus_test.go
@@ -151,6 +151,10 @@ func TestPrometheus(t *testing.T) {
 		RouterReqsBytesCounter().
 		With("router", "demo", "service", "service1", "code", strconv.Itoa(http.StatusOK), "method", http.MethodGet, "protocol", "http").
 		Add(1)
+	prometheusRegistry.
+		RouterOpenConnectionsGauge().
+		With("router", "demo", "service", "service1").
+		Set(1)
 
 	prometheusRegistry.
 		ServiceReqsCounter().
@@ -310,6 +314,14 @@ func TestPrometheus(t *testing.T) {
 				"router":   "demo",
 			},
 			assert: buildCounterAssert(t, routerRespsBytesTotalName, 1),
+		},
+		{
+			name: routerOpenConnectionsName,
+			labels: map[string]string{
+				"router":  "demo",
+				"service": "service1",
+			},
+			assert: buildGaugeAssert(t, routerOpenConnectionsName, 1),
 		},
 		{
 			name: serviceReqsTotalName,

--- a/pkg/observability/metrics/statsd.go
+++ b/pkg/observability/metrics/statsd.go
@@ -34,6 +34,7 @@ const (
 	statsdRouterReqsDurationName = "router.request.duration"
 	statsdRouterReqsBytesName    = "router.requests.bytes.total"
 	statsdRouterRespsBytesName   = "router.responses.bytes.total"
+	statsdRouterOpenConnsName    = "router.open.connections"
 
 	statsdServiceReqsName         = "service.request.total"
 	statsdServiceReqsTLSName      = "service.request.tls.total"
@@ -80,6 +81,7 @@ func RegisterStatsd(ctx context.Context, config *otypes.Statsd) Registry {
 		registry.routerReqDurationHistogram, _ = NewHistogramWithScale(statsdClient.NewTiming(statsdRouterReqsDurationName, 1.0), time.Millisecond)
 		registry.routerReqsBytesCounter = statsdClient.NewCounter(statsdRouterReqsBytesName, 1.0)
 		registry.routerRespsBytesCounter = statsdClient.NewCounter(statsdRouterRespsBytesName, 1.0)
+		registry.routerOpenConnectionsGauge = statsdClient.NewGauge(statsdRouterOpenConnsName)
 	}
 
 	if config.AddServicesLabels {

--- a/pkg/server/router/tcp/manager_test.go
+++ b/pkg/server/router/tcp/manager_test.go
@@ -367,7 +367,7 @@ func TestRuntimeConfiguration(t *testing.T) {
 			middlewaresBuilder := tcpmiddleware.NewBuilder(conf.TCPMiddlewares)
 
 			routerManager := NewManager(conf, serviceManager, middlewaresBuilder,
-				nil, nil, tlsManager)
+				nil, nil, tlsManager, nil)
 
 			_ = routerManager.BuildHandlers(t.Context(), entryPoints)
 
@@ -668,7 +668,7 @@ func TestDomainFronting(t *testing.T) {
 
 			middlewaresBuilder := tcpmiddleware.NewBuilder(conf.TCPMiddlewares)
 
-			routerManager := NewManager(conf, serviceManager, middlewaresBuilder, nil, httpsHandler, tlsManager)
+			routerManager := NewManager(conf, serviceManager, middlewaresBuilder, nil, httpsHandler, tlsManager, nil)
 
 			routers := routerManager.BuildHandlers(t.Context(), entryPoints)
 

--- a/pkg/server/router/tcp/metrics_test.go
+++ b/pkg/server/router/tcp/metrics_test.go
@@ -1,0 +1,145 @@
+package tcp
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/metrics"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/traefik/traefik/v3/pkg/config/dynamic"
+	"github.com/traefik/traefik/v3/pkg/config/runtime"
+	traefikmetrics "github.com/traefik/traefik/v3/pkg/observability/metrics"
+	tcpmiddleware "github.com/traefik/traefik/v3/pkg/server/middleware/tcp"
+	"github.com/traefik/traefik/v3/pkg/server/service/tcp"
+	tcp2 "github.com/traefik/traefik/v3/pkg/tcp"
+	traefiktls "github.com/traefik/traefik/v3/pkg/tls"
+)
+
+type mockRegistry struct {
+	traefikmetrics.Registry
+	routerOpenConnectionsGauge *mockGauge
+}
+
+func (m *mockRegistry) IsRouterEnabled() bool {
+	return true
+}
+
+func (m *mockRegistry) RouterOpenConnectionsGauge() metrics.Gauge {
+	return m.routerOpenConnectionsGauge
+}
+
+type mockGauge struct {
+	value       float64
+	labelValues []string
+}
+
+func (m *mockGauge) With(labelValues ...string) metrics.Gauge {
+	m.labelValues = labelValues
+	return m
+}
+
+func (m *mockGauge) Set(value float64) {
+	m.value = value
+}
+
+func (m *mockGauge) Add(delta float64) {
+	m.value += delta
+}
+
+func TestRouterOpenConnectionsMetrics(t *testing.T) {
+	routerName := "test-router"
+	serviceName := "test-service"
+	entryPointName := "web"
+
+	conf := &runtime.Configuration{
+		TCPServices: map[string]*runtime.TCPServiceInfo{
+			serviceName: {
+				TCPService: &dynamic.TCPService{
+					LoadBalancer: &dynamic.TCPServersLoadBalancer{
+						Servers: []dynamic.TCPServer{
+							{Address: "127.0.0.1:9999"},
+						},
+					},
+				},
+			},
+		},
+		TCPRouters: map[string]*runtime.TCPRouterInfo{
+			routerName: {
+				TCPRouter: &dynamic.TCPRouter{
+					EntryPoints: []string{entryPointName},
+					Service:     serviceName,
+					Rule:        "HostSNI(`*`)",
+				},
+			},
+		},
+	}
+
+	gauge := &mockGauge{}
+	registry := &mockRegistry{
+		routerOpenConnectionsGauge: gauge,
+	}
+
+	dialerManager := tcp2.NewDialerManager(nil)
+	dialerManager.Update(map[string]*dynamic.TCPServersTransport{"default@internal": {}})
+	svcManager := tcp.NewManager(conf, dialerManager)
+
+	middlewaresBuilder := tcpmiddleware.NewBuilder(conf.TCPMiddlewares)
+
+	manager := NewManager(conf,
+		svcManager,
+		middlewaresBuilder, nil, nil,
+		traefiktls.NewManager(nil),
+		registry,
+	)
+
+	handlers := manager.BuildHandlers(context.Background(), []string{entryPointName})
+	_, ok := handlers[entryPointName]
+	require.True(t, ok)
+
+	// Verify that the gauge's With method was called with the correct labels
+	// during handler construction. The With method on our mock stores the label values.
+	assert.Equal(t, []string{"router", routerName, "service", serviceName}, gauge.labelValues)
+}
+
+func TestRouterOpenConnectionsMetrics_ServeTCP(t *testing.T) {
+	// Test the metricsMiddleware directly to verify increment/decrement behavior.
+	gauge := &mockGauge{}
+
+	mockHandler := &mockTCPHandler{}
+	middleware := &metricsMiddleware{
+		next:                 mockHandler,
+		openConnectionsGauge: gauge,
+	}
+
+	conn := &mockConn{}
+	middleware.ServeTCP(conn)
+
+	// After ServeTCP completes, the gauge should have been incremented and decremented.
+	assert.Equal(t, float64(0), gauge.value)
+	assert.True(t, mockHandler.called, "next handler should have been called")
+}
+
+type mockTCPHandler struct {
+	called bool
+}
+
+func (m *mockTCPHandler) ServeTCP(conn tcp2.WriteCloser) {
+	m.called = true
+}
+
+type mockConn struct {
+	tcp2.WriteCloser
+}
+
+func (m *mockConn) Close() error                       { return nil }
+func (m *mockConn) CloseWrite() error                  { return nil }
+func (m *mockConn) Read(b []byte) (n int, err error)   { return 0, nil }
+func (m *mockConn) Write(b []byte) (n int, err error)  { return 0, nil }
+func (m *mockConn) RemoteAddr() net.Addr               { return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 1234} }
+func (m *mockConn) LocalAddr() net.Addr                { return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 80} }
+func (m *mockConn) SetDeadline(t time.Time) error      { return nil }
+func (m *mockConn) SetReadDeadline(t time.Time) error  { return nil }
+func (m *mockConn) SetWriteDeadline(t time.Time) error { return nil }

--- a/pkg/server/router/tcp/router_test.go
+++ b/pkg/server/router/tcp/router_test.go
@@ -202,7 +202,7 @@ func Test_Routing(t *testing.T) {
 	middlewaresBuilder := tcpmiddleware.NewBuilder(conf.TCPMiddlewares)
 
 	manager := NewManager(conf, serviceManager, middlewaresBuilder,
-		nil, nil, tlsManager)
+		nil, nil, tlsManager, nil)
 
 	type checkCase struct {
 		checkRouter

--- a/pkg/server/routerfactory.go
+++ b/pkg/server/routerfactory.go
@@ -120,7 +120,7 @@ func (f *RouterFactory) CreateRouters(rtConf *runtime.Configuration) (map[string
 
 	middlewaresTCPBuilder := tcpmiddleware.NewBuilder(rtConf.TCPMiddlewares)
 
-	rtTCPManager := tcprouter.NewManager(rtConf, svcTCPManager, middlewaresTCPBuilder, handlersNonTLS, handlersTLS, f.tlsManager)
+	rtTCPManager := tcprouter.NewManager(rtConf, svcTCPManager, middlewaresTCPBuilder, handlersNonTLS, handlersTLS, f.tlsManager, f.observabilityMgr.MetricsRegistry())
 	routersTCP := rtTCPManager.BuildHandlers(ctx, f.entryPointsTCP)
 
 	for ep, r := range routersTCP {


### PR DESCRIPTION
### What does this PR do?

Reintroduces a router-level open connections gauge metric (`traefik_router_open_connections`) for TCP routers, with `router` and `service` labels. This restores per-service connection visibility that was available in Traefik v2 but removed in v3.

Fixes #11006

### Motivation

In Traefik v3, `traefik_open_connections` only exposes entrypoint-level aggregation and no longer includes router/service labels. This makes it impossible to attribute open connections to specific backends, which is critical for:

- Per-service load visibility
- Accurate autoscaling signals (e.g. KEDA, HPA)
- Detecting stuck or overloaded backends

This change restores observability parity with Traefik v2 while aligning with v3's metric model.

### Implementation Details

- Added `RouterOpenConnectionsGauge()` to the metrics `Registry` interface
- Implemented `metricsMiddleware` in the TCP router manager that wraps handlers to track open connections (increment on connect, decrement on close via `defer`)
- Applied metrics wrapping to all three TCP routing paths: non-TLS, TLS passthrough, and TLS terminating
- Registered the metric across all 5 backends:
  - **Prometheus**: `traefik_router_open_connections` with labels `["router", "service"]`
  - **Datadog**: `router.open.connections`
  - **StatsD**: `router.open.connections`
  - **InfluxDB2**: `traefik.router.open.connections`
  - **OpenTelemetry**: `traefik_router_open_connections`
- Gated behind the existing `AddRoutersLabels` config flag, consistent with other router metrics
- Existing `traefik_open_connections` (entrypoint-level) remains unchanged — fully backward compatible

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

- Low cardinality: labels are limited to `router` and `service` names from the dynamic configuration
- Stale metric cleanup is handled via `promState.vectors` for Prometheus
- Tests cover both handler construction with correct label wiring and direct middleware increment/decrement behavior
- This issue is tagged `contributor/wanted` on the upstream tracker