### PR TITLE
Handle duplicate server-alias on ingress-nginx provider

### DIFF
--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-server-alias-alias-conflict.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-server-alias-alias-conflict.yml
@@ -1,0 +1,43 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: first-ingress
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/server-alias: "shared.localhost"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: first.localhost
+      http:
+        paths:
+          - backend:
+              service:
+                name: whoami
+                port:
+                  number: 80
+            path: /
+            pathType: Prefix
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: second-ingress
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/server-alias: "shared.localhost"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: second.localhost
+      http:
+        paths:
+          - backend:
+              service:
+                name: whoami
+                port:
+                  number: 80
+            path: /
+            pathType: Prefix

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"regexp"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -481,29 +482,23 @@ func (p *Provider) loadConfiguration(ctx context.Context) *dynamic.Configuration
 
 	// Sort the ingresses by creation timestamps, to help to decide when two ingresses have the same server-alias value.
 	listedIngresses := p.k8sClient.ListIngresses()
-	slices.SortStableFunc(listedIngresses, func(a, b *netv1.Ingress) int {
-		ta, tb := a.CreationTimestamp.Time, b.CreationTimestamp.Time
-
-		if !ta.Equal(tb) {
-			if ta.Before(tb) {
-				return -1
-			}
-			return 1
-		}
+	sort.SliceStable(listedIngresses, func(a, b int) bool {
+		ta, tb := listedIngresses[a].CreationTimestamp, listedIngresses[b].CreationTimestamp
 
 		// When the timestamp is exactly the same, fallback to descending namespace/name lexicographic order.
 		// The same fallback and debug log with ingress-nginx.
 		// Ref: https://github.com/kubernetes/ingress-nginx/blob/main/internal/ingress/controller/store/store.go#L1102-L1115.
-		ia, ib := a.Namespace+"/"+a.Name, b.Namespace+"/"+b.Name
-		log.Ctx(ctx).Debug().
-			Str("ingress_a", ia).
-			Str("ingress_b", ib).
-			Msg("Ingresses have identical CreationTimestamp, falling back to lexicographic ordering")
-
-		if ia > ib {
-			return -1
+		if ta.Equal(&tb) {
+			ia := fmt.Sprintf("%v/%v", listedIngresses[a].Namespace, listedIngresses[a].Name)
+			ib := fmt.Sprintf("%v/%v", listedIngresses[b].Namespace, listedIngresses[b].Name)
+			log.Ctx(ctx).Debug().
+				Str("ingress_a", ia).
+				Str("ingress_b", ib).
+				Msg("Ingresses have identical CreationTimestamp, falling back to lexicographic ordering")
+			return ia > ib
 		}
-		return 1
+
+		return ta.Before(&tb)
 	})
 
 	hosts := make(map[string]bool)
@@ -575,13 +570,10 @@ func (p *Provider) loadConfiguration(ctx context.Context) *dynamic.Configuration
 			}
 		}
 
-		if i.IngressConfig.ServerAlias != nil {
-			key := i.Namespace + "/" + i.Name
-			for _, alias := range *i.IngressConfig.ServerAlias {
-				serverAlias := strings.ToLower(alias)
-				if _, exist := claimedAliases[serverAlias]; !exist {
-					claimedAliases[serverAlias] = key
-				}
+		for _, alias := range ptr.Deref(i.IngressConfig.ServerAlias, nil) {
+			serverAlias := strings.ToLower(alias)
+			if _, exist := claimedAliases[serverAlias]; !exist {
+				claimedAliases[serverAlias] = i.Namespace + "/" + i.Name
 			}
 		}
 

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
@@ -489,12 +489,12 @@ func (p *Provider) loadConfiguration(ctx context.Context) *dynamic.Configuration
 		// The same fallback and debug log with ingress-nginx.
 		// Ref: https://github.com/kubernetes/ingress-nginx/blob/main/internal/ingress/controller/store/store.go#L1102-L1115.
 		if ta.Equal(&tb) {
-			ia := fmt.Sprintf("%v/%v", listedIngresses[a].Namespace, listedIngresses[a].Name)
-			ib := fmt.Sprintf("%v/%v", listedIngresses[b].Namespace, listedIngresses[b].Name)
+			ia := listedIngresses[a].Namespace + "/" + listedIngresses[a].Name
+			ib := listedIngresses[b].Namespace + "/" + listedIngresses[b].Name
 			log.Ctx(ctx).Debug().
 				Str("ingress_a", ia).
 				Str("ingress_b", ib).
-				Msg("Ingresses have identical CreationTimestamp, falling back to lexicographic ordering")
+				Msg("Ingresses have identical CreationTimestamp, falling back to descending namespace/name lexicographic order")
 			return ia > ib
 		}
 

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
@@ -869,7 +869,7 @@ func (p *Provider) loadConfiguration(ctx context.Context) *dynamic.Configuration
 
 				rt := &dynamic.Router{
 					EntryPoints: p.NonTLSEntryPoints,
-					Rule:        buildRule(ctxIngress, rule.Host, pa, ingress.IngressConfig, hosts, hostsWithUseRegex, claimedAliases, ingress.Namespace+"/"+ingress.Name),
+					Rule:        buildRule(ctxIngress, ingress, rule.Host, pa, hosts, hostsWithUseRegex, claimedAliases),
 					// "default" stands for the default rule syntax in Traefik v3, i.e. the v3 syntax.
 					RuleSyntax:    "default",
 					Service:       serviceName,
@@ -2300,26 +2300,27 @@ func basicAuthUsers(secret *corev1.Secret, authSecretType string) (dynamic.Users
 	return users, nil
 }
 
-func buildRule(ctx context.Context, host string, pa netv1.HTTPIngressPath, config IngressConfig, allHosts map[string]bool, hostsWithUseRegex map[string]bool, claimedAliases map[string]string, ingressKey string) string {
+func buildRule(ctx context.Context, ingress ingress, host string, pa netv1.HTTPIngressPath, allHosts map[string]bool, hostsWithUseRegex map[string]bool, claimedAliases map[string]string) string {
 	var rules []string
 	if host != "" {
 		hosts := []string{host}
-		if config.ServerAlias != nil {
-			for _, alias := range *config.ServerAlias {
-				serverAlias := strings.ToLower(alias)
-				if _, ok := allHosts[serverAlias]; ok {
-					log.Ctx(ctx).Debug().
-						Str("alias", alias).
-						Msg("Skipping server-alias because it is already defined as a host in another Ingress")
-					continue
-				}
-				if owner, ok := claimedAliases[serverAlias]; ok && owner != ingressKey {
-					log.Ctx(ctx).Debug().Str("alias", alias).Str("ingress", ingressKey).
-						Msgf("Skipping server-alias because it is already claimed by %s Ingress", owner)
-					continue
-				}
-				hosts = append(hosts, alias)
+		for _, alias := range ptr.Deref(ingress.IngressConfig.ServerAlias, nil) {
+			serverAlias := strings.ToLower(alias)
+			if _, ok := allHosts[serverAlias]; ok {
+				log.Ctx(ctx).Debug().
+					Str("alias", alias).
+					Msg("Skipping server-alias because it is already defined as a host in another Ingress")
+				continue
 			}
+			ingressKey := ingress.Namespace + "/" + ingress.Name
+			if owner, ok := claimedAliases[serverAlias]; ok && owner != ingressKey {
+				log.Ctx(ctx).Debug().
+					Str("alias", alias).
+					Str("ingress", ingressKey).
+					Msgf("Skipping server-alias because it is already claimed by %s Ingress", owner)
+				continue
+			}
+			hosts = append(hosts, alias)
 		}
 
 		var hostRules []string

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
@@ -479,11 +479,42 @@ func (p *Provider) loadConfiguration(ctx context.Context) *dynamic.Configuration
 		canaryIngresses []ingress
 	)
 
+	// Sort the ingresses by creation timestamps, to help to decide when two ingresses have the same server-alias value.
+	listedIngresses := p.k8sClient.ListIngresses()
+	slices.SortStableFunc(listedIngresses, func(a, b *netv1.Ingress) int {
+		ta, tb := a.CreationTimestamp.Time, b.CreationTimestamp.Time
+
+		if !ta.Equal(tb) {
+			if ta.Before(tb) {
+				return -1
+			}
+			return 1
+		}
+
+		// When the timestamp is exactly the same, fallback to descending namespace/name lexicographic order.
+		// The same fallback and debug log with ingress-nginx.
+		// Ref: https://github.com/kubernetes/ingress-nginx/blob/main/internal/ingress/controller/store/store.go#L1102-L1115.
+		ia, ib := a.Namespace+"/"+a.Name, b.Namespace+"/"+b.Name
+		log.Ctx(ctx).Debug().
+			Str("ingress_a", ia).
+			Str("ingress_b", ib).
+			Msg("Ingresses have identical CreationTimestamp, falling back to lexicographic ordering")
+
+		if ia > ib {
+			return -1
+		}
+		return 1
+	})
+
 	hosts := make(map[string]bool)
 	hostsWithUseRegex := make(map[string]bool)
 	serverSnippets := make(map[string]string)
 	ingressPaths := make(map[string]ingressPath) // indexed by namespace+host+path+pathType.
-	for _, ing := range p.k8sClient.ListIngresses() {
+	// Build a map of claimed server-aliases: the first ingress (by creation time) to
+	// declare an alias owns it; any later ingress that repeats the same alias is denied.
+	claimedAliases := make(map[string]string)
+
+	for _, ing := range listedIngresses {
 		if !p.shouldProcessIngress(ing, ingressClasses) {
 			continue
 		}
@@ -540,6 +571,16 @@ func (p *Provider) loadConfiguration(ctx context.Context) *dynamic.Configuration
 						HTTPIngressPath: pa,
 						IngressConfig:   i.IngressConfig,
 					}
+				}
+			}
+		}
+
+		if i.IngressConfig.ServerAlias != nil {
+			key := i.Namespace + "/" + i.Name
+			for _, alias := range *i.IngressConfig.ServerAlias {
+				serverAlias := strings.ToLower(alias)
+				if _, exist := claimedAliases[serverAlias]; !exist {
+					claimedAliases[serverAlias] = key
 				}
 			}
 		}
@@ -836,7 +877,7 @@ func (p *Provider) loadConfiguration(ctx context.Context) *dynamic.Configuration
 
 				rt := &dynamic.Router{
 					EntryPoints: p.NonTLSEntryPoints,
-					Rule:        buildRule(ctxIngress, rule.Host, pa, ingress.IngressConfig, hosts, hostsWithUseRegex),
+					Rule:        buildRule(ctxIngress, rule.Host, pa, ingress.IngressConfig, hosts, hostsWithUseRegex, claimedAliases, ingress.Namespace+"/"+ingress.Name),
 					// "default" stands for the default rule syntax in Traefik v3, i.e. the v3 syntax.
 					RuleSyntax:    "default",
 					Service:       serviceName,
@@ -2267,16 +2308,22 @@ func basicAuthUsers(secret *corev1.Secret, authSecretType string) (dynamic.Users
 	return users, nil
 }
 
-func buildRule(ctx context.Context, host string, pa netv1.HTTPIngressPath, config IngressConfig, allHosts map[string]bool, hostsWithUseRegex map[string]bool) string {
+func buildRule(ctx context.Context, host string, pa netv1.HTTPIngressPath, config IngressConfig, allHosts map[string]bool, hostsWithUseRegex map[string]bool, claimedAliases map[string]string, ingressKey string) string {
 	var rules []string
 	if host != "" {
 		hosts := []string{host}
 		if config.ServerAlias != nil {
 			for _, alias := range *config.ServerAlias {
-				if _, ok := allHosts[strings.ToLower(alias)]; ok {
+				serverAlias := strings.ToLower(alias)
+				if _, ok := allHosts[serverAlias]; ok {
 					log.Ctx(ctx).Debug().
 						Str("alias", alias).
 						Msg("Skipping server-alias because it is already defined as a host in another Ingress")
+					continue
+				}
+				if owner, ok := claimedAliases[serverAlias]; ok && owner != ingressKey {
+					log.Ctx(ctx).Debug().Str("alias", alias).Str("ingress", ingressKey).
+						Msgf("Skipping server-alias because it is already claimed by %s Ingress", owner)
 					continue
 				}
 				hosts = append(hosts, alias)

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -10825,6 +10825,174 @@ func TestLoadIngresses(t *testing.T) {
 			},
 		},
 		{
+			desc: "Server Alias with Alias-Alias Conflict",
+			paths: []string{
+				"services.yml",
+				"ingressclasses.yml",
+				"ingresses/ingress-with-server-alias-alias-conflict.yml",
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-first-ingress-rule-0-path-0": {
+							EntryPoints: []string{"http"},
+							Rule:        `Host("first.localhost") && PathPrefix("/")`,
+							RuleSyntax:  "default",
+							Middlewares: []string{"default-first-ingress-rule-0-path-0-retry"},
+							Service:     "default-first-ingress-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "first-ingress",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+						},
+						"default-second-ingress-rule-0-path-0": {
+							EntryPoints: []string{"http"},
+							Rule:        `(Host("second.localhost") || Host("shared.localhost")) && PathPrefix("/")`,
+							RuleSyntax:  "default",
+							Middlewares: []string{"default-second-ingress-rule-0-path-0-retry"},
+							Service:     "default-second-ingress-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "second-ingress",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+						},
+						"default-first-ingress-rule-0-path-0-tls": {
+							EntryPoints: []string{"https"},
+							Rule:        `Host("first.localhost") && PathPrefix("/")`,
+							RuleSyntax:  "default",
+							Middlewares: []string{"default-first-ingress-rule-0-path-0-tls-retry"},
+							Service:     "default-first-ingress-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "first-ingress",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							TLS: &dynamic.RouterTLSConfig{},
+						},
+						"default-second-ingress-rule-0-path-0-tls": {
+							EntryPoints: []string{"https"},
+							Rule:        `(Host("second.localhost") || Host("shared.localhost")) && PathPrefix("/")`,
+							RuleSyntax:  "default",
+							Middlewares: []string{"default-second-ingress-rule-0-path-0-tls-retry"},
+							Service:     "default-second-ingress-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "second-ingress",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							TLS: &dynamic.RouterTLSConfig{},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-first-ingress-rule-0-path-0-retry": {
+							Retry: &dynamic.Retry{
+								Attempts: 3,
+							},
+						},
+						"default-first-ingress-rule-0-path-0-tls-retry": {
+							Retry: &dynamic.Retry{
+								Attempts: 3,
+							},
+						},
+						"default-second-ingress-rule-0-path-0-retry": {
+							Retry: &dynamic.Retry{
+								Attempts: 3,
+							},
+						},
+						"default-second-ingress-rule-0-path-0-tls-retry": {
+							Retry: &dynamic.Retry{
+								Attempts: 3,
+							},
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"unavailable-service": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+						"default-first-ingress-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{URL: "http://10.10.0.1:80"},
+									{URL: "http://10.10.0.2:80"},
+								},
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+								ServersTransport: "default-first-ingress",
+							},
+						},
+						"default-second-ingress-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{URL: "http://10.10.0.1:80"},
+									{URL: "http://10.10.0.2:80"},
+								},
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+								ServersTransport: "default-second-ingress",
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{
+						"default-first-ingress": {
+							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
+								DialTimeout:     ptypes.Duration(60 * time.Second),
+								ReadTimeout:     ptypes.Duration(60 * time.Second),
+								WriteTimeout:    ptypes.Duration(60 * time.Second),
+								IdleConnTimeout: ptypes.Duration(60 * time.Second),
+							},
+						},
+						"default-second-ingress": {
+							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
+								DialTimeout:     ptypes.Duration(60 * time.Second),
+								ReadTimeout:     ptypes.Duration(60 * time.Second),
+								WriteTimeout:    ptypes.Duration(60 * time.Second),
+								IdleConnTimeout: ptypes.Duration(60 * time.Second),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
 			desc: "Proxy HTTP version 1.1",
 			paths: []string{
 				"services.yml",


### PR DESCRIPTION
### What does this PR do?

This PR brings a fix so that when two ingresses have the same server alias, precedence is given to the ingress that was created first, as determined by its `CreationTimestamp`. If the ingresses have exactly the same timestamp, it falls back to descending lexicographic order based on namespace/name. This behavior matches that of ingress-nginx.


### Motivation

To have the same behavior as ingress-nginx.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

