### PR TITLE
feat(gateway): support per-Gateway status address annotations

### DIFF
--- a/docs/content/reference/routing-configuration/kubernetes/gateway-api.md
+++ b/docs/content/reference/routing-configuration/kubernetes/gateway-api.md
@@ -734,6 +734,61 @@ Once everything is deployed, sending the WHO command should return the following
     IP: fe80::d873:20ff:fef5:be86
     ```
 
+## Per-Gateway Status Addresses
+
+By default, Traefik copies the same status addresses (configured via `statusAddress`) to all `Gateway` resources it manages.
+When running multiple `Gateway` objects backed by different `Service` resources (e.g. internal and public), each `Gateway` needs its own address in `.status.addresses` so that tools like external-dns can resolve the correct IP per `Gateway`.
+
+It is possible to override the static `statusAddress` configuration on a per-`Gateway` basis using annotations.
+
+The following annotations are supported on `Gateway` resources:
+
+| Annotation | Description |
+|:-----------|:------------|
+| `traefik.io/statusaddress.ip` | IP address to use for this Gateway's status. |
+| `traefik.io/statusaddress.hostname` | Hostname to use for this Gateway's status. |
+| `traefik.io/statusaddress.service.name` | Kubernetes Service name to copy status addresses from. |
+| `traefik.io/statusaddress.service.namespace` | Kubernetes Service namespace to copy status addresses from. |
+
+When `service.name` is set, the `LoadBalancer` ingress addresses of the referenced `Service` are copied to the `Gateway` status, the same way the static `statusAddress.publishedService` option works.
+If `service.namespace` is omitted, it defaults to the `Gateway`'s own namespace.
+Cross-namespace service references require a [`ReferenceGrant`](https://gateway-api.sigs.k8s.io/api-types/referencegrant/) in the target namespace.
+
+If no status address annotations are present on a `Gateway`, the static `statusAddress` configuration is used as a fallback.
+
+```yaml
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: internal-gateway
+  namespace: default
+  annotations:
+    traefik.io/statusaddress.service.name: traefik-internal
+    traefik.io/statusaddress.service.namespace: traefik-system
+spec:
+  gatewayClassName: traefik
+  listeners:
+    - name: https
+      port: 8443
+      protocol: HTTPS
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: public-gateway
+  namespace: default
+  annotations:
+    traefik.io/statusaddress.service.name: traefik-public
+    traefik.io/statusaddress.service.namespace: traefik-system
+spec:
+  gatewayClassName: traefik
+  listeners:
+    - name: https
+      port: 8444
+      protocol: HTTPS
+```
+
 ## Native Load Balancing
 
 By default, Traefik sends the traffic directly to the pod IPs and reuses the established connections to the backends for performance purposes.

--- a/pkg/provider/kubernetes/gateway/annotations.go
+++ b/pkg/provider/kubernetes/gateway/annotations.go
@@ -19,6 +19,11 @@ type Service struct {
 	NativeLB *bool `json:"nativeLB"`
 }
 
+// GatewayConfig is the gateway's root configuration from annotations.
+type GatewayConfig struct {
+	StatusAddress StatusAddress `json:"statusaddress"`
+}
+
 func parseServiceAnnotations(annotations map[string]string) (ServiceConfig, error) {
 	var svcConf ServiceConfig
 
@@ -32,6 +37,33 @@ func parseServiceAnnotations(annotations map[string]string) (ServiceConfig, erro
 	}
 
 	return svcConf, nil
+}
+
+// parseGatewayAnnotations parses Gateway annotations for per-Gateway status
+// address overrides. Returns nil when no statusaddress annotations are present.
+func parseGatewayAnnotations(annotations map[string]string) (*StatusAddress, error) {
+	labels := convertAnnotations(annotations)
+	if len(labels) == 0 {
+		return nil, nil
+	}
+
+	hasStatusAddr := false
+	for key := range labels {
+		if strings.HasPrefix(key, "traefik.statusaddress.") {
+			hasStatusAddr = true
+			break
+		}
+	}
+	if !hasStatusAddr {
+		return nil, nil
+	}
+
+	var gwConf GatewayConfig
+	if err := label.Decode(labels, &gwConf, "traefik.statusaddress."); err != nil {
+		return nil, fmt.Errorf("decoding labels: %w", err)
+	}
+
+	return &gwConf.StatusAddress, nil
 }
 
 func convertAnnotations(annotations map[string]string) map[string]string {

--- a/pkg/provider/kubernetes/gateway/annotations_test.go
+++ b/pkg/provider/kubernetes/gateway/annotations_test.go
@@ -51,6 +51,89 @@ func Test_parseServiceConfig(t *testing.T) {
 	}
 }
 
+func Test_parseGatewayAnnotations(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		annotations map[string]string
+		want        *StatusAddress
+		wantErr     bool
+	}{
+		{
+			desc:        "nil annotations",
+			annotations: nil,
+			want:        nil,
+		},
+		{
+			desc:        "empty annotations",
+			annotations: map[string]string{},
+			want:        nil,
+		},
+		{
+			desc: "no statusaddress annotations",
+			annotations: map[string]string{
+				"traefik.io/service.nativelb": "true",
+			},
+			want: nil,
+		},
+		{
+			desc: "IP annotation",
+			annotations: map[string]string{
+				"traefik.io/statusaddress.ip": "10.0.0.1",
+			},
+			want: &StatusAddress{
+				IP: "10.0.0.1",
+			},
+		},
+		{
+			desc: "hostname annotation",
+			annotations: map[string]string{
+				"traefik.io/statusaddress.hostname": "internal.example.com",
+			},
+			want: &StatusAddress{
+				Hostname: "internal.example.com",
+			},
+		},
+		{
+			desc: "service annotations",
+			annotations: map[string]string{
+				"traefik.io/statusaddress.service.name":      "traefik-public",
+				"traefik.io/statusaddress.service.namespace": "traefik-system",
+			},
+			want: &StatusAddress{
+				Service: ServiceRef{
+					Name:      "traefik-public",
+					Namespace: "traefik-system",
+				},
+			},
+		},
+		{
+			desc: "mixed with unrelated annotations",
+			annotations: map[string]string{
+				"traefik.io/statusaddress.ip": "10.0.0.1",
+				"traefik.io/service.nativelb": "true",
+				"kubernetes.io/ingress.class": "traefik",
+			},
+			want: &StatusAddress{
+				IP: "10.0.0.1",
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseGatewayAnnotations(test.annotations)
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
 func Test_convertAnnotations(t *testing.T) {
 	testCases := []struct {
 		desc        string

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -311,7 +311,7 @@ func (p *Provider) loadConfigurationFromGateways(ctx context.Context) *dynamic.C
 		TLS: &dynamic.TLSConfiguration{},
 	}
 
-	addresses, err := p.gatewayAddresses()
+	defaultAddresses, err := p.resolveStatusAddress(p.StatusAddress)
 	if err != nil {
 		log.Ctx(ctx).Error().Err(err).Msg("Unable to get Gateway status addresses")
 		return nil
@@ -399,6 +399,15 @@ func (p *Provider) loadConfigurationFromGateways(ctx context.Context) *dynamic.C
 			if listener.GWName == gateway.Name && listener.GWNamespace == gateway.Namespace {
 				listeners = append(listeners, listener)
 			}
+		}
+
+		addresses, err := p.gatewayStatusAddresses(gateway)
+		if err != nil {
+			logger.Error().Err(err).Msg("Unable to get Gateway status addresses")
+			continue
+		}
+		if addresses == nil {
+			addresses = defaultAddresses
 		}
 
 		gatewayStatus, errConditions := p.makeGatewayStatus(gateway, listeners, addresses)
@@ -745,28 +754,61 @@ func (p *Provider) makeGatewayStatus(gateway *gatev1.Gateway, listeners []gatewa
 	return gatewayStatus, nil
 }
 
-func (p *Provider) gatewayAddresses() ([]gatev1.GatewayStatusAddress, error) {
-	if p.StatusAddress == nil {
+// gatewayStatusAddresses resolves status addresses from Gateway annotations.
+// Returns nil, nil when no statusaddress annotations are present.
+func (p *Provider) gatewayStatusAddresses(gateway *gatev1.Gateway) ([]gatev1.GatewayStatusAddress, error) {
+	sa, err := parseGatewayAnnotations(gateway.Annotations)
+	if err != nil {
+		return nil, fmt.Errorf("parsing Gateway annotations: %w", err)
+	}
+
+	if sa == nil {
 		return nil, nil
 	}
 
-	if p.StatusAddress.IP != "" {
+	if sa.Service.Name != "" && sa.Service.Namespace == "" {
+		sa.Service.Namespace = gateway.Namespace
+	}
+
+	// Annotation-sourced service references require a ReferenceGrant for
+	// cross-namespace access (static config is operator-controlled and exempt).
+	if sa.Service.Name != "" && sa.Service.Namespace != gateway.Namespace {
+		if err := p.isReferenceGranted(kindGateway, gateway.Namespace, groupCore, kindService, sa.Service.Name, sa.Service.Namespace); err != nil {
+			return nil, fmt.Errorf("cross-namespace service reference from Gateway %s/%s to Service %s/%s: %w",
+				gateway.Namespace, gateway.Name, sa.Service.Namespace, sa.Service.Name, err)
+		}
+	}
+
+	return p.resolveStatusAddress(sa)
+}
+
+// resolveStatusAddress resolves a StatusAddress configuration to Gateway API
+// status addresses.
+func (p *Provider) resolveStatusAddress(sa *StatusAddress) ([]gatev1.GatewayStatusAddress, error) {
+	if sa == nil {
+		return nil, nil
+	}
+
+	if sa.IP != "" {
 		return []gatev1.GatewayStatusAddress{{
 			Type:  ptr.To(gatev1.IPAddressType),
-			Value: p.StatusAddress.IP,
+			Value: sa.IP,
 		}}, nil
 	}
 
-	if p.StatusAddress.Hostname != "" {
+	if sa.Hostname != "" {
 		return []gatev1.GatewayStatusAddress{{
 			Type:  ptr.To(gatev1.HostnameAddressType),
-			Value: p.StatusAddress.Hostname,
+			Value: sa.Hostname,
 		}}, nil
 	}
 
-	svcRef := p.StatusAddress.Service
-	if svcRef.Name != "" && svcRef.Namespace != "" {
-		svc, err := p.client.GetService(svcRef.Namespace, svcRef.Name)
+	if sa.Service.Name != "" || sa.Service.Namespace != "" {
+		if sa.Service.Name == "" || sa.Service.Namespace == "" {
+			return nil, errors.New("statusAddress service requires both name and namespace")
+		}
+
+		svc, err := p.client.GetService(sa.Service.Namespace, sa.Service.Name)
 		if err != nil {
 			return nil, fmt.Errorf("getting service: %w", err)
 		}

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -7942,7 +7942,7 @@ func Test_referenceGrantMatchesTo(t *testing.T) {
 	}
 }
 
-func Test_gatewayAddresses(t *testing.T) {
+func Test_resolveStatusAddress(t *testing.T) {
 	testCases := []struct {
 		desc          string
 		statusAddress *StatusAddress
@@ -8027,6 +8027,24 @@ func Test_gatewayAddresses(t *testing.T) {
 			paths:   []string{"services.yml"},
 			wantErr: require.NoError,
 		},
+		{
+			desc: "partial service ref: name only",
+			statusAddress: &StatusAddress{
+				Service: ServiceRef{
+					Name: "some-service",
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			desc: "partial service ref: namespace only",
+			statusAddress: &StatusAddress{
+				Service: ServiceRef{
+					Namespace: "default",
+				},
+			},
+			wantErr: require.Error,
+		},
 	}
 
 	for _, test := range testCases {
@@ -8053,7 +8071,167 @@ func Test_gatewayAddresses(t *testing.T) {
 				client:        client,
 			}
 
-			got, err := p.gatewayAddresses()
+			got, err := p.resolveStatusAddress(test.statusAddress)
+			test.wantErr(t, err)
+
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func Test_gatewayStatusAddresses(t *testing.T) {
+	testCases := []struct {
+		desc              string
+		staticAddr        *StatusAddress
+		gatewayAnnotation map[string]string
+		paths             []string
+		wantErr           require.ErrorAssertionFunc
+		want              []gatev1.GatewayStatusAddress
+	}{
+		{
+			desc:              "no annotations, returns nil for caller to handle fallback",
+			staticAddr:        &StatusAddress{IP: "1.2.3.4"},
+			gatewayAnnotation: nil,
+			wantErr:           require.NoError,
+			want:              nil,
+		},
+		{
+			desc:       "annotation IP overrides static config",
+			staticAddr: &StatusAddress{IP: "1.2.3.4"},
+			gatewayAnnotation: map[string]string{
+				"traefik.io/statusaddress.ip": "5.6.7.8",
+			},
+			wantErr: require.NoError,
+			want: []gatev1.GatewayStatusAddress{
+				{Type: ptr.To(gatev1.IPAddressType), Value: "5.6.7.8"},
+			},
+		},
+		{
+			desc:       "annotation hostname overrides static config",
+			staticAddr: &StatusAddress{IP: "1.2.3.4"},
+			gatewayAnnotation: map[string]string{
+				"traefik.io/statusaddress.hostname": "internal.example.com",
+			},
+			wantErr: require.NoError,
+			want: []gatev1.GatewayStatusAddress{
+				{Type: ptr.To(gatev1.HostnameAddressType), Value: "internal.example.com"},
+			},
+		},
+		{
+			desc:       "annotation service overrides static config",
+			staticAddr: &StatusAddress{IP: "1.2.3.4"},
+			gatewayAnnotation: map[string]string{
+				"traefik.io/statusaddress.service.name":      "status-address",
+				"traefik.io/statusaddress.service.namespace": "default",
+			},
+			paths:   []string{"services.yml"},
+			wantErr: require.NoError,
+			want: []gatev1.GatewayStatusAddress{
+				{Type: ptr.To(gatev1.HostnameAddressType), Value: "foo.bar"},
+				{Type: ptr.To(gatev1.IPAddressType), Value: "1.2.3.4"},
+			},
+		},
+		{
+			desc:       "annotation service not found falls back to error",
+			staticAddr: &StatusAddress{IP: "10.0.0.1"},
+			gatewayAnnotation: map[string]string{
+				"traefik.io/statusaddress.service.name":      "does-not-exist",
+				"traefik.io/statusaddress.service.namespace": "default",
+			},
+			wantErr: require.Error,
+		},
+		{
+			desc:              "no annotations, no static config",
+			staticAddr:        nil,
+			gatewayAnnotation: nil,
+			wantErr:           require.NoError,
+			want:              nil,
+		},
+		{
+			desc: "unrelated annotations only, returns nil",
+			staticAddr: &StatusAddress{
+				Hostname: "default.example.com",
+			},
+			gatewayAnnotation: map[string]string{
+				"traefik.io/service.nativelb": "true",
+			},
+			wantErr: require.NoError,
+			want:    nil,
+		},
+		{
+			desc:              "no annotations, returns nil regardless of static config",
+			staticAddr:        &StatusAddress{},
+			gatewayAnnotation: nil,
+			wantErr:           require.NoError,
+			want:              nil,
+		},
+		{
+			desc:       "IP and hostname annotations, IP takes precedence",
+			staticAddr: nil,
+			gatewayAnnotation: map[string]string{
+				"traefik.io/statusaddress.ip":       "10.0.0.1",
+				"traefik.io/statusaddress.hostname": "example.com",
+			},
+			wantErr: require.NoError,
+			want: []gatev1.GatewayStatusAddress{
+				{Type: ptr.To(gatev1.IPAddressType), Value: "10.0.0.1"},
+			},
+		},
+		{
+			desc:       "annotation with service name only defaults namespace to gateway",
+			staticAddr: &StatusAddress{IP: "1.2.3.4"},
+			gatewayAnnotation: map[string]string{
+				"traefik.io/statusaddress.service.name": "status-address",
+			},
+			paths:   []string{"services.yml"},
+			wantErr: require.NoError,
+			want: []gatev1.GatewayStatusAddress{
+				{Type: ptr.To(gatev1.HostnameAddressType), Value: "foo.bar"},
+				{Type: ptr.To(gatev1.IPAddressType), Value: "1.2.3.4"},
+			},
+		},
+		{
+			desc:       "empty annotation value overrides default with error",
+			staticAddr: &StatusAddress{IP: "1.2.3.4"},
+			gatewayAnnotation: map[string]string{
+				"traefik.io/statusaddress.ip": "",
+			},
+			wantErr: require.Error,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			k8sObjects, gwObjects := readResources(t, test.paths)
+
+			kubeClient := kubefake.NewSimpleClientset(k8sObjects...)
+			gwClient := newGatewaySimpleClientSet(t, gwObjects...)
+
+			client := newClientImpl(kubeClient, gwClient)
+
+			eventCh, err := client.WatchAll(nil, make(chan struct{}))
+			require.NoError(t, err)
+
+			if len(k8sObjects) > 0 || len(gwObjects) > 0 {
+				<-eventCh
+			}
+
+			p := Provider{
+				StatusAddress: test.staticAddr,
+				client:        client,
+			}
+
+			gw := &gatev1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-gateway",
+					Namespace:   "default",
+					Annotations: test.gatewayAnnotation,
+				},
+			}
+
+			got, err := p.gatewayStatusAddresses(gw)
 			test.wantErr(t, err)
 
 			assert.Equal(t, test.want, got)


### PR DESCRIPTION
### What does this PR do?

Adds per-Gateway status address annotations that allow overriding the static `statusAddress` configuration on individual `Gateway` resources. This enables multiple Gateways backed by different Services (e.g. internal vs public) to report distinct addresses in `.status.addresses`.

### Motivation

When running Traefik with multiple `Gateway` objects fronted by different `LoadBalancer` Services, all Gateways currently report the same address in `.status.addresses` because the `statusAddress` is a single static configuration. This breaks tools like external-dns that read Gateway status to create DNS records, since every Gateway gets the same IP regardless of which Service actually fronts it. See #12500 for the full discussion.

Rather than an auto-discovery mechanism (which would require heuristic matching of listener ports to Services), this PR takes an explicit annotation-based approach that reuses the existing annotation infrastructure (`convertAnnotations` + `label.Decode`) and mirrors the static config options:

- `traefik.io/statusaddress.ip` - direct IP override
- `traefik.io/statusaddress.hostname` - direct hostname override
- `traefik.io/statusaddress.service.name` + `traefik.io/statusaddress.service.namespace` - copy addresses from a specific Service's LoadBalancer status

If `service.namespace` is omitted, it defaults to the Gateway's own namespace. Cross-namespace service references require a `ReferenceGrant` in the target namespace, consistent with how TLS certificate cross-namespace refs are already handled in this provider. When no annotations are present, behavior is identical to before (fully backward compatible).

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

- The `resolveStatusAddress` method was extracted from the former `gatewayAddresses` to make the core resolution logic reusable for both static config and annotation-sourced overrides.
- Partial `ServiceRef` (name without namespace or vice versa) now returns a clear error message instead of the misleading "empty Gateway status address configuration".
- If annotation-based address resolution fails for a Gateway, the status update for that Gateway is skipped entirely rather than silently falling back to the default address.

Ref: #12500