### PR TITLE
Use unicode.MaxASCII for clearer ASCII check

### DIFF
--- a/pkg/muxer/http/matcher.go
+++ b/pkg/muxer/http/matcher.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
-	"unicode/utf8"
+	"unicode"
 
 	"github.com/rs/zerolog/log"
 	"github.com/traefik/traefik/v3/pkg/ip"
@@ -256,7 +256,7 @@ func queryRegexp(tree *matchersTree, queries ...string) error {
 // IsASCII checks if the given string contains only ASCII characters.
 func IsASCII(s string) bool {
 	for i := range len(s) {
-		if s[i] >= utf8.RuneSelf {
+		if s[i] > unicode.MaxASCII {
 			return false
 		}
 	}

--- a/pkg/muxer/tcp/matcher.go
+++ b/pkg/muxer/tcp/matcher.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
-	"unicode/utf8"
+	"unicode"
 
 	"github.com/go-acme/lego/v4/challenge/tlsalpn01"
 	"github.com/rs/zerolog/log"
@@ -120,7 +120,7 @@ func hostSNIRegexp(tree *matchersTree, templates ...string) error {
 // isASCII checks if the given string contains only ASCII characters.
 func isASCII(s string) bool {
 	for i := range len(s) {
-		if s[i] >= utf8.RuneSelf {
+		if s[i] > unicode.MaxASCII {
 			return false
 		}
 	}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Using unicode.MaxASCII with a greater-than check (>) more explicitly conveys the intent: "check if the character is outside the standard ASCII range". This aligns better with the function name IsASCII and makes the code more self-documenting for readers.

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
