### PR TITLE
Fix panic with Failover services in Kubernetes

### DIFF
--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -769,8 +769,13 @@ func (c configBuilder) buildFailover(ctx context.Context, tService *traefikv1alp
 	}
 
 	conf[id] = &dynamic.Service{Failover: failover}
-	conf[serviceName] = service
-	conf[fallbackName] = fallback
+	if service != nil {
+		conf[serviceName] = service
+	}
+
+	if fallback != nil {
+		conf[fallbackName] = fallback
+	}
 
 	return nil
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes a panic with failover TraefikService in kubernetescrd provider.

