### PR TITLE
Inject active span context into request headers for plugin middlewares

### DIFF
--- a/pkg/middlewares/observability/entrypoint.go
+++ b/pkg/middlewares/observability/entrypoint.go
@@ -67,6 +67,11 @@ func (e *entryPointTracing) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 
 	req = req.WithContext(loggerCtx)
 
+	// Inject the active span context into the request headers so downstream
+	// middlewares (notably plugins) can propagate trace context on outbound
+	// requests they make.
+	tracing.InjectContextIntoCarrier(req)
+
 	span.SetAttributes(attribute.String("entry_point", e.entryPoint))
 
 	e.tracer.CaptureServerRequest(span, req)

--- a/pkg/middlewares/observability/entrypoint_test.go
+++ b/pkg/middlewares/observability/entrypoint_test.go
@@ -8,7 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/traefik/traefik/v3/pkg/observability/tracing"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
 )
 
 func TestEntryPointMiddleware_tracing(t *testing.T) {
@@ -110,4 +112,27 @@ func TestEntryPointMiddleware_tracing(t *testing.T) {
 			assert.Equal(t, test.expected.attributes, tracer.spans[0].attributes)
 		})
 	}
+}
+
+func TestEntryPointMiddleware_injectsTraceparent(t *testing.T) {
+	prevPropagator := otel.GetTextMapPropagator()
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() { otel.SetTextMapPropagator(prevPropagator) })
+
+	req := httptest.NewRequest(http.MethodGet, "http://www.test.com/", nil)
+	rw := httptest.NewRecorder()
+
+	var gotTraceparent string
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotTraceparent = r.Header.Get("traceparent")
+	})
+
+	req = req.WithContext(WithObservability(req.Context(), Observability{TracingEnabled: true}))
+
+	handler := newEntryPoint(t.Context(), tracing.NewTracer(&mockTracer{}, nil, nil, nil), "test", next)
+	handler.ServeHTTP(rw, req)
+
+	// mockSpan returns TraceID{1}/SpanID{1}, which the W3C TraceContext
+	// propagator serializes as: 00-<traceid hex>-<spanid hex>-<flags>.
+	assert.Equal(t, "00-01000000000000000000000000000000-0100000000000000-00", gotTraceparent)
 }

--- a/pkg/middlewares/observability/middleware.go
+++ b/pkg/middlewares/observability/middleware.go
@@ -60,6 +60,11 @@ func (w *middlewareTracing) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 
 		req = req.WithContext(tracingCtx)
 
+		// Inject the active span context into the request headers so the
+		// wrapped middleware (notably plugins) can propagate trace context on
+		// outbound requests they make.
+		tracing.InjectContextIntoCarrier(req)
+
 		span.SetAttributes(attribute.String("traefik.middleware.name", w.name))
 	}
 

--- a/pkg/middlewares/observability/middleware_test.go
+++ b/pkg/middlewares/observability/middleware_test.go
@@ -1,0 +1,63 @@
+package observability
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/traefik/traefik/v3/pkg/observability/tracing"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestMiddlewareTracing_injectsTraceparent(t *testing.T) {
+	prevPropagator := otel.GetTextMapPropagator()
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() { otel.SetTextMapPropagator(prevPropagator) })
+
+	tracer := tracing.NewTracer(&mockTracer{}, nil, nil, nil)
+	ctx, span := tracer.Start(t.Context(), "entry", trace.WithSpanKind(trace.SpanKindServer))
+	defer span.End()
+
+	ctx = WithObservability(ctx, Observability{TracingEnabled: true, DetailedTracingEnabled: true})
+
+	req := httptest.NewRequest(http.MethodGet, "http://www.test.com/", nil).WithContext(ctx)
+	rw := httptest.NewRecorder()
+
+	var gotTraceparent string
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotTraceparent = r.Header.Get("traceparent")
+	})
+
+	NewMiddleware(next, "my-middleware", "MyType").ServeHTTP(rw, req)
+
+	// mockSpan returns TraceID{1}/SpanID{1}, which the W3C TraceContext
+	// propagator serializes as: 00-<traceid hex>-<spanid hex>-<flags>.
+	assert.Equal(t, "00-01000000000000000000000000000000-0100000000000000-00", gotTraceparent)
+}
+
+func TestMiddlewareTracing_skipsWhenDetailedTracingDisabled(t *testing.T) {
+	prevPropagator := otel.GetTextMapPropagator()
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() { otel.SetTextMapPropagator(prevPropagator) })
+
+	tracer := tracing.NewTracer(&mockTracer{}, nil, nil, nil)
+	ctx, span := tracer.Start(t.Context(), "entry", trace.WithSpanKind(trace.SpanKindServer))
+	defer span.End()
+
+	ctx = WithObservability(ctx, Observability{TracingEnabled: true, DetailedTracingEnabled: false})
+
+	req := httptest.NewRequest(http.MethodGet, "http://www.test.com/", nil).WithContext(ctx)
+	rw := httptest.NewRecorder()
+
+	var gotTraceparent string
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotTraceparent = r.Header.Get("traceparent")
+	})
+
+	NewMiddleware(next, "my-middleware", "MyType").ServeHTTP(rw, req)
+
+	assert.Empty(t, gotTraceparent)
+}


### PR DESCRIPTION
Before this change, traefik created a trace span for each incoming request but did not propagate the resulting traceparent/tracestate through the request headers. Downstream middlewares - particularly plugins that read raw headers to propagate trace context on outbound calls - never saw the active span, causing orphaned traces in distributed tracing setups.

Inject the active span context into the request headers in the tracing entry point and in the per-middleware tracing wrapper so plugins making outbound calls can propagate trace context correctly.

closes #12891

<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Injects the active span context into request headers inside the tracing
entry point and the per-middleware tracing wrapper, so plugin middlewares
that read raw headers (e.g. to propagate trace context on outbound calls
they make themselves) see the correct `traceparent` / `tracestate`.

Previously, traefik started a span per request but only injected its
headers on the outbound proxied request in the RoundTripper
(`pkg/proxy/httputil/observability.go`). Plugin middlewares making
side-band HTTP calls never saw the active span, producing orphaned
traces in distributed setups.

### Motivation

<!-- What inspired you to submit this pull request? -->
Looking to get commits into golang repos with high traffic.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

**Behavioral change to be aware of:** any inbound `traceparent` /
`tracestate` headers on the request are now overwritten before
downstream middlewares run. This is the correct W3C semantics
(downstream should see the current span, not the client's parent
span), and matches what the outbound RoundTripper already does - but
it is a visible change for any middleware that introspects those
headers directly.

The middleware-side injection is gated on `DetailedTracingEnabled`,
so when detailed tracing is off, plugins see the entry-point span's
`traceparent` (not a per-middleware one).