### PR TITLE
Fix rewrite-target to handle full URL

### DIFF
--- a/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target.go
+++ b/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target.go
@@ -64,15 +64,24 @@ func (rt *rewriteTarget) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		currentPath = req.URL.EscapedPath()
 	}
 
+	var newTarget string
 	if rt.regexp != nil {
 		if !rt.regexp.MatchString(currentPath) {
 			rt.next.ServeHTTP(rw, req)
 			return
 		}
-		req.URL.RawPath = rt.regexp.ReplaceAllString(currentPath, rt.replacement)
+		newTarget = rt.regexp.ReplaceAllString(currentPath, rt.replacement)
 	} else {
-		req.URL.RawPath = rt.replacement
+		newTarget = rt.replacement
 	}
+
+	// If the replacement resolves to an absolute URL, issue a 302 redirect.
+	if parsed, err := url.Parse(newTarget); err == nil && parsed.Scheme != "" {
+		http.Redirect(rw, req, newTarget, http.StatusFound)
+		return
+	}
+
+	req.URL.RawPath = newTarget
 
 	if rt.xForwardedPrefix != "" {
 		prefix := rt.xForwardedPrefix

--- a/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target_test.go
+++ b/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target_test.go
@@ -18,6 +18,8 @@ func TestRewriteTarget(t *testing.T) {
 		expectedPath             string
 		expectedRawPath          string
 		expectedXForwardedPrefix string
+		expectedStatusCode       int
+		expectedRedirectURL      string
 		expectsError             bool
 	}{
 		{
@@ -140,6 +142,25 @@ func TestRewriteTarget(t *testing.T) {
 			expectedRawPath:          "",
 			expectedXForwardedPrefix: "",
 		},
+		{
+			desc: "full URL replacement issues 302 redirect",
+			path: "/some/path",
+			config: dynamic.RewriteTarget{
+				Replacement: "https://bar.example.org/some/path",
+			},
+			expectedStatusCode:  http.StatusFound,
+			expectedRedirectURL: "https://bar.example.org/some/path",
+		},
+		{
+			desc: "regex with full URL replacement issues 302 redirect",
+			path: "/prefix/foo",
+			config: dynamic.RewriteTarget{
+				Regex:       `(?i)/prefix(/|$)(.*)`,
+				Replacement: "https://bar.example.org/$2",
+			},
+			expectedStatusCode:  http.StatusFound,
+			expectedRedirectURL: "https://bar.example.org/foo",
+		},
 	}
 
 	for _, test := range testCases {
@@ -162,9 +183,25 @@ func TestRewriteTarget(t *testing.T) {
 			server := httptest.NewServer(handler)
 			defer server.Close()
 
-			resp, err := http.Get(server.URL + test.path)
+			client := &http.Client{
+				CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+					return http.ErrUseLastResponse
+				},
+			}
+
+			resp, err := client.Get(server.URL + test.path)
 			require.NoError(t, err)
-			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			expectedStatus := test.expectedStatusCode
+			if expectedStatus == 0 {
+				expectedStatus = http.StatusOK
+			}
+			require.Equal(t, expectedStatus, resp.StatusCode)
+
+			if test.expectedRedirectURL != "" {
+				assert.Equal(t, test.expectedRedirectURL, resp.Header.Get("Location"), "Unexpected redirect location.")
+				return
+			}
 
 			assert.Equal(t, test.expectedPath, actualPath, "Unexpected path.")
 			assert.Equal(t, test.expectedRawPath, actualRawPath, "Unexpected raw path.")


### PR DESCRIPTION
### What does this PR do?

Fix `rewrite-target` annotation behavior, to be able to handle full URL.

### Motivation

Fixes https://github.com/traefik/traefik/issues/12839.

To align with ingress-nginx's behavior.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

