### PR TITLE
Use float64-safe maximum for Priority in CRD definitions

### DIFF
--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
@@ -136,7 +136,7 @@ spec:
                       description: |-
                         Priority defines the router's priority.
                         More info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/routing/rules-and-priority/#priority
-                      maximum: 9223372036854775000
+                      maximum: 9007199254740991
                       type: integer
                     services:
                       description: |-
@@ -570,7 +570,7 @@ spec:
                       description: |-
                         Priority defines the router's priority.
                         More info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/tcp/routing/rules-and-priority/#priority
-                      maximum: 9223372036854775000
+                      maximum: 9007199254740991
                       type: integer
                     services:
                       description: Services defines the list of TCP services.

--- a/docs/content/reference/dynamic-configuration/traefik.io_ingressroutes.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_ingressroutes.yaml
@@ -137,7 +137,7 @@ spec:
                       description: |-
                         Priority defines the router's priority.
                         More info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/routing/rules-and-priority/#priority
-                      maximum: 9223372036854775000
+                      maximum: 9007199254740991
                       type: integer
                     services:
                       description: |-

--- a/docs/content/reference/dynamic-configuration/traefik.io_ingressroutetcps.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_ingressroutetcps.yaml
@@ -85,7 +85,7 @@ spec:
                       description: |-
                         Priority defines the router's priority.
                         More info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/tcp/routing/rules-and-priority/#priority
-                      maximum: 9223372036854775000
+                      maximum: 9007199254740991
                       type: integer
                     services:
                       description: Services defines the list of TCP services.

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -137,7 +137,7 @@ spec:
                       description: |-
                         Priority defines the router's priority.
                         More info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/routing/rules-and-priority/#priority
-                      maximum: 9223372036854775000
+                      maximum: 9007199254740991
                       type: integer
                     services:
                       description: |-
@@ -571,7 +571,7 @@ spec:
                       description: |-
                         Priority defines the router's priority.
                         More info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/tcp/routing/rules-and-priority/#priority
-                      maximum: 9223372036854775000
+                      maximum: 9007199254740991
                       type: integer
                     services:
                       description: Services defines the list of TCP services.

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroute.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroute.go
@@ -39,7 +39,7 @@ type Route struct {
 	Kind string `json:"kind,omitempty"`
 	// Priority defines the router's priority.
 	// More info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/routing/rules-and-priority/#priority
-	// +kubebuilder:validation:Maximum=9223372036854774807
+	// +kubebuilder:validation:Maximum=9007199254740991
 	Priority int `json:"priority,omitempty"`
 	// Syntax defines the router's rule syntax.
 	// More info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/routing/rules-and-priority/#rulesyntax

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroutetcp.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroutetcp.go
@@ -30,7 +30,7 @@ type RouteTCP struct {
 	Match string `json:"match"`
 	// Priority defines the router's priority.
 	// More info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/tcp/routing/rules-and-priority/#priority
-	// +kubebuilder:validation:Maximum=9223372036854774807
+	// +kubebuilder:validation:Maximum=9007199254740991
 	Priority int `json:"priority,omitempty"`
 	// Syntax defines the router's rule syntax.
 	// More info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/tcp/routing/rules-and-priority/#rulesyntax


### PR DESCRIPTION
## Summary

The Priority field maximum in IngressRoute/IngressRouteTCP CRDs uses `9223372036854774807`, which is not exactly representable as a float64. Different tools round it to different values:

- kubebuilder → `9223372036854775000`
- go-jsonnet (used by ArgoCD) → `9223372036854774784`
- Kubernetes API → `9223372036854775000`

This causes CRDs to be perpetually out-of-sync in GitOps workflows (ArgoCD always sees a diff).

## Fix

Replaced with `9007199254740991` (`Number.MAX_SAFE_INTEGER` / `2^53 - 1`) — the largest integer that round-trips cleanly through any JSON implementation. This is more than sufficient for router priority values.

## Changes

- `pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroute.go` — kubebuilder annotation
- `pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroutetcp.go` — kubebuilder annotation
- `docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml` — generated CRD
- `docs/content/reference/dynamic-configuration/traefik.io_ingressroutes.yaml` — generated CRD
- `docs/content/reference/dynamic-configuration/traefik.io_ingressroutetcps.yaml` — generated CRD
- `integration/fixtures/k8s/01-traefik-crd.yml` — test fixture CRD

Closes #12693