### PR TITLE
Honor allowCrossNamespace with chain middleware CRD

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -785,3 +785,13 @@ The default value for this option is -1, which means there is no limit to the re
 However, it is strongly recommended to set this option to a suitable value to avoid performance issues such as memory exhaustion.
 
 Please check out the [HTTP](../providers/http.md#maxresponsebodysize) provider documentation for more details.
+
+## v2.11.43
+
+### Kubernetes CRD: Chain middleware and `allowCrossNamespace`
+
+In `v2.11.43`, the `Chain` middleware now honors the Kubernetes CRD provider's `allowCrossNamespace` option.
+Previously, a `Chain` could reference middlewares in other namespaces regardless of the `allowCrossNamespace` configuration.
+
+If `allowCrossNamespace` is set to `false` (the default) and a `Chain` middleware references a middleware in a different namespace from its own,
+the whole `Chain` is now rejected and an error is logged.

--- a/pkg/provider/kubernetes/crd/fixtures/with_middleware_cross_namespace.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_middleware_cross_namespace.yml
@@ -46,6 +46,7 @@ spec:
       port: 80
     middlewares:
     - name: test-chain
+    - name: test-chain-cross-provider
 
 ---
 apiVersion: traefik.io/v1alpha1
@@ -71,6 +72,18 @@ spec:
     middlewares:
       - name: stripprefix
         namespace: cross-ns
+
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: test-chain-cross-provider
+  namespace: default
+
+spec:
+  chain:
+    middlewares:
+      - name: other-middleware@kubernetescrd
 
 ---
 apiVersion: traefik.io/v1alpha1

--- a/pkg/provider/kubernetes/crd/fixtures/with_middleware_cross_namespace.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_middleware_cross_namespace.yml
@@ -37,6 +37,15 @@ spec:
       port: 80
     middlewares:
     - name: cross-ns-stripprefix@kubernetescrd
+  - match: Host(`foo.com`) && PathPrefix(`/chain`)
+    kind: Rule
+    priority: 12
+    services:
+    - name: whoami
+      namespace: default
+      port: 80
+    middlewares:
+    - name: test-chain
 
 ---
 apiVersion: traefik.io/v1alpha1
@@ -49,6 +58,19 @@ spec:
   stripPrefix:
     prefixes:
       - /stripit
+
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: test-chain
+  namespace: default
+
+spec:
+  chain:
+    middlewares:
+      - name: stripprefix
+        namespace: cross-ns
 
 ---
 apiVersion: traefik.io/v1alpha1

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -279,13 +279,19 @@ func (p *Provider) loadConfigurationFromCRD(ctx context.Context, client Client) 
 			continue
 		}
 
+		chain, err := createChainMiddleware(ctxMid, middleware.Namespace, middleware.Spec.Chain, p.AllowCrossNamespace)
+		if err != nil {
+			log.FromContext(ctxMid).Errorf("Error while reading chain middleware: %v", err)
+			continue
+		}
+
 		conf.HTTP.Middlewares[id] = &dynamic.Middleware{
 			AddPrefix:         middleware.Spec.AddPrefix,
 			StripPrefix:       middleware.Spec.StripPrefix,
 			StripPrefixRegex:  middleware.Spec.StripPrefixRegex,
 			ReplacePath:       middleware.Spec.ReplacePath,
 			ReplacePathRegex:  middleware.Spec.ReplacePathRegex,
-			Chain:             createChainMiddleware(ctxMid, middleware.Namespace, middleware.Spec.Chain),
+			Chain:             chain,
 			IPWhiteList:       middleware.Spec.IPWhiteList,
 			IPAllowList:       middleware.Spec.IPAllowList,
 			Headers:           middleware.Spec.Headers,
@@ -854,9 +860,9 @@ func loadAuthCredentials(secret *corev1.Secret) ([]string, error) {
 	return credentials, nil
 }
 
-func createChainMiddleware(ctx context.Context, namespace string, chain *traefikv1alpha1.Chain) *dynamic.Chain {
+func createChainMiddleware(ctx context.Context, parentNamespace string, chain *traefikv1alpha1.Chain, allowCrossNamespace bool) (*dynamic.Chain, error) {
 	if chain == nil {
-		return nil
+		return nil, nil
 	}
 
 	var mds []string
@@ -870,13 +876,19 @@ func createChainMiddleware(ctx context.Context, namespace string, chain *traefik
 			continue
 		}
 
-		ns := mi.Namespace
-		if len(ns) == 0 {
-			ns = namespace
+		ns := parentNamespace
+		if len(mi.Namespace) > 0 {
+			if !isNamespaceAllowed(allowCrossNamespace, parentNamespace, mi.Namespace) {
+				return nil, fmt.Errorf("middleware %s/%s is not in the chain namespace %s", mi.Namespace, mi.Name, parentNamespace)
+			}
+
+			ns = mi.Namespace
 		}
+
 		mds = append(mds, makeID(ns, mi.Name))
 	}
-	return &dynamic.Chain{Middlewares: mds}
+
+	return &dynamic.Chain{Middlewares: mds}, nil
 }
 
 func buildTLSOptions(ctx context.Context, client Client) map[string]tls.Options {

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -867,6 +867,13 @@ func createChainMiddleware(ctx context.Context, parentNamespace string, chain *t
 
 	var mds []string
 	for _, mi := range chain.Middlewares {
+		if !allowCrossNamespace && strings.HasSuffix(mi.Name, providerNamespaceSeparator+providerName) {
+			// Since we are not able to know if another namespace is in the name (namespace-name@kubernetescrd),
+			// if the provider namespace kubernetescrd is used,
+			// we don't allow this format to avoid cross namespace references.
+			return nil, fmt.Errorf("invalid reference to middleware %s: with crossnamespace disallowed, the namespace field needs to be explicitly specified", mi.Name)
+		}
+
 		if strings.Contains(mi.Name, providerNamespaceSeparator) {
 			if len(mi.Namespace) > 0 {
 				log.FromContext(ctx).

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -870,8 +870,8 @@ func createChainMiddleware(ctx context.Context, parentNamespace string, chain *t
 		if !allowCrossNamespace && strings.HasSuffix(mi.Name, providerNamespaceSeparator+providerName) {
 			// Since we are not able to know if another namespace is in the name (namespace-name@kubernetescrd),
 			// if the provider namespace kubernetescrd is used,
-			// we don't allow this format to avoid cross namespace references.
-			return nil, fmt.Errorf("invalid reference to middleware %s: with crossnamespace disallowed, the namespace field needs to be explicitly specified", mi.Name)
+			// we don't allow this format to avoid cross-namespace references.
+			return nil, fmt.Errorf("invalid reference to middleware %s: when allowCrossNamespace is disabled @kubernetescrd provider references are disallowed", mi.Name)
 		}
 
 		if strings.Contains(mi.Name, providerNamespaceSeparator) {

--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -166,8 +166,8 @@ func (p *Provider) makeMiddlewareKeys(ctx context.Context, ingRouteNamespace str
 		if !p.AllowCrossNamespace && strings.HasSuffix(mi.Name, providerNamespaceSeparator+providerName) {
 			// Since we are not able to know if another namespace is in the name (namespace-name@kubernetescrd),
 			// if the provider namespace kubernetescrd is used,
-			// we don't allow this format to avoid cross namespace references.
-			return nil, fmt.Errorf("invalid reference to middleware %s: with crossnamespace disallowed, the namespace field needs to be explicitly specified", mi.Name)
+			// we don't allow this format to avoid cross-namespace references.
+			return nil, fmt.Errorf("invalid reference to middleware %s: when allowCrossNamespace is disabled @kubernetescrd provider references are disallowed", mi.Name)
 		}
 
 		if strings.Contains(name, providerNamespaceSeparator) {

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -5079,7 +5079,10 @@ func TestCrossNamespace(t *testing.T) {
 							Service:     "default-test-crossnamespace-route-4932ffbbcd99474df323",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/chain`)",
 							Priority:    12,
-							Middlewares: []string{"default-test-chain"},
+							Middlewares: []string{
+								"default-test-chain",
+								"default-test-chain-cross-provider",
+							},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{
@@ -5167,7 +5170,10 @@ func TestCrossNamespace(t *testing.T) {
 							Service:     "default-test-crossnamespace-route-4932ffbbcd99474df323",
 							Rule:        "Host(`foo.com`) && PathPrefix(`/chain`)",
 							Priority:    12,
-							Middlewares: []string{"default-test-chain"},
+							Middlewares: []string{
+								"default-test-chain",
+								"default-test-chain-cross-provider",
+							},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{
@@ -5187,6 +5193,11 @@ func TestCrossNamespace(t *testing.T) {
 						"default-test-chain": {
 							Chain: &dynamic.Chain{
 								Middlewares: []string{"cross-ns-stripprefix"},
+							},
+						},
+						"default-test-chain-cross-provider": {
+							Chain: &dynamic.Chain{
+								Middlewares: []string{"other-middleware@kubernetescrd"},
 							},
 						},
 					},

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -5074,6 +5074,13 @@ func TestCrossNamespace(t *testing.T) {
 							Priority:    12,
 							Middlewares: []string{"default-test-errorpage"},
 						},
+						"default-test-crossnamespace-route-4932ffbbcd99474df323": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test-crossnamespace-route-4932ffbbcd99474df323",
+							Rule:        "Host(`foo.com`) && PathPrefix(`/chain`)",
+							Priority:    12,
+							Middlewares: []string{"default-test-chain"},
+						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{
 						"cross-ns-stripprefix": {
@@ -5085,6 +5092,19 @@ func TestCrossNamespace(t *testing.T) {
 					},
 					Services: map[string]*dynamic.Service{
 						"default-test-crossnamespace-route-9313b71dbe6a649d5049": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: pointer(true),
+							},
+						},
+						"default-test-crossnamespace-route-4932ffbbcd99474df323": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
@@ -5142,6 +5162,13 @@ func TestCrossNamespace(t *testing.T) {
 							Priority:    12,
 							Middlewares: []string{"cross-ns-stripprefix@kubernetescrd"},
 						},
+						"default-test-crossnamespace-route-4932ffbbcd99474df323": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test-crossnamespace-route-4932ffbbcd99474df323",
+							Rule:        "Host(`foo.com`) && PathPrefix(`/chain`)",
+							Priority:    12,
+							Middlewares: []string{"default-test-chain"},
+						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{
 						"cross-ns-stripprefix": {
@@ -5155,6 +5182,11 @@ func TestCrossNamespace(t *testing.T) {
 								Status:  []string{"500-599"},
 								Service: "default-test-errorpage-errorpage-service",
 								Query:   "/{status}.html",
+							},
+						},
+						"default-test-chain": {
+							Chain: &dynamic.Chain{
+								Middlewares: []string{"cross-ns-stripprefix"},
 							},
 						},
 					},
@@ -5199,6 +5231,19 @@ func TestCrossNamespace(t *testing.T) {
 							},
 						},
 						"default-test-crossnamespace-route-a1963878aac7331b7950": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: pointer(true),
+							},
+						},
+						"default-test-crossnamespace-route-4932ffbbcd99474df323": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR changes the way chain middleware CRD is discovered to honor the allowCrossNamespace configuration with the chain middleware CRD.

If `allowCrossNamespace` is set to `false` (the default) and a `Chain` middleware references a middleware in a different namespace from its own,
the whole `Chain` is now rejected and an error is logged.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

To honor allowCrossNamespace configuration.
<!-- What inspired you to submit this pull request? -->

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
