### PR TITLE
Clarify that NGINX Ingress watchNamespace watches only one namespace

### DIFF
--- a/docs/content/reference/routing-configuration/kubernetes/ingress-nginx.md
+++ b/docs/content/reference/routing-configuration/kubernetes/ingress-nginx.md
@@ -24,7 +24,7 @@ This provider discovers all Ingresses in the cluster by default, which may lead 
 **Best Practices:**
 
 - Use IngressClass to specify which Ingresses should be handled by this provider
-- Configure `watchNamespace` to limit discovery to specific namespaces
+- Configure `watchNamespace` to limit discovery to a single namespace
 - Use `watchNamespaceSelector` to target Ingresses based on namespace labels
 
 ## Routing Configuration


### PR DESCRIPTION
### What does this PR do?

Clarify documentation for kubernetesNGINXIngress provider - only one namespace is supported by watchNamespace. Avoids confusion with migration to Traefik.

### Motivation

Fixes https://github.com/traefik/traefik/issues/12826
-> was confused by this and tried to make it work, but it didn't.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes
