### PR TITLE
Log removed containers at debug level instead of warn in Docker provider

### DIFF
--- a/pkg/provider/docker/shared.go
+++ b/pkg/provider/docker/shared.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/cli/cli/connhelper"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/go-connections/nat"
 	"github.com/docker/go-connections/sockets"
 	"github.com/rs/zerolog/log"
@@ -39,7 +40,11 @@ type Shared struct {
 func inspectContainers(ctx context.Context, dockerClient client.ContainerAPIClient, containerID string) dockerData {
 	containerInspected, err := dockerClient.ContainerInspect(ctx, containerID)
 	if err != nil {
-		log.Ctx(ctx).Warn().Err(err).Msgf("Failed to inspect container %s", containerID)
+		if errdefs.IsNotFound(err) {
+			log.Ctx(ctx).Debug().Err(err).Msgf("Container %s not found, it was probably removed during inspection", containerID)
+		} else {
+			log.Ctx(ctx).Warn().Err(err).Msgf("Failed to inspect container %s", containerID)
+		}
 		return dockerData{}
 	}
 


### PR DESCRIPTION
## Summary

Fixes #12868

When `ContainerList` is called with `All: true`, short-lived containers (CI runners, certbot renewals, etc.) can be removed between the `ContainerList` and `ContainerInspect` calls. This race condition produces spurious `WRN Failed to inspect container` log entries.

This change detects "not found" errors from `ContainerInspect` using `errdefs.IsNotFound()` and logs them at **DEBUG** level instead of **WARN**. Other inspection errors remain at WARN level.

## Changes

- `pkg/provider/docker/shared.go`: In `inspectContainers()`, check if the error is a "not found" error and downgrade log level accordingly.

## Test plan

- [x] Built custom Traefik binary from this branch and deployed to a production server running Traefik 3.6.11 with Docker provider and ephemeral containers (Gitea Act Runner)
- [x] Verified no more WRN-level log spam for disappeared containers
- [x] Verified routing, TLS, and provider functionality are unaffected