### PR TITLE
Fix casing of 'defaultMode' to 'defaultmode'

### DIFF
--- a/docs/content/observe/logs-and-access-logs.md
+++ b/docs/content/observe/logs-and-access-logs.md
@@ -55,7 +55,7 @@ accessLog:
     names:
       ClientUsername: drop
     headers:
-      defaultMode: keep
+      defaultmode: keep
       names:
         User-Agent: redact
         Content-Type: keep
@@ -70,7 +70,7 @@ accessLog:
     [accessLog.fields.names]
       ClientUsername = "drop"
     [accessLog.fields.headers]
-      defaultMode = "keep"
+      defaultmode = "keep"
       [accessLog.fields.headers.names]
         "User-Agent" = "redact"
         "Content-Type" = "keep"
@@ -91,7 +91,7 @@ logs:
       names:
         ClientUsername: drop
       headers:
-        defaultMode: keep
+        defaultmode: keep
         names:
           User-Agent: redact
           Content-Type: keep


### PR DESCRIPTION
### What does this PR do?

This PR fixes a typo in access logs. Helm did not set the correct args for logging headers. Now it is aligned with the values.yml in traefiks helm chart repo.


### Motivation

We were unable to change the values for logging headers in the access log.


### More

- [ ] Added/updated tests
- [x] Added/updated documentation
