### PR TITLE
Bump lodash version

### DIFF
--- a/.github/workflows/template-webui.yaml
+++ b/.github/workflows/template-webui.yaml
@@ -2,7 +2,7 @@ name: Build Web UI
 on:
   workflow_call: {}
 env:
-  SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS: 360  # 15 days
+  SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS: 72  # 3 days
 jobs:
 
   build-webui:

--- a/webui/package.json
+++ b/webui/package.json
@@ -71,7 +71,7 @@
     "globals": "^16.0.0",
     "jest-extended": "^4.0.2",
     "jsdom": "^24.0.0",
-    "lodash": "^4.17.21",
+    "lodash": "4.18.1",
     "msw": "^2.1.7",
     "query-string": "^6.9.0",
     "react": "^18.2.0",
@@ -101,5 +101,9 @@
       "public"
     ]
   },
-  "packageManager": "yarn@4.12.0"
+  "packageManager": "yarn@4.13.0",
+  "resolutions": {
+    "lodash": "4.18.1",
+    "lodash-es": "4.18.1"
+  }
 }

--- a/webui/yarn.lock
+++ b/webui/yarn.lock
@@ -12879,10 +12879,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash-es@npm:^4.17.21":
-  version: 4.17.22
-  resolution: "lodash-es@npm:4.17.22"
-  checksum: 10c0/5f28a262183cca43e08c580622557f393cb889386df2d8adf7c852bfdff7a84c5e629df5aa6c5c6274e83b38172f239d3e4e72e1ad27352d9ae9766627338089
+"lodash-es@npm:4.18.1":
+  version: 4.18.1
+  resolution: "lodash-es@npm:4.18.1"
+  checksum: 10c0/35d4dcf87ef07f8d090f409447575800108057e360b445f590d0d25d09e3d1e33a163d2fc100d4d072b0f901d5e2fc533cd7c4bfd8eeb38a06abec693823c8b8
   languageName: node
   linkType: hard
 
@@ -12956,10 +12956,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.12, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:~4.17.15":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
+"lodash@npm:4.18.1":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
   languageName: node
   linkType: hard
 
@@ -17686,7 +17686,7 @@ __metadata:
     jest-extended: "npm:^4.0.2"
     jsdom: "npm:^24.0.0"
     lint-staged: "npm:^9.5.0"
-    lodash: "npm:^4.17.21"
+    lodash: "npm:4.18.1"
     msw: "npm:^2.1.7"
     prettier: "npm:^3.5.3"
     query-string: "npm:^6.9.0"


### PR DESCRIPTION
### What does this PR do?

Bump lodash version and pin it to v4.18.1


### Motivation

To have the latest version of lodash.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

