### PR TITLE
Add docker provider polling

### DIFF
--- a/pkg/provider/docker/pdocker.go
+++ b/pkg/provider/docker/pdocker.go
@@ -92,12 +92,10 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 			}
 
 			if p.Watch {
-				startStopHandle := func(m eventtypes.Message) {
-					logger.Debug().Msgf("Provider event received %+v", m)
+				refreshHandle := func() {
 					containers, err := p.listContainers(ctx, dockerClient)
 					if err != nil {
 						logger.Error().Err(err).Msg("Failed to list containers for docker")
-						// Call cancel to get out of the monitor
 						return
 					}
 
@@ -114,11 +112,25 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 					}
 				}
 
+				startStopHandle := func(m eventtypes.Message) {
+					logger.Debug().Msgf("Provider event received %+v", m)
+					refreshHandle()
+				}
+
+				var tickerc <-chan time.Time
+				if p.RefreshSeconds > 0 {
+					ticker := time.NewTicker(time.Duration(p.RefreshSeconds))
+					tickerc = ticker.C
+					defer ticker.Stop()
+				}
+
 				res := dockerClient.Events(ctx, client.EventsListOptions{
 					Filters: make(client.Filters).Add("type", string(eventtypes.ContainerEventType)),
 				})
 				for {
 					select {
+					case <-tickerc:
+						refreshHandle()
 					case event := <-res.Messages:
 						if event.Action == "start" ||
 							event.Action == "die" ||

--- a/pkg/provider/docker/pswarm.go
+++ b/pkg/provider/docker/pswarm.go
@@ -29,8 +29,6 @@ var _ provider.Provider = (*SwarmProvider)(nil)
 type SwarmProvider struct {
 	Shared       `yaml:",inline" export:"true"`
 	ClientConfig `yaml:",inline" export:"true"`
-
-	RefreshSeconds ptypes.Duration `description:"Polling interval for swarm mode." json:"refreshSeconds,omitempty" toml:"refreshSeconds,omitempty" yaml:"refreshSeconds,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values.

--- a/pkg/provider/docker/shared.go
+++ b/pkg/provider/docker/shared.go
@@ -33,8 +33,9 @@ type Shared struct {
 	Network            string `description:"Default Docker network used." json:"network,omitempty" toml:"network,omitempty" yaml:"network,omitempty" export:"true"`
 	UseBindPortIP      bool   `description:"Use the ip address from the bound port, rather than from the inner network." json:"useBindPortIP,omitempty" toml:"useBindPortIP,omitempty" yaml:"useBindPortIP,omitempty" export:"true"`
 
-	Watch       bool   `description:"Watch Docker events." json:"watch,omitempty" toml:"watch,omitempty" yaml:"watch,omitempty" export:"true"`
-	DefaultRule string `description:"Default rule." json:"defaultRule,omitempty" toml:"defaultRule,omitempty" yaml:"defaultRule,omitempty"`
+	Watch          bool            `description:"Watch Docker events." json:"watch,omitempty" toml:"watch,omitempty" yaml:"watch,omitempty" export:"true"`
+	RefreshSeconds ptypes.Duration `description:"Polling interval." json:"refreshSeconds,omitempty" toml:"refreshSeconds,omitempty" yaml:"refreshSeconds,omitempty" export:"true"`
+	DefaultRule    string          `description:"Default rule." json:"defaultRule,omitempty" toml:"defaultRule,omitempty" yaml:"defaultRule,omitempty"`
 
 	defaultRuleTpl *template.Template
 }


### PR DESCRIPTION
### What does this PR do?

This PR enables the use of optional polling on the Docker provider, which can be useful in non-standard setups, e.g. podman (https://community.traefik.io/t/need-to-restart-traefik-whenever-a-converter-is-restarted-even-if-compose-yml-configuration-does-not-change/21166),

### Motivation

I got tired of restarting traefik every time a podman container restarted, and I couldn't figure it out on the podman side :)

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

If this is something that seems merge-able, I will look into updating docs and tests. Thanks for the great work on traefik!