### PR TITLE
Fix basePath validation for dashboard template

### DIFF
--- a/pkg/api/dashboard/dashboard.go
+++ b/pkg/api/dashboard/dashboard.go
@@ -2,11 +2,11 @@ package dashboard
 
 import (
 	"fmt"
+	"html/template"
 	"io/fs"
 	"net/http"
 	"net/url"
 	"strings"
-	"html/template"
 
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog/log"

--- a/pkg/api/dashboard/dashboard.go
+++ b/pkg/api/dashboard/dashboard.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"text/template"
+	"html/template"
 
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog/log"

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -3,7 +3,6 @@ package static
 import (
 	"errors"
 	"fmt"
-	"path"
 	"regexp"
 	"strings"
 	"time"
@@ -59,7 +58,7 @@ const (
 )
 
 // Allowed characters in URL following RFC 3986 (https://www.rfc-editor.org/rfc/rfc3986#section-2)
-var validURLRegex = regexp.MustCompile(`^[a-zA-Z0-9\-._~!$&'()*+,;=:@/%]+$`)
+var validBasePath = regexp.MustCompile(`^/[a-zA-Z0-9/_.-]*$`)
 
 // Configuration is the static configuration.
 type Configuration struct {
@@ -468,14 +467,8 @@ func (c *Configuration) ValidateConfiguration() error {
 		}
 	}
 
-	if c.API != nil {
-		if !path.IsAbs(c.API.BasePath) {
-			return errors.New("API basePath must be a valid absolute path")
-		}
-
-		if !validURLRegex.MatchString(c.API.BasePath) {
-			return errors.New("API basePath must be a valid URL path")
-		}
+	if c.API != nil && !validBasePath.MatchString(c.API.BasePath) {
+		return errors.New("API basePath must be a valid absolute URL path")
 	}
 
 	if c.OCSP != nil {

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"regexp"
 	"strings"
 	"time"
 
@@ -56,6 +57,9 @@ const (
 	// before releasing all resources related to that session.
 	DefaultUDPTimeout = 3 * time.Second
 )
+
+// Allowed characters in URL following RFC 3986 (https://www.rfc-editor.org/rfc/rfc3986#section-2)
+var validURLRegex = regexp.MustCompile(`^[a-zA-Z0-9\-._~!$&'()*+,;=:@/%]+$`)
 
 // Configuration is the static configuration.
 type Configuration struct {
@@ -464,8 +468,14 @@ func (c *Configuration) ValidateConfiguration() error {
 		}
 	}
 
-	if c.API != nil && !path.IsAbs(c.API.BasePath) {
-		return errors.New("API basePath must be a valid absolute path")
+	if c.API != nil {
+		if !path.IsAbs(c.API.BasePath) {
+			return errors.New("API basePath must be a valid absolute path")
+		}
+
+		if !validURLRegex.MatchString(c.API.BasePath) {
+			return errors.New("API basePath must be a valid URL path")
+		}
 	}
 
 	if c.OCSP != nil {

--- a/pkg/config/static/static_config_test.go
+++ b/pkg/config/static/static_config_test.go
@@ -324,6 +324,31 @@ func TestValidateConfiguration_BasePath(t *testing.T) {
 			basePath:  "/path/<evil>",
 			expectErr: true,
 		},
+		{
+			desc:      "path with query string",
+			basePath:  "/api?foo=bar",
+			expectErr: true,
+		},
+		{
+			desc:      "path with fragment",
+			basePath:  "/api#section",
+			expectErr: true,
+		},
+		{
+			desc:      "valid root path",
+			basePath:  "/",
+			expectErr: false,
+		},
+		{
+			desc:      "path with quote",
+			basePath:  "/api/'onclick=alert(1)",
+			expectErr: true,
+		},
+		{
+			desc:      "path with encoded character",
+			basePath:  "/api%2Ftoto",
+			expectErr: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/config/static/static_config_test.go
+++ b/pkg/config/static/static_config_test.go
@@ -282,3 +282,64 @@ func TestConfiguration_SetEffectiveConfiguration(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateConfiguration_BasePath(t *testing.T) {
+	tests := []struct {
+		desc      string
+		basePath  string
+		expectErr bool
+	}{
+		{
+			desc:      "valid simple path",
+			basePath:  "/api",
+			expectErr: false,
+		},
+		{
+			desc:      "valid path with segments",
+			basePath:  "/my/base/path",
+			expectErr: false,
+		},
+		{
+			desc:      "valid path with allowed special chars",
+			basePath:  "/valid/path-123",
+			expectErr: false,
+		},
+		{
+			desc:      "relative path",
+			basePath:  "api/path",
+			expectErr: true,
+		},
+		{
+			desc:      "XSS payload",
+			basePath:  `/api/"></script><script>alert("XSS")</script>`,
+			expectErr: true,
+		},
+		{
+			desc:      "path with spaces",
+			basePath:  "/path with spaces",
+			expectErr: true,
+		},
+		{
+			desc:      "path with angle brackets",
+			basePath:  "/path/<evil>",
+			expectErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &Configuration{
+				API: &API{BasePath: test.basePath},
+			}
+
+			err := cfg.ValidateConfiguration()
+			if test.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Replace the imported `text/template` with `html/template` for the dashboard template and add validation for the `basePath` configuration.


### Motivation

A stricter regex validation will allow user to be warned early if the URL in their `basePath` is not a valid URL.
`text/template` provides no automatic escaping for HTML or JavaScript contexts. Switching to `html/template` ensures values rendered into the dashboard template are properly escaped, preventing potential injection issues.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

