### PR TITLE
Update vulnerability submission guidelines

### DIFF
--- a/docs/content/contributing/submitting-security-issues.md
+++ b/docs/content/contributing/submitting-security-issues.md
@@ -15,12 +15,38 @@ You can subscribe by sending an email to security+subscribe@traefik.io or on [th
 Reported vulnerabilities can be found on
 [cve.mitre.org](https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=traefik).
 
+CVEs are only created for vulnerabilities affecting **Generally Available (GA) versions** of Traefik.
+Vulnerabilities discovered in non-GA versions (release candidates, betas, early access, or development branches)
+will be fixed without creating a CVE.
+
 ## Report a Vulnerability
 
 We want to keep Traefik safe for everyone.
 If you've discovered a security vulnerability in Traefik,
 we appreciate your help in disclosing it to us in a responsible manner,
 by creating a [security advisory](https://github.com/traefik/traefik/security/advisories).
+
+## Code of Conduct for Vulnerability Submissions
+
+We are committed to handling every legitimate report responsibly,
+and we expect submitters to engage with our security team in a respectful and collaborative manner.
+
+The following behaviors are **not acceptable** and will not be tolerated:
+
+- **Threats** to publicly disclose the vulnerability if it is not fixed within a timeframe you set unilaterally.
+- **Ultimatums** or pressure tactics intended to force a faster response than our normal triage and remediation process allows.
+- **Demands** for payment, bug bounties, or any form of compensation in exchange for not disclosing the issue
+  (Traefik does not operate a paid bug bounty program).
+- **Aggressive, abusive, or disrespectful communication** with our security team.
+
+Submitters who engage in any of the above may face the following consequences:
+
+- The submitter **will not be credited** in the security advisory or any subsequent communication.
+- The submitter's GitHub profile may be **reported to GitHub** for violation of platform terms of service.
+- We may **decline to engage further** on the report, while still addressing the underlying issue if it is legitimate.
+
+We take security seriously and act on legitimate reports as quickly as our resources allow.
+Patience and constructive dialogue help us protect users effectively.
 
 ## Submission Quality Guidelines
 


### PR DESCRIPTION
### What does this PR do?

Adds two updates to the security vulnerability submission guidelines (`docs/content/contributing/submitting-security-issues.md`):

- **Code of Conduct for Vulnerability Submissions**: a new section explicitly stating that threats, ultimatums, demands for payment, or abusive communication are not acceptable. Submitters engaging in such behavior may not be credited in the advisory and may be reported to GitHub.
- **CVE GA-only policy**: clarifies that CVEs are only created for vulnerabilities affecting Generally Available (GA) versions. Vulnerabilities found on non-GA versions (RC, beta, early access, dev branches) are fixed without creating a CVE.

### Motivation

We have been receiving an increasing number of vulnerability submissions that include threats of public disclosure if a fix is not released within an arbitrary timeframe set by the submitter. This is unacceptable and prevents healthy collaboration with security researchers.

We also need to clarify our CVE policy: pre-GA versions are by definition not yet officially released, so they should not generate CVEs. Issues found there are fixed before GA without going through the CVE process.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

The new "Code of Conduct" section complements the existing "Submission Quality Guidelines" and "Policy on AI-Generated Reports" sections.