### PR TITLE
Downgrade inspect error to debug for removed containers

### DIFF
--- a/pkg/provider/docker/shared.go
+++ b/pkg/provider/docker/shared.go
@@ -39,7 +39,11 @@ type Shared struct {
 func inspectContainers(ctx context.Context, dockerClient client.ContainerAPIClient, containerID string) dockerData {
 	containerInspected, err := dockerClient.ContainerInspect(ctx, containerID)
 	if err != nil {
-		log.Ctx(ctx).Warn().Err(err).Msgf("Failed to inspect container %s", containerID)
+		if client.IsErrNotFound(err) {
+			log.Ctx(ctx).Debug().Err(err).Msgf("Failed to inspect container %s", containerID)
+		} else {
+			log.Ctx(ctx).Warn().Err(err).Msgf("Failed to inspect container %s", containerID)
+		}
 		return dockerData{}
 	}
 


### PR DESCRIPTION
## Summary

Since v3.6.0, `ContainerList` uses `All: true` to include stopped containers. Short-lived containers (CI runners, certbot, one-shot jobs) that are removed between list and inspect cause harmless "No such container" errors logged at WARN level, spamming logs on busy systems.

## Changes

- **`pkg/provider/docker/shared.go`**: Check if the inspect error is a "not found" error using `client.IsErrNotFound(err)`. If so, log at DEBUG level instead of WARN. Other inspect errors remain at WARN.

## Before/After

```
# Before: noisy warning for every ephemeral container
WRN Failed to inspect container f9e09815... error="No such container: f9e09815..."

# After: only visible at debug level
DBG Failed to inspect container f9e09815... error="No such container: f9e09815..."
```

Closes #12868