### PR TITLE
Fix docker-compose.yaml location in Docker setup page

### DIFF
--- a/docs/content/setup/docker.md
+++ b/docs/content/setup/docker.md
@@ -59,7 +59,7 @@ tls:
       keyFile:  /certs/local.key
 ```
 
-In the same folder as the `dynamic/tls.yaml` file, create a `docker-compose.yaml` file and include the following:
+In your project root folder (the parent folder to the `dynamic/tls.yaml` file), create a `docker-compose.yaml` file and include the following:
 
 ```yaml
 services:


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

—>

**N.B:** Trying to follow PR guidelines to my best ability, have used branch v3.6 (Doc fix)

### What does this PR do?

<!-- A brief description of the change being made with this pull request. —>

When following guidance from the Docker [’setup’](https://doc.traefik.io/traefik/setup/docker/) article, I came across a discrepancy. The `docker-compose.yaml` file provided directs a volume mount for `./dynamic` (in order to discover the `tls.yaml` file), however the docs instruct the selfsame docker file to be created within the folder `./dynamic` itself (from project root.

In terms of the tutorial itself, this doesn’t actually seem to break any functionality, however it does introduce an file watcher error message in docker logs:

```log
❯ docker-compose up
WARN[0000] a network with name proxy exists but was not created for project "dynamic".
Set `external: true` to use an existing network
[+] Running 2/2
 ✔ Container traefik  Created                                                                                                                             0.1s
 ✔ Container whoami   Created                                                                                                                             0.1s
Attaching to traefik, whoami
whoami  | 2026/03/21 13:55:45 Starting up on port 80
traefik  | 2026-03-21T13:55:45Z WRN Traefik can reject some encoded characters in the request path. When your backend is not fully compliant with [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986), it is recommended to set these options to `false` to avoid split-view situation. Refer to the documentation for more details: https://doc.traefik.io/traefik/v3.6/migrate/v3/#encoded-characters-configuration-default-values
traefik  | 2026-03-21T13:55:45Z INF Traefik version 3.6.11 built on 2026-03-19T09:18:31Z version=3.6.11
traefik  | 2026-03-21T13:55:45Z INF Version check is enabled.
traefik  | 2026-03-21T13:55:45Z INF Traefik checks for new releases to notify you if your version is out of date.
traefik  | 2026-03-21T13:55:45Z INF It also collects usage data during this process.
traefik  | 2026-03-21T13:55:45Z INF Check the documentation to get more info: https://doc.traefik.io/traefik/contributing/data-collection/
traefik  | 2026-03-21T13:55:45Z INF
traefik  | Stats collection is disabled.
traefik  | Help us improve Traefik by turning this feature on :)
traefik  | More details on: https://doc.traefik.io/traefik/contributing/data-collection/
traefik  |
traefik  | 2026-03-21T13:55:45Z INF Starting provider aggregator *aggregator.ProviderAggregator
traefik  | 2026-03-21T13:55:45Z INF Starting provider *file.Provider
traefik  | 2026-03-21T13:55:45Z ERR Cannot start the provider *file.Provider error="error adding file watcher: no such file or directory"
traefik  | 2026-03-21T13:55:45Z INF Starting provider *traefik.Provider
traefik  | 2026-03-21T13:55:45Z INF Starting provider *docker.Provider
traefik  | 2026-03-21T13:55:45Z INF Starting provider *acme.ChallengeTLSALPN
```

When the `docker-compose.yaml` file is in the parent to `dynamic/`, this error doesn’t exist (and a seperate `certs/` dir need not be created within `dynamic/` as well)

### Motivation

<!-- What inspired you to submit this pull request? —>

To assist with the clarity of Traefik docs

### More

- [ ] Added/updated tests
- [*] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
