### PR TITLE
Make FLAGS Make variable usable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ generate:
 #? binary: Build the binary
 binary: generate-webui dist
 	@echo SHA: $(VERSION) $(CODENAME) $(DATE)
-	CGO_ENABLED=0 GOGC=${GOGC} GOOS=${GOOS} GOARCH=${GOARCH} go build ${FLAGS[*]} -ldflags "-s -w \
+	CGO_ENABLED=0 GOGC=${GOGC} GOOS=${GOOS} GOARCH=${GOARCH} go build ${FLAGS} -ldflags "-s -w \
     -X github.com/traefik/traefik/v2/pkg/version.Version=$(VERSION) \
     -X github.com/traefik/traefik/v2/pkg/version.Codename=$(CODENAME) \
     -X github.com/traefik/traefik/v2/pkg/version.BuildDate=$(DATE)" \


### PR DESCRIPTION
### What does this PR do?

Strip the [*] suffix, so it's usable in the expected way when invoking make, e.g. like so: `make FLAGS=-trimpath`.

### Motivation

Previously, it was using the bash array syntax, which has no special meaning at all in a Makefile. Using something like `make FLAGS[*]=-trimpath` worked, but that doesn't seem intentional.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Fixes: 39b0aa665 ("Improve makefile")
