### PR TITLE
Allow docker image to bind to privileged ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 # syntax=docker/dockerfile:1.2
 FROM alpine:3.23
 
-RUN apk add --no-cache --no-progress ca-certificates tzdata
 
 ARG TARGETPLATFORM
 COPY ./dist/$TARGETPLATFORM/traefik /
+
+RUN apk add --no-cache --no-progress ca-certificates libcap-setcap tzdata && \
+  setcap    cap_net_bind_service=+ep /traefik && \
+  setcap -v cap_net_bind_service=+ep /traefik
 
 EXPOSE 80
 VOLUME ["/tmp"]


### PR DESCRIPTION
### What does this PR do?

Allows traefik to bind to ports below 1024, like the standards http and https ports (80 and 443).

### Motivation

While migrating from ingress-nginx to traefik, we got timeout issues in some applications, typically those authenticating with OpenID Connect.

This is due to how network policies are handled (at least with Cilium):

- we have an *egress* network policy in the source namespace allowing connections to any destination on port 443
- when the source pod targets a website in the same cluster published thru a LoadBalancer service (for example Keycloak, served by traefik), Cilium sends the packets directly to the service's backend (NB : we also use [Cilium to manage LoadBalancer services](https://docs.cilium.io/en/stable/network/l2-announcements/))
- in this case, the target port in 8443 (websecure in the pods) and not 443 (in the service)
- for this reason, the connection is not allowed and leads to timeout

To fix this, we use and image including this PR, and the following values in the Helm chart:

```yaml
ports:
  web:
    port: 80
  websecure:
    port: 443

securityContext:
  capabilities:
    add:
      - NET_BIND_SERVICE
``` 

Related issues:

- https://github.com/traefik/traefik/issues/11679
- https://github.com/traefik/traefik/issues/8595

Related refs:

- [Unable to listen on port (80/443)](https://github.com/kubernetes/ingress-nginx/blob/dbb11b92ddb77bee9c35e462479129354c84f939/docs/troubleshooting.md#unable-to-listen-on-port-80443) in ingress-nginx *Troubleshooting* doc.

### More

- [x] Added/updated tests (with `setcap -v`)
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
