### PR TITLE
Update gateway-api link in getting-started to v1.5.1

### DIFF
--- a/docs/content/getting-started/kubernetes.md
+++ b/docs/content/getting-started/kubernetes.md
@@ -250,7 +250,7 @@ To use the Gateway API:
 Install the Gateway API CRDs in your cluster:
 
 ```bash
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
 ```
 
 Create an HTTPRoute. This configuration:


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
update to k8s gateway-api version from 1.2.1 to 1.5.1 in k8s getting-started document. 
k8s gateway-api 1.5.1 is supported since traefik 3.7.0.

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
