### PR TITLE
fix(provider/k8s/ingress-nginx): clarify watchNamespace is for single namespace

### DIFF
--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
@@ -175,7 +175,7 @@ type Provider struct {
 	CertAuthFilePath string              `description:"Kubernetes certificate authority file path (not needed for in-cluster client)." json:"certAuthFilePath,omitempty" toml:"certAuthFilePath,omitempty" yaml:"certAuthFilePath,omitempty"`
 	ThrottleDuration ptypes.Duration     `description:"Ingress refresh throttle duration." json:"throttleDuration,omitempty" toml:"throttleDuration,omitempty" yaml:"throttleDuration,omitempty" export:"true"`
 
-	WatchNamespace         string `description:"Namespace the controller watches for updates to Kubernetes objects. All namespaces are watched if this parameter is left empty." json:"watchNamespace,omitempty" toml:"watchNamespace,omitempty" yaml:"watchNamespace,omitempty" export:"true"`
+	WatchNamespace         string `description:"The single namespace the controller watches for updates to Kubernetes objects. All namespaces are watched if this parameter is left empty. For monitoring multiple namespaces, use the watchNamespaceSelector option instead." json:"watchNamespace,omitempty" toml:"watchNamespace,omitempty" yaml:"watchNamespace,omitempty" export:"true"`
 	WatchNamespaceSelector string `description:"Selector selects namespaces the controller watches for updates to Kubernetes objects." json:"watchNamespaceSelector,omitempty" toml:"watchNamespaceSelector,omitempty" yaml:"watchNamespaceSelector,omitempty" export:"true"`
 
 	IngressClass             string `description:"Name of the ingress class this controller satisfies." json:"ingressClass,omitempty" toml:"ingressClass,omitempty" yaml:"ingressClass,omitempty" export:"true"`


### PR DESCRIPTION
## What does this PR do?
Clarify the description of the `watchNamespace` option in the `kubernetes-ingress-nginx` provider. It explicitly states that this option supports only a **single namespace**, and points users to `watchNamespaceSelector` for monitoring multiple namespaces.

## Motivation
This addresses #12826. Users were confused because it wasn't clear that `watchNamespace` doesn't support a comma-separated list of namespaces, leading to unexpected behavior (404s).

## Additional Notes
- Updated the `description` tag in [pkg/provider/kubernetes/ingress-nginx/kubernetes.go](cci:7://file:///Users/amazon/lunch.cancelled/cloud-native-go/traefik/pkg/provider/kubernetes/ingress-nginx/kubernetes.go:0:0-0:0).

Fixes #12826
