### PR TITLE
Add ingress-nginx CTA in Docs Home Page

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -5,6 +5,10 @@ description: "Traefik Proxy, an open-source Edge Router, auto-discovers configur
 
 # What is Traefik?
 
+!!! tip "Moving from ingress-nginx?"
+    No need to start over. Traefik supports your existing ingress-nginx annotations as-is — no rewrites, no downtime.
+    See our [migration guide](./migrate/nginx-to-traefik.md) and [annotation reference](./reference/routing-configuration/kubernetes/ingress-nginx.md) to get started.
+
 ![Architecture](assets/img/traefik-architecture.png)
 
 Traefik is an [open-source](https://github.com/traefik/traefik) Application Proxy and the core of the Traefik Hub Runtime Platform.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Adds a callout banner to the top of the documentation home page surfacing the ingress-nginx migration path

### Motivation

The ingress-nginx controller is being retired in March 2026, which has driven a large influx of users looking to migrate to Traefik. The migration path already exists in the docs and the provider already has annotation-compatibility support, this PR makes the migration story front-and-center for anyone landing on the docs.

### More

- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
