### PR TITLE
Add errorRequestHeaders option to Errors middleware

### DIFF
--- a/docs/content/middlewares/http/errorpages.md
+++ b/docs/content/middlewares/http/errorpages.md
@@ -160,6 +160,6 @@ The table below lists all the available variables and their associated values.
 Defines the list of original request headers forwarded to the error page service.
 
 By default (`errorRequestHeaders` not set), all request headers — including authentication material such as `Authorization` and `Cookie` — are forwarded.
-If the error page service is a separate trust domain, use this option to restrict which headers cross the service boundary.
+If the error page service is in a separate trust domain, use this option to restrict which headers cross the service boundary.
 
 Set to an explicit list to forward only those headers, or set to an empty list (`errorRequestHeaders: []`) to forward no headers.

--- a/docs/content/middlewares/http/errorpages.md
+++ b/docs/content/middlewares/http/errorpages.md
@@ -24,6 +24,7 @@ labels:
   - "traefik.http.middlewares.test-errors.errors.status=500,501,503,505-599"
   - "traefik.http.middlewares.test-errors.errors.service=serviceError"
   - "traefik.http.middlewares.test-errors.errors.query=/{status}.html"
+  - "traefik.http.middlewares.test-errors.errors.forwardHeaders=X-Request-Id,Cookie"
 ```
 
 ```yaml tab="Kubernetes"
@@ -42,6 +43,9 @@ spec:
     service:
       name: whoami
       port: 80
+    forwardHeaders:
+      - "X-Request-Id"
+      - "Cookie"
 ```
 
 ```yaml tab="Consul Catalog"
@@ -49,13 +53,15 @@ spec:
 - "traefik.http.middlewares.test-errors.errors.status=500,501,503,505-599"
 - "traefik.http.middlewares.test-errors.errors.service=serviceError"
 - "traefik.http.middlewares.test-errors.errors.query=/{status}.html"
+- "traefik.http.middlewares.test-errors.errors.forwardHeaders=X-Request-Id,Cookie"
 ```
 
 ```json tab="Marathon"
 "labels": {
   "traefik.http.middlewares.test-errors.errors.status": "500,501,503,505-599",
   "traefik.http.middlewares.test-errors.errors.service": "serviceError",
-  "traefik.http.middlewares.test-errors.errors.query": "/{status}.html"
+  "traefik.http.middlewares.test-errors.errors.query": "/{status}.html",
+  "traefik.http.middlewares.test-errors.errors.forwardHeaders": "X-Request-Id,Cookie"
 }
 ```
 
@@ -65,6 +71,7 @@ labels:
   - "traefik.http.middlewares.test-errors.errors.status=500,501,503,505-599"
   - "traefik.http.middlewares.test-errors.errors.service=serviceError"
   - "traefik.http.middlewares.test-errors.errors.query=/{status}.html"
+  - "traefik.http.middlewares.test-errors.errors.forwardHeaders=X-Request-Id,Cookie"
 ```
 
 ```yaml tab="File (YAML)"
@@ -80,6 +87,9 @@ http:
           - "505-599"
         service: serviceError
         query: "/{status}.html"
+        forwardHeaders:
+          - "X-Request-Id"
+          - "Cookie"
 
   services:
     # ... definition of error-handler-service and my-service
@@ -92,6 +102,7 @@ http:
     status = ["500","501","503","505-599"]
     service = "serviceError"
     query = "/{status}.html"
+    forwardHeaders = ["X-Request-Id","Cookie"]
 
 [http.services]
   # ... definition of error-handler-service and my-service
@@ -143,3 +154,12 @@ The table below lists all the available variables and their associated values.
 |------------|--------------------------------------------------------------------|
 | `{status}` | The response status code.                                          |
 | `{url}`    | The [escaped](https://pkg.go.dev/net/url#QueryEscape) request URL. |
+
+### `forwardHeaders`
+
+Defines the list of original request headers forwarded to the error page service.
+
+By default (`forwardHeaders` not set), all request headers — including authentication material such as `Authorization` and `Cookie` — are forwarded.
+If the error page service is a separate trust domain, use this option to restrict which headers cross the service boundary.
+
+Set to an explicit list to forward only those headers, or set to an empty list (`forwardHeaders: []`) to forward no headers.

--- a/docs/content/middlewares/http/errorpages.md
+++ b/docs/content/middlewares/http/errorpages.md
@@ -24,7 +24,7 @@ labels:
   - "traefik.http.middlewares.test-errors.errors.status=500,501,503,505-599"
   - "traefik.http.middlewares.test-errors.errors.service=serviceError"
   - "traefik.http.middlewares.test-errors.errors.query=/{status}.html"
-  - "traefik.http.middlewares.test-errors.errors.forwardHeaders=X-Request-Id,Cookie"
+  - "traefik.http.middlewares.test-errors.errors.errorRequestHeaders=X-Request-Id,Cookie"
 ```
 
 ```yaml tab="Kubernetes"
@@ -43,7 +43,7 @@ spec:
     service:
       name: whoami
       port: 80
-    forwardHeaders:
+    errorRequestHeaders:
       - "X-Request-Id"
       - "Cookie"
 ```
@@ -53,7 +53,7 @@ spec:
 - "traefik.http.middlewares.test-errors.errors.status=500,501,503,505-599"
 - "traefik.http.middlewares.test-errors.errors.service=serviceError"
 - "traefik.http.middlewares.test-errors.errors.query=/{status}.html"
-- "traefik.http.middlewares.test-errors.errors.forwardHeaders=X-Request-Id,Cookie"
+- "traefik.http.middlewares.test-errors.errors.errorRequestHeaders=X-Request-Id,Cookie"
 ```
 
 ```json tab="Marathon"
@@ -61,7 +61,7 @@ spec:
   "traefik.http.middlewares.test-errors.errors.status": "500,501,503,505-599",
   "traefik.http.middlewares.test-errors.errors.service": "serviceError",
   "traefik.http.middlewares.test-errors.errors.query": "/{status}.html",
-  "traefik.http.middlewares.test-errors.errors.forwardHeaders": "X-Request-Id,Cookie"
+  "traefik.http.middlewares.test-errors.errors.errorRequestHeaders": "X-Request-Id,Cookie"
 }
 ```
 
@@ -71,7 +71,7 @@ labels:
   - "traefik.http.middlewares.test-errors.errors.status=500,501,503,505-599"
   - "traefik.http.middlewares.test-errors.errors.service=serviceError"
   - "traefik.http.middlewares.test-errors.errors.query=/{status}.html"
-  - "traefik.http.middlewares.test-errors.errors.forwardHeaders=X-Request-Id,Cookie"
+  - "traefik.http.middlewares.test-errors.errors.errorRequestHeaders=X-Request-Id,Cookie"
 ```
 
 ```yaml tab="File (YAML)"
@@ -87,7 +87,7 @@ http:
           - "505-599"
         service: serviceError
         query: "/{status}.html"
-        forwardHeaders:
+        errorRequestHeaders:
           - "X-Request-Id"
           - "Cookie"
 
@@ -102,7 +102,7 @@ http:
     status = ["500","501","503","505-599"]
     service = "serviceError"
     query = "/{status}.html"
-    forwardHeaders = ["X-Request-Id","Cookie"]
+    errorRequestHeaders = ["X-Request-Id","Cookie"]
 
 [http.services]
   # ... definition of error-handler-service and my-service
@@ -155,11 +155,11 @@ The table below lists all the available variables and their associated values.
 | `{status}` | The response status code.                                          |
 | `{url}`    | The [escaped](https://pkg.go.dev/net/url#QueryEscape) request URL. |
 
-### `forwardHeaders`
+### `errorRequestHeaders`
 
 Defines the list of original request headers forwarded to the error page service.
 
-By default (`forwardHeaders` not set), all request headers — including authentication material such as `Authorization` and `Cookie` — are forwarded.
+By default (`errorRequestHeaders` not set), all request headers — including authentication material such as `Authorization` and `Cookie` — are forwarded.
 If the error page service is a separate trust domain, use this option to restrict which headers cross the service boundary.
 
-Set to an explicit list to forward only those headers, or set to an empty list (`forwardHeaders: []`) to forward no headers.
+Set to an explicit list to forward only those headers, or set to an empty list (`errorRequestHeaders: []`) to forward no headers.

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -807,9 +807,9 @@ Please check out the [ForwardAuth](../middlewares/http/forwardauth.md#trustforwa
 
 ## v2.11.44
 
-In `v2.11.44`, a new `forwardHeaders` option has been added to the Errors middleware.
+In `v2.11.44`, a new `errorRequestHeaders` option has been added to the Errors middleware.
 
 By default, the behavior is unchanged: all original request headers are forwarded to the error page service.
-If the error page service is in a separate trust domain, consider using `forwardHeaders` to restrict which headers are forwarded.
+If the error page service is in a separate trust domain, consider using `errorRequestHeaders` to restrict which headers are forwarded.
 
 Please check out the [Error Pages](../middlewares/http/errorpages.md#forwardheaders) middleware documentation for more details.

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -804,3 +804,12 @@ some `X-Forwarded-*` headers (e.g. `X-Forwarded-For`, `X-Forwarded-Proto`) are r
 To silence the warning and avoid security concerns, explicitly set `trustForwardHeader` to `true` or `false` in your ForwardAuth middleware configuration.
 
 Please check out the [ForwardAuth](../middlewares/http/forwardauth.md#trustforwardheader) middleware documentation for more details.
+
+## v2.11.44
+
+In `v2.11.44`, a new `forwardHeaders` option has been added to the Errors middleware.
+
+By default, the behavior is unchanged: all original request headers are forwarded to the error page service.
+If the error page service is in a separate trust domain, consider using `forwardHeaders` to restrict which headers are forwarded.
+
+Please check out the [Error Pages](../middlewares/http/errorpages.md#forwardheaders) middleware documentation for more details.

--- a/docs/content/reference/dynamic-configuration/docker-labels.yml
+++ b/docs/content/reference/dynamic-configuration/docker-labels.yml
@@ -25,6 +25,7 @@
 - "traefik.http.middlewares.middleware08.digestauth.removeheader=true"
 - "traefik.http.middlewares.middleware08.digestauth.users=foobar, foobar"
 - "traefik.http.middlewares.middleware08.digestauth.usersfile=foobar"
+- "traefik.http.middlewares.middleware09.errors.forwardheaders=foobar, foobar"
 - "traefik.http.middlewares.middleware09.errors.query=foobar"
 - "traefik.http.middlewares.middleware09.errors.service=foobar"
 - "traefik.http.middlewares.middleware09.errors.status=foobar, foobar"

--- a/docs/content/reference/dynamic-configuration/docker-labels.yml
+++ b/docs/content/reference/dynamic-configuration/docker-labels.yml
@@ -25,7 +25,7 @@
 - "traefik.http.middlewares.middleware08.digestauth.removeheader=true"
 - "traefik.http.middlewares.middleware08.digestauth.users=foobar, foobar"
 - "traefik.http.middlewares.middleware08.digestauth.usersfile=foobar"
-- "traefik.http.middlewares.middleware09.errors.forwardheaders=foobar, foobar"
+- "traefik.http.middlewares.middleware09.errors.errorrequestheaders=foobar, foobar"
 - "traefik.http.middlewares.middleware09.errors.query=foobar"
 - "traefik.http.middlewares.middleware09.errors.service=foobar"
 - "traefik.http.middlewares.middleware09.errors.status=foobar, foobar"

--- a/docs/content/reference/dynamic-configuration/file.toml
+++ b/docs/content/reference/dynamic-configuration/file.toml
@@ -148,7 +148,7 @@
         status = ["foobar", "foobar"]
         service = "foobar"
         query = "foobar"
-        forwardHeaders = ["foobar", "foobar"]
+        errorRequestHeaders = ["foobar", "foobar"]
     [http.middlewares.Middleware10]
       [http.middlewares.Middleware10.forwardAuth]
         address = "foobar"

--- a/docs/content/reference/dynamic-configuration/file.toml
+++ b/docs/content/reference/dynamic-configuration/file.toml
@@ -148,6 +148,7 @@
         status = ["foobar", "foobar"]
         service = "foobar"
         query = "foobar"
+        forwardHeaders = ["foobar", "foobar"]
     [http.middlewares.Middleware10]
       [http.middlewares.Middleware10.forwardAuth]
         address = "foobar"

--- a/docs/content/reference/dynamic-configuration/file.yaml
+++ b/docs/content/reference/dynamic-configuration/file.yaml
@@ -159,6 +159,9 @@ http:
           - foobar
         service: foobar
         query: foobar
+        forwardHeaders:
+          - foobar
+          - foobar
     Middleware10:
       forwardAuth:
         address: foobar

--- a/docs/content/reference/dynamic-configuration/file.yaml
+++ b/docs/content/reference/dynamic-configuration/file.yaml
@@ -159,7 +159,7 @@ http:
           - foobar
         service: foobar
         query: foobar
-        forwardHeaders:
+        errorRequestHeaders:
           - foobar
           - foobar
     Middleware10:

--- a/docs/content/reference/dynamic-configuration/kv-ref.md
+++ b/docs/content/reference/dynamic-configuration/kv-ref.md
@@ -33,8 +33,8 @@ THIS FILE MUST NOT BE EDITED BY HAND
 | `traefik/http/middlewares/Middleware08/digestAuth/users/0` | `foobar` |
 | `traefik/http/middlewares/Middleware08/digestAuth/users/1` | `foobar` |
 | `traefik/http/middlewares/Middleware08/digestAuth/usersFile` | `foobar` |
-| `traefik/http/middlewares/Middleware09/errors/forwardHeaders/0` | `foobar` |
-| `traefik/http/middlewares/Middleware09/errors/forwardHeaders/1` | `foobar` |
+| `traefik/http/middlewares/Middleware09/errors/errorRequestHeaders/0` | `foobar` |
+| `traefik/http/middlewares/Middleware09/errors/errorRequestHeaders/1` | `foobar` |
 | `traefik/http/middlewares/Middleware09/errors/query` | `foobar` |
 | `traefik/http/middlewares/Middleware09/errors/service` | `foobar` |
 | `traefik/http/middlewares/Middleware09/errors/status/0` | `foobar` |

--- a/docs/content/reference/dynamic-configuration/kv-ref.md
+++ b/docs/content/reference/dynamic-configuration/kv-ref.md
@@ -33,6 +33,8 @@ THIS FILE MUST NOT BE EDITED BY HAND
 | `traefik/http/middlewares/Middleware08/digestAuth/users/0` | `foobar` |
 | `traefik/http/middlewares/Middleware08/digestAuth/users/1` | `foobar` |
 | `traefik/http/middlewares/Middleware08/digestAuth/usersFile` | `foobar` |
+| `traefik/http/middlewares/Middleware09/errors/forwardHeaders/0` | `foobar` |
+| `traefik/http/middlewares/Middleware09/errors/forwardHeaders/1` | `foobar` |
 | `traefik/http/middlewares/Middleware09/errors/query` | `foobar` |
 | `traefik/http/middlewares/Middleware09/errors/service` | `foobar` |
 | `traefik/http/middlewares/Middleware09/errors/status/0` | `foobar` |

--- a/docs/content/reference/dynamic-configuration/marathon-labels.json
+++ b/docs/content/reference/dynamic-configuration/marathon-labels.json
@@ -25,6 +25,7 @@
 "traefik.http.middlewares.middleware08.digestauth.removeheader": "true",
 "traefik.http.middlewares.middleware08.digestauth.users": "foobar, foobar",
 "traefik.http.middlewares.middleware08.digestauth.usersfile": "foobar",
+"traefik.http.middlewares.middleware09.errors.forwardheaders": "foobar, foobar",
 "traefik.http.middlewares.middleware09.errors.query": "foobar",
 "traefik.http.middlewares.middleware09.errors.service": "foobar",
 "traefik.http.middlewares.middleware09.errors.status": "foobar, foobar",

--- a/docs/content/reference/dynamic-configuration/marathon-labels.json
+++ b/docs/content/reference/dynamic-configuration/marathon-labels.json
@@ -25,7 +25,7 @@
 "traefik.http.middlewares.middleware08.digestauth.removeheader": "true",
 "traefik.http.middlewares.middleware08.digestauth.users": "foobar, foobar",
 "traefik.http.middlewares.middleware08.digestauth.usersfile": "foobar",
-"traefik.http.middlewares.middleware09.errors.forwardheaders": "foobar, foobar",
+"traefik.http.middlewares.middleware09.errors.errorrequestheaders": "foobar, foobar",
 "traefik.http.middlewares.middleware09.errors.query": "foobar",
 "traefik.http.middlewares.middleware09.errors.service": "foobar",
 "traefik.http.middlewares.middleware09.errors.status": "foobar, foobar",

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -194,10 +194,10 @@ type ErrorPage struct {
 	// Query defines the URL for the error page (hosted by service).
 	// The {status} variable can be used in order to insert the status code in the URL.
 	Query string `json:"query,omitempty" toml:"query,omitempty" yaml:"query,omitempty" export:"true"`
-	// ForwardHeaders defines the list of request headers forwarded to the error page service.
+	// ErrorRequestHeaders defines the list of request headers forwarded to the error page service.
 	// When nil (not set), all original request headers are forwarded.
 	// Set to an empty list to forward no headers, or list specific headers to forward only those.
-	ForwardHeaders []string `json:"forwardHeaders,omitempty" toml:"forwardHeaders,omitempty" yaml:"forwardHeaders,omitempty" export:"true"`
+	ErrorRequestHeaders []string `json:"errorRequestHeaders,omitempty" toml:"errorRequestHeaders,omitempty" yaml:"errorRequestHeaders,omitempty" export:"true"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -194,6 +194,10 @@ type ErrorPage struct {
 	// Query defines the URL for the error page (hosted by service).
 	// The {status} variable can be used in order to insert the status code in the URL.
 	Query string `json:"query,omitempty" toml:"query,omitempty" yaml:"query,omitempty" export:"true"`
+	// ForwardHeaders defines the list of request headers forwarded to the error page service.
+	// When nil (not set), all original request headers are forwarded.
+	// Set to an empty list to forward no headers, or list specific headers to forward only those.
+	ForwardHeaders []string `json:"forwardHeaders,omitempty" toml:"forwardHeaders,omitempty" yaml:"forwardHeaders,omitempty" export:"true"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/config/dynamic/zz_generated.deepcopy.go
+++ b/pkg/config/dynamic/zz_generated.deepcopy.go
@@ -272,6 +272,11 @@ func (in *ErrorPage) DeepCopyInto(out *ErrorPage) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ForwardHeaders != nil {
+		in, out := &in.ForwardHeaders, &out.ForwardHeaders
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/config/dynamic/zz_generated.deepcopy.go
+++ b/pkg/config/dynamic/zz_generated.deepcopy.go
@@ -272,8 +272,8 @@ func (in *ErrorPage) DeepCopyInto(out *ErrorPage) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.ForwardHeaders != nil {
-		in, out := &in.ForwardHeaders, &out.ForwardHeaders
+	if in.ErrorRequestHeaders != nil {
+		in, out := &in.ErrorRequestHeaders, &out.ErrorRequestHeaders
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/pkg/middlewares/customerrors/custom_errors.go
+++ b/pkg/middlewares/customerrors/custom_errors.go
@@ -40,6 +40,7 @@ type customErrors struct {
 	backendHandler http.Handler
 	httpCodeRanges types.HTTPCodeRanges
 	backendQuery   string
+	forwardHeaders []string
 }
 
 // New creates a new custom error pages middleware.
@@ -62,6 +63,7 @@ func New(ctx context.Context, next http.Handler, config dynamic.ErrorPage, servi
 		backendHandler: backend,
 		httpCodeRanges: httpCodeRanges,
 		backendQuery:   config.Query,
+		forwardHeaders: config.ForwardHeaders,
 	}, nil
 }
 
@@ -104,7 +106,15 @@ func (c *customErrors) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	utils.CopyHeaders(pageReq.Header, req.Header)
+	if c.forwardHeaders != nil {
+		for _, header := range c.forwardHeaders {
+			if values := req.Header.Values(header); len(values) > 0 {
+				pageReq.Header[http.CanonicalHeaderKey(header)] = values
+			}
+		}
+	} else {
+		utils.CopyHeaders(pageReq.Header, req.Header)
+	}
 
 	c.backendHandler.ServeHTTP(newCodeModifier(rw, code),
 		pageReq.WithContext(req.Context()))

--- a/pkg/middlewares/customerrors/custom_errors.go
+++ b/pkg/middlewares/customerrors/custom_errors.go
@@ -35,12 +35,12 @@ type serviceBuilder interface {
 
 // customErrors is a middleware that provides the custom error pages.
 type customErrors struct {
-	name           string
-	next           http.Handler
-	backendHandler http.Handler
-	httpCodeRanges types.HTTPCodeRanges
-	backendQuery   string
-	forwardHeaders []string
+	name                string
+	next                http.Handler
+	backendHandler      http.Handler
+	httpCodeRanges      types.HTTPCodeRanges
+	backendQuery        string
+	errorRequestHeaders []string
 }
 
 // New creates a new custom error pages middleware.
@@ -58,12 +58,12 @@ func New(ctx context.Context, next http.Handler, config dynamic.ErrorPage, servi
 	}
 
 	return &customErrors{
-		name:           name,
-		next:           next,
-		backendHandler: backend,
-		httpCodeRanges: httpCodeRanges,
-		backendQuery:   config.Query,
-		forwardHeaders: config.ForwardHeaders,
+		name:                name,
+		next:                next,
+		backendHandler:      backend,
+		httpCodeRanges:      httpCodeRanges,
+		backendQuery:        config.Query,
+		errorRequestHeaders: config.ErrorRequestHeaders,
 	}, nil
 }
 
@@ -106,8 +106,8 @@ func (c *customErrors) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if c.forwardHeaders != nil {
-		for _, header := range c.forwardHeaders {
+	if c.errorRequestHeaders != nil {
+		for _, header := range c.errorRequestHeaders {
 			if values := req.Header.Values(header); len(values) > 0 {
 				pageReq.Header[http.CanonicalHeaderKey(header)] = values
 			}

--- a/pkg/middlewares/customerrors/custom_errors.go
+++ b/pkg/middlewares/customerrors/custom_errors.go
@@ -35,12 +35,12 @@ type serviceBuilder interface {
 
 // customErrors is a middleware that provides the custom error pages.
 type customErrors struct {
-	name                string
-	next                http.Handler
-	backendHandler      http.Handler
-	httpCodeRanges      types.HTTPCodeRanges
-	backendQuery        string
-	errorRequestHeaders []string
+	name           string
+	next           http.Handler
+	backendHandler http.Handler
+	httpCodeRanges types.HTTPCodeRanges
+	backendQuery   string
+	requestHeaders []string
 }
 
 // New creates a new custom error pages middleware.
@@ -58,12 +58,12 @@ func New(ctx context.Context, next http.Handler, config dynamic.ErrorPage, servi
 	}
 
 	return &customErrors{
-		name:                name,
-		next:                next,
-		backendHandler:      backend,
-		httpCodeRanges:      httpCodeRanges,
-		backendQuery:        config.Query,
-		errorRequestHeaders: config.ErrorRequestHeaders,
+		name:           name,
+		next:           next,
+		backendHandler: backend,
+		httpCodeRanges: httpCodeRanges,
+		backendQuery:   config.Query,
+		requestHeaders: config.ErrorRequestHeaders,
 	}, nil
 }
 
@@ -106,8 +106,8 @@ func (c *customErrors) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if c.errorRequestHeaders != nil {
-		for _, header := range c.errorRequestHeaders {
+	if c.requestHeaders != nil {
+		for _, header := range c.requestHeaders {
 			if values := req.Header.Values(header); len(values) > 0 {
 				pageReq.Header[http.CanonicalHeaderKey(header)] = values
 			}

--- a/pkg/middlewares/customerrors/custom_errors_test.go
+++ b/pkg/middlewares/customerrors/custom_errors_test.go
@@ -23,6 +23,7 @@ func TestHandler(t *testing.T) {
 		backendCode         int
 		backendErrorHandler http.HandlerFunc
 		validate            func(t *testing.T, recorder *httptest.ResponseRecorder)
+		requestHeaders      map[string]string
 	}{
 		{
 			desc:        "no error",
@@ -154,6 +155,60 @@ func TestHandler(t *testing.T) {
 				assert.Contains(t, recorder.Body.String(), "My 503 page.")
 			},
 		},
+		{
+			desc:      "forward all headers by default",
+			errorPage: &dynamic.ErrorPage{Service: "error", Query: "/test", Status: []string{"503"}},
+			requestHeaders: map[string]string{
+				"X-Request-Id":  "trace-abc",
+				"Authorization": "Bearer secret",
+			},
+			backendCode: http.StatusServiceUnavailable,
+			backendErrorHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintln(w, r.Header.Get("X-Request-Id"))
+				fmt.Fprintln(w, r.Header.Get("Authorization"))
+			}),
+			validate: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				t.Helper()
+				assert.Contains(t, recorder.Body.String(), "trace-abc")
+				assert.Contains(t, recorder.Body.String(), "Bearer secret")
+			},
+		},
+		{
+			desc:      "forward only allowlisted headers",
+			errorPage: &dynamic.ErrorPage{Service: "error", Query: "/test", Status: []string{"503"}, ForwardHeaders: []string{"X-Request-Id"}},
+			requestHeaders: map[string]string{
+				"X-Request-Id":  "trace-abc",
+				"Authorization": "Bearer secret",
+			},
+			backendCode: http.StatusServiceUnavailable,
+			backendErrorHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintln(w, r.Header.Get("X-Request-Id"))
+				fmt.Fprintln(w, r.Header.Get("Authorization"))
+			}),
+			validate: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				t.Helper()
+				assert.Contains(t, recorder.Body.String(), "trace-abc")
+				assert.NotContains(t, recorder.Body.String(), "Bearer secret")
+			},
+		},
+		{
+			desc:      "forward no headers",
+			errorPage: &dynamic.ErrorPage{Service: "error", Query: "/test", Status: []string{"503"}, ForwardHeaders: []string{}},
+			requestHeaders: map[string]string{
+				"X-Request-Id":  "trace-abc",
+				"Authorization": "Bearer secret",
+			},
+			backendCode: http.StatusServiceUnavailable,
+			backendErrorHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintln(w, r.Header.Get("X-Request-Id"))
+				fmt.Fprintln(w, r.Header.Get("Authorization"))
+			}),
+			validate: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				t.Helper()
+				assert.NotContains(t, recorder.Body.String(), "trace-abc")
+				assert.NotContains(t, recorder.Body.String(), "Bearer secret")
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -174,6 +229,9 @@ func TestHandler(t *testing.T) {
 			require.NoError(t, err)
 
 			req := testhelpers.MustNewRequest(http.MethodGet, "http://localhost/test?foo=bar&baz=buz", nil)
+			for k, v := range test.requestHeaders {
+				req.Header.Set(k, v)
+			}
 
 			recorder := httptest.NewRecorder()
 			errorPageHandler.ServeHTTP(recorder, req)

--- a/pkg/middlewares/customerrors/custom_errors_test.go
+++ b/pkg/middlewares/customerrors/custom_errors_test.go
@@ -175,7 +175,7 @@ func TestHandler(t *testing.T) {
 		},
 		{
 			desc:      "forward only allowlisted headers",
-			errorPage: &dynamic.ErrorPage{Service: "error", Query: "/test", Status: []string{"503"}, ForwardHeaders: []string{"X-Request-Id"}},
+			errorPage: &dynamic.ErrorPage{Service: "error", Query: "/test", Status: []string{"503"}, ErrorRequestHeaders: []string{"X-Request-Id"}},
 			requestHeaders: map[string]string{
 				"X-Request-Id":  "trace-abc",
 				"Authorization": "Bearer secret",
@@ -193,7 +193,7 @@ func TestHandler(t *testing.T) {
 		},
 		{
 			desc:      "forward no headers",
-			errorPage: &dynamic.ErrorPage{Service: "error", Query: "/test", Status: []string{"503"}, ForwardHeaders: []string{}},
+			errorPage: &dynamic.ErrorPage{Service: "error", Query: "/test", Status: []string{"503"}, ErrorRequestHeaders: []string{}},
 			requestHeaders: map[string]string{
 				"X-Request-Id":  "trace-abc",
 				"Authorization": "Bearer secret",


### PR DESCRIPTION
### What does this PR do?

This PR adds a new `errorRequestHeaders` option to the Errors middleware. This option contains a list of headers that will be forwarded to the Error page service. If left unset, it will forward all of the headers, which is the current behavior. Empty list means no header will be forwarded.


### Motivation

This option lets operators explicitly control which headers cross to the errors page service, without changing behavior for existing configurations.  This could avoid unintentionally leak authentication credentials across a service trust boundary.


### More

- [x] Added/updated tests
- [x] Added/updated documentation
