### PR TITLE
fix: handle Host header in Gateway API RequestHeaderModifier

### DIFF
--- a/pkg/middlewares/gatewayapi/headermodifier/request_header_modifier.go
+++ b/pkg/middlewares/gatewayapi/headermodifier/request_header_modifier.go
@@ -3,6 +3,7 @@ package headermodifier
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
 	"github.com/traefik/traefik/v3/pkg/middlewares"
@@ -40,10 +41,21 @@ func (r *requestHeaderModifier) GetTracingInformation() (string, string) {
 
 func (r *requestHeaderModifier) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	for headerName, headerValue := range r.set {
+		// In Go's net/http, the Host header is not stored in the Header map
+		// but in the Request.Host field. Setting it via Header.Set is a no-op
+		// for the actual host used in upstream requests.
+		if strings.EqualFold(headerName, "Host") {
+			req.Host = headerValue
+			continue
+		}
 		req.Header.Set(headerName, headerValue)
 	}
 
 	for headerName, headerValue := range r.add {
+		if strings.EqualFold(headerName, "Host") {
+			req.Host = headerValue
+			continue
+		}
 		req.Header.Add(headerName, headerValue)
 	}
 

--- a/pkg/middlewares/gatewayapi/headermodifier/request_header_modifier_test.go
+++ b/pkg/middlewares/gatewayapi/headermodifier/request_header_modifier_test.go
@@ -17,6 +17,7 @@ func TestRequestHeaderModifier(t *testing.T) {
 		config          dynamic.HeaderModifier
 		requestHeaders  http.Header
 		expectedHeaders http.Header
+		expectedHost    string
 	}{
 		{
 			desc:            "no config",
@@ -47,6 +48,14 @@ func TestRequestHeaderModifier(t *testing.T) {
 			expectedHeaders: map[string][]string{"Foo": {"Bar"}, "Bar": {"Foo"}},
 		},
 		{
+			desc: "set Host header modifies request host",
+			config: dynamic.HeaderModifier{
+				Set: map[string]string{"Host": "example.com"},
+			},
+			expectedHeaders: map[string][]string{},
+			expectedHost:    "example.com",
+		},
+		{
 			desc: "add header",
 			config: dynamic.HeaderModifier{
 				Add: map[string]string{"Foo": "Bar"},
@@ -68,6 +77,14 @@ func TestRequestHeaderModifier(t *testing.T) {
 			},
 			requestHeaders:  map[string][]string{"Foo": {"Baz"}, "Bar": {"Foobar"}},
 			expectedHeaders: map[string][]string{"Foo": {"Baz", "Bar"}, "Bar": {"Foobar", "Foo"}},
+		},
+		{
+			desc: "add Host header modifies request host",
+			config: dynamic.HeaderModifier{
+				Add: map[string]string{"Host": "example.com"},
+			},
+			expectedHeaders: map[string][]string{},
+			expectedHost:    "example.com",
 		},
 		{
 			desc: "remove header",
@@ -99,8 +116,10 @@ func TestRequestHeaderModifier(t *testing.T) {
 			t.Parallel()
 
 			var gotHeaders http.Header
+			var gotHost string
 			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				gotHeaders = r.Header
+				gotHost = r.Host
 			})
 
 			handler := NewRequestHeaderModifier(t.Context(), next, test.config, "foo-request-header-modifier")
@@ -112,6 +131,9 @@ func TestRequestHeaderModifier(t *testing.T) {
 			handler.ServeHTTP(resp, req)
 
 			assert.Equal(t, test.expectedHeaders, gotHeaders)
+			if test.expectedHost != "" {
+				assert.Equal(t, test.expectedHost, gotHost)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## What does this PR do?

Fixes #12793

The Gateway API `RequestHeaderModifier` filter does not correctly modify the `Host` header. In Go's `net/http`, the `Host` header is special: calling `req.Header.Set("Host", value)` only modifies the `Header` map but does **not** update `req.Host`, which is the field actually used when forwarding requests to backend services. This means setting the `Host` header via the Gateway API `RequestHeaderModifier` filter is silently ignored.

## Root Cause

The existing `headers` middleware (`customRequestHeaders`) already handles this correctly in [`pkg/middlewares/headers/header.go`](https://github.com/traefik/traefik/blob/master/pkg/middlewares/headers/header.go#L128-L129):

```go
case strings.EqualFold(header, "Host"):
    req.Host = value
```

But the Gateway API middleware in [`pkg/middlewares/gatewayapi/headermodifier/request_header_modifier.go`](https://github.com/traefik/traefik/blob/master/pkg/middlewares/gatewayapi/headermodifier/request_header_modifier.go) does not apply this pattern, so `Host` modifications are silently dropped.

## Changes

- Added special handling for the `Host` header in both `set` and `add` operations of the `requestHeaderModifier.ServeHTTP` method, using `strings.EqualFold` for case-insensitive matching and setting `req.Host` directly
- Added two new test cases (`set Host header modifies request host` and `add Host header modifies request host`) to verify the fix
- All existing tests continue to pass

## Test Plan

- [x] `go test ./pkg/middlewares/gatewayapi/headermodifier/...` -- all 12 tests pass (10 existing + 2 new)
- [x] Verified the fix matches the pattern used by the existing `headers` middleware