### PR TITLE
Add ingress-nginx migration banner on documentation pages

### DIFF
--- a/docs/content/assets/css/banner.css
+++ b/docs/content/assets/css/banner.css
@@ -1,0 +1,41 @@
+#migration-doc-banner {
+  display: block;
+  position: relative;
+  padding: 0.6em 1.2em;
+  border: 1px solid #00b3ce;
+  border-radius: 8px;
+  background-color: #00b3ce1a;
+  color: #00b3ce;
+  font-size: 0.85em;
+  margin-bottom: 1em;
+}
+
+#migration-doc-banner a {
+  color: #00b3ce;
+  font-weight: 600;
+  text-decoration: underline;
+}
+
+#migration-doc-banner p {
+  margin: 0;
+}
+
+#migration-doc-banner-close {
+  position: absolute;
+  top: 0.4em;
+  right: 0.6em;
+  background: none;
+  border: none;
+  color: #00b3ce;
+  font-size: 1.5em;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+}
+
+/* Breakpoint for the collapsed sidebar */
+@media (min-width: 1220px) {
+  #migration-doc-banner {
+    margin-top: -24px;
+  }
+}

--- a/docs/content/assets/js/banner.js
+++ b/docs/content/assets/js/banner.js
@@ -1,0 +1,38 @@
+(function () {
+  var BANNER_ID = 'migration-doc-banner';
+  var SESSION_KEY = 'migration-doc-banner-dismissed';
+
+  function createBanner() {
+    if (document.getElementById(BANNER_ID)) return;
+    if (sessionStorage.getItem(SESSION_KEY)) return;
+
+    var banner = document.createElement('div');
+    banner.id = BANNER_ID;
+    banner.innerHTML =
+      '<p><strong>Moving from ingress-nginx?</strong></p>' +
+      '<p>No need to start over. Traefik supports your existing ingress-nginx annotations as-is &mdash; no rewrites, no downtime.</p>' +
+      '<p>See our <a href="/traefik/migrate/nginx-to-traefik/">migration guide</a> and <a href="/traefik/reference/routing-configuration/kubernetes/ingress-nginx/">annotation reference</a> to get started.</p>' +
+      '<button id="migration-doc-banner-close" aria-label="Dismiss banner">&times;</button>';
+
+    var target =
+      document.querySelector('.md-content__inner') ||
+      document.querySelector('.md-main__inner') ||
+      document.querySelector('article') ||
+      document.querySelector('main');
+
+    if (target) {
+      target.insertBefore(banner, target.firstChild);
+    }
+
+    document.getElementById('migration-doc-banner-close').addEventListener('click', function () {
+      banner.remove();
+      sessionStorage.setItem(SESSION_KEY, '1');
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', createBanner);
+  } else {
+    createBanner();
+  }
+})();

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -35,11 +35,13 @@ copyright: 'Traefik Labs • Copyright &copy; 2016-2026'
 extra_javascript:
   - assets/js/hljs/highlight.pack.js # Download from https://highlightjs.org/download/ and enable YAML, TOML and Dockerfile
   - assets/js/extra.js
+  - assets/js/banner.js
 
 extra_css:
   - assets/css/menu-icons.css
   - assets/css/code-copy.css
   - assets/css/content-width.css
+  - assets/css/banner.css
 
 plugins:
   - search


### PR DESCRIPTION
### What does this PR do?

Add a banner on top of the documentation pages to inform user about the migration path from ingress-nginx.
This banner is present on all of the pages. Upon closing, the hidden state will persist during the session.

Preview:
<img width="3790" height="1815" alt="image" src="https://github.com/user-attachments/assets/d4dd49fb-aa8c-4d16-aeb4-e705d71092da" />

### Motivation

To inform user about the capability to migrate from ingress-nginx to Traefik.


### More

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~

