### PR TITLE
Add OVHcloud (OpenStack Octavia) to Cloud-Specific IP Management

### DIFF
--- a/docs/content/migrate/nginx-to-traefik.md
+++ b/docs/content/migrate/nginx-to-traefik.md
@@ -453,17 +453,15 @@ kubectl get svc -n ingress-nginx ingress-nginx-controller -o go-template='{{ $in
     
     ```bash
     NGINX_IP=$(kubectl get svc -n ingress-nginx ingress-nginx-controller \
-      -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  -o go-template='{{ $ing := index .status.loadBalancer.ingress 0 }}{{ if $ing.ip }}{{ $ing.ip }}{{ else }}{{ $ing.hostname }}{{ end }}')
+     
     echo "NGINX IP: $NGINX_IP"
     ```
     
-    **Edit and update your existing NGINX LoadBalancer service to ensure that the floating IP is not released when the loadbalancer service is deleted:**
+    **Edit your existing NGINX LoadBalancer service to ensure that the floating IP is not released when the loadbalancer service is deleted:**
     
-    ```yaml
-    service:
-      type: LoadBalancer
-      annotations:
-        loadbalancer.openstack.org/keep-floatingip: "true"
+    
+    kubectl annotate svc my-lb-svc loadbalancer.openstack.org/keep-floatingip=true
     ```
     
     The `keep-floatingip` annotation prevents the floating IP from being released when the service is deleted or modified.


### PR DESCRIPTION
### What does this PR do?

- Added "OVHcloud (OpenStack Octavia)" block in the Cloud-Specific IP Management section of docs/content/migrate/nginx-to-traefik.md
- Includes `loadbalancer.openstack.org/keep-floatingip` annotation for Floating IP retention
- Includes `loadBalancerIP` spec for claiming an existing Floating IP
- Links to official OVHcloud documentation

### Motivation

OVHcloud Managed Kubernetes Service is a CNCF-certified Kubernetes offering used by thousands of customers in Europe. With the NGINX Ingress Controller retirement announced for March 2026, OVHcloud MKS users need clear migration guidance specific to their infrastructure.


### More

- [x] Added/updated documentation

### Additional Notes

- OVHcloud is preparing a dedicated migration guide for MKS users that will reference the Traefik documentation
- Blog post for context: [Moving beyond Ingress - Why should OVHcloud MKS users start looking at the Gateway API](https://blog.ovhcloud.com/moving-beyond-ingress-why-should-ovhcloud-managed-kubernetes-service-mks-users-start-looking-at-the-gateway-api/)
