### PR TITLE
Remove unused context import from test file

### DIFF
--- a/pkg/server/server_entrypoint_listenconfig_other_test.go
+++ b/pkg/server/server_entrypoint_listenconfig_other_test.go
@@ -3,7 +3,6 @@
 package server
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
Removed unused import of 'context' in test file.

<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Introduced by https://github.com/traefik/traefik/commit/bd4bfd89191dcc5a1c3d3d806bd55b694f31d779#diff-f5efc682085f64573f888f64778282292e080fa2a1322d00e177313ad2c59f91