### PR TITLE
Fix rewrite directive in configuration-snippet to trim quotes

### DIFF
--- a/pkg/middlewares/ingressnginx/snippet/action.go
+++ b/pkg/middlewares/ingressnginx/snippet/action.go
@@ -722,7 +722,7 @@ func createRewriteAction(d config.IDirective) (action, error) {
 	}
 
 	pattern := params[0].String()
-	replacement := params[1].String()
+	replacement := trimQuote(params[1].String())
 
 	var flag string
 	if len(params) >= 3 {

--- a/pkg/middlewares/ingressnginx/snippet/snippet_test.go
+++ b/pkg/middlewares/ingressnginx/snippet/snippet_test.go
@@ -1118,6 +1118,24 @@ rewrite ^/old$ http://other.example.com/new last;
 			expectedStatusCode:  http.StatusFound,
 			expectedRedirectURL: "http://other.example.com/new",
 		},
+		{
+			desc: "rewrite with quoted replacement",
+			configurationSnippet: `
+rewrite ^/search$ "/new?" last;
+`,
+			path:          "/search?q=test",
+			expectedPath:  "/new",
+			expectedQuery: "",
+		},
+		{
+			desc: "rewrite with quoted replacement and uri variable",
+			configurationSnippet: `
+rewrite ^/(.*)$ "${uri}?" break;
+`,
+			path:          "/some/path?q=test",
+			expectedPath:  "/some/path",
+			expectedQuery: "",
+		},
 		// --- add_header always tests ---
 		{
 			desc: "add_header with always applies to 200 status",


### PR DESCRIPTION
### What does this PR do?

Fix the handling of rewrite directive in the configuration snippet for ingress-nginx provider, to correctly trim the quotes.


### Motivation

Fixes https://github.com/traefik/traefik/issues/12852.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation
