### PR TITLE
Avoid 302 redirect when rewrite-target value is not an absolute URL for ingress-nginx provider

### DIFF
--- a/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target.go
+++ b/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target.go
@@ -28,6 +28,7 @@ type rewriteTarget struct {
 	replacement      string
 	xForwardedPrefix string
 	name             string
+	redirectAbsolute bool
 }
 
 // New creates a new rewrite target middleware.
@@ -43,6 +44,10 @@ func New(ctx context.Context, next http.Handler, config dynamic.RewriteTarget, n
 		replacement:      strings.TrimSpace(config.Replacement),
 		xForwardedPrefix: config.XForwardedPrefix,
 		name:             name,
+	}
+
+	if parsed, err := url.Parse(mw.replacement); err == nil && parsed.Scheme != "" {
+		mw.redirectAbsolute = true
 	}
 
 	if config.Regex != "" {
@@ -77,8 +82,9 @@ func (rt *rewriteTarget) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		newTarget = replacementRegex.ReplaceAllString(rt.replacement, "")
 	}
 
-	// If the replacement resolves to an absolute URL, issue a 302 redirect.
-	if parsed, err := url.Parse(newTarget); err == nil && parsed.Scheme != "" {
+	// Only issue a 302 redirect if the replacement template itself is an absolute URL.
+	// Prevent user-controlled capture group content from injecting an absolute URL redirect.
+	if rt.redirectAbsolute {
 		http.Redirect(rw, req, newTarget, http.StatusFound)
 		return
 	}

--- a/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target.go
+++ b/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target.go
@@ -28,7 +28,7 @@ type rewriteTarget struct {
 	replacement      string
 	xForwardedPrefix string
 	name             string
-	// absoluteURLRedirect  is true when the replacement template is an absolute URL,
+	// absoluteURLRedirect is true when the replacement template is an absolute URL,
 	// indicating the operator explicitly configured a redirect to an external destination.
 	absoluteURLRedirect bool
 }

--- a/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target.go
+++ b/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target.go
@@ -28,7 +28,9 @@ type rewriteTarget struct {
 	replacement      string
 	xForwardedPrefix string
 	name             string
-	redirectAbsolute bool
+	// absoluteURLRedirect  is true when the replacement template is an absolute URL,
+	// indicating the operator explicitly configured a redirect to an external destination.
+	absoluteURLRedirect bool
 }
 
 // New creates a new rewrite target middleware.
@@ -47,7 +49,7 @@ func New(ctx context.Context, next http.Handler, config dynamic.RewriteTarget, n
 	}
 
 	if parsed, err := url.Parse(mw.replacement); err == nil && parsed.Scheme != "" {
-		mw.redirectAbsolute = true
+		mw.absoluteURLRedirect = true
 	}
 
 	if config.Regex != "" {
@@ -84,7 +86,7 @@ func (rt *rewriteTarget) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	// Only issue a 302 redirect if the replacement template itself is an absolute URL.
 	// Prevent user-controlled capture group content from injecting an absolute URL redirect.
-	if rt.redirectAbsolute {
+	if rt.absoluteURLRedirect {
 		http.Redirect(rw, req, newTarget, http.StatusFound)
 		return
 	}

--- a/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target_test.go
+++ b/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target_test.go
@@ -171,6 +171,17 @@ func TestRewriteTarget(t *testing.T) {
 			expectedStatusCode:  http.StatusFound,
 			expectedRedirectURL: "https://bar.example.org/",
 		},
+		{
+			desc: "path with an absolute redirect URL in the capture group should not issue a 302 redirect",
+			path: "/prefix/http://evil.com/malicious",
+			config: dynamic.RewriteTarget{
+				Regex:       `^/prefix/(.*)`,
+				Replacement: "$1",
+			},
+			expectedPath:       "http://evil.com/malicious",
+			expectedRawPath:    "http://evil.com/malicious",
+			expectedStatusCode: http.StatusOK,
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
### What does this PR do?

When the rewrite-target is configured as an absolute URL, Traefik issues a 302 redirect. However, when using a capture group replacement (e.g. $1), a user-controlled path segment containing an absolute URL could also trigger an open redirect.

This fix ensures a 302 redirect is only issued when the replacement template itself is an absolute URL, not when one is injected via a capture group.

### Motivation

To avoid open redirect via user-injected capture group content.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
