### PR TITLE
Preserve request query on absolute-URL redirect

### DIFF
--- a/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target.go
+++ b/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target.go
@@ -112,16 +112,21 @@ func (rt *rewriteTarget) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	// Only issue a 302 redirect if the replacement template itself is an absolute URL.
 	// Prevent user-controlled capture group content from injecting an absolute URL redirect.
 	if rt.absoluteURLRedirect {
+		newTargetURL, err := url.Parse(newTarget)
+		if err != nil {
+			http.Error(rw, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
 		// Carry the incoming query string through the redirect so an
 		// absolute-URL rewrite behaves like ingress-nginx, which preserves
 		// query parameters on rewrite-target redirects. Only fill it in
 		// when the rewrite itself didn't supply one, matching the nginx
 		// precedence of rewrite-set query over request query.
-		if parsed.RawQuery == "" && req.URL.RawQuery != "" {
-			parsed.RawQuery = req.URL.RawQuery
-			newTarget = parsed.String()
+		if newTargetURL.RawQuery == "" && req.URL.RawQuery != "" {
+			newTargetURL.RawQuery = req.URL.RawQuery
 		}
-		http.Redirect(rw, req, newTarget, http.StatusFound)
+
+		http.Redirect(rw, req, newTargetURL.String(), http.StatusFound)
 		return
 	}
 

--- a/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target.go
+++ b/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target.go
@@ -112,6 +112,15 @@ func (rt *rewriteTarget) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	// Only issue a 302 redirect if the replacement template itself is an absolute URL.
 	// Prevent user-controlled capture group content from injecting an absolute URL redirect.
 	if rt.absoluteURLRedirect {
+		// Carry the incoming query string through the redirect so an
+		// absolute-URL rewrite behaves like ingress-nginx, which preserves
+		// query parameters on rewrite-target redirects. Only fill it in
+		// when the rewrite itself didn't supply one, matching the nginx
+		// precedence of rewrite-set query over request query.
+		if parsed.RawQuery == "" && req.URL.RawQuery != "" {
+			parsed.RawQuery = req.URL.RawQuery
+			newTarget = parsed.String()
+		}
 		http.Redirect(rw, req, newTarget, http.StatusFound)
 		return
 	}

--- a/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target_test.go
+++ b/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target_test.go
@@ -192,6 +192,24 @@ func TestRewriteTarget(t *testing.T) {
 			expectedStatusCode:  http.StatusFound,
 			expectedRedirectURL: "https://bar.example.org/",
 		},
+		{
+			desc: "full URL replacement preserves incoming query",
+			path: "/some/path?foo=bar&baz=qux",
+			config: dynamic.RewriteTarget{
+				Replacement: "https://bar.example.org/some/path",
+			},
+			expectedStatusCode:  http.StatusFound,
+			expectedRedirectURL: "https://bar.example.org/some/path?foo=bar&baz=qux",
+		},
+		{
+			desc: "full URL replacement keeps rewrite-supplied query over request query",
+			path: "/some/path?foo=bar",
+			config: dynamic.RewriteTarget{
+				Replacement: "https://bar.example.org/some/path?tenant=acme",
+			},
+			expectedStatusCode:  http.StatusFound,
+			expectedRedirectURL: "https://bar.example.org/some/path?tenant=acme",
+		},
 	}
 
 	for _, test := range testCases {

--- a/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target_test.go
+++ b/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target_test.go
@@ -210,6 +210,16 @@ func TestRewriteTarget(t *testing.T) {
 			expectedStatusCode:  http.StatusFound,
 			expectedRedirectURL: "https://bar.example.org/some/path?tenant=acme",
 		},
+		{
+			desc: "regex with full URL replacement and capture group preserves incoming query",
+			path: "/report/view/foo/bar?tenant=acme&id=42",
+			config: dynamic.RewriteTarget{
+				Regex:       `^/report/view/(.*)`,
+				Replacement: "https://portal.example.org/site/$1",
+			},
+			expectedStatusCode:  http.StatusFound,
+			expectedRedirectURL: "https://portal.example.org/site/foo/bar?tenant=acme&id=42",
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
## Summary

Fixes #12991.

ingress-nginx's `rewrite-target` annotation keeps the incoming query on both relative rewrites and absolute-URL redirects. In the Traefik port, `ServeHTTP` takes `currentPath = req.URL.RawPath` (or `req.URL.EscapedPath()`), which doesn't carry the query string, so when the replacement resolves to an absolute URL and Traefik issues a 302 the `Location` header is query-less. The reporter's capture group intentionally expected `$1` to cover both additional path segments and query; this fix reaches parity on the absolute-URL redirect path.

## Fix

After parsing `newTarget` in the absolute-URL branch of `pkg/middlewares/ingressnginx/rewritetarget/rewrite_target.go`, if the parsed URL has no query and the inbound request does, carry `req.URL.RawQuery` over. If the rewrite target already has a query (e.g. `Replacement: "https://bar.example.org/some/path?tenant=acme"`), the rewrite wins — matching nginx precedence.

## Tests

Two table-driven cases added to `TestRewriteTarget`:

- `full URL replacement preserves incoming query` — request `/some/path?foo=bar&baz=qux` with replacement `https://bar.example.org/some/path` now redirects to `https://bar.example.org/some/path?foo=bar&baz=qux` (previously the query was dropped).
- `full URL replacement keeps rewrite-supplied query over request query` — pins the precedence rule so the rewrite's query wins when both exist.

`go test ./pkg/middlewares/ingressnginx/rewritetarget/...` green; `go vet` clean. Relative (non-absolute) rewrites and the existing 302 test cases are untouched.
