### PR TITLE
Fix rewrite target with full URL and no regex in ingress path

### DIFF
--- a/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target.go
+++ b/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target.go
@@ -15,19 +15,22 @@ import (
 )
 
 const (
-	typeName               = "RewriteTarget"
-	xForwardedPrefixHeader = "X-Forwarded-Prefix"
+	typeName         = "RewriteTarget"
+	xForwardedPrefix = "X-Forwarded-Prefix"
 )
 
+// This regex is used to remove the capture groups when no regex is provided,
+// as the replacement string may contain capture group references like $1, $2, etc.
+// that should be ignored in this case.
 var replacementRegex = regexp.MustCompile(`\$[0-9]+`)
 
-// RewriteTarget is a middleware used to replace the path of a URL request.
+// rewriteTarget is a middleware used to replace the path of a URL request.
 type rewriteTarget struct {
+	name             string
 	next             http.Handler
 	regexp           *regexp.Regexp
 	replacement      string
 	xForwardedPrefix string
-	name             string
 	// absoluteURLRedirect is true when the replacement template is an absolute URL,
 	// indicating the operator explicitly configured a redirect to an external destination.
 	absoluteURLRedirect bool
@@ -41,26 +44,38 @@ func New(ctx context.Context, next http.Handler, config dynamic.RewriteTarget, n
 		return nil, errors.New("replacement cannot be empty")
 	}
 
-	mw := &rewriteTarget{
-		next:             next,
-		replacement:      strings.TrimSpace(config.Replacement),
-		xForwardedPrefix: config.XForwardedPrefix,
-		name:             name,
+	var absoluteURLRedirect bool
+	if parsed, err := url.Parse(config.Replacement); err == nil && parsed.Scheme != "" {
+		absoluteURLRedirect = true
 	}
 
-	if parsed, err := url.Parse(mw.replacement); err == nil && parsed.Scheme != "" {
-		mw.absoluteURLRedirect = true
-	}
-
+	var re *regexp.Regexp
 	if config.Regex != "" {
-		exp, err := regexp.Compile(strings.TrimSpace(config.Regex))
+		var err error
+		re, err = regexp.Compile("(?i)" + strings.TrimSpace(config.Regex)) // regex on ingress-nginx are case-insensitive.
 		if err != nil {
 			return nil, fmt.Errorf("compiling regular expression %s: %w", config.Regex, err)
 		}
-		mw.regexp = exp
+
+		// When rewrite-target is a full URL and there's no capture group,
+		// append .* to match the entire path and avoid leaking unmatched suffix.
+		// See https://github.com/traefik/traefik/issues/12931
+		if re.NumSubexp() == 0 && absoluteURLRedirect {
+			re, err = regexp.Compile("(?i)" + strings.TrimSpace(config.Regex) + ".*")
+			if err != nil {
+				return nil, fmt.Errorf("compiling regular expression for absolute URL %s: %w", config.Regex, err)
+			}
+		}
 	}
 
-	return mw, nil
+	return &rewriteTarget{
+		name:                name,
+		next:                next,
+		regexp:              re,
+		replacement:         strings.TrimSpace(config.Replacement),
+		xForwardedPrefix:    config.XForwardedPrefix,
+		absoluteURLRedirect: absoluteURLRedirect,
+	}, nil
 }
 
 func (rt *rewriteTarget) GetTracingInformation() (string, string) {
@@ -68,20 +83,30 @@ func (rt *rewriteTarget) GetTracingInformation() (string, string) {
 }
 
 func (rt *rewriteTarget) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	logger := middlewares.GetLogger(req.Context(), rt.name, typeName)
+
 	currentPath := req.URL.RawPath
 	if currentPath == "" {
 		currentPath = req.URL.EscapedPath()
 	}
 
+	// regexp doex not match, nothing to rewrite.
+	if rt.regexp != nil && !rt.regexp.MatchString(currentPath) {
+		rt.next.ServeHTTP(rw, req)
+		return
+	}
+
 	var newTarget string
 	if rt.regexp != nil {
-		if !rt.regexp.MatchString(currentPath) {
-			rt.next.ServeHTTP(rw, req)
-			return
-		}
 		newTarget = rt.regexp.ReplaceAllString(currentPath, rt.replacement)
 	} else {
 		newTarget = replacementRegex.ReplaceAllString(rt.replacement, "")
+	}
+
+	// Same as ingress-nginx when the new target is empty we reply with an error.
+	if newTarget == "" {
+		http.Error(rw, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
 	}
 
 	// Only issue a 302 redirect if the replacement template itself is an absolute URL.
@@ -91,24 +116,24 @@ func (rt *rewriteTarget) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	req.URL.RawPath = newTarget
-
 	if rt.xForwardedPrefix != "" {
 		prefix := rt.xForwardedPrefix
 		if rt.regexp != nil {
 			prefix = rt.regexp.ReplaceAllString(currentPath, rt.xForwardedPrefix)
 		}
-		req.Header.Set(xForwardedPrefixHeader, prefix)
+		req.Header.Set(xForwardedPrefix, prefix)
 	}
 
-	// as replacement can introduce escaped characters
+	// As replacement can introduce escaped characters
 	// Path must remain an unescaped version of RawPath
 	// Doesn't handle multiple times encoded replacement (`/` => `%2F` => `%252F` => ...)
+	req.URL.RawPath = newTarget
+
 	var err error
 	req.URL.Path, err = url.PathUnescape(req.URL.RawPath)
 	if err != nil {
-		middlewares.GetLogger(context.Background(), rt.name, typeName).Error().Msgf("Unable to unescape url raw path %q: %v", req.URL.RawPath, err)
-		observability.SetStatusErrorf(req.Context(), "Unable to unescape url raw path %q: %v", req.URL.RawPath, err)
+		logger.Error().Msgf("Unable to unescape URL RawPath %q: %v", req.URL.RawPath, err)
+		observability.SetStatusErrorf(req.Context(), "Unable to unescape URL RawPath %q: %v", req.URL.RawPath, err)
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target_test.go
+++ b/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target_test.go
@@ -217,7 +217,7 @@ func TestRewriteTarget(t *testing.T) {
 			if expectedStatus == 0 {
 				expectedStatus = http.StatusOK
 			}
-			require.Equal(t, expectedStatus, resp.StatusCode)
+			assert.Equal(t, expectedStatus, resp.StatusCode)
 
 			if test.expectedRedirectURL != "" {
 				assert.Equal(t, test.expectedRedirectURL, resp.Header.Get("Location"), "Unexpected redirect location.")

--- a/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target_test.go
+++ b/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target_test.go
@@ -30,6 +30,14 @@ func TestRewriteTarget(t *testing.T) {
 			expectsError: true,
 		},
 		{
+			desc: "invalid regex",
+			config: dynamic.RewriteTarget{
+				Regex:       `^(?err)/invalid/regexp/([^/]+)$`,
+				Replacement: "/valid/$1",
+			},
+			expectsError: true,
+		},
+		{
 			desc: "plain replacement",
 			path: "/foo/bar",
 			config: dynamic.RewriteTarget{
@@ -97,14 +105,6 @@ func TestRewriteTarget(t *testing.T) {
 			},
 			expectedPath:    "/foo/bar",
 			expectedRawPath: "",
-		},
-		{
-			desc: "invalid regex",
-			config: dynamic.RewriteTarget{
-				Regex:       `^(?err)/invalid/regexp/([^/]+)$`,
-				Replacement: "/valid/$1",
-			},
-			expectsError: true,
 		},
 		{
 			desc: "regex with x-forwarded-prefix capture group",
@@ -182,6 +182,16 @@ func TestRewriteTarget(t *testing.T) {
 			expectedRawPath:    "http://evil.com/malicious",
 			expectedStatusCode: http.StatusOK,
 		},
+		{
+			desc: "regex with full URL replacement with no capture groups",
+			path: "/foo/a/b/c",
+			config: dynamic.RewriteTarget{
+				Regex:       "/foo",
+				Replacement: "https://bar.example.org/$1",
+			},
+			expectedStatusCode:  http.StatusFound,
+			expectedRedirectURL: "https://bar.example.org/",
+		},
 	}
 
 	for _, test := range testCases {
@@ -190,7 +200,7 @@ func TestRewriteTarget(t *testing.T) {
 			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				actualPath = r.URL.Path
 				actualRawPath = r.URL.RawPath
-				actualXForwardedPrefix = r.Header.Get(xForwardedPrefixHeader)
+				actualXForwardedPrefix = r.Header.Get(xForwardedPrefix)
 				requestURI = r.RequestURI
 			})
 
@@ -226,7 +236,7 @@ func TestRewriteTarget(t *testing.T) {
 
 			assert.Equal(t, test.expectedPath, actualPath, "Unexpected path.")
 			assert.Equal(t, test.expectedRawPath, actualRawPath, "Unexpected raw path.")
-			assert.Equal(t, test.expectedXForwardedPrefix, actualXForwardedPrefix, "Unexpected %s header.", xForwardedPrefixHeader)
+			assert.Equal(t, test.expectedXForwardedPrefix, actualXForwardedPrefix, "Unexpected %s header.", xForwardedPrefix)
 
 			if actualRawPath == "" {
 				assert.Equal(t, actualPath, requestURI, "Unexpected request URI.")

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"regexp"
 	"slices"
@@ -1669,13 +1670,6 @@ func (p *Provider) applyCustomHeaders(namespace, routerName string, ingressConfi
 	return nil
 }
 
-// To validate full URL in rewrite target.
-var urlSchemeRegex = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.-]*://`)
-
-func isFullURL(value string) bool {
-	return urlSchemeRegex.MatchString(value)
-}
-
 func applyRewriteTargetConfiguration(rulePath, routerName string, ingressConfig IngressConfig, rt *dynamic.Router, conf *dynamic.Configuration) {
 	rewrite := ptr.Deref(ingressConfig.RewriteTarget, "")
 	if rewrite == "" || rulePath == "" {
@@ -1689,7 +1683,6 @@ func applyRewriteTargetConfiguration(rulePath, routerName string, ingressConfig 
 
 	rewriteTargetMiddlewareName := routerName + "-rewrite-target"
 	regex := rulePath
-	isFullURLRewrite := isFullURL(rewrite)
 	hasCaptureGroup := strings.Contains(regex, "(")
 
 	if regex != "" {
@@ -1700,7 +1693,7 @@ func applyRewriteTargetConfiguration(rulePath, routerName string, ingressConfig 
 	// When rewrite-target is a full URL and there's no capture group,
 	// append .* to match the entire path and avoid leaking unmatched suffix.
 	// See https://github.com/traefik/traefik/issues/12931
-	if isFullURLRewrite && !hasCaptureGroup {
+	if parsed, err := url.Parse(rulePath); err == nil && parsed.Scheme != "" && !hasCaptureGroup {
 		regex += ".*"
 	}
 
@@ -2321,6 +2314,11 @@ func buildRule(ctx context.Context, host string, pa netv1.HTTPIngressPath, confi
 	if len(pa.Path) > 0 {
 		pathType := ptr.Deref(pa.PathType, netv1.PathTypePrefix)
 		if pathType == netv1.PathTypeImplementationSpecific {
+			pathType = netv1.PathTypePrefix
+		}
+
+		// When rewrite-target annotation is on the ingress, we should match the whole request path.
+		if pathType == netv1.PathTypeExact && config.RewriteTarget != nil {
 			pathType = netv1.PathTypePrefix
 		}
 

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
@@ -1669,9 +1669,16 @@ func (p *Provider) applyCustomHeaders(namespace, routerName string, ingressConfi
 	return nil
 }
 
+// To validate full URL in rewrite target.
+var urlSchemeRegex = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.-]*://`)
+
+func isFullURL(value string) bool {
+	return urlSchemeRegex.MatchString(value)
+}
+
 func applyRewriteTargetConfiguration(rulePath, routerName string, ingressConfig IngressConfig, rt *dynamic.Router, conf *dynamic.Configuration) {
 	rewrite := ptr.Deref(ingressConfig.RewriteTarget, "")
-	if rewrite == "" {
+	if rewrite == "" || rulePath == "" {
 		return
 	}
 
@@ -1682,9 +1689,19 @@ func applyRewriteTargetConfiguration(rulePath, routerName string, ingressConfig 
 
 	rewriteTargetMiddlewareName := routerName + "-rewrite-target"
 	regex := rulePath
+	isFullURLRewrite := isFullURL(rewrite)
+	hasCaptureGroup := strings.Contains(regex, "(")
+
 	if regex != "" {
 		// Location modifier regex on ingress-nginx is case-insensitive.
 		regex = "(?i)" + regex
+	}
+
+	// When rewrite-target is a full URL and there's no capture group,
+	// append .* to match the entire path and avoid leaking unmatched suffix.
+	// See https://github.com/traefik/traefik/issues/12931
+	if isFullURLRewrite && !hasCaptureGroup {
+		regex += ".*"
 	}
 
 	// The usage of rewrite-target annotation implies the usage of regex.

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
@@ -8,7 +8,6 @@ import (
 	"math"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"regexp"
 	"slices"
@@ -1672,7 +1671,7 @@ func (p *Provider) applyCustomHeaders(namespace, routerName string, ingressConfi
 
 func applyRewriteTargetConfiguration(rulePath, routerName string, ingressConfig IngressConfig, rt *dynamic.Router, conf *dynamic.Configuration) {
 	rewrite := ptr.Deref(ingressConfig.RewriteTarget, "")
-	if rewrite == "" || rulePath == "" {
+	if rewrite == "" {
 		return
 	}
 
@@ -1681,25 +1680,9 @@ func applyRewriteTargetConfiguration(rulePath, routerName string, ingressConfig 
 		return
 	}
 
-	rewriteTargetMiddlewareName := routerName + "-rewrite-target"
-	regex := rulePath
-	hasCaptureGroup := strings.Contains(regex, "(")
-
-	if regex != "" {
-		// Location modifier regex on ingress-nginx is case-insensitive.
-		regex = "(?i)" + regex
-	}
-
-	// When rewrite-target is a full URL and there's no capture group,
-	// append .* to match the entire path and avoid leaking unmatched suffix.
-	// See https://github.com/traefik/traefik/issues/12931
-	if parsed, err := url.Parse(rulePath); err == nil && parsed.Scheme != "" && !hasCaptureGroup {
-		regex += ".*"
-	}
-
 	// The usage of rewrite-target annotation implies the usage of regex.
 	rewriteTarget := &dynamic.RewriteTarget{
-		Regex:       regex,
+		Regex:       rulePath,
 		Replacement: rewrite,
 	}
 
@@ -1711,6 +1694,7 @@ func applyRewriteTargetConfiguration(rulePath, routerName string, ingressConfig 
 		}
 	}
 
+	rewriteTargetMiddlewareName := routerName + "-rewrite-target"
 	conf.HTTP.Middlewares[rewriteTargetMiddlewareName] = &dynamic.Middleware{
 		RewriteTarget: rewriteTarget,
 	}
@@ -2314,11 +2298,6 @@ func buildRule(ctx context.Context, host string, pa netv1.HTTPIngressPath, confi
 	if len(pa.Path) > 0 {
 		pathType := ptr.Deref(pa.PathType, netv1.PathTypePrefix)
 		if pathType == netv1.PathTypeImplementationSpecific {
-			pathType = netv1.PathTypePrefix
-		}
-
-		// When rewrite-target annotation is on the ingress, we should match the whole request path.
-		if pathType == netv1.PathTypeExact && config.RewriteTarget != nil {
 			pathType = netv1.PathTypePrefix
 		}
 

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -2964,7 +2964,7 @@ func TestLoadIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"default-ingress-with-x-forwarded-prefix-rule-0-path-0": {
 							EntryPoints: []string{"http"},
-							Rule:        `Host("x-forwarded-prefix.localhost") && Path("/")`,
+							Rule:        `Host("x-forwarded-prefix.localhost") && PathRegexp("(?i)^/")`,
 							RuleSyntax:  "default",
 							Middlewares: []string{"default-ingress-with-x-forwarded-prefix-rule-0-path-0-rewrite-target", "default-ingress-with-x-forwarded-prefix-rule-0-path-0-retry"},
 							Service:     "default-ingress-with-x-forwarded-prefix-whoami-80",
@@ -3015,7 +3015,7 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-x-forwarded-prefix-rule-0-path-0-tls": {
 							EntryPoints: []string{"https"},
-							Rule:        `Host("x-forwarded-prefix.localhost") && Path("/")`,
+							Rule:        `Host("x-forwarded-prefix.localhost") && PathRegexp("(?i)^/")`,
 							RuleSyntax:  "default",
 							Middlewares: []string{"default-ingress-with-x-forwarded-prefix-rule-0-path-0-tls-rewrite-target", "default-ingress-with-x-forwarded-prefix-rule-0-path-0-tls-retry"},
 							Service:     "default-ingress-with-x-forwarded-prefix-whoami-80",
@@ -3898,7 +3898,7 @@ func TestLoadIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"default-ingress-with-rewrite-target-no-regex-rule-0-path-0": {
 							EntryPoints: []string{"http"},
-							Rule:        `Host("rewrite-target-no-regex.localhost") && Path("/original")`,
+							Rule:        `Host("rewrite-target-no-regex.localhost") && PathRegexp("(?i)^/original")`,
 							RuleSyntax:  "default",
 							Service:     "default-ingress-with-rewrite-target-no-regex-whoami-80",
 							Observability: &dynamic.RouterObservabilityConfig{
@@ -3918,7 +3918,7 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-rewrite-target-no-regex-rule-0-path-0-tls": {
 							EntryPoints: []string{"https"},
-							Rule:        `Host("rewrite-target-no-regex.localhost") && Path("/original")`,
+							Rule:        `Host("rewrite-target-no-regex.localhost") && PathRegexp("(?i)^/original")`,
 							RuleSyntax:  "default",
 							Service:     "default-ingress-with-rewrite-target-no-regex-whoami-80",
 							Observability: &dynamic.RouterObservabilityConfig{

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -2964,7 +2964,7 @@ func TestLoadIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"default-ingress-with-x-forwarded-prefix-rule-0-path-0": {
 							EntryPoints: []string{"http"},
-							Rule:        `Host("x-forwarded-prefix.localhost") && PathRegexp("(?i)^/")`,
+							Rule:        `Host("x-forwarded-prefix.localhost") && Path("/")`,
 							RuleSyntax:  "default",
 							Middlewares: []string{"default-ingress-with-x-forwarded-prefix-rule-0-path-0-rewrite-target", "default-ingress-with-x-forwarded-prefix-rule-0-path-0-retry"},
 							Service:     "default-ingress-with-x-forwarded-prefix-whoami-80",
@@ -3015,7 +3015,7 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-x-forwarded-prefix-rule-0-path-0-tls": {
 							EntryPoints: []string{"https"},
-							Rule:        `Host("x-forwarded-prefix.localhost") && PathRegexp("(?i)^/")`,
+							Rule:        `Host("x-forwarded-prefix.localhost") && Path("/")`,
 							RuleSyntax:  "default",
 							Middlewares: []string{"default-ingress-with-x-forwarded-prefix-rule-0-path-0-tls-rewrite-target", "default-ingress-with-x-forwarded-prefix-rule-0-path-0-tls-retry"},
 							Service:     "default-ingress-with-x-forwarded-prefix-whoami-80",
@@ -3071,14 +3071,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-x-forwarded-prefix-three-groups-rule-0-path-0-rewrite-target": {
 							RewriteTarget: &dynamic.RewriteTarget{
-								Regex:            "(?i)/(prefix)/(sub)/(.*)",
+								Regex:            "/(prefix)/(sub)/(.*)",
 								Replacement:      "/$3",
 								XForwardedPrefix: "/$1/$2",
 							},
 						},
 						"default-ingress-with-x-forwarded-prefix-three-groups-rule-0-path-0-tls-rewrite-target": {
 							RewriteTarget: &dynamic.RewriteTarget{
-								Regex:            "(?i)/(prefix)/(sub)/(.*)",
+								Regex:            "/(prefix)/(sub)/(.*)",
 								Replacement:      "/$3",
 								XForwardedPrefix: "/$1/$2",
 							},
@@ -3095,14 +3095,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-x-forwarded-prefix-rule-0-path-0-rewrite-target": {
 							RewriteTarget: &dynamic.RewriteTarget{
-								Regex:            "(?i)/",
+								Regex:            "/",
 								Replacement:      "/path",
 								XForwardedPrefix: "x-forwarded-prefix-header-value",
 							},
 						},
 						"default-ingress-with-x-forwarded-prefix-rule-0-path-0-tls-rewrite-target": {
 							RewriteTarget: &dynamic.RewriteTarget{
-								Regex:            "(?i)/",
+								Regex:            "/",
 								Replacement:      "/path",
 								XForwardedPrefix: "x-forwarded-prefix-header-value",
 							},
@@ -3119,14 +3119,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-x-forwarded-prefix-regex-rule-0-path-0-rewrite-target": {
 							RewriteTarget: &dynamic.RewriteTarget{
-								Regex:            "(?i)/(something)(/.+)",
+								Regex:            "/(something)(/.+)",
 								Replacement:      "$2",
 								XForwardedPrefix: "$1",
 							},
 						},
 						"default-ingress-with-x-forwarded-prefix-regex-rule-0-path-0-tls-rewrite-target": {
 							RewriteTarget: &dynamic.RewriteTarget{
-								Regex:            "(?i)/(something)(/.+)",
+								Regex:            "/(something)(/.+)",
 								Replacement:      "$2",
 								XForwardedPrefix: "$1",
 							},
@@ -3782,13 +3782,13 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-rewrite-target-rule-0-path-0-rewrite-target": {
 							RewriteTarget: &dynamic.RewriteTarget{
-								Regex:       "(?i)/something(/|$)(.*)",
+								Regex:       "/something(/|$)(.*)",
 								Replacement: "/$2",
 							},
 						},
 						"default-ingress-with-rewrite-target-rule-0-path-0-tls-rewrite-target": {
 							RewriteTarget: &dynamic.RewriteTarget{
-								Regex:       "(?i)/something(/|$)(.*)",
+								Regex:       "/something(/|$)(.*)",
 								Replacement: "/$2",
 							},
 						},
@@ -3898,7 +3898,7 @@ func TestLoadIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"default-ingress-with-rewrite-target-no-regex-rule-0-path-0": {
 							EntryPoints: []string{"http"},
-							Rule:        `Host("rewrite-target-no-regex.localhost") && PathRegexp("(?i)^/original")`,
+							Rule:        `Host("rewrite-target-no-regex.localhost") && Path("/original")`,
 							RuleSyntax:  "default",
 							Service:     "default-ingress-with-rewrite-target-no-regex-whoami-80",
 							Observability: &dynamic.RouterObservabilityConfig{
@@ -3918,7 +3918,7 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-rewrite-target-no-regex-rule-0-path-0-tls": {
 							EntryPoints: []string{"https"},
-							Rule:        `Host("rewrite-target-no-regex.localhost") && PathRegexp("(?i)^/original")`,
+							Rule:        `Host("rewrite-target-no-regex.localhost") && Path("/original")`,
 							RuleSyntax:  "default",
 							Service:     "default-ingress-with-rewrite-target-no-regex-whoami-80",
 							Observability: &dynamic.RouterObservabilityConfig{
@@ -3941,13 +3941,13 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-rewrite-target-no-regex-rule-0-path-0-rewrite-target": {
 							RewriteTarget: &dynamic.RewriteTarget{
-								Regex:       "(?i)/original",
+								Regex:       "/original",
 								Replacement: "/rewritten",
 							},
 						},
 						"default-ingress-with-rewrite-target-no-regex-rule-0-path-0-tls-rewrite-target": {
 							RewriteTarget: &dynamic.RewriteTarget{
-								Regex:       "(?i)/original",
+								Regex:       "/original",
 								Replacement: "/rewritten",
 							},
 						},
@@ -4093,13 +4093,13 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-a-with-rewrite-target-rule-0-path-0-rewrite-target": {
 							RewriteTarget: &dynamic.RewriteTarget{
-								Regex:       "(?i)/something(/|$)(.*)",
+								Regex:       "/something(/|$)(.*)",
 								Replacement: "/$2",
 							},
 						},
 						"default-ingress-a-with-rewrite-target-rule-0-path-0-tls-rewrite-target": {
 							RewriteTarget: &dynamic.RewriteTarget{
-								Regex:       "(?i)/something(/|$)(.*)",
+								Regex:       "/something(/|$)(.*)",
 								Replacement: "/$2",
 							},
 						},
@@ -4265,13 +4265,13 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-a-with-rewrite-target-rule-0-path-0-rewrite-target": {
 							RewriteTarget: &dynamic.RewriteTarget{
-								Regex:       "(?i)/something(/|$)(.*)",
+								Regex:       "/something(/|$)(.*)",
 								Replacement: "/$2",
 							},
 						},
 						"default-ingress-a-with-rewrite-target-rule-0-path-0-tls-rewrite-target": {
 							RewriteTarget: &dynamic.RewriteTarget{
-								Regex:       "(?i)/something(/|$)(.*)",
+								Regex:       "/something(/|$)(.*)",
 								Replacement: "/$2",
 							},
 						},
@@ -4402,13 +4402,13 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-rewrite-target-use-regex-false-rule-0-path-0-rewrite-target": {
 							RewriteTarget: &dynamic.RewriteTarget{
-								Regex:       "(?i)/something(/|$)(.*)",
+								Regex:       "/something(/|$)(.*)",
 								Replacement: "/$2",
 							},
 						},
 						"default-ingress-with-rewrite-target-use-regex-false-rule-0-path-0-tls-rewrite-target": {
 							RewriteTarget: &dynamic.RewriteTarget{
-								Regex:       "(?i)/something(/|$)(.*)",
+								Regex:       "/something(/|$)(.*)",
 								Replacement: "/$2",
 							},
 						},


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This PR fixes the `rewrite-target` annotation when there is a full URL, and the ingress path doesn't contain a regex (`pathType: Prefix`).

### Motivation

<!-- What inspired you to submit this pull request? -->
Partially fix https://github.com/traefik/traefik/issues/12982
Closes https://github.com/traefik/traefik/issues/12931

### More

~- [x] Added/updated tests~ (see the e2e tests in the ingress-nginx-migration tool)
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
It doesn't fix the other issue mentioned with the redirection status code. This requires more refactoring and discussions. (case B)