### PR TITLE
fix(forwardedheaders): strip non-canonical X-Forwarded-* variants from untrusted clients

### DIFF
--- a/pkg/middlewares/forwardedheaders/forwarded_header.go
+++ b/pkg/middlewares/forwardedheaders/forwarded_header.go
@@ -143,6 +143,19 @@ func (x *XForwarded) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		for _, h := range xHeaders {
 			unsafeHeader(r.Header).Del(h)
 		}
+		// Also strip any non-canonical variants (e.g. underscore-separated "X_Forwarded_Proto")
+		// that Go's net/http does not fold into the canonical form and that some
+		// downstream stacks (CGI/WSGI/nginx) treat as equivalent to their dashed
+		// counterparts, which would otherwise allow spoofing the managed X-Forwarded-* headers.
+		for name := range r.Header {
+			if name == http.CanonicalHeaderKey(name) {
+				continue
+			}
+			canonical := http.CanonicalHeaderKey(strings.ReplaceAll(name, "_", "-"))
+			if slices.Contains(xHeaders, canonical) {
+				delete(r.Header, name)
+			}
+		}
 	}
 
 	x.rewrite(r)

--- a/pkg/middlewares/forwardedheaders/forwarded_header_test.go
+++ b/pkg/middlewares/forwardedheaders/forwarded_header_test.go
@@ -171,6 +171,34 @@ func TestServeHTTP(t *testing.T) {
 			},
 		},
 		{
+			desc:       "insecure false strips underscore-separated X-Forwarded-* variants",
+			insecure:   false,
+			remoteAddr: "10.0.1.101:80",
+			incomingHeaders: map[string][]string{
+				"X_Forwarded_Proto": {"https"},
+				"X_Forwarded_Host":  {"attacker.example"},
+				"X_Forwarded_For":   {"1.2.3.4"},
+				"X_Real_Ip":         {"1.2.3.4"},
+			},
+			expectedHeaders: map[string]string{
+				"X_Forwarded_Proto": "",
+				"X_Forwarded_Host":  "",
+				"X_Forwarded_For":   "",
+				"X_Real_Ip":         "",
+			},
+		},
+		{
+			desc:       "insecure true keeps underscore-separated X-Forwarded-* variants",
+			insecure:   true,
+			remoteAddr: "10.0.1.101:80",
+			incomingHeaders: map[string][]string{
+				"X_Forwarded_Proto": {"https"},
+			},
+			expectedHeaders: map[string]string{
+				"X_Forwarded_Proto": "https",
+			},
+		},
+		{
 			desc:     "xForwardedFor with multiple header(s) values",
 			insecure: true,
 			incomingHeaders: map[string][]string{


### PR DESCRIPTION
## What does this PR do?

Hardens the `forwardedheaders` entry-point middleware to also strip non-canonical variants of the managed `X-Forwarded-*` headers (e.g. `X_Forwarded_Proto`, `X_Real_Ip`) when the request comes from a non-trusted client.

## Motivation

Go's `net/http` header canonicalization (`textproto.CanonicalMIMEHeaderKey`) uppercases the first letter and any letter following a `-`, but does **not** fold `_` into `-`. A client-supplied header like:

```
X_Forwarded_Proto: https
```

is therefore stored under the map key `X_forwarded_proto`, which is distinct from `X-Forwarded-Proto`. The existing cleanup loop only deletes canonical forms:

```go
for _, h := range xHeaders {
    unsafeHeader(r.Header).Del(h) // only deletes "X-Forwarded-Proto"
}
```

so the underscore variant survives and is forwarded downstream. Several commonly-used backends treat the two forms as equivalent:

- CGI/WSGI environments map both `X-Forwarded-Proto` and `X_Forwarded_Proto` to the same `HTTP_X_FORWARDED_PROTO` env var.
- `nginx` with `underscores_in_headers on` preserves them and hands them to the application.
- Various application frameworks normalize header names before lookup.

In those setups, an untrusted client can spoof values that Traefik is explicitly trying to manage itself — proto, host, for, port, prefix, real-ip, tls-client-cert, etc.

## Fix

After the existing canonical-name deletion loop, iterate the header map and delete any non-canonical key whose `_`→`-` canonical form matches one of the managed `xHeaders`. Canonical entries are skipped, so legitimate traffic is untouched.

The change is scoped to the existing `if !x.insecure && !x.isTrustedIP(...)` branch, so trusted clients and `insecure=true` setups are unaffected.

## Tests

Two cases added to `TestServeHTTP`:

- `insecure false strips underscore-separated X-Forwarded-* variants` — confirms `X_Forwarded_Proto`, `X_Forwarded_Host`, `X_Forwarded_For`, `X_Real_Ip` are cleared when the remote is not trusted.
- `insecure true keeps underscore-separated X-Forwarded-* variants` — confirms the insecure path preserves the existing behavior.

## Related

Complements CVE-2025-54385 / CVE-2025-32432 style header-injection hardening already in place for the canonical forms.