### PR TITLE
Upgrade form-data to 2.5.4, 3.0.4, 4.0.4

### DIFF
--- a/webui/package.json
+++ b/webui/package.json
@@ -101,5 +101,8 @@
       "public"
     ]
   },
-  "packageManager": "yarn@4.9.1"
+  "packageManager": "yarn@4.9.1",
+  "resolutions": {
+    "form-data": "4.0.4"
+  }
 }

--- a/webui/yarn.lock
+++ b/webui/yarn.lock
@@ -10373,15 +10373,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.0":
-  version: 4.0.2
-  resolution: "form-data@npm:4.0.2"
+"form-data@npm:4.0.4":
+  version: 4.0.4
+  resolution: "form-data@npm:4.0.4"
   dependencies:
     asynckit: "npm:^0.4.0"
     combined-stream: "npm:^1.0.8"
     es-set-tostringtag: "npm:^2.1.0"
+    hasown: "npm:^2.0.2"
     mime-types: "npm:^2.1.12"
-  checksum: 10c0/e534b0cf025c831a0929bf4b9bbe1a9a6b03e273a8161f9947286b9b13bf8fb279c6944aae0070c4c311100c6d6dbb815cd955dc217728caf73fad8dc5b8ee9c
+  checksum: 10c0/373525a9a034b9d57073e55eab79e501a714ffac02e7a9b01be1c820780652b16e4101819785e1e18f8d98f0aee866cc654d660a435c378e16a72f2e7cac9695
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Upgrade form-data from 4.0.2 to 2.5.4, 3.0.4, 4.0.4 to fix CVE-2025-7783.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2025-7783 |
| **Severity** | CRITICAL |
| **Scanner** | trivy |
| **Rule** | `CVE-2025-7783` |
| **File** | `webui/yarn.lock` |

**Description**: form-data: Unsafe random function in form-data

## Changes
- `webui/package.json`
- `webui/yarn.lock`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
