### PR TITLE
Remove AGPL license in code

### DIFF
--- a/webui/src/components/buttons/IconButton.tsx
+++ b/webui/src/components/buttons/IconButton.tsx
@@ -1,17 +1,3 @@
-/*
-Copyright (C) 2022-2024 Traefik Labs
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as published
-by the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Affero General Public License for more details.
-You should have received a copy of the GNU Affero General Public License
-along with this program. If not, see <https://www.gnu.org/licenses/>.
-*/
-
 import { Button, Flex, Text } from '@traefiklabs/faency'
 import { ComponentProps, ReactNode } from 'react'
 


### PR DESCRIPTION
### What does this PR do?

Remove erroneous AGPL-3.0 license header from `webui/src/components/buttons/IconButton.tsx`.

### Motivation

The project is MIT-licensed, but this file contained an AGPL-3.0 header that was likely copied by mistake from another Traefik Labs product. Fixes #12774.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

No code changes — only the license header block (lines 1–13) was removed.

