### PR TITLE
docs: fix duplicate "the the" typo in api-dashboard reference

### DIFF
--- a/docs/content/reference/install-configuration/api-dashboard.md
+++ b/docs/content/reference/install-configuration/api-dashboard.md
@@ -222,7 +222,7 @@ The dashboard is available by default on the path  `/dashboard/`.
 
 !!! note
 
-    - The trailing slash `/` in `/dashboard/` is mandatory. This limitation can be mitigated using the the [RedirectRegex Middleware](../../reference/routing-configuration/http/middlewares/redirectregex.md).
+    - The trailing slash `/` in `/dashboard/` is mandatory. This limitation can be mitigated using the [RedirectRegex Middleware](../../reference/routing-configuration/http/middlewares/redirectregex.md).
 	  - There is also a redirect from the path `/` to `/dashboard/`, but you should not rely on this behavior, as it is subject to change and may complicate routing rules.
 
 As mentioned above in the [Security](#security) section, it is important to secure access to both the dashboard and the API.


### PR DESCRIPTION

**Repo:** traefik/traefik (⭐ 49000)
**Type:** docs
**Files changed:** 1
**Lines:** +1/-1

## What
Fixes a small grammatical typo ("the the") in `docs/content/reference/install-configuration/api-dashboard.md`, where the dashboard trailing-slash note links to the RedirectRegex Middleware. The duplicate article is removed so the sentence reads "mitigated using the [RedirectRegex Middleware]".

## Why
The duplicate word is visible in the rendered Traefik documentation (api-dashboard reference page). It is a trivial readability defect, and was the only `the the` occurrence found across the `docs/` tree. No code paths or configuration semantics are affected.

## Testing
- Visual diff inspection of the changed Markdown line.
- Repo-wide `grep` confirms no other `the the` occurrences remain in `docs/`.
- No build/test impact: docs-only change.

## Risk
Low — single-word documentation fix, no code or config touched.
