### PR TITLE
Fix allow colons and tildes in api.basePath validation

### DIFF
--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -58,7 +58,7 @@ const (
 )
 
 // Allowed characters in URL following RFC 3986 (https://www.rfc-editor.org/rfc/rfc3986#section-2)
-var validBasePath = regexp.MustCompile(`^/[a-zA-Z0-9/_.-]*$`)
+var validBasePath = regexp.MustCompile(`^/[a-zA-Z0-9/_.:~-]*$`)
 
 // Configuration is the static configuration.
 type Configuration struct {

--- a/pkg/config/static/static_config_test.go
+++ b/pkg/config/static/static_config_test.go
@@ -349,6 +349,16 @@ func TestValidateConfiguration_BasePath(t *testing.T) {
 			basePath:  "/api%2Ftoto",
 			expectErr: true,
 		},
+		{
+			desc:      "valid path with colons",
+			basePath:  "/k8s/clusters/c-abcd0/api/v1/namespaces/my-ns/services/http:traefik:8080/proxy",
+			expectErr: false,
+		},
+		{
+			desc:      "valid path with tilde",
+			basePath:  "/~user/dashboard",
+			expectErr: false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
### What does this PR do?

The basePath validation regex introduced in #12729 blocks `:` characters,                                                                                                                                                                                                                                     

which breaks Rancher UI integration that uses paths like `/k8s/clusters/c-abcd0/api/v1/namespaces/my-ns/services/http:traefik:8080/proxy/`.

This updates the regex to also allow `:` and `~`, which are valid URI `pchar` characters per RFC 3986 and pose no XSS risk (the switch to `html/template` in #12729 already handles escaping).

### Motivation

Fixes #12836

### More

- [x] Added/updated tests
- ~[ ] Added/updated documentation~

### Additional Notes

<!-- Anything else we should know when reviewing? -->
