### PR TITLE
Fix from to www nginx annotation

### DIFF
--- a/pkg/middlewares/redirect/redirect_regex_test.go
+++ b/pkg/middlewares/redirect/redirect_regex_test.go
@@ -139,6 +139,51 @@ func TestRedirectRegexHandler(t *testing.T) {
 			expectedStatus: http.StatusTemporaryRedirect,
 		},
 		{
+			desc: "www-redirect without port",
+			config: dynamic.RedirectRegex{
+				Regex:       `(https?)://[^/:]+(:[0-9]+)?/(.*)`,
+				Replacement: "$1://example.com$2/$3",
+				Permanent:   true,
+			},
+			url:            "http://www.example.com/path",
+			expectedURL:    "http://example.com/path",
+			expectedStatus: http.StatusMovedPermanently,
+		},
+		{
+			desc: "www-redirect with port",
+			config: dynamic.RedirectRegex{
+				Regex:       `(https?)://[^/:]+(:[0-9]+)?/(.*)`,
+				Replacement: "$1://example.com$2/$3",
+				Permanent:   true,
+			},
+			url:            "http://www.example.com:8080/path",
+			expectedURL:    "http://example.com:8080/path",
+			expectedStatus: http.StatusMovedPermanently,
+		},
+		{
+			desc: "www-redirect without port, root path",
+			config: dynamic.RedirectRegex{
+				Regex:       `(https?)://[^/:]+(:[0-9]+)?/(.*)`,
+				Replacement: "$1://example.com$2/$3",
+				Permanent:   true,
+			},
+			url:            "http://www.example.com/",
+			expectedURL:    "http://example.com/",
+			expectedStatus: http.StatusMovedPermanently,
+		},
+		{
+			desc: "www-redirect HTTPS without port",
+			config: dynamic.RedirectRegex{
+				Regex:       `(https?)://[^/:]+(:[0-9]+)?/(.*)`,
+				Replacement: "$1://example.com$2/$3",
+				Permanent:   true,
+			},
+			secured:        true,
+			url:            "https://www.example.com/path",
+			expectedURL:    "https://example.com/path",
+			expectedStatus: http.StatusMovedPermanently,
+		},
+		{
 			desc: "HTTP to HTTP POST permanent",
 			config: dynamic.RedirectRegex{
 				Regex:       `^http://`,

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
@@ -1164,9 +1164,9 @@ func applyFromToWwwRedirect(hosts map[string]bool, ruleHost, routerName string, 
 	fromToWwwRedirectMiddlewareName := routerName + "-from-to-www-redirect"
 	conf.HTTP.Middlewares[fromToWwwRedirectMiddlewareName] = &dynamic.Middleware{
 		RedirectRegex: &dynamic.RedirectRegex{
-			Regex:       `(https?)://[^/]+:([0-9]+)/(.*)`,
-			Replacement: fmt.Sprintf("$1://%s:$2/$3", ruleHost),
-			Permanent:   true,
+			Regex:       `(https?)://[^/:]+(:[0-9]+)?/(.*)`,
+			Replacement: fmt.Sprintf("$1://%s$2/$3", ruleHost),
+			StatusCode:  ptr.To(http.StatusPermanentRedirect),
 		},
 	}
 

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -1238,9 +1238,9 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-www-host-rule-0-path-0-from-to-www-redirect": {
 							RedirectRegex: &dynamic.RedirectRegex{
-								Regex:       `(https?)://[^/]+:([0-9]+)/(.*)`,
-								Replacement: "$1://www.host.localhost:$2/$3",
-								Permanent:   true,
+								Regex:       `(https?)://[^/:]+(:[0-9]+)?/(.*)`,
+								Replacement: "$1://www.host.localhost$2/$3",
+								StatusCode:  ptr.To(http.StatusPermanentRedirect),
 							},
 						},
 						"default-ingress-with-www-host-rule-0-path-0-retry": {
@@ -1312,9 +1312,9 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-host-rule-0-path-0-from-to-www-redirect": {
 							RedirectRegex: &dynamic.RedirectRegex{
-								Regex:       `(https?)://[^/]+:([0-9]+)/(.*)`,
-								Replacement: "$1://host.localhost:$2/$3",
-								Permanent:   true,
+								Regex:       `(https?)://[^/:]+(:[0-9]+)?/(.*)`,
+								Replacement: "$1://host.localhost$2/$3",
+								StatusCode:  ptr.To(http.StatusPermanentRedirect),
 							},
 						},
 						"default-ingress-with-host-rule-0-path-0-retry": {


### PR DESCRIPTION
### What does this PR do?

When the annotation `nginx.ingress.kubernetes.io/from-to-www-redirect` is set to true, Traefik returns a 301 instead of 308.
It also fixes the regex that was not matching the host with no port.

### Motivation

Having the same behaviour as Ingress Nginx

### More

- [x] Added/updated tests
- ~[ ] Added/updated documentation~

### Additional Notes

<!-- Anything else we should know when reviewing? -->
