### PR TITLE
Fix auth-response-headers whitespace trimming in ingress-nginx provider

### DIFF
--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-forwardauth.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-forwardauth.yml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/auth-url: "http://whoami.default.svc/"
     nginx.ingress.kubernetes.io/auth-method: "GET"
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Foo"
+    nginx.ingress.kubernetes.io/auth-response-headers: "X-Foo, X-Bar"
 
 spec:
   ingressClassName: nginx

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
@@ -1004,7 +1004,14 @@ func applyForwardAuthConfiguration(routerName string, ingressConfig ingressConfi
 		return errors.New("empty auth-url found in ingress annotations")
 	}
 
-	authResponseHeaders := strings.Split(ptr.Deref(ingressConfig.AuthResponseHeaders, ""), ",")
+	var authResponseHeaders []string
+	if raw := ptr.Deref(ingressConfig.AuthResponseHeaders, ""); raw != "" {
+		for h := range strings.SplitSeq(raw, ",") {
+			if trimmed := strings.TrimSpace(h); trimmed != "" {
+				authResponseHeaders = append(authResponseHeaders, trimmed)
+			}
+		}
+	}
 
 	forwardMiddlewareName := routerName + "-forward-auth"
 	conf.HTTP.Middlewares[forwardMiddlewareName] = &dynamic.Middleware{

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -196,7 +196,7 @@ func TestLoadIngresses(t *testing.T) {
 						"default-ingress-with-forwardauth-rule-0-path-0-forward-auth": {
 							ForwardAuth: &dynamic.ForwardAuth{
 								Address:             "http://whoami.default.svc/",
-								AuthResponseHeaders: []string{"X-Foo"},
+								AuthResponseHeaders: []string{"X-Foo", "X-Bar"},
 							},
 						},
 					},


### PR DESCRIPTION
### What does this PR do?

Trim whitespace from auth-response-headers annotation values when splitting on commas. Previously, "X-Foo, Authorization" produced ["X-Foo", " Authorization"] (with leading space), causing the header to never match. This aligns with how other comma-separated annotations are already handled in annotations.go.                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                
### Motivation

Fixes #12848

### More

- [x] Added/updated tests
- ~[ ] Added/updated documentation~

### Additional Notes

<!-- Anything else we should know when reviewing? -->
