### PR TITLE
Remove unsupported servers[n].address from TCP label examples

### DIFF
--- a/docs/content/reference/routing-configuration/tcp/service.md
+++ b/docs/content/reference/routing-configuration/tcp/service.md
@@ -50,8 +50,6 @@ tcp:
 
 ```yaml tab="Labels"
 labels:
-  - "traefik.tcp.services.my-service.loadBalancer.servers[0].address=xx.xx.xx.xx:xx"
-  - "traefik.tcp.services.my-service.loadBalancer.servers[1].address=xx.xx.xx.xx:xx"
   - "traefik.tcp.services.my-service.loadBalancer.healthCheck.send=PING"
   - "traefik.tcp.services.my-service.loadBalancer.healthCheck.expect=PONG"
   - "traefik.tcp.services.my-service.loadBalancer.healthCheck.interval=10s"
@@ -62,8 +60,6 @@ labels:
 ```json tab="Tags"
 {
   "Tags": [
-    "traefik.tcp.services.my-service.loadBalancer.servers[0].address=xx.xx.xx.xx:xx",
-    "traefik.tcp.services.my-service.loadBalancer.servers[1].address=xx.xx.xx.xx:xx",
     "traefik.tcp.services.my-service.loadBalancer.healthCheck.send=PING",
     "traefik.tcp.services.my-service.loadBalancer.healthCheck.expect=PONG",
     "traefik.tcp.services.my-service.loadBalancer.healthCheck.interval=10s",


### PR DESCRIPTION


<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

The TCPServer.Address field has `label:"-"` in its struct tag, meaning it is intentionally excluded from Docker label parsing.
The servers[n].address labels shown in the docs do not work with Docker or Consul Catalog providers (only with the file provider).


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated documentation

### Additional Notes

related: https://github.com/traefik/traefik/issues/12386
