### PR TITLE
kubernetes/ingress-nginx: add defaultTLS compatibility flag

### DIFF
--- a/docs/content/reference/install-configuration/providers/kubernetes/kubernetes-ingress-nginx.md
+++ b/docs/content/reference/install-configuration/providers/kubernetes/kubernetes-ingress-nginx.md
@@ -73,6 +73,9 @@ providers:
     globalAllowedResponseHeaders:
       - "X-Custom-Header1"
       - "X-Custom-Header2"
+    # Compatibility: treat ingresses without spec.tls as TLS
+    # when only TLS entrypoints exist
+    defaultTLS: false
 ```
 
 ```toml tab="File (TOML)"
@@ -97,6 +100,9 @@ providers:
   customHTTPErrors = ["404", "503"]
   allowCrossNamespaceResources = true
   globalAllowedResponseHeaders = ["X-Custom-Header1", "X-Custom-Header2"]
+  # Compatibility: treat ingresses without spec.tls as TLS
+  # when only TLS entrypoints exist
+  defaultTLS = false
 ```
 
 ```bash tab="CLI"
@@ -116,6 +122,7 @@ providers:
 --providers.kubernetesingressnginx.customhttperrors=404,503
 --providers.kubernetesingressnginx.allowCrossNamespaceResources=true
 --providers.kubernetesingressnginx.globalAllowedResponseHeaders=X-Custom-Header1,X-Custom-Header2
+--providers.kubernetesingressnginx.defaulttls=false
 ```
 
 ```yaml tab="Helm Chart Values"
@@ -141,6 +148,9 @@ providers:
     watchIngressWithoutClass: false
     # -- Define if Ingress Controller should watch for Ingress Class by Name together with Controller Class
     ingressClassByName: false
+    # -- Compatibility: treat ingresses without spec.tls as TLS
+    # when only TLS entrypoints exist
+    defaultTLS: false
 ```
 
 This provider watches for incoming Ingress events and automatically translates NGINX annotations into Traefik's dynamic configuration, creating the corresponding routers, services, middlewares, and other components needed to route traffic to your cluster services.
@@ -178,6 +188,7 @@ This provider watches for incoming Ingress events and automatically translates N
 | <a id="opt-providers-kubernetesIngressNGINX-proxyNextUpstreamTimeouta" href="#opt-providers-kubernetesIngressNGINX-proxyNextUpstreamTimeouta" title="#opt-providers-kubernetesIngressNGINX-proxyNextUpstreamTimeouta">`providers.`<br/>`kubernetesIngressNGINX.`<br/>`proxyNextUpstreamTimeout`</a></a> | Limits the total elapsed time to retry the request if the backend server does not reply. Timeout value is unitless and in seconds. 0 means no timeout. This is used as the global retry timeout when no ingress-specific value is configured. An ingress-specific retry timeout can be set using [`nginx.ingress.kubernetes.io/proxy-next-upstream-timeout`](../../../../routing-configuration/kubernetes/ingress-nginx/#opt-nginx-ingress-kubernetes-ioproxy-next-upstream-timeout) annotation.                                                                | 0               | No       |
 | <a id="opt-providers-kubernetesIngressNGINX-customHTTPErrors" href="#opt-providers-kubernetesIngressNGINX-customHTTPErrors" title="#opt-providers-kubernetesIngressNGINX-customHTTPErrors">`providers.`<br/>`kubernetesIngressNGINX.`<br/>`customHTTPErrors`<br/></a> | Defines which status should result in calling the default backend to return an error page.                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | []              | No       || <a id="opt-providers-kubernetesIngressNGINX-allowCrossNamespaceResources" href="#opt-providers-kubernetesIngressNGINX-allowCrossNamespaceResources" title="#opt-providers-kubernetesIngressNGINX-allowCrossNamespaceResources">`providers.`<br/>`kubernetesIngressNGINX.`<br/>`allowCrossNamespaceResources`</a> | Allow Ingress to reference resources (e.g. ConfigMaps, Secrets) in different namespaces.                                                                                                                                                                                                                                                                                                                                                              | false   | No       |
 | <a id="opt-providers-kubernetesIngressNGINX-globalAllowedResponseHeaders" href="#opt-providers-kubernetesIngressNGINX-globalAllowedResponseHeaders" title="#opt-providers-kubernetesIngressNGINX-globalAllowedResponseHeaders">`providers.`<br/>`kubernetesIngressNGINX.`<br/>`globalAllowedResponseHeaders`</a> | List of allowed response headers inside the custom headers annotations. It is required to configure it for the custom headers annotations to take effect.                                                                                                                                                                                                                                                                                                                                                                                                       | []      | No       |
+| <a id="opt-providers-kubernetesIngressNGINX-defaultTLS" href="#opt-providers-kubernetesIngressNGINX-defaultTLS" title="#opt-providers-kubernetesIngressNGINX-defaultTLS">`providers.`<br/>`kubernetesIngressNGINX.`<br/>`defaultTLS`</a> | Treat ingresses without spec.tls as TLS when only TLS entrypoints exist (uses the default TLS store certificate).                                                                                                                                                                                                                                                                                                                                                                                     | false  | No       |
 | <a id="opt-providers-kubernetesIngressNGINX-httpentrypoint" href="#opt-providers-kubernetesIngressNGINX-httpentrypoint" title="#opt-providers-kubernetesIngressNGINX-httpentrypoint">`providers.`<br/>`kubernetesIngressNGINX.`<br/>`httpentrypoint`</a> | Defines the EntryPoint to use for HTTP requests.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | ""     | No       |
 | <a id="opt-providers-kubernetesIngressNGINX-httpsentrypoint" href="#opt-providers-kubernetesIngressNGINX-httpsentrypoint" title="#opt-providers-kubernetesIngressNGINX-httpsentrypoint">`providers.`<br/>`kubernetesIngressNGINX.`<br/>`httpsentrypoint`</a> | Defines the EntryPoint to use for HTTPS requests.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | ""     | No       |
 

--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-without-tls.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-without-tls.yml
@@ -1,0 +1,19 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-without-tls
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: whoami-no-tls.localhost
+      http:
+        paths:
+          - backend:
+              service:
+                name: whoami
+                port:
+                  number: 80
+            path: /
+            pathType: Prefix

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
@@ -211,6 +211,8 @@ type Provider struct {
 
 	AllowSnippetAnnotations bool `description:"Enables to parse and add -snippet annotations/directives." json:"allowSnippetAnnotations,omitempty" toml:"allowSnippetAnnotations,omitempty" yaml:"allowSnippetAnnotations,omitempty" export:"true"`
 
+	DefaultTLS bool `description:"Treat ingresses without spec.tls as TLS when only TLS entrypoints exist (uses the default TLS store certificate)." json:"defaultTLS,omitempty" toml:"defaultTLS,omitempty" yaml:"defaultTLS,omitempty" export:"true"`
+
 	HTTPEntryPoint  string `description:"Defines the EntryPoint to use for HTTP requests." json:"httpEntryPoint,omitempty" toml:"httpEntryPoint,omitempty" yaml:"httpEntryPoint,omitempty" export:"true"`
 	HTTPSEntryPoint string `description:"Defines the EntryPoint to use for HTTPS requests." json:"httpsEntryPoint,omitempty" toml:"httpsEntryPoint,omitempty" yaml:"httpsEntryPoint,omitempty" export:"true"`
 	// TLSEntryPoints is set to the HTTPSEntryPoint value if it is set, otherwise it is left empty.
@@ -544,6 +546,11 @@ func (p *Provider) loadConfiguration(ctx context.Context) *dynamic.Configuration
 				logger.Error().Err(err).Msg("Error configuring TLS")
 				continue
 			}
+		}
+		// Optional compatibility mode: when only TLS entrypoints exist, treat ingresses without
+		// spec.tls as TLS and rely on the default TLS store certificate.
+		if p.DefaultTLS && !hasTLS && len(p.NonTLSEntryPoints) == 0 && len(p.TLSEntryPoints) > 0 {
+			hasTLS = true
 		}
 
 		var clientAuthTLSOptionName string

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -31,6 +31,10 @@ func TestLoadIngresses(t *testing.T) {
 		allowCrossNamespaceResources   bool
 		globalAllowedResponseHeaders   []string
 		allowSnippetAnnotations        bool
+		defaultTLS                     bool
+		entryPointsSet                 bool
+		nonTLSEntryPoints              []string
+		tlsEntryPoints                 []string
 		paths                          []string
 		expected                       *dynamic.Configuration
 	}{
@@ -466,6 +470,87 @@ func TestLoadIngresses(t *testing.T) {
 						},
 					},
 				},
+			},
+		},
+		{
+			desc:              "No TLS with defaultTLS and only TLS entrypoints",
+			defaultTLS:        true,
+			entryPointsSet:    true,
+			nonTLSEntryPoints: []string{},
+			tlsEntryPoints:    []string{"https"},
+			paths: []string{
+				"ingresses/ingress-without-tls.yml",
+				"ingressclasses.yml",
+				"services.yml",
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-ingress-without-tls-rule-0-path-0": {
+							EntryPoints: []string{"https"},
+							Rule:        "Host(`whoami-no-tls.localhost`) && PathPrefix(`/`)",
+							RuleSyntax:  "default",
+							TLS:         &dynamic.RouterTLSConfig{},
+							Middlewares: []string{"default-ingress-without-tls-rule-0-path-0-retry"},
+							Service:     "default-ingress-without-tls-whoami-80",
+						},
+						"default-ingress-without-tls-rule-0-path-0-http": {
+							EntryPoints: []string{},
+							Rule:        "Host(`whoami-no-tls.localhost`) && PathPrefix(`/`)",
+							RuleSyntax:  "default",
+							Middlewares: []string{"default-ingress-without-tls-rule-0-path-0-redirect-scheme"},
+							Service:     "noop@internal",
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-ingress-without-tls-rule-0-path-0-redirect-scheme": {
+							RedirectScheme: &dynamic.RedirectScheme{
+								Scheme:                 "https",
+								ForcePermanentRedirect: true,
+							},
+						},
+						"default-ingress-without-tls-rule-0-path-0-retry": {
+							Retry: &dynamic.Retry{
+								Attempts: 3,
+							},
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"default-ingress-without-tls-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								Strategy:         "wrr",
+								PassHostHeader:   ptr.To(true),
+								ServersTransport: "default-ingress-without-tls",
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{
+						"default-ingress-without-tls": {
+							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
+								DialTimeout:     ptypes.Duration(60 * time.Second),
+								ReadTimeout:     ptypes.Duration(60 * time.Second),
+								WriteTimeout:    ptypes.Duration(60 * time.Second),
+								IdleConnTimeout: ptypes.Duration(60 * time.Second),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
 			},
 		},
 		{
@@ -7083,13 +7168,21 @@ func TestLoadIngresses(t *testing.T) {
 				<-eventCh
 			}
 
+			nonTLSEntryPoints := []string{"http"}
+			tlsEntryPoints := []string{"https"}
+			if test.entryPointsSet {
+				nonTLSEntryPoints = test.nonTLSEntryPoints
+				tlsEntryPoints = test.tlsEntryPoints
+			}
+
 			p := Provider{
 				k8sClient:                      client,
 				defaultBackendServiceName:      test.defaultBackendServiceName,
 				defaultBackendServiceNamespace: test.defaultBackendServiceNamespace,
 				AllowSnippetAnnotations:        test.allowSnippetAnnotations,
-				NonTLSEntryPoints:              []string{"http"},
-				TLSEntryPoints:                 []string{"https"},
+				DefaultTLS:                     test.defaultTLS,
+				NonTLSEntryPoints:              nonTLSEntryPoints,
+				TLSEntryPoints:                 tlsEntryPoints,
 				allowedHeaders:                 test.globalAllowedResponseHeaders,
 				AllowCrossNamespaceResources:   test.allowCrossNamespaceResources,
 			}


### PR DESCRIPTION
### What does this PR do?

Adds a `defaultTLS` option to the Kubernetes Ingress NGINX provider.
When enabled, ingresses without `spec.tls` are treated as TLS if only TLS entrypoints exist,
so the default TLS store certificate can be used.

### Motivation

Upgrading to v3.7 changes entrypoint attachment for ingresses without `spec.tls`.
This option preserves the previous behavior for users relying on a default TLS certificate,
without forcing a spec.tls update on every ingress.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

- Tests not run locally because `go` is not available in this environment.
- Generated configuration options doc was not regenerated for the same reason.
