### PR TITLE
fix: preserve health check status updater when service has headers

### DIFF
--- a/pkg/server/service/service.go
+++ b/pkg/server/service/service.go
@@ -330,13 +330,18 @@ func (m *Manager) getServiceHandler(ctx context.Context, service dynamic.WRRServ
 	}
 
 	if service.Headers != nil {
-		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		var handler http.Handler = http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			for k, v := range service.Headers {
 				req.Header.Set(k, v)
 			}
 
 			svcHandler.ServeHTTP(rw, req)
-		}), nil
+		})
+		if su, ok := svcHandler.(healthcheck.StatusUpdater); ok {
+			handler = &statusUpdaterHandler{Handler: handler, statusUpdater: su}
+		}
+
+		return handler, nil
 	}
 
 	return svcHandler, nil
@@ -507,6 +512,17 @@ type serverBalancer interface {
 	healthcheck.StatusSetter
 
 	AddServer(name string, handler http.Handler, server dynamic.Server)
+}
+
+// statusUpdaterHandler wraps an http.Handler while preserving the
+// healthcheck.StatusUpdater interface from the original handler.
+type statusUpdaterHandler struct {
+	http.Handler
+	statusUpdater healthcheck.StatusUpdater
+}
+
+func (s *statusUpdaterHandler) RegisterStatusUpdater(fn func(up bool)) error {
+	return s.statusUpdater.RegisterStatusUpdater(fn)
 }
 
 func shuffle[T any](values []T, r *rand.Rand) []T {

--- a/pkg/server/service/service_test.go
+++ b/pkg/server/service/service_test.go
@@ -729,6 +729,65 @@ func (s serviceBuilderFunc) BuildHTTP(ctx context.Context, serviceName string) (
 	return s(ctx, serviceName)
 }
 
+func TestGetServiceHandler_HealthCheck(t *testing.T) {
+	pb := httputil.NewProxyBuilder(&transportManagerMock{}, nil)
+
+	testCases := []struct {
+		desc        string
+		withHeaders bool
+	}{
+		{
+			desc: "without service headers",
+		},
+		{
+			desc:        "with service headers",
+			withHeaders: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(backend.Close)
+
+			childSvc := &dynamic.Service{
+				LoadBalancer: &dynamic.ServersLoadBalancer{
+					Servers: []dynamic.Server{{URL: backend.URL}},
+					HealthCheck: &dynamic.ServerHealthCheck{
+						Path: "/health",
+					},
+				},
+			}
+
+			wrrService := dynamic.WRRService{Name: "child@file", Weight: pointer(1)}
+			if test.withHeaders {
+				wrrService.Headers = map[string]string{"X-Custom": "value"}
+			}
+
+			configs := map[string]*runtime.ServiceInfo{
+				"child@file": {Service: childSvc},
+				"wrr@file": {
+					Service: &dynamic.Service{
+						Weighted: &dynamic.WeightedRoundRobin{
+							Services:    []dynamic.WRRService{wrrService},
+							HealthCheck: &dynamic.HealthCheck{},
+						},
+					},
+				},
+			}
+
+			manager := NewManager(configs, nil, nil, &transportManagerMock{}, pb)
+
+			_, err := manager.BuildHTTP(t.Context(), "wrr@file")
+			require.NoError(t, err)
+		})
+	}
+}
+
 type internalHandler struct{}
 
 func (internalHandler) ServeHTTP(_ http.ResponseWriter, _ *http.Request) {}


### PR DESCRIPTION

<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Wrap the headers handler in a `statusUpdaterHandler` that preserves the `StatusUpdater` interface from the original service handler. 

### Motivation

When a WRR child service has both headers and health checks configured, the headers wrapping was losing the `StatusUpdater` interface, preventing health check status propagation to the parent load balancer.

### More

- [x] Added/updated tests
- [ ] ~Added/updated documentation~


### Additional Notes

I'm targeting v3.6 since this piece of code has been introduced in v3.6.0.