### PR TITLE
Clarify install config watchNamespace watches only one namespace

### DIFF
--- a/docs/content/reference/install-configuration/providers/kubernetes/kubernetes-ingress-nginx.md
+++ b/docs/content/reference/install-configuration/providers/kubernetes/kubernetes-ingress-nginx.md
@@ -39,7 +39,7 @@ This provider discovers all Ingresses in the cluster by default, which may lead 
 **Best Practices:**
 
 - Use IngressClass to specify which Ingresses should be handled by this provider
-- Configure `watchNamespace` to limit discovery to specific namespaces
+- Configure `watchNamespace` to limit discovery to a single namespace
 - Use `watchNamespaceSelector` to target Ingresses based on namespace labels
 
 ### IngressClass Selection Logic


### PR DESCRIPTION
### What does this PR do?

Follow-up on https://github.com/traefik/traefik/pull/12873 - updates install doc to specify only one namespace can be watched by Kubernetes IngressNGINX provider

### Motivation

See https://github.com/traefik/traefik/pull/12873 - this was updated for configuration, this just updates the install documentation to match.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes
