### PR TITLE
Fix Host header not being modified by RequestHeaderModifier

### DIFF
--- a/pkg/middlewares/gatewayapi/headermodifier/request_header_modifier.go
+++ b/pkg/middlewares/gatewayapi/headermodifier/request_header_modifier.go
@@ -3,6 +3,7 @@ package headermodifier
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
 	"github.com/traefik/traefik/v3/pkg/middlewares"
@@ -40,6 +41,10 @@ func (r *requestHeaderModifier) GetTracingInformation() (string, string) {
 
 func (r *requestHeaderModifier) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	for headerName, headerValue := range r.set {
+		if strings.EqualFold(headerName, "Host") {
+			req.Host = headerValue
+			continue
+		}
 		req.Header.Set(headerName, headerValue)
 	}
 

--- a/pkg/middlewares/gatewayapi/headermodifier/request_header_modifier_test.go
+++ b/pkg/middlewares/gatewayapi/headermodifier/request_header_modifier_test.go
@@ -17,6 +17,7 @@ func TestRequestHeaderModifier(t *testing.T) {
 		config          dynamic.HeaderModifier
 		requestHeaders  http.Header
 		expectedHeaders http.Header
+		expectedHost    string
 	}{
 		{
 			desc:            "no config",
@@ -92,6 +93,14 @@ func TestRequestHeaderModifier(t *testing.T) {
 			requestHeaders:  map[string][]string{"Foo": {"Bar"}, "Bar": {"Foo"}, "Baz": {"Bar"}},
 			expectedHeaders: map[string][]string{"Baz": {"Bar"}},
 		},
+		{
+			desc: "set Host header",
+			config: dynamic.HeaderModifier{
+				Set: map[string]string{"Host": "example.com"},
+			},
+			expectedHeaders: map[string][]string{},
+			expectedHost:    "example.com",
+		},
 	}
 
 	for _, test := range testCases {
@@ -99,8 +108,10 @@ func TestRequestHeaderModifier(t *testing.T) {
 			t.Parallel()
 
 			var gotHeaders http.Header
+			var gotHost string
 			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				gotHeaders = r.Header
+				gotHost = r.Host
 			})
 
 			handler := NewRequestHeaderModifier(t.Context(), next, test.config, "foo-request-header-modifier")
@@ -112,6 +123,9 @@ func TestRequestHeaderModifier(t *testing.T) {
 			handler.ServeHTTP(resp, req)
 
 			assert.Equal(t, test.expectedHeaders, gotHeaders)
+			if test.expectedHost != "" {
+				assert.Equal(t, test.expectedHost, gotHost)
+			}
 		})
 	}
 }

--- a/pkg/middlewares/gatewayapi/headermodifier/request_header_modifier_test.go
+++ b/pkg/middlewares/gatewayapi/headermodifier/request_header_modifier_test.go
@@ -48,6 +48,14 @@ func TestRequestHeaderModifier(t *testing.T) {
 			expectedHeaders: map[string][]string{"Foo": {"Bar"}, "Bar": {"Foo"}},
 		},
 		{
+			desc: "set Host header",
+			config: dynamic.HeaderModifier{
+				Set: map[string]string{"Host": "example.com"},
+			},
+			expectedHeaders: map[string][]string{},
+			expectedHost:    "example.com",
+		},
+		{
 			desc: "add header",
 			config: dynamic.HeaderModifier{
 				Add: map[string]string{"Foo": "Bar"},
@@ -93,25 +101,19 @@ func TestRequestHeaderModifier(t *testing.T) {
 			requestHeaders:  map[string][]string{"Foo": {"Bar"}, "Bar": {"Foo"}, "Baz": {"Bar"}},
 			expectedHeaders: map[string][]string{"Baz": {"Bar"}},
 		},
-		{
-			desc: "set Host header",
-			config: dynamic.HeaderModifier{
-				Set: map[string]string{"Host": "example.com"},
-			},
-			expectedHeaders: map[string][]string{},
-			expectedHost:    "example.com",
-		},
 	}
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			var gotHeaders http.Header
-			var gotHost string
+			var (
+				gotHost    string
+				gotHeaders http.Header
+			)
 			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				gotHeaders = r.Header
 				gotHost = r.Host
+				gotHeaders = r.Header
 			})
 
 			handler := NewRequestHeaderModifier(t.Context(), next, test.config, "foo-request-header-modifier")
@@ -123,8 +125,11 @@ func TestRequestHeaderModifier(t *testing.T) {
 			handler.ServeHTTP(resp, req)
 
 			assert.Equal(t, test.expectedHeaders, gotHeaders)
+
 			if test.expectedHost != "" {
 				assert.Equal(t, test.expectedHost, gotHost)
+			} else {
+				assert.Equal(t, "localhost", gotHost)
 			}
 		})
 	}


### PR DESCRIPTION
### What does this PR do?

In Go's net/http, setting the Host header via req.Header.Set is a no-op. The Host header must be set directly on req.Host, similar to what is already done in the customRequestHeaders middleware.

### Motivation

Fixes #12793

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

To my understanding this does not need extra doc, because it is more of fix than extra feature.
