### PR TITLE
Use QuoteMeta for cookie name when building canary rules

### DIFF
--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingresses-with-canary-by-cookie.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingresses-with-canary-by-cookie.yml
@@ -27,7 +27,7 @@ metadata:
   namespace: default
   annotations:
     nginx.ingress.kubernetes.io/canary: "true"
-    nginx.ingress.kubernetes.io/canary-by-cookie: "foo"
+    nginx.ingress.kubernetes.io/canary-by-cookie: "foo.bar"
 
 spec:
   ingressClassName: nginx

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
@@ -147,7 +147,7 @@ func (c canaryBackend) AppendCanaryRule(rule string) string {
 	}
 
 	if c.Cookie != "" {
-		cookieRule := fmt.Sprintf(`HeaderRegexp("Cookie", %q)`, fmt.Sprintf("(^|;\\s*)%s=always(;|$)", c.Cookie))
+		cookieRule := fmt.Sprintf(`HeaderRegexp("Cookie", %q)`, fmt.Sprintf("(^|;\\s*)%s=always(;|$)", regexp.QuoteMeta(c.Cookie)))
 		if c.Header != "" && c.HeaderValue == "" && c.HeaderPattern == "" {
 			cookieRule = fmt.Sprintf("(%s && !%s)", cookieRule, fmt.Sprintf(`Header(%q, "never")`, c.Header))
 		}
@@ -165,7 +165,7 @@ func (c canaryBackend) AppendNonCanaryRule(rule string) string {
 		rules = append(rules, fmt.Sprintf(`Header(%q, "never")`, c.Header))
 	}
 	if c.Cookie != "" {
-		rules = append(rules, fmt.Sprintf(`HeaderRegexp("Cookie", %q)`, fmt.Sprintf("(^|;\\s*)%s=never(;|$)", c.Cookie)))
+		rules = append(rules, fmt.Sprintf(`HeaderRegexp("Cookie", %q)`, fmt.Sprintf("(^|;\\s*)%s=never(;|$)", regexp.QuoteMeta(c.Cookie))))
 	}
 
 	return fmt.Sprintf("(%s) && (%s)", rule, strings.Join(rules, " || "))

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -11070,7 +11070,7 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-canary-by-cookie-rule-0-path-0-canary": {
 							EntryPoints: []string{"http"},
-							Rule:        `(Host("production.localhost") && PathPrefix("/")) && (HeaderRegexp("Cookie", "(^|;\\s*)foo=always(;|$)"))`,
+							Rule:        `(Host("production.localhost") && PathPrefix("/")) && (HeaderRegexp("Cookie", "(^|;\\s*)foo\\.bar=always(;|$)"))`,
 							RuleSyntax:  "default",
 							Service:     "default-ingress-with-canary-by-cookie-whoami-80-canary",
 							Observability: &dynamic.RouterObservabilityConfig{
@@ -11105,7 +11105,7 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-canary-by-cookie-rule-0-path-0-canary-tls": {
 							EntryPoints: []string{"https"},
-							Rule:        `(Host("production.localhost") && PathPrefix("/")) && (HeaderRegexp("Cookie", "(^|;\\s*)foo=always(;|$)"))`,
+							Rule:        `(Host("production.localhost") && PathPrefix("/")) && (HeaderRegexp("Cookie", "(^|;\\s*)foo\\.bar=always(;|$)"))`,
 							RuleSyntax:  "default",
 							Service:     "default-ingress-with-canary-by-cookie-whoami-80-canary",
 							Observability: &dynamic.RouterObservabilityConfig{


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request escapes the Cookie name when building the canary rules.


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [X] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
