### PR TITLE
Add redirects for deleted pages

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -110,6 +110,7 @@ plugins:
         'https/acme.md': 'reference/install-configuration/tls/certificate-resolvers/acme.md'
         'https/tailscale.md': 'reference/install-configuration/tls/certificate-resolvers/tailscale.md'
         'https/spiffe.md': 'reference/install-configuration/tls/spiffe.md'
+        'https/ocsp.md': 'reference/install-configuration/tls/ocsp.md'
         # Middlewares
         'middlewares/overview.md': 'reference/routing-configuration/http/middlewares/overview.md'
         # HTTP
@@ -168,6 +169,11 @@ plugins:
         "reference/dynamic-configuration/nomad.md": 'reference/routing-configuration/other-providers/nomad.md'
         'reference/dynamic-configuration/ecs.md': 'reference/routing-configuration/other-providers/ecs.md'
         'reference/dynamic-configuration/kv.md': 'reference/routing-configuration/other-providers/kv.md'
+        'reference/dynamic-configuration/kv-ref.md': 'reference/routing-configuration/other-providers/kv.md'
+        'reference/install-configuration/cli-options-list.md': 'reference/install-configuration/configuration-options.md'
+        'reference/install-configuration/observability/healthcheck/cli.md': 'reference/install-configuration/observability/healthcheck.md'
+        'reference/install-configuration/observability/healthcheck/ping.md': 'reference/install-configuration/observability/healthcheck.md'
+        'reference/install-configuration/observability/options-list.md': 'reference/install-configuration/configuration-options.md'
         ## Plugins
         'plugins/index.md': "extend/extend-traefik.md"
         ## Migration


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Adds missing redirects for 6 deleted documentation files from PR #12376 to prevent broken bookmarks and links.


### Motivation

PR #12376 removed 71 hidden documentation files to improve user experience (they were appearing in search results). While most deleted files already had redirects configured, 6 files were missing from the `redirect_maps` in `mkdocs.yml`:

- `https/ocsp.md`
- `reference/dynamic-configuration/kv-ref.md`
- `reference/install-configuration/cli-options-list.md`
- `reference/install-configuration/observability/healthcheck/cli.md`
- `reference/install-configuration/observability/healthcheck/ping.md`
- `reference/install-configuration/observability/options-list.md`

Without these redirects, users with bookmarks or external links to these pages would encounter 404 errors. This PR ensures all deleted pages redirect to their appropriate replacement locations.

### More

- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
