### PR TITLE
Configure retry according to buffering configuration

### DIFF
--- a/pkg/middlewares/retry/retry.go
+++ b/pkg/middlewares/retry/retry.go
@@ -175,7 +175,7 @@ func (r *retry) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	var reusableReq *mirror.ReusableRequest
-	if len(r.statusCode) > 0 {
+	if len(statusCodes) > 0 {
 		var err error
 		var readBytes []byte
 		reusableReq, readBytes, err = mirror.NewReusableRequest(req, r.maxRequestBodyBytes)

--- a/pkg/middlewares/retry/retry.go
+++ b/pkg/middlewares/retry/retry.go
@@ -64,8 +64,6 @@ func ContextShouldRetry(ctx context.Context) ShouldRetry {
 func WrapHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if shouldRetry := ContextShouldRetry(req.Context()); shouldRetry != nil {
-			shouldRetry(true)
-
 			trace := &httptrace.ClientTrace{
 				WroteHeaders: func() {
 					shouldRetry(false)
@@ -146,21 +144,43 @@ func (r *retry) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	logger := middlewares.GetLogger(req.Context(), r.name, typeName)
 
+	// statusCodes contains the retriable status codes,
+	// it stands as a condition for HTTP retry.
+	var statusCodes types.HTTPCodeRanges
+	isIdempotent := req.Method != http.MethodPost && req.Method != http.MethodPatch && req.Method != "LOCK"
+	if r.retryNonIdempotentMethod || isIdempotent {
+		// statusCode controls whether the request is retried.
+		// A nil value bypass the retry.
+		statusCodes = r.statusCode
+	}
+
 	var reusableReq *mirror.ReusableRequest
 	if len(r.statusCode) > 0 {
 		var err error
-		reusableReq, _, err = mirror.NewReusableRequest(req, r.maxRequestBodyBytes)
+		var readBytes []byte
+		reusableReq, readBytes, err = mirror.NewReusableRequest(req, r.maxRequestBodyBytes)
 		if err != nil && !errors.Is(err, mirror.ErrBodyTooLarge) {
 			logger.Debug().Err(err).Msg("Error while creating reusable request for retry middleware")
 			http.Error(rw, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
 
+		// If the request body has failed to be read,
+		// disable the HTTP retry.
 		if errors.Is(err, mirror.ErrBodyTooLarge) {
-			http.Error(rw, "Request body too large", http.StatusRequestEntityTooLarge)
-			return
+			statusCodes = nil
+
+			req.Body = &peekedBody{
+				ReadCloser: req.Body,
+				peeked:     readBytes,
+			}
+
+			//http.Error(rw, "Request body too large", http.StatusRequestEntityTooLarge)
+			//return
 		}
-	} else {
+	}
+
+	if reusableReq == nil {
 		closableBody := req.Body
 		defer closableBody.Close()
 
@@ -198,14 +218,6 @@ func (r *retry) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		}
 
 		remainAttempts := attempts < r.attempts
-
-		var statusCodes types.HTTPCodeRanges
-		isIdempotent := req.Method != http.MethodPost && req.Method != http.MethodPatch && req.Method != "LOCK"
-		if r.retryNonIdempotentMethod || isIdempotent {
-			// statusCode controls whether the request is retried.
-			// A nil value bypass the retry.
-			statusCodes = r.statusCode
-		}
 
 		retryResponseWriter := newResponseWriter(rw, statusCodes, remainAttempts, start, r.timeout)
 
@@ -283,7 +295,7 @@ func newResponseWriter(rw http.ResponseWriter, statusCodeRanges types.HTTPCodeRa
 type responseWriter struct {
 	responseWriter  http.ResponseWriter
 	headers         http.Header
-	shouldRetry     bool
+	shouldRetry     *bool
 	written         bool
 	statusCodeRange types.HTTPCodeRanges
 	remainAttempts  bool
@@ -292,11 +304,13 @@ type responseWriter struct {
 }
 
 func (r *responseWriter) ShouldRetry() bool {
-	return r.shouldRetry
+	return r.remainAttempts && (r.shouldRetry == nil || *r.shouldRetry)
 }
 
 func (r *responseWriter) SetShouldRetry(shouldRetry bool) {
-	r.shouldRetry = shouldRetry
+	if r.shouldRetry == nil {
+		r.shouldRetry = &shouldRetry
+	}
 }
 
 func (r *responseWriter) Header() http.Header {
@@ -304,7 +318,8 @@ func (r *responseWriter) Header() http.Header {
 	// return the real response writer's headers. During a retry (shouldRetry=true),
 	// even after written=true, return the internal headers map so that failed-attempt
 	// headers are discarded and not leaked to the client.
-	if r.written && !r.shouldRetry {
+	// here if I switch the && for a || the TestRetryFlakyBufferingOnRecovers succeeds.
+	if r.written && !r.ShouldRetry() {
 		return r.responseWriter.Header()
 	}
 
@@ -312,7 +327,7 @@ func (r *responseWriter) Header() http.Header {
 }
 
 func (r *responseWriter) Write(buf []byte) (int, error) {
-	if r.shouldRetry {
+	if r.ShouldRetry() {
 		return len(buf), nil
 	}
 
@@ -324,7 +339,7 @@ func (r *responseWriter) Write(buf []byte) (int, error) {
 }
 
 func (r *responseWriter) WriteHeader(code int) {
-	if r.shouldRetry || r.written {
+	if r.ShouldRetry() || r.written {
 		return
 	}
 
@@ -341,10 +356,10 @@ func (r *responseWriter) WriteHeader(code int) {
 
 	if r.statusCodeRange != nil {
 		timedOut := r.timeout > 0 && time.Since(r.start) >= r.timeout
-		r.shouldRetry = r.statusCodeRange.Contains(code) && r.remainAttempts && !timedOut
+		r.SetShouldRetry(r.statusCodeRange.Contains(code) && !timedOut)
 	}
 
-	if r.shouldRetry {
+	if r.ShouldRetry() {
 		return
 	}
 
@@ -371,4 +386,24 @@ func (r *responseWriter) Flush() {
 	if flusher, ok := r.responseWriter.(http.Flusher); ok {
 		flusher.Flush()
 	}
+}
+
+type peekedBody struct {
+	io.ReadCloser
+
+	peeked []byte
+}
+
+// Read drains accumulated peeked bytes first, then reads the body.
+func (p *peekedBody) Read(b []byte) (int, error) {
+	if len(p.peeked) > 0 {
+		n := copy(b, p.peeked)
+		p.peeked = p.peeked[n:]
+		if len(p.peeked) == 0 {
+			p.peeked = nil
+		}
+		return n, nil
+	}
+
+	return p.ReadCloser.Read(b)
 }

--- a/pkg/middlewares/retry/retry.go
+++ b/pkg/middlewares/retry/retry.go
@@ -51,7 +51,7 @@ func (l Listeners) Retried(req *http.Request, attempt int) {
 
 type wroteRequestContextKey struct{}
 
-// WroteRequest is a function allowing to enable/disable the retry middleware mechanism.
+// WroteRequest is a function to signal if the request has been written to the backend.
 type WroteRequest func()
 
 // ContextWroteRequest returns the WroteRequest function if it has been set by the Retry middleware in the chain.

--- a/pkg/middlewares/retry/retry.go
+++ b/pkg/middlewares/retry/retry.go
@@ -49,47 +49,25 @@ func (l Listeners) Retried(req *http.Request, attempt int) {
 	}
 }
 
-type wroteRequestContextKey struct{}
-
-// WroteRequest is a function to signal if the request has been written to the backend.
-type WroteRequest func()
-
-// ContextWroteRequest returns the WroteRequest function if it has been set by the Retry middleware in the chain.
-func ContextWroteRequest(ctx context.Context) WroteRequest {
-	f, _ := ctx.Value(wroteRequestContextKey{}).(WroteRequest)
-	return f
-}
-
-type proxyReachedContextKey struct{}
-
-// ProxyReached is a function signaling that the request reached the backend proxy.
-type ProxyReached func()
-
-// ContextProxyReached returns the ProxyReached function if it has been set by the Retry middleware in the chain.
-func ContextProxyReached(ctx context.Context) ProxyReached {
-	f, _ := ctx.Value(proxyReachedContextKey{}).(ProxyReached)
-	return f
-}
+type retryResponseWriterContextKey struct{}
 
 // WrapHandler wraps a given http.Handler to inject the httptrace.ClientTrace in the request context when it is needed
 // by the retry middleware.
 func WrapHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		// Reaching this handler means the request reached the proxy layer,
-		// which arms the network-error retry (a dial failure still reaches here and writes
-		// a 502 without sending bytes). Responses produced earlier in the chain
-		// (e.g. an auth middleware returning 401) never reach here and must not be retried.
-		if proxyReached := ContextProxyReached(req.Context()); proxyReached != nil {
-			proxyReached()
-		}
+		if retryResponseWriter, _ := req.Context().Value(retryResponseWriterContextKey{}).(*responseWriter); retryResponseWriter != nil {
+			// Reaching this handler means the request reached the proxy layer,
+			// which arms the network-error retry (a dial failure still reaches here and writes
+			// a 502 without sending bytes). Responses produced earlier in the chain
+			// (e.g. an auth middleware returning 401) never reach here and must not be retried.
+			retryResponseWriter.proxyReached.Store(true)
 
-		if wroteRequest := ContextWroteRequest(req.Context()); wroteRequest != nil {
 			trace := &httptrace.ClientTrace{
 				WroteHeaders: func() {
-					wroteRequest()
+					retryResponseWriter.wroteRequest.Store(true)
 				},
 				WroteRequest: func(httptrace.WroteRequestInfo) {
-					wroteRequest()
+					retryResponseWriter.wroteRequest.Store(true)
 				},
 			}
 			newCtx := httptrace.WithClientTrace(req.Context(), trace)
@@ -247,17 +225,7 @@ func (r *retry) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 		retryReq := req
 		if !r.disableRetryOnNetworkError {
-			var wroteRequest WroteRequest = func() {
-				retryResponseWriter.wroteRequest.Store(true)
-			}
-			ctx := context.WithValue(req.Context(), wroteRequestContextKey{}, wroteRequest)
-
-			var proxyReached ProxyReached = func() {
-				retryResponseWriter.proxyReached.Store(true)
-			}
-			ctx = context.WithValue(ctx, proxyReachedContextKey{}, proxyReached)
-
-			retryReq = req.Clone(ctx)
+			retryReq = req.Clone(context.WithValue(req.Context(), retryResponseWriterContextKey{}, retryResponseWriter))
 		}
 
 		r.next.ServeHTTP(retryResponseWriter, retryReq)

--- a/pkg/middlewares/retry/retry.go
+++ b/pkg/middlewares/retry/retry.go
@@ -60,10 +60,29 @@ func ContextWroteRequest(ctx context.Context) WroteRequest {
 	return f
 }
 
+type proxyReachedContextKey struct{}
+
+// ProxyReached is a function signaling that the request reached the backend proxy.
+type ProxyReached func()
+
+// ContextProxyReached returns the ProxyReached function if it has been set by the Retry middleware in the chain.
+func ContextProxyReached(ctx context.Context) ProxyReached {
+	f, _ := ctx.Value(proxyReachedContextKey{}).(ProxyReached)
+	return f
+}
+
 // WrapHandler wraps a given http.Handler to inject the httptrace.ClientTrace in the request context when it is needed
 // by the retry middleware.
 func WrapHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// Reaching this handler means the request reached the proxy layer,
+		// which arms the network-error retry (a dial failure still reaches here and writes
+		// a 502 without sending bytes). Responses produced earlier in the chain
+		// (e.g. an auth middleware returning 401) never reach here and must not be retried.
+		if proxyReached := ContextProxyReached(req.Context()); proxyReached != nil {
+			proxyReached()
+		}
+
 		if wroteRequest := ContextWroteRequest(req.Context()); wroteRequest != nil {
 			trace := &httptrace.ClientTrace{
 				WroteHeaders: func() {
@@ -231,7 +250,14 @@ func (r *retry) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			var wroteRequest WroteRequest = func() {
 				retryResponseWriter.wroteRequest.Store(true)
 			}
-			retryReq = req.Clone(context.WithValue(req.Context(), wroteRequestContextKey{}, wroteRequest))
+			ctx := context.WithValue(req.Context(), wroteRequestContextKey{}, wroteRequest)
+
+			var proxyReached ProxyReached = func() {
+				retryResponseWriter.proxyReached.Store(true)
+			}
+			ctx = context.WithValue(ctx, proxyReachedContextKey{}, proxyReached)
+
+			retryReq = req.Clone(ctx)
 		}
 
 		r.next.ServeHTTP(retryResponseWriter, retryReq)
@@ -302,6 +328,7 @@ type responseWriter struct {
 	start                      time.Time
 	timeout                    time.Duration
 
+	proxyReached   atomic.Bool
 	wroteRequest   atomic.Bool
 	written        bool
 	shouldNotWrite bool
@@ -333,7 +360,10 @@ func (r *responseWriter) WriteHeader(code int) {
 	}
 
 	timedOut := r.timeout > 0 && time.Since(r.start) >= r.timeout
-	if !timedOut && !r.disableRetryOnNetworkError && !r.wroteRequest.Load() {
+	// Retry on a network error only when the request reached the backend proxy
+	// but no bytes were sent to the backend yet. Responses produced before reaching the
+	// proxy (e.g. an auth middleware returning 401) must flow through to the client.
+	if !timedOut && !r.disableRetryOnNetworkError && r.proxyReached.Load() && !r.wroteRequest.Load() {
 		r.shouldNotWrite = true
 		return
 	}

--- a/pkg/middlewares/retry/retry.go
+++ b/pkg/middlewares/retry/retry.go
@@ -310,6 +310,13 @@ func (r *responseWriter) ShouldRetry() bool {
 func (r *responseWriter) SetShouldRetry(shouldRetry bool) {
 	if r.shouldRetry == nil {
 		r.shouldRetry = &shouldRetry
+		return
+	}
+
+	// Allow upgrading from false to true (HTTP status code overrides TCP baseline),
+	// but not downgrading from true to false.
+	if shouldRetry {
+		*r.shouldRetry = true
 	}
 }
 
@@ -327,19 +334,24 @@ func (r *responseWriter) Header() http.Header {
 }
 
 func (r *responseWriter) Write(buf []byte) (int, error) {
-	if r.ShouldRetry() {
-		return len(buf), nil
-	}
-
 	if !r.written {
 		r.WriteHeader(http.StatusOK)
+	}
+
+	if r.ShouldRetry() {
+		return len(buf), nil
 	}
 
 	return r.responseWriter.Write(buf)
 }
 
 func (r *responseWriter) WriteHeader(code int) {
-	if r.ShouldRetry() || r.written {
+	if r.written {
+		return
+	}
+
+	// If TCP-level retry has already been signaled, discard this response.
+	if r.shouldRetry != nil && *r.shouldRetry {
 		return
 	}
 

--- a/pkg/middlewares/retry/retry.go
+++ b/pkg/middlewares/retry/retry.go
@@ -23,7 +23,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 	"go.opentelemetry.io/otel/trace"
-	"k8s.io/utils/ptr"
 )
 
 // Compile time validation that the response writer implements http interfaces correctly.
@@ -49,14 +48,14 @@ func (l Listeners) Retried(req *http.Request, attempt int) {
 	}
 }
 
-type shouldRetryContextKey struct{}
+type wroteRequestContextKey struct{}
 
-// ShouldRetry is a function allowing to enable/disable the retry middleware mechanism.
-type ShouldRetry func(shouldRetry bool)
+// WroteRequest is a function allowing to enable/disable the retry middleware mechanism.
+type WroteRequest func()
 
-// ContextShouldRetry returns the ShouldRetry function if it has been set by the Retry middleware in the chain.
-func ContextShouldRetry(ctx context.Context) ShouldRetry {
-	f, _ := ctx.Value(shouldRetryContextKey{}).(ShouldRetry)
+// ContextWroteRequest returns the WroteRequest function if it has been set by the Retry middleware in the chain.
+func ContextWroteRequest(ctx context.Context) WroteRequest {
+	f, _ := ctx.Value(wroteRequestContextKey{}).(WroteRequest)
 	return f
 }
 
@@ -64,13 +63,13 @@ func ContextShouldRetry(ctx context.Context) ShouldRetry {
 // by the retry middleware.
 func WrapHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		if shouldRetry := ContextShouldRetry(req.Context()); shouldRetry != nil {
+		if wroteRequest := ContextWroteRequest(req.Context()); wroteRequest != nil {
 			trace := &httptrace.ClientTrace{
 				WroteHeaders: func() {
-					shouldRetry(false)
+					wroteRequest()
 				},
 				WroteRequest: func(httptrace.WroteRequestInfo) {
-					shouldRetry(false)
+					wroteRequest()
 				},
 			}
 			newCtx := httptrace.WithClientTrace(req.Context(), trace)
@@ -215,26 +214,30 @@ func (r *retry) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			req = req.WithContext(tracingCtx)
 		}
 
-		remainAttempts := attempts < r.attempts
-
-		retryResponseWriter := newResponseWriter(rw, statusCodes, remainAttempts, start, r.timeout)
-
 		if reusableReq != nil {
 			req = reusableReq.Clone(req.Context())
 		}
 
+		if attempts == r.attempts {
+			r.next.ServeHTTP(rw, req)
+			return nil
+		}
+
+		retryResponseWriter := newResponseWriter(rw, statusCodes, start, r.timeout)
+
 		retryReq := req
-		if !r.disableRetryOnNetworkError {
-			var shouldRetry ShouldRetry = func(shouldRetry bool) {
-				timedOut := r.timeout > 0 && time.Since(start) >= r.timeout
-				retryResponseWriter.SetShouldRetry(shouldRetry && remainAttempts && !timedOut)
+		if statusCodes == nil && !r.disableRetryOnNetworkError {
+			var wroteRequest WroteRequest = func() {
+				retryResponseWriter.wroteRequest = true
 			}
-			retryReq = req.Clone(context.WithValue(req.Context(), shouldRetryContextKey{}, shouldRetry))
+			retryReq = req.Clone(context.WithValue(req.Context(), wroteRequestContextKey{}, wroteRequest))
 		}
 
 		r.next.ServeHTTP(retryResponseWriter, retryReq)
 
-		if !retryResponseWriter.ShouldRetry() || !remainAttempts || (r.timeout > 0 && time.Since(start) >= r.timeout) {
+		//if !retryResponseWriter.ShouldRetry() || !remainAttempts || (r.timeout > 0 && time.Since(start) >= r.timeout) {
+		// End the operation as soon as the client received something.
+		if retryResponseWriter.written {
 			return nil
 		}
 
@@ -279,55 +282,36 @@ func (r *retry) newBackOff() backoff.BackOff {
 	return b
 }
 
-func newResponseWriter(rw http.ResponseWriter, statusCodeRanges types.HTTPCodeRanges, remainAttempts bool, start time.Time, timeout time.Duration) *responseWriter {
+func newResponseWriter(rw http.ResponseWriter, statusCodeRanges types.HTTPCodeRanges, start time.Time, timeout time.Duration) *responseWriter {
 	return &responseWriter{
 		responseWriter:  rw,
 		headers:         make(http.Header),
 		statusCodeRange: statusCodeRanges,
-		remainAttempts:  remainAttempts,
 		start:           start,
 		timeout:         timeout,
 	}
 }
 
 type responseWriter struct {
-	responseWriter  http.ResponseWriter
-	headers         http.Header
-	shouldRetry     *bool
-	written         bool
-	statusCodeRange types.HTTPCodeRanges
-	remainAttempts  bool
-	start           time.Time
-	timeout         time.Duration
-}
+	responseWriter http.ResponseWriter
+	headers        http.Header
+	written        bool
+	wroteRequest   bool
+	shouldNotWrite bool
 
-func (r *responseWriter) ShouldRetry() bool {
-	return r.remainAttempts && (r.shouldRetry == nil || *r.shouldRetry)
-}
+	disableRetryOnNetworkError bool
+	statusCodeRange            types.HTTPCodeRanges
 
-func (r *responseWriter) SetShouldRetry(shouldRetry bool) {
-	if r.shouldRetry == nil {
-		r.shouldRetry = &shouldRetry
-		return
-	}
-
-	// Allow upgrading from false to true (HTTP status code overrides TCP baseline),
-	// but not downgrading from true to false.
-	if shouldRetry {
-		r.shouldRetry = ptr.To(true)
-	}
+	start   time.Time
+	timeout time.Duration
 }
 
 func (r *responseWriter) Header() http.Header {
-	// After headers have been written to the downstream client and no retry is pending,
-	// return the real response writer's headers. During a retry (shouldRetry=true),
-	// even after written=true, return the internal headers map so that failed-attempt
-	// headers are discarded and not leaked to the client.
-	if r.written && !r.ShouldRetry() {
-		return r.responseWriter.Header()
+	if r.shouldNotWrite || !r.written {
+		return r.headers
 	}
 
-	return r.headers
+	return r.responseWriter.Header()
 }
 
 func (r *responseWriter) Write(buf []byte) (int, error) {
@@ -335,7 +319,7 @@ func (r *responseWriter) Write(buf []byte) (int, error) {
 		r.WriteHeader(http.StatusOK)
 	}
 
-	if r.ShouldRetry() {
+	if r.shouldNotWrite {
 		return len(buf), nil
 	}
 
@@ -343,12 +327,13 @@ func (r *responseWriter) Write(buf []byte) (int, error) {
 }
 
 func (r *responseWriter) WriteHeader(code int) {
-	if r.written {
+	if r.shouldNotWrite || r.written {
 		return
 	}
 
-	// If TCP-level retry has already been signaled, discard this response.
-	if r.shouldRetry != nil && *r.shouldRetry {
+	timedOut := r.timeout > 0 && time.Since(r.start) >= r.timeout
+	if !timedOut && !r.disableRetryOnNetworkError && !r.wroteRequest {
+		r.shouldNotWrite = true
 		return
 	}
 
@@ -363,12 +348,11 @@ func (r *responseWriter) WriteHeader(code int) {
 		return
 	}
 
-	if r.statusCodeRange != nil {
-		timedOut := r.timeout > 0 && time.Since(r.start) >= r.timeout
-		r.SetShouldRetry(r.statusCodeRange.Contains(code) && !timedOut)
+	if !timedOut && r.statusCodeRange != nil {
+		r.shouldNotWrite = r.statusCodeRange.Contains(code)
 	}
 
-	if r.ShouldRetry() {
+	if r.shouldNotWrite {
 		return
 	}
 

--- a/pkg/middlewares/retry/retry.go
+++ b/pkg/middlewares/retry/retry.go
@@ -224,7 +224,7 @@ func (r *retry) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			return nil
 		}
 
-		retryResponseWriter := newResponseWriter(rw, statusCodes, start, r.timeout)
+		retryResponseWriter := newResponseWriter(rw, statusCodes, start, r.timeout, r.disableRetryOnNetworkError)
 
 		retryReq := req
 		if !r.disableRetryOnNetworkError {
@@ -282,13 +282,14 @@ func (r *retry) newBackOff() backoff.BackOff {
 	return b
 }
 
-func newResponseWriter(rw http.ResponseWriter, statusCodeRanges types.HTTPCodeRanges, start time.Time, timeout time.Duration) *responseWriter {
+func newResponseWriter(rw http.ResponseWriter, statusCodeRanges types.HTTPCodeRanges, start time.Time, timeout time.Duration, disableRetryOnNetworkError bool) *responseWriter {
 	return &responseWriter{
-		responseWriter:  rw,
-		headers:         make(http.Header),
-		statusCodeRange: statusCodeRanges,
-		start:           start,
-		timeout:         timeout,
+		responseWriter:             rw,
+		headers:                    make(http.Header),
+		statusCodeRange:            statusCodeRanges,
+		start:                      start,
+		timeout:                    timeout,
+		disableRetryOnNetworkError: disableRetryOnNetworkError,
 	}
 }
 

--- a/pkg/middlewares/retry/retry.go
+++ b/pkg/middlewares/retry/retry.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 	"go.opentelemetry.io/otel/trace"
+	"k8s.io/utils/ptr"
 )
 
 // Compile time validation that the response writer implements http interfaces correctly.
@@ -313,7 +314,7 @@ func (r *responseWriter) SetShouldRetry(shouldRetry bool) {
 	// Allow upgrading from false to true (HTTP status code overrides TCP baseline),
 	// but not downgrading from true to false.
 	if shouldRetry {
-		*r.shouldRetry = true
+		r.shouldRetry = ptr.To(true)
 	}
 }
 

--- a/pkg/middlewares/retry/retry.go
+++ b/pkg/middlewares/retry/retry.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptrace"
+	"sync/atomic"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -226,16 +227,15 @@ func (r *retry) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		retryResponseWriter := newResponseWriter(rw, statusCodes, start, r.timeout)
 
 		retryReq := req
-		if statusCodes == nil && !r.disableRetryOnNetworkError {
+		if !r.disableRetryOnNetworkError {
 			var wroteRequest WroteRequest = func() {
-				retryResponseWriter.wroteRequest = true
+				retryResponseWriter.wroteRequest.Store(true)
 			}
 			retryReq = req.Clone(context.WithValue(req.Context(), wroteRequestContextKey{}, wroteRequest))
 		}
 
 		r.next.ServeHTTP(retryResponseWriter, retryReq)
 
-		//if !retryResponseWriter.ShouldRetry() || !remainAttempts || (r.timeout > 0 && time.Since(start) >= r.timeout) {
 		// End the operation as soon as the client received something.
 		if retryResponseWriter.written {
 			return nil
@@ -295,15 +295,15 @@ func newResponseWriter(rw http.ResponseWriter, statusCodeRanges types.HTTPCodeRa
 type responseWriter struct {
 	responseWriter http.ResponseWriter
 	headers        http.Header
-	written        bool
-	wroteRequest   bool
-	shouldNotWrite bool
 
 	disableRetryOnNetworkError bool
 	statusCodeRange            types.HTTPCodeRanges
+	start                      time.Time
+	timeout                    time.Duration
 
-	start   time.Time
-	timeout time.Duration
+	wroteRequest   atomic.Bool
+	written        bool
+	shouldNotWrite bool
 }
 
 func (r *responseWriter) Header() http.Header {
@@ -332,7 +332,7 @@ func (r *responseWriter) WriteHeader(code int) {
 	}
 
 	timedOut := r.timeout > 0 && time.Since(r.start) >= r.timeout
-	if !timedOut && !r.disableRetryOnNetworkError && !r.wroteRequest {
+	if !timedOut && !r.disableRetryOnNetworkError && !r.wroteRequest.Load() {
 		r.shouldNotWrite = true
 		return
 	}
@@ -348,8 +348,8 @@ func (r *responseWriter) WriteHeader(code int) {
 		return
 	}
 
-	if !timedOut && r.statusCodeRange != nil {
-		r.shouldNotWrite = r.statusCodeRange.Contains(code)
+	if r.statusCodeRange != nil {
+		r.shouldNotWrite = !timedOut && r.statusCodeRange.Contains(code)
 	}
 
 	if r.shouldNotWrite {

--- a/pkg/middlewares/retry/retry.go
+++ b/pkg/middlewares/retry/retry.go
@@ -174,9 +174,6 @@ func (r *retry) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 				ReadCloser: req.Body,
 				peeked:     readBytes,
 			}
-
-			//http.Error(rw, "Request body too large", http.StatusRequestEntityTooLarge)
-			//return
 		}
 	}
 

--- a/pkg/middlewares/retry/retry.go
+++ b/pkg/middlewares/retry/retry.go
@@ -323,7 +323,6 @@ func (r *responseWriter) Header() http.Header {
 	// return the real response writer's headers. During a retry (shouldRetry=true),
 	// even after written=true, return the internal headers map so that failed-attempt
 	// headers are discarded and not leaked to the client.
-	// here if I switch the && for a || the TestRetryFlakyBufferingOnRecovers succeeds.
 	if r.written && !r.ShouldRetry() {
 		return r.responseWriter.Header()
 	}

--- a/pkg/middlewares/retry/retry_test.go
+++ b/pkg/middlewares/retry/retry_test.go
@@ -563,6 +563,19 @@ func TestRetryHTTPStatusCodes(t *testing.T) {
 			wantRetryAttempts:   1,
 			wantResponseStatus:  http.StatusOK,
 		},
+		{
+			desc: "no retry on TCP failure when disableRetryOnNetworkError is set",
+			config: dynamic.Retry{
+				Attempts:                   3,
+				Status:                     []string{"503"},
+				DisableRetryOnNetworkError: true,
+				MaxRequestBodyBytes:        ptr.To[int64](1024),
+			},
+			responseStatusCodes: []int{http.StatusOK, http.StatusOK},
+			amountOfTCPFailures: 1,
+			wantRetryAttempts:   0, // Network error retry is disabled, so the TCP failure must not be retried.
+			wantResponseStatus:  http.StatusGatewayTimeout,
+		},
 	}
 
 	for _, test := range testCases {

--- a/pkg/middlewares/retry/retry_test.go
+++ b/pkg/middlewares/retry/retry_test.go
@@ -167,11 +167,6 @@ func TestMultipleRetriesShouldNotLooseHeaders(t *testing.T) {
 	expectedHeaderValue := "bar"
 
 	next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		shouldRetry := ContextShouldRetry(req.Context())
-		if shouldRetry != nil {
-			shouldRetry(true)
-		}
-
 		headerName := fmt.Sprintf("X-Foo-Test-%d", attempt)
 		rw.Header().Add(headerName, expectedHeaderValue)
 		if attempt < 2 {
@@ -179,14 +174,17 @@ func TestMultipleRetriesShouldNotLooseHeaders(t *testing.T) {
 			return
 		}
 
-		// Request has been successfully written to backend
-		shouldRetry(false)
+		// Signal that request headers have been sent to the backend.
+		trace := httptrace.ContextClientTrace(req.Context())
+		require.NotNil(t, trace)
+
+		trace.WroteHeaders()
 
 		// And we decide to answer to client.
 		rw.WriteHeader(http.StatusNoContent)
 	})
 
-	retry, err := New(t.Context(), next, dynamic.Retry{Attempts: 3}, &countingRetryListener{}, "traefikTest")
+	retry, err := New(t.Context(), WrapHandler(next), dynamic.Retry{Attempts: 3}, &countingRetryListener{}, "traefikTest")
 	require.NoError(t, err)
 
 	res := httptest.NewRecorder()
@@ -210,17 +208,18 @@ func TestRetryShouldNotLooseHeadersOnWrite(t *testing.T) {
 	next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.Header().Add("X-Foo-Test", "bar")
 
-		// Request has been successfully written to backend.
-		shouldRetry := ContextShouldRetry(req.Context())
-		if shouldRetry != nil {
-			shouldRetry(false)
-		}
+		// Signal that request headers have been sent to the backend.
+		trace := httptrace.ContextClientTrace(req.Context())
+		require.NotNil(t, trace)
+
+		trace.WroteHeaders()
+
 		// And we decide to answer to client without calling WriteHeader.
 		_, err := rw.Write([]byte("bar"))
 		require.NoError(t, err)
 	})
 
-	retry, err := New(t.Context(), next, dynamic.Retry{Attempts: 3}, &countingRetryListener{}, "traefikTest")
+	retry, err := New(t.Context(), WrapHandler(next), dynamic.Retry{Attempts: 3}, &countingRetryListener{}, "traefikTest")
 	require.NoError(t, err)
 
 	res := httptest.NewRecorder()
@@ -286,19 +285,13 @@ func TestRetryWebsocket(t *testing.T) {
 
 			retryAttempts := 0
 			next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-				// This signals that a connection will be established with the backend
-				// to enable the Retry middleware mechanism.
-				shouldRetry := ContextShouldRetry(req.Context())
-				if shouldRetry != nil {
-					shouldRetry(true)
-				}
-
 				retryAttempts++
 
 				if retryAttempts > test.amountFaultyEndpoints {
-					// This signals that request headers have been sent to the backend.
-					if shouldRetry != nil {
-						shouldRetry(false)
+					// Signal that request headers have been sent to the backend.
+					trace := httptrace.ContextClientTrace(req.Context())
+					if trace != nil {
+						trace.WroteHeaders()
 					}
 
 					upgrader := websocket.Upgrader{}
@@ -313,7 +306,7 @@ func TestRetryWebsocket(t *testing.T) {
 			})
 
 			retryListener := &countingRetryListener{}
-			retryH, err := New(t.Context(), next, dynamic.Retry{Attempts: test.maxRequestAttempts}, retryListener, "traefikTest")
+			retryH, err := New(t.Context(), WrapHandler(next), dynamic.Retry{Attempts: test.maxRequestAttempts}, retryListener, "traefikTest")
 			require.NoError(t, err)
 
 			retryServer := httptest.NewServer(retryH)
@@ -587,8 +580,8 @@ func TestRetryHTTPStatusCodes(t *testing.T) {
 				time.Sleep(test.responseDelay)
 
 				if callCount < test.amountOfTCPFailures {
-					// This signals that a connection will be established with the backend
-					// to enable the Retry middleware mechanism.
+					// Simulate a TCP-level failure: the request was not forwarded
+					// to the backend, signal that retry is possible.
 					shouldRetry := ContextShouldRetry(req.Context())
 					if shouldRetry != nil {
 						shouldRetry(true)
@@ -598,6 +591,12 @@ func TestRetryHTTPStatusCodes(t *testing.T) {
 					rw.WriteHeader(http.StatusGatewayTimeout)
 					return
 				}
+
+				trace := httptrace.ContextClientTrace(req.Context())
+				require.NotNil(t, trace)
+
+				// Signal that request headers have been sent to the backend.
+				trace.WroteHeaders()
 
 				// Verify the body is readable on each attempt.
 				if test.requestBody != "" {
@@ -629,7 +628,7 @@ func TestRetryHTTPStatusCodes(t *testing.T) {
 			})
 
 			retryListener := &countingRetryListener{}
-			retry, err := New(t.Context(), next, test.config, retryListener, "traefikTest")
+			retry, err := New(t.Context(), WrapHandler(next), test.config, retryListener, "traefikTest")
 			require.NoError(t, err)
 
 			recorder := httptest.NewRecorder()
@@ -750,11 +749,17 @@ func TestRetryHTTPStatusCodesLargeBodyError(t *testing.T) {
 	}
 
 	next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		trace := httptrace.ContextClientTrace(req.Context())
+		require.NotNil(t, trace)
+
+		// Signal that request headers have been sent to the backend.
+		trace.WroteHeaders()
+
 		rw.WriteHeader(http.StatusServiceUnavailable)
 	})
 
 	retryListener := &countingRetryListener{}
-	retry, err := New(t.Context(), next, config, retryListener, "traefikTest")
+	retry, err := New(t.Context(), WrapHandler(next), config, retryListener, "traefikTest")
 	require.NoError(t, err)
 
 	recorder := httptest.NewRecorder()

--- a/pkg/middlewares/retry/retry_test.go
+++ b/pkg/middlewares/retry/retry_test.go
@@ -1,6 +1,7 @@
 package retry
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -815,5 +816,46 @@ func TestRetryHTTPStatusCodesLargeBodyError(t *testing.T) {
 	retry.ServeHTTP(recorder, req)
 
 	assert.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+	assert.Equal(t, 0, retryListener.timesCalled)
+}
+
+// errReader fails on the first read, simulating a request body that cannot be buffered.
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("boom") }
+
+// TestRetryDoesNotBufferBodyForNonIdempotentMethod ensures the HTTP status retry body
+// buffering is gated on the effective retriable status codes, which are nil for a
+// non-idempotent method when RetryNonIdempotentMethod is disabled. Buffering the body
+// anyway would surface a body read error as a spurious 500 instead of letting the
+// request flow through to the backend.
+func TestRetryDoesNotBufferBodyForNonIdempotentMethod(t *testing.T) {
+	config := dynamic.Retry{
+		Attempts:            3,
+		Status:              []string{"503"},
+		MaxRequestBodyBytes: ptr.To[int64](1024),
+	}
+
+	next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// This signals that request headers have been sent to the backend.
+		if trace := httptrace.ContextClientTrace(req.Context()); trace != nil {
+			trace.WroteHeaders()
+		}
+
+		rw.WriteHeader(http.StatusOK)
+	})
+
+	retryListener := &countingRetryListener{}
+	retry, err := New(t.Context(), WrapHandler(next), config, retryListener, "traefikTest")
+	require.NoError(t, err)
+
+	recorder := httptest.NewRecorder()
+	// POST is non-idempotent and RetryNonIdempotentMethod is unset,
+	// so no status code is retriable and the body must not be buffered.
+	req := httptest.NewRequest(http.MethodPost, "http://localhost:3000/ok", io.NopCloser(errReader{}))
+
+	retry.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
 	assert.Equal(t, 0, retryListener.timesCalled)
 }

--- a/pkg/middlewares/retry/retry_test.go
+++ b/pkg/middlewares/retry/retry_test.go
@@ -224,6 +224,55 @@ func TestRetryShouldNotLooseHeadersOnWrite(t *testing.T) {
 	assert.Equal(t, "bar", headerValue)
 }
 
+func TestRetryShouldNotRetryWhenProxyNotReached(t *testing.T) {
+	// Simulates a middleware (e.g. BasicAuth) short-circuiting the chain with a 401
+	// before the request reaches the backend proxy: such a response is not a network
+	// error and must not trigger the network-error retry.
+	callCount := 0
+	next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		callCount++
+		rw.WriteHeader(http.StatusUnauthorized)
+	})
+
+	retryListener := &countingRetryListener{}
+	retry, err := New(t.Context(), next, dynamic.Retry{Attempts: 3}, retryListener, "traefikTest")
+	require.NoError(t, err)
+
+	recorder := httptest.NewRecorder()
+	retry.ServeHTTP(recorder, testhelpers.MustNewRequest(http.MethodGet, "http://test", http.NoBody))
+
+	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+	assert.Equal(t, 1, callCount)
+	assert.Equal(t, 0, retryListener.timesCalled)
+}
+
+func TestRetryOnStatusWhenProxyNotReached(t *testing.T) {
+	// A middleware emitting a retriable status code short-circuits the chain before
+	// reaching the backend proxy. Unlike the network-error retry, the status-code retry
+	// must still trigger regardless of who produced the response.
+	callCount := 0
+	next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		callCount++
+		if callCount == 1 {
+			rw.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		rw.WriteHeader(http.StatusOK)
+	})
+
+	config := dynamic.Retry{Attempts: 3, Status: []string{"503"}, MaxRequestBodyBytes: ptr.To[int64](1024)}
+	retryListener := &countingRetryListener{}
+	retry, err := New(t.Context(), next, config, retryListener, "traefikTest")
+	require.NoError(t, err)
+
+	recorder := httptest.NewRecorder()
+	retry.ServeHTTP(recorder, testhelpers.MustNewRequest(http.MethodGet, "http://test", http.NoBody))
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Equal(t, 2, callCount)
+	assert.Equal(t, 1, retryListener.timesCalled)
+}
+
 func TestRetryWithFlush(t *testing.T) {
 	next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusOK)

--- a/pkg/middlewares/retry/retry_test.go
+++ b/pkg/middlewares/retry/retry_test.go
@@ -110,10 +110,9 @@ func TestRetry(t *testing.T) {
 
 				if retryAttempts > test.amountFaultyEndpoints {
 					// This signals that request headers have been sent to the backend.
-					trace := httptrace.ContextClientTrace(req.Context())
-					require.NotNil(t, trace)
-
-					trace.WroteHeaders()
+					if trace := httptrace.ContextClientTrace(req.Context()); trace != nil {
+						trace.WroteHeaders()
+					}
 
 					rw.WriteHeader(http.StatusOK)
 					return
@@ -140,10 +139,9 @@ func TestRetry(t *testing.T) {
 func TestRetryEmptyServerList(t *testing.T) {
 	next := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		// This signals that request headers have been sent to the backend.
-		trace := httptrace.ContextClientTrace(r.Context())
-		require.NotNil(t, trace)
-
-		trace.WroteHeaders()
+		if trace := httptrace.ContextClientTrace(r.Context()); trace != nil {
+			trace.WroteHeaders()
+		}
 
 		rw.WriteHeader(http.StatusServiceUnavailable)
 	})
@@ -173,11 +171,10 @@ func TestMultipleRetriesShouldNotLooseHeaders(t *testing.T) {
 			return
 		}
 
-		// Signal that request headers have been sent to the backend.
-		trace := httptrace.ContextClientTrace(req.Context())
-		require.NotNil(t, trace)
-
-		trace.WroteHeaders()
+		// This signals that request headers have been sent to the backend.
+		if trace := httptrace.ContextClientTrace(req.Context()); trace != nil {
+			trace.WroteHeaders()
+		}
 
 		// And we decide to answer to client.
 		rw.WriteHeader(http.StatusNoContent)
@@ -207,11 +204,10 @@ func TestRetryShouldNotLooseHeadersOnWrite(t *testing.T) {
 	next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.Header().Add("X-Foo-Test", "bar")
 
-		// Signal that request headers have been sent to the backend.
-		trace := httptrace.ContextClientTrace(req.Context())
-		require.NotNil(t, trace)
-
-		trace.WroteHeaders()
+		// This signals that request headers have been sent to the backend.
+		if trace := httptrace.ContextClientTrace(req.Context()); trace != nil {
+			trace.WroteHeaders()
+		}
 
 		// And we decide to answer to client without calling WriteHeader.
 		_, err := rw.Write([]byte("bar"))
@@ -287,9 +283,8 @@ func TestRetryWebsocket(t *testing.T) {
 				retryAttempts++
 
 				if retryAttempts > test.amountFaultyEndpoints {
-					// Signal that request headers have been sent to the backend.
-					trace := httptrace.ContextClientTrace(req.Context())
-					if trace != nil {
+					// This signals that request headers have been sent to the backend.
+					if trace := httptrace.ContextClientTrace(req.Context()); trace != nil {
 						trace.WroteHeaders()
 					}
 
@@ -581,9 +576,9 @@ func TestRetryHTTPStatusCodes(t *testing.T) {
 				if callCount < test.amountOfTCPFailures {
 					// Simulate a TCP-level failure: the request was not forwarded
 					// to the backend, signal that retry is possible.
-					shouldRetry := ContextShouldRetry(req.Context())
-					if shouldRetry != nil {
-						shouldRetry(true)
+					wroteRequest := ContextWroteRequest(req.Context())
+					if wroteRequest != nil {
+						wroteRequest()
 					}
 
 					callCount++
@@ -591,11 +586,10 @@ func TestRetryHTTPStatusCodes(t *testing.T) {
 					return
 				}
 
-				trace := httptrace.ContextClientTrace(req.Context())
-				require.NotNil(t, trace)
-
-				// Signal that request headers have been sent to the backend.
-				trace.WroteHeaders()
+				// This signals that request headers have been sent to the backend.
+				if trace := httptrace.ContextClientTrace(req.Context()); trace != nil {
+					trace.WroteHeaders()
+				}
 
 				// Verify the body is readable on each attempt.
 				if test.requestBody != "" {
@@ -748,11 +742,10 @@ func TestRetryHTTPStatusCodesLargeBodyError(t *testing.T) {
 	}
 
 	next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		trace := httptrace.ContextClientTrace(req.Context())
-		require.NotNil(t, trace)
-
-		// Signal that request headers have been sent to the backend.
-		trace.WroteHeaders()
+		// This signals that request headers have been sent to the backend.
+		if trace := httptrace.ContextClientTrace(req.Context()); trace != nil {
+			trace.WroteHeaders()
+		}
 
 		rw.WriteHeader(http.StatusServiceUnavailable)
 	})

--- a/pkg/middlewares/retry/retry_test.go
+++ b/pkg/middlewares/retry/retry_test.go
@@ -106,20 +106,15 @@ func TestRetry(t *testing.T) {
 
 			retryAttempts := 0
 			next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-				// This signals that a connection will be established with the backend
-				// to enable the Retry middleware mechanism.
-				shouldRetry := ContextShouldRetry(req.Context())
-				if shouldRetry != nil {
-					shouldRetry(true)
-				}
 
 				retryAttempts++
 
 				if retryAttempts > test.amountFaultyEndpoints {
 					// This signals that request headers have been sent to the backend.
-					if shouldRetry != nil {
-						shouldRetry(false)
-					}
+					trace := httptrace.ContextClientTrace(req.Context())
+					require.NotNil(t, trace)
+
+					trace.WroteHeaders()
 
 					rw.WriteHeader(http.StatusOK)
 					return
@@ -129,13 +124,13 @@ func TestRetry(t *testing.T) {
 			})
 
 			retryListener := &countingRetryListener{}
-			retry, err := New(t.Context(), next, test.config, retryListener, "traefikTest")
+			retryHandler, err := New(t.Context(), WrapHandler(next), test.config, retryListener, "traefikTest")
 			require.NoError(t, err)
 
 			recorder := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, "http://localhost:3000/ok", nil)
 
-			retry.ServeHTTP(recorder, req)
+			retryHandler.ServeHTTP(recorder, req)
 
 			assert.Equal(t, test.wantResponseStatus, recorder.Code)
 			assert.Equal(t, test.wantRetryAttempts, retryListener.timesCalled)
@@ -145,11 +140,17 @@ func TestRetry(t *testing.T) {
 
 func TestRetryEmptyServerList(t *testing.T) {
 	next := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		// This signals that request headers have been sent to the backend.
+		trace := httptrace.ContextClientTrace(r.Context())
+		require.NotNil(t, trace)
+
+		trace.WroteHeaders()
+
 		rw.WriteHeader(http.StatusServiceUnavailable)
 	})
 
 	retryListener := &countingRetryListener{}
-	retry, err := New(t.Context(), next, dynamic.Retry{Attempts: 3}, retryListener, "traefikTest")
+	retry, err := New(t.Context(), WrapHandler(next), dynamic.Retry{Attempts: 3}, retryListener, "traefikTest")
 	require.NoError(t, err)
 
 	recorder := httptest.NewRecorder()
@@ -506,10 +507,10 @@ func TestRetryHTTPStatusCodes(t *testing.T) {
 				Status:              []string{"502"},
 				MaxRequestBodyBytes: ptr.To[int64](8),
 			},
-			responseStatusCodes: []int{http.StatusOK},
+			responseStatusCodes: []int{http.StatusBadGateway, http.StatusOK},
 			requestBody:         "test request body",
 			wantRetryAttempts:   0, // Should not retry because body is too large to buffer
-			wantResponseStatus:  http.StatusRequestEntityTooLarge,
+			wantResponseStatus:  http.StatusBadGateway,
 		},
 		{
 			desc: "retry with timeout stops retries early",
@@ -761,7 +762,6 @@ func TestRetryHTTPStatusCodesLargeBodyError(t *testing.T) {
 
 	retry.ServeHTTP(recorder, req)
 
-	// Should return 413 Request Entity Too Large when body is too large
-	assert.Equal(t, http.StatusRequestEntityTooLarge, recorder.Code)
+	assert.Equal(t, http.StatusServiceUnavailable, recorder.Code)
 	assert.Equal(t, 0, retryListener.timesCalled)
 }

--- a/pkg/middlewares/retry/retry_test.go
+++ b/pkg/middlewares/retry/retry_test.go
@@ -531,7 +531,7 @@ func TestRetryHTTPStatusCodes(t *testing.T) {
 				Status:              []string{"503"},
 				MaxRequestBodyBytes: ptr.To[int64](1024),
 			},
-			responseStatusCodes: []int{http.StatusServiceUnavailable, http.StatusServiceUnavailable, http.StatusOK},
+			responseStatusCodes: []int{http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusOK},
 			amountOfTCPFailures: 1,
 			requestBody:         "test request body",
 			wantRetryAttempts:   2,
@@ -574,13 +574,6 @@ func TestRetryHTTPStatusCodes(t *testing.T) {
 				time.Sleep(test.responseDelay)
 
 				if callCount < test.amountOfTCPFailures {
-					// Simulate a TCP-level failure: the request was not forwarded
-					// to the backend, signal that retry is possible.
-					wroteRequest := ContextWroteRequest(req.Context())
-					if wroteRequest != nil {
-						wroteRequest()
-					}
-
 					callCount++
 					rw.WriteHeader(http.StatusGatewayTimeout)
 					return

--- a/pkg/middlewares/retry/retry_test.go
+++ b/pkg/middlewares/retry/retry_test.go
@@ -106,7 +106,6 @@ func TestRetry(t *testing.T) {
 
 			retryAttempts := 0
 			next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-
 				retryAttempts++
 
 				if retryAttempts > test.amountFaultyEndpoints {

--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-http-status-retry-and-buffering-off.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-http-status-retry-and-buffering-off.yml
@@ -2,10 +2,11 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: ingress-with-proxy-body-size-zero-retry
+  name: ingress-with-http-status-retry-and-buffering-off
   namespace: default
   annotations:
-    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/proxy-next-upstream: "error http_502"
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
 
 spec:
   ingressClassName: nginx

--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-proxy-body-size-retry.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-proxy-body-size-retry.yml
@@ -1,0 +1,22 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-with-proxy-body-size-retry
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "5M"
+
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: hostname.localhost
+      http:
+        paths:
+          - path: /
+            pathType: Exact
+            backend:
+              service:
+                name: whoami
+                port:
+                  number: 80

--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-proxy-body-size-zero-retry.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-proxy-body-size-zero-retry.yml
@@ -1,0 +1,22 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-with-proxy-body-size-retry
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: hostname.localhost
+      http:
+        paths:
+          - path: /
+            pathType: Exact
+            backend:
+              service:
+                name: whoami
+                port:
+                  number: 80

--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-proxy-next-upstream-status-only.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-proxy-next-upstream-status-only.yml
@@ -1,0 +1,22 @@
+---
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: ingress-with-proxy-next-upstream-status-only
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-next-upstream: "http_502 http_503"
+
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: whoami.localhost
+      http:
+        paths:
+          - path: /
+            pathType: Exact
+            backend:
+              service:
+                name: whoami
+                port:
+                  number: 80

--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-proxy-request-buffering-off.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-proxy-request-buffering-off.yml
@@ -1,0 +1,22 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-with-proxy-request-buffering-off
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
+
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: hostname.localhost
+      http:
+        paths:
+          - path: /
+            pathType: Exact
+            backend:
+              service:
+                name: whoami
+                port:
+                  number: 80

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -34,6 +34,7 @@ func TestLoadIngresses(t *testing.T) {
 		allowSnippetAnnotations        bool
 		globalAuthURL                  string
 		strictValidatePathType         *bool
+		proxyRequestBuffering          bool
 		paths                          []string
 		expected                       *dynamic.Configuration
 	}{
@@ -9112,7 +9113,8 @@ func TestLoadIngresses(t *testing.T) {
 			},
 		},
 		{
-			desc: "Proxy request buffering off disables retry",
+			desc:                  "Proxy request buffering annotation off disables retry",
+			proxyRequestBuffering: true,
 			paths: []string{
 				"services.yml",
 				"ingressclasses.yml",
@@ -9140,6 +9142,7 @@ func TestLoadIngresses(t *testing.T) {
 									},
 								},
 							},
+							Middlewares: []string{"default-ingress-with-proxy-request-buffering-off-rule-0-path-0-retry"},
 						},
 						"default-ingress-with-proxy-request-buffering-off-rule-0-path-0-tls": {
 							EntryPoints: []string{"https"},
@@ -9156,10 +9159,24 @@ func TestLoadIngresses(t *testing.T) {
 									},
 								},
 							},
-							TLS: &dynamic.RouterTLSConfig{},
+							Middlewares: []string{"default-ingress-with-proxy-request-buffering-off-rule-0-path-0-tls-retry"},
+							TLS:         &dynamic.RouterTLSConfig{},
 						},
 					},
-					Middlewares: map[string]*dynamic.Middleware{},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-ingress-with-proxy-request-buffering-off-rule-0-path-0-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(int64(defaultProxyBodySize)),
+							},
+						},
+						"default-ingress-with-proxy-request-buffering-off-rule-0-path-0-tls-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(int64(defaultProxyBodySize)),
+							},
+						},
+					},
 					Services: map[string]*dynamic.Service{
 						"unavailable-service": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
@@ -9324,34 +9341,34 @@ func TestLoadIngresses(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"default-ingress-with-proxy-body-size-retry-rule-0-path-0": {
+						"default-ingress-with-proxy-body-size-zero-retry-rule-0-path-0": {
 							EntryPoints: []string{"http"},
 							Rule:        `Host("hostname.localhost") && Path("/")`,
 							RuleSyntax:  "default",
-							Middlewares: []string{"default-ingress-with-proxy-body-size-retry-rule-0-path-0-retry"},
-							Service:     "default-ingress-with-proxy-body-size-retry-whoami-80",
+							Middlewares: []string{"default-ingress-with-proxy-body-size-zero-retry-rule-0-path-0-retry"},
+							Service:     "default-ingress-with-proxy-body-size-zero-retry-whoami-80",
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
 									Ingress: &dynamic.KubernetesIngressMetadata{
 										Namespace:   "default",
-										IngressName: "ingress-with-proxy-body-size-retry",
+										IngressName: "ingress-with-proxy-body-size-zero-retry",
 										ServiceName: "whoami",
 										ServicePort: "80",
 									},
 								},
 							},
 						},
-						"default-ingress-with-proxy-body-size-retry-rule-0-path-0-tls": {
+						"default-ingress-with-proxy-body-size-zero-retry-rule-0-path-0-tls": {
 							EntryPoints: []string{"https"},
 							Rule:        `Host("hostname.localhost") && Path("/")`,
 							RuleSyntax:  "default",
-							Middlewares: []string{"default-ingress-with-proxy-body-size-retry-rule-0-path-0-tls-retry"},
-							Service:     "default-ingress-with-proxy-body-size-retry-whoami-80",
+							Middlewares: []string{"default-ingress-with-proxy-body-size-zero-retry-rule-0-path-0-tls-retry"},
+							Service:     "default-ingress-with-proxy-body-size-zero-retry-whoami-80",
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
 									Ingress: &dynamic.KubernetesIngressMetadata{
 										Namespace:   "default",
-										IngressName: "ingress-with-proxy-body-size-retry",
+										IngressName: "ingress-with-proxy-body-size-zero-retry",
 										ServiceName: "whoami",
 										ServicePort: "80",
 									},
@@ -9361,13 +9378,13 @@ func TestLoadIngresses(t *testing.T) {
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{
-						"default-ingress-with-proxy-body-size-retry-rule-0-path-0-retry": {
+						"default-ingress-with-proxy-body-size-zero-retry-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
 								Attempts:            3,
 								MaxRequestBodyBytes: ptr.To(int64(-1)),
 							},
 						},
-						"default-ingress-with-proxy-body-size-retry-rule-0-path-0-tls-retry": {
+						"default-ingress-with-proxy-body-size-zero-retry-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
 								Attempts:            3,
 								MaxRequestBodyBytes: ptr.To(int64(-1)),
@@ -9384,7 +9401,7 @@ func TestLoadIngresses(t *testing.T) {
 								},
 							},
 						},
-						"default-ingress-with-proxy-body-size-retry-whoami-80": {
+						"default-ingress-with-proxy-body-size-zero-retry-whoami-80": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
@@ -9399,12 +9416,104 @@ func TestLoadIngresses(t *testing.T) {
 								ResponseForwarding: &dynamic.ResponseForwarding{
 									FlushInterval: dynamic.DefaultFlushInterval,
 								},
-								ServersTransport: "default-ingress-with-proxy-body-size-retry",
+								ServersTransport: "default-ingress-with-proxy-body-size-zero-retry",
 							},
 						},
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{
-						"default-ingress-with-proxy-body-size-retry": {
+						"default-ingress-with-proxy-body-size-zero-retry": {
+							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
+								DialTimeout:     ptypes.Duration(60 * time.Second),
+								ReadTimeout:     ptypes.Duration(60 * time.Second),
+								WriteTimeout:    ptypes.Duration(60 * time.Second),
+								IdleConnTimeout: ptypes.Duration(60 * time.Second),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc: "HTTP status retry disabled when request buffering off",
+			paths: []string{
+				"services.yml",
+				"ingressclasses.yml",
+				"ingresses/ingress-with-http-status-retry-and-buffering-off.yml",
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-ingress-with-http-status-retry-and-buffering-off-rule-0-path-0": {
+							EntryPoints: []string{"http"},
+							Rule:        `Host("hostname.localhost") && Path("/")`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-http-status-retry-and-buffering-off-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-http-status-retry-and-buffering-off",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+						},
+						"default-ingress-with-http-status-retry-and-buffering-off-rule-0-path-0-tls": {
+							EntryPoints: []string{"https"},
+							Rule:        `Host("hostname.localhost") && Path("/")`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-http-status-retry-and-buffering-off-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-http-status-retry-and-buffering-off",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							TLS: &dynamic.RouterTLSConfig{},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"unavailable-service": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+						"default-ingress-with-http-status-retry-and-buffering-off-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+								ServersTransport: "default-ingress-with-http-status-retry-and-buffering-off",
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{
+						"default-ingress-with-http-status-retry-and-buffering-off": {
 							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
 								DialTimeout:     ptypes.Duration(60 * time.Second),
 								ReadTimeout:     ptypes.Duration(60 * time.Second),
@@ -11144,7 +11253,6 @@ func TestLoadIngresses(t *testing.T) {
 									},
 								},
 							},
-							Middlewares: []string{"default-ingress-with-proxy-next-upstream-rule-0-path-0-retry"},
 						},
 						"default-ingress-with-proxy-next-upstream-off-rule-0-path-0": {
 							EntryPoints: []string{"http"},
@@ -11177,8 +11285,7 @@ func TestLoadIngresses(t *testing.T) {
 									},
 								},
 							},
-							Middlewares: []string{"default-ingress-with-proxy-next-upstream-rule-0-path-0-tls-retry"},
-							TLS:         &dynamic.RouterTLSConfig{},
+							TLS: &dynamic.RouterTLSConfig{},
 						},
 						"default-ingress-with-proxy-next-upstream-off-rule-0-path-0-tls": {
 							EntryPoints: []string{"https"},
@@ -11198,7 +11305,197 @@ func TestLoadIngresses(t *testing.T) {
 							TLS: &dynamic.RouterTLSConfig{},
 						},
 					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"unavailable-service": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+						"default-ingress-with-proxy-next-upstream-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{URL: "http://10.10.0.1:80"},
+									{URL: "http://10.10.0.2:80"},
+								},
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+								ServersTransport: "default-ingress-with-proxy-next-upstream",
+							},
+						},
+						"default-ingress-with-proxy-next-upstream-off-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{URL: "http://10.10.0.1:80"},
+									{URL: "http://10.10.0.2:80"},
+								},
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+								ServersTransport: "default-ingress-with-proxy-next-upstream-off",
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{
+						"default-ingress-with-proxy-next-upstream": {
+							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
+								DialTimeout:     ptypes.Duration(60 * time.Second),
+								ReadTimeout:     ptypes.Duration(60 * time.Second),
+								WriteTimeout:    ptypes.Duration(60 * time.Second),
+								IdleConnTimeout: ptypes.Duration(60 * time.Second),
+							},
+						},
+						"default-ingress-with-proxy-next-upstream-off": {
+							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
+								DialTimeout:     ptypes.Duration(60 * time.Second),
+								ReadTimeout:     ptypes.Duration(60 * time.Second),
+								WriteTimeout:    ptypes.Duration(60 * time.Second),
+								IdleConnTimeout: ptypes.Duration(60 * time.Second),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc: "Proxy next upstream with proxyRequestBuffering true",
+			paths: []string{
+				"services.yml",
+				"ingressclasses.yml",
+				"ingresses/ingress-with-proxy-next-upstream.yml",
+			},
+			proxyRequestBuffering: true,
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-ingress-with-proxy-next-upstream-rule-0-path-0": {
+							EntryPoints: []string{"http"},
+							Rule:        `Host("whoami.localhost") && Path("/")`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-proxy-next-upstream-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-proxy-next-upstream",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							Middlewares: []string{
+								"default-ingress-with-proxy-next-upstream-rule-0-path-0-buffering",
+								"default-ingress-with-proxy-next-upstream-rule-0-path-0-retry",
+							},
+						},
+						"default-ingress-with-proxy-next-upstream-off-rule-0-path-0": {
+							EntryPoints: []string{"http"},
+							Rule:        `Host("whoami.localhost") && Path("/")`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-proxy-next-upstream-off-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-proxy-next-upstream-off",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							Middlewares: []string{
+								"default-ingress-with-proxy-next-upstream-off-rule-0-path-0-buffering",
+							},
+						},
+						"default-ingress-with-proxy-next-upstream-rule-0-path-0-tls": {
+							EntryPoints: []string{"https"},
+							Rule:        `Host("whoami.localhost") && Path("/")`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-proxy-next-upstream-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-proxy-next-upstream",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							Middlewares: []string{
+								"default-ingress-with-proxy-next-upstream-rule-0-path-0-tls-buffering",
+								"default-ingress-with-proxy-next-upstream-rule-0-path-0-tls-retry",
+							},
+							TLS: &dynamic.RouterTLSConfig{},
+						},
+						"default-ingress-with-proxy-next-upstream-off-rule-0-path-0-tls": {
+							EntryPoints: []string{"https"},
+							Rule:        `Host("whoami.localhost") && Path("/")`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-proxy-next-upstream-off-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-proxy-next-upstream-off",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							Middlewares: []string{
+								"default-ingress-with-proxy-next-upstream-off-rule-0-path-0-tls-buffering",
+							},
+							TLS: &dynamic.RouterTLSConfig{},
+						},
+					},
 					Middlewares: map[string]*dynamic.Middleware{
+						"default-ingress-with-proxy-next-upstream-off-rule-0-path-0-buffering": {
+							Buffering: &dynamic.Buffering{
+								MaxRequestBodyBytes:   defaultProxyBodySize,
+								MemRequestBodyBytes:   defaultClientBodyBufferSize,
+								MemResponseBodyBytes:  defaultProxyBufferSize * int64(defaultProxyBuffersNumber),
+								DisableResponseBuffer: true,
+							},
+						},
+						"default-ingress-with-proxy-next-upstream-off-rule-0-path-0-tls-buffering": {
+							Buffering: &dynamic.Buffering{
+								MaxRequestBodyBytes:   defaultProxyBodySize,
+								MemRequestBodyBytes:   defaultClientBodyBufferSize,
+								MemResponseBodyBytes:  defaultProxyBufferSize * int64(defaultProxyBuffersNumber),
+								DisableResponseBuffer: true,
+							},
+						},
+						"default-ingress-with-proxy-next-upstream-rule-0-path-0-buffering": {
+							Buffering: &dynamic.Buffering{
+								MaxRequestBodyBytes:   defaultProxyBodySize,
+								MemRequestBodyBytes:   defaultClientBodyBufferSize,
+								MemResponseBodyBytes:  defaultProxyBufferSize * int64(defaultProxyBuffersNumber),
+								DisableResponseBuffer: true,
+							},
+						},
+						"default-ingress-with-proxy-next-upstream-rule-0-path-0-tls-buffering": {
+							Buffering: &dynamic.Buffering{
+								MaxRequestBodyBytes:   defaultProxyBodySize,
+								MemRequestBodyBytes:   defaultClientBodyBufferSize,
+								MemResponseBodyBytes:  defaultProxyBufferSize * int64(defaultProxyBuffersNumber),
+								DisableResponseBuffer: true,
+							},
+						},
 						"default-ingress-with-proxy-next-upstream-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
 								Attempts:                 3,
@@ -16386,6 +16683,7 @@ func TestLoadIngresses(t *testing.T) {
 				IPAllowListStrategy:            test.ipAllowListStrategy,
 				AllowCrossNamespaceResources:   test.allowCrossNamespaceResources,
 				GlobalAuthURL:                  test.globalAuthURL,
+				ProxyRequestBuffering:          test.proxyRequestBuffering,
 			}
 			p.SetDefaults()
 			if test.strictValidatePathType != nil {

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -9129,7 +9129,7 @@ func TestLoadIngresses(t *testing.T) {
 			},
 		},
 		{
-			desc:                  "Proxy request buffering annotation off disables retry",
+			desc:                  "Proxy request buffering off keeps network retry when no status codes are set",
 			proxyRequestBuffering: true,
 			paths: []string{
 				"services.yml",

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -9311,6 +9311,113 @@ func TestLoadIngresses(t *testing.T) {
 			},
 		},
 		{
+			desc: "Proxy body size zero influences retry max request body bytes",
+			paths: []string{
+				"services.yml",
+				"ingressclasses.yml",
+				"ingresses/ingress-with-proxy-body-size-zero-retry.yml",
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-ingress-with-proxy-body-size-retry-rule-0-path-0": {
+							EntryPoints: []string{"http"},
+							Rule:        `Host("hostname.localhost") && Path("/")`,
+							RuleSyntax:  "default",
+							Middlewares: []string{"default-ingress-with-proxy-body-size-retry-rule-0-path-0-retry"},
+							Service:     "default-ingress-with-proxy-body-size-retry-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-proxy-body-size-retry",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+						},
+						"default-ingress-with-proxy-body-size-retry-rule-0-path-0-tls": {
+							EntryPoints: []string{"https"},
+							Rule:        `Host("hostname.localhost") && Path("/")`,
+							RuleSyntax:  "default",
+							Middlewares: []string{"default-ingress-with-proxy-body-size-retry-rule-0-path-0-tls-retry"},
+							Service:     "default-ingress-with-proxy-body-size-retry-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-proxy-body-size-retry",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							TLS: &dynamic.RouterTLSConfig{},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-ingress-with-proxy-body-size-retry-rule-0-path-0-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(int64(-1)),
+							},
+						},
+						"default-ingress-with-proxy-body-size-retry-rule-0-path-0-tls-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(int64(-1)),
+							},
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"unavailable-service": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+						"default-ingress-with-proxy-body-size-retry-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+								ServersTransport: "default-ingress-with-proxy-body-size-retry",
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{
+						"default-ingress-with-proxy-body-size-retry": {
+							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
+								DialTimeout:     ptypes.Duration(60 * time.Second),
+								ReadTimeout:     ptypes.Duration(60 * time.Second),
+								WriteTimeout:    ptypes.Duration(60 * time.Second),
+								IdleConnTimeout: ptypes.Duration(60 * time.Second),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
 			desc: "Buffering with client body buffer size of 10MB",
 			paths: []string{
 				"services.yml",

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -11420,6 +11420,113 @@ func TestLoadIngresses(t *testing.T) {
 			},
 		},
 		{
+			desc: "Proxy next upstream with status only conditions",
+			paths: []string{
+				"services.yml",
+				"ingressclasses.yml",
+				"ingresses/ingress-with-proxy-next-upstream-status-only.yml",
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-ingress-with-proxy-next-upstream-status-only-rule-0-path-0": {
+							EntryPoints: []string{"http"},
+							Rule:        `Host("whoami.localhost") && Path("/")`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-proxy-next-upstream-status-only-whoami-80",
+							Middlewares: []string{"default-ingress-with-proxy-next-upstream-status-only-rule-0-path-0-retry"},
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-proxy-next-upstream-status-only",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+						},
+						"default-ingress-with-proxy-next-upstream-status-only-rule-0-path-0-tls": {
+							EntryPoints: []string{"https"},
+							Rule:        `Host("whoami.localhost") && Path("/")`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-proxy-next-upstream-status-only-whoami-80",
+							Middlewares: []string{"default-ingress-with-proxy-next-upstream-status-only-rule-0-path-0-tls-retry"},
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-proxy-next-upstream-status-only",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							TLS: &dynamic.RouterTLSConfig{},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-ingress-with-proxy-next-upstream-status-only-rule-0-path-0-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:                   3,
+								Status:                     []string{"502", "503"},
+								DisableRetryOnNetworkError: true,
+								MaxRequestBodyBytes:        ptr.To(int64(0)),
+							},
+						},
+						"default-ingress-with-proxy-next-upstream-status-only-rule-0-path-0-tls-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:                   3,
+								Status:                     []string{"502", "503"},
+								DisableRetryOnNetworkError: true,
+								MaxRequestBodyBytes:        ptr.To(int64(0)),
+							},
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"unavailable-service": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+						"default-ingress-with-proxy-next-upstream-status-only-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{URL: "http://10.10.0.1:80"},
+									{URL: "http://10.10.0.2:80"},
+								},
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+								ServersTransport: "default-ingress-with-proxy-next-upstream-status-only",
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{
+						"default-ingress-with-proxy-next-upstream-status-only": {
+							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
+								DialTimeout:     ptypes.Duration(60 * time.Second),
+								ReadTimeout:     ptypes.Duration(60 * time.Second),
+								WriteTimeout:    ptypes.Duration(60 * time.Second),
+								IdleConnTimeout: ptypes.Duration(60 * time.Second),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
 			desc: "Proxy next upstream with proxyRequestBuffering true",
 			paths: []string{
 				"services.yml",

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -16148,7 +16148,10 @@ func TestLoadIngresses(t *testing.T) {
 							},
 						},
 						"default-ingress-with-tls-multi-secrets-rule-0-path-0-tls-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
+							},
 						},
 						"default-ingress-with-tls-multi-secrets-rule-1-path-0-redirect-scheme": {
 							RedirectScheme: &dynamic.RedirectScheme{
@@ -16157,7 +16160,10 @@ func TestLoadIngresses(t *testing.T) {
 							},
 						},
 						"default-ingress-with-tls-multi-secrets-rule-1-path-0-tls-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
+							},
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -16345,7 +16351,10 @@ func TestLoadIngresses(t *testing.T) {
 							},
 						},
 						"default-ingress-with-auth-tls-pass-certificate-to-upstream-optional-no-ca-rule-0-path-0-tls-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
+							},
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -16505,10 +16514,16 @@ func TestLoadIngresses(t *testing.T) {
 							},
 						},
 						"default-ingress-with-custom-http-errors-and-upstream-hash-by-rule-0-path-0-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
+							},
 						},
 						"default-ingress-with-custom-http-errors-and-upstream-hash-by-rule-0-path-0-tls-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
+							},
 						},
 					},
 					Services: map[string]*dynamic.Service{

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -5519,12 +5519,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-backend-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-backend-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -5656,16 +5658,28 @@ func TestLoadIngresses(t *testing.T) {
 					},
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-default-backend-annotations-rule-0-path-0-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
+							},
 						},
 						"default-ingress-with-default-backend-annotations-rule-0-path-0-tls-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
+							},
 						},
 						"default-ingress-with-default-backend-annotations-default-backend-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
+							},
 						},
 						"default-ingress-with-default-backend-annotations-default-backend-tls-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
+							},
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -6491,12 +6505,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-allowlist-single-ip-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-allowlist-single-ip-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -15312,8 +15328,18 @@ func TestLoadIngresses(t *testing.T) {
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{
-						"default-ingress-with-limit-connections-rule-0-path-0-retry":     {Retry: &dynamic.Retry{Attempts: 3}},
-						"default-ingress-with-limit-connections-rule-0-path-0-tls-retry": {Retry: &dynamic.Retry{Attempts: 3}},
+						"default-ingress-with-limit-connections-rule-0-path-0-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
+							},
+						},
+						"default-ingress-with-limit-connections-rule-0-path-0-tls-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
+							},
+						},
 						"default-ingress-with-limit-connections-rule-0-path-0-limit-connections": {
 							InFlightReq: &dynamic.InFlightReq{
 								Amount: 10,

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -16752,10 +16752,16 @@ func TestLoadIngresses(t *testing.T) {
 					},
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-endpoint-conditions-rule-0-path-0-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
+							},
 						},
 						"default-ingress-with-endpoint-conditions-rule-0-path-0-tls-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
+							},
 						},
 					},
 					Services: map[string]*dynamic.Service{

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -9453,6 +9453,7 @@ func TestLoadIngresses(t *testing.T) {
 							Rule:        `Host("hostname.localhost") && Path("/")`,
 							RuleSyntax:  "default",
 							Service:     "default-ingress-with-http-status-retry-and-buffering-off-whoami-80",
+							Middlewares: []string{"default-ingress-with-http-status-retry-and-buffering-off-rule-0-path-0-retry"},
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
 									Ingress: &dynamic.KubernetesIngressMetadata{
@@ -9469,6 +9470,7 @@ func TestLoadIngresses(t *testing.T) {
 							Rule:        `Host("hostname.localhost") && Path("/")`,
 							RuleSyntax:  "default",
 							Service:     "default-ingress-with-http-status-retry-and-buffering-off-whoami-80",
+							Middlewares: []string{"default-ingress-with-http-status-retry-and-buffering-off-rule-0-path-0-tls-retry"},
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
 									Ingress: &dynamic.KubernetesIngressMetadata{
@@ -9482,7 +9484,22 @@ func TestLoadIngresses(t *testing.T) {
 							TLS: &dynamic.RouterTLSConfig{},
 						},
 					},
-					Middlewares: map[string]*dynamic.Middleware{},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-ingress-with-http-status-retry-and-buffering-off-rule-0-path-0-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								Status:              []string{"502"},
+								MaxRequestBodyBytes: ptr.To(int64(0)),
+							},
+						},
+						"default-ingress-with-http-status-retry-and-buffering-off-rule-0-path-0-tls-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								Status:              []string{"502"},
+								MaxRequestBodyBytes: ptr.To(int64(0)),
+							},
+						},
+					},
 					Services: map[string]*dynamic.Service{
 						"unavailable-service": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
@@ -11243,6 +11260,7 @@ func TestLoadIngresses(t *testing.T) {
 							Rule:        `Host("whoami.localhost") && Path("/")`,
 							RuleSyntax:  "default",
 							Service:     "default-ingress-with-proxy-next-upstream-whoami-80",
+							Middlewares: []string{"default-ingress-with-proxy-next-upstream-rule-0-path-0-retry"},
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
 									Ingress: &dynamic.KubernetesIngressMetadata{
@@ -11275,6 +11293,7 @@ func TestLoadIngresses(t *testing.T) {
 							Rule:        `Host("whoami.localhost") && Path("/")`,
 							RuleSyntax:  "default",
 							Service:     "default-ingress-with-proxy-next-upstream-whoami-80",
+							Middlewares: []string{"default-ingress-with-proxy-next-upstream-rule-0-path-0-tls-retry"},
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
 									Ingress: &dynamic.KubernetesIngressMetadata{
@@ -11305,7 +11324,24 @@ func TestLoadIngresses(t *testing.T) {
 							TLS: &dynamic.RouterTLSConfig{},
 						},
 					},
-					Middlewares: map[string]*dynamic.Middleware{},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-ingress-with-proxy-next-upstream-rule-0-path-0-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:                 3,
+								Status:                   []string{"400"},
+								RetryNonIdempotentMethod: true,
+								MaxRequestBodyBytes:      ptr.To(int64(0)),
+							},
+						},
+						"default-ingress-with-proxy-next-upstream-rule-0-path-0-tls-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:                 3,
+								Status:                   []string{"400"},
+								RetryNonIdempotentMethod: true,
+								MaxRequestBodyBytes:      ptr.To(int64(0)),
+							},
+						},
+					},
 					Services: map[string]*dynamic.Service{
 						"unavailable-service": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -15454,42 +15454,50 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-external-name-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-external-name-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-external-name-rule-0-path-1-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-external-name-rule-0-path-1-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-external-name-rule-0-path-2-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-external-name-rule-0-path-2-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-external-name-rule-0-path-3-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-external-name-rule-0-path-3-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -9167,13 +9167,13 @@ func TestLoadIngresses(t *testing.T) {
 						"default-ingress-with-proxy-request-buffering-off-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
 								Attempts:            3,
-								MaxRequestBodyBytes: ptr.To(int64(defaultProxyBodySize)),
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-proxy-request-buffering-off-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
 								Attempts:            3,
-								MaxRequestBodyBytes: ptr.To(int64(defaultProxyBodySize)),
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -120,12 +120,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-service-unavailable-http-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-service-unavailable-http-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -216,12 +218,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-service-unavailable-http-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-service-unavailable-http-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-service-unavailable-http-rule-0-path-0-redirect": {
@@ -361,22 +365,26 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-service-unavailable-default-backend-default-backend-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-service-unavailable-default-backend-default-backend-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-service-unavailable-default-backend-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-service-unavailable-default-backend-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -527,7 +535,8 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-custom-headers-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-cross-namespace-headers-rule-0-path-0-custom-headers": {
@@ -537,7 +546,8 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-cross-namespace-headers-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-custom-headers-rule-0-path-0-tls-custom-headers": {
@@ -547,7 +557,8 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-custom-headers-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-cross-namespace-headers-rule-0-path-0-tls-custom-headers": {
@@ -557,7 +568,8 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-cross-namespace-headers-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -816,12 +828,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-custom-headers-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-custom-headers-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -994,12 +1008,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-custom-headers-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-custom-headers-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-cross-namespace-headers-rule-0-path-0-custom-headers": {
@@ -1014,12 +1030,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-cross-namespace-headers-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-cross-namespace-headers-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -1152,7 +1170,8 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-no-annotation-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -1277,12 +1296,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-basicauth-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-basicauth-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -1433,12 +1454,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-forwardauth-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-forwardauth-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -1593,12 +1616,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-forwardauth-snippet-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-forwardauth-snippet-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -1712,10 +1737,10 @@ func TestLoadIngresses(t *testing.T) {
 							},
 						},
 						"default-ingress-without-auth-rule-0-path-0-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)},
 						},
 						"default-ingress-without-auth-rule-0-path-0-tls-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)},
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -1810,10 +1835,10 @@ func TestLoadIngresses(t *testing.T) {
 					},
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-global-auth-disabled-rule-0-path-0-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)},
 						},
 						"default-ingress-with-global-auth-disabled-rule-0-path-0-tls-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)},
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -1928,10 +1953,10 @@ func TestLoadIngresses(t *testing.T) {
 							},
 						},
 						"default-ingress-with-forwardauth-rule-0-path-0-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)},
 						},
 						"default-ingress-with-forwardauth-rule-0-path-0-tls-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)},
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -2025,10 +2050,10 @@ func TestLoadIngresses(t *testing.T) {
 					},
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-without-auth-rule-0-path-0-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)},
 						},
 						"default-ingress-without-auth-rule-0-path-0-tls-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)},
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -2200,17 +2225,20 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-ssl-redirect-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-without-ssl-redirect-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-without-ssl-redirect-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-force-ssl-redirect-rule-0-path-0-redirect-scheme": {
@@ -2221,7 +2249,8 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-force-ssl-redirect-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -2438,12 +2467,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-sticky-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-sticky-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -2556,12 +2587,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-proxy-ssl-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-proxy-ssl-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -2684,12 +2717,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-cors-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-cors-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -2789,12 +2824,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-service-upstream-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-service-upstream-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -2915,12 +2952,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-upstream-vhost-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-upstream-vhost-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -3020,12 +3059,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-x-forwarded-prefix-no-rewrite-target-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-x-forwarded-prefix-no-rewrite-target-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -3209,12 +3250,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-x-forwarded-prefix-three-groups-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-x-forwarded-prefix-three-groups-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-x-forwarded-prefix-rule-0-path-0-rewrite-target": {
@@ -3233,12 +3276,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-x-forwarded-prefix-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-x-forwarded-prefix-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-x-forwarded-prefix-regex-rule-0-path-0-rewrite-target": {
@@ -3257,12 +3302,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-x-forwarded-prefix-regex-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-x-forwarded-prefix-regex-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -3414,12 +3461,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-use-regex-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-use-regex-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -3554,22 +3603,26 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-a-with-use-regex-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-a-with-use-regex-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-b-without-use-regex-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-b-without-use-regex-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -3730,22 +3783,26 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-a-with-use-regex-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-a-with-use-regex-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-b-without-use-regex-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-b-without-use-regex-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -3918,22 +3975,26 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-rewrite-target-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-rewrite-target-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-rewrite-target-no-regex-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-rewrite-target-no-regex-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -4077,12 +4138,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-rewrite-target-no-regex-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-rewrite-target-no-regex-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -4228,16 +4291,16 @@ func TestLoadIngresses(t *testing.T) {
 							},
 						},
 						"default-ingress-a-with-rewrite-target-rule-0-path-0-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)},
 						},
 						"default-ingress-a-with-rewrite-target-rule-0-path-0-tls-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)},
 						},
 						"default-ingress-b-without-rewrite-target-rule-0-path-0-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)},
 						},
 						"default-ingress-b-without-rewrite-target-rule-0-path-0-tls-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)},
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -4400,16 +4463,16 @@ func TestLoadIngresses(t *testing.T) {
 							},
 						},
 						"default-ingress-a-with-rewrite-target-rule-0-path-0-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)},
 						},
 						"default-ingress-a-with-rewrite-target-rule-0-path-0-tls-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)},
 						},
 						"default-ingress-b-without-rewrite-target-rule-0-path-0-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)},
 						},
 						"default-ingress-b-without-rewrite-target-rule-0-path-0-tls-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)},
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -4537,10 +4600,10 @@ func TestLoadIngresses(t *testing.T) {
 							},
 						},
 						"default-ingress-with-rewrite-target-use-regex-false-rule-0-path-0-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)},
 						},
 						"default-ingress-with-rewrite-target-use-regex-false-rule-0-path-0-tls-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)},
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -4647,12 +4710,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-app-root-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-app-root-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -4752,12 +4817,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-app-root-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-app-root-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -4906,12 +4973,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-www-host-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-www-host-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -5060,12 +5129,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-host-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-host-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -5200,22 +5271,26 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-host-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-host-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-www-host-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-www-host-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -5726,12 +5801,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-whitelist-single-ip-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-whitelist-single-ip-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -5841,12 +5918,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-whitelist-single-cidr-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-whitelist-single-cidr-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -5956,12 +6035,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-whitelist-multiple-ip-and-cidr-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-whitelist-multiple-ip-and-cidr-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -6061,12 +6142,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-whitelist-empty-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-whitelist-empty-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -6166,12 +6249,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-allowlist-empty-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-allowlist-empty-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -6281,12 +6366,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-allowlist-single-ip-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-allowlist-single-ip-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -6518,12 +6605,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-allowlist-single-cidr-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-allowlist-single-cidr-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -6633,12 +6722,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-allowlist-multiple-ip-and-cidr-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-allowlist-multiple-ip-and-cidr-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -6810,12 +6901,12 @@ func TestLoadIngresses(t *testing.T) {
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{
-						"default-ingress-with-access-log-enabled-rule-0-path-0-retry":      {Retry: &dynamic.Retry{Attempts: 3}},
-						"default-ingress-with-access-log-enabled-rule-0-path-0-tls-retry":  {Retry: &dynamic.Retry{Attempts: 3}},
-						"default-ingress-with-access-log-disabled-rule-0-path-0-retry":     {Retry: &dynamic.Retry{Attempts: 3}},
-						"default-ingress-with-access-log-disabled-rule-0-path-0-tls-retry": {Retry: &dynamic.Retry{Attempts: 3}},
-						"default-ingress-with-access-log-default-rule-0-path-0-retry":      {Retry: &dynamic.Retry{Attempts: 3}},
-						"default-ingress-with-access-log-default-rule-0-path-0-tls-retry":  {Retry: &dynamic.Retry{Attempts: 3}},
+						"default-ingress-with-access-log-enabled-rule-0-path-0-retry":      {Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)}},
+						"default-ingress-with-access-log-enabled-rule-0-path-0-tls-retry":  {Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)}},
+						"default-ingress-with-access-log-disabled-rule-0-path-0-retry":     {Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)}},
+						"default-ingress-with-access-log-disabled-rule-0-path-0-tls-retry": {Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)}},
+						"default-ingress-with-access-log-default-rule-0-path-0-retry":      {Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)}},
+						"default-ingress-with-access-log-default-rule-0-path-0-tls-retry":  {Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)}},
 					},
 					Services: map[string]*dynamic.Service{
 						"unavailable-service": {
@@ -6967,12 +7058,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-permanent-redirect-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-permanent-redirect-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -7086,12 +7179,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-permanent-redirect-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-permanent-redirect-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -7205,12 +7300,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-permanent-redirect-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-permanent-redirect-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -7324,12 +7421,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-redirect-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-redirect-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -7443,12 +7542,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-temporal-redirect-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-temporal-redirect-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -7562,12 +7663,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-temporal-redirect-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-temporal-redirect-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -7681,12 +7784,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-temporal-redirect-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-temporal-redirect-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -7786,12 +7891,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-proxy-timeout-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-proxy-timeout-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -7887,12 +7994,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-proxy-timeout-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-proxy-timeout-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -7988,12 +8097,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-proxy-timeout-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-proxy-timeout-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -8098,7 +8209,8 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-auth-tls-secret-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -8240,7 +8352,8 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-auth-tls-verify-client-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -8396,12 +8509,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-custom-http-errors-and-default-backend-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-custom-http-errors-and-default-backend-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -8594,12 +8709,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-custom-http-errors-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-custom-http-errors-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -8715,10 +8832,10 @@ func TestLoadIngresses(t *testing.T) {
 					},
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-custom-http-errors-rule-0-path-0-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)},
 						},
 						"default-ingress-with-custom-http-errors-rule-0-path-0-tls-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)},
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -8817,12 +8934,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-default-backend-annotation-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-default-backend-annotation-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -8938,12 +9057,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-proxy-body-size-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(int64(10 * 1024 * 1024)),
 							},
 						},
 						"default-ingress-with-proxy-body-size-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(int64(10 * 1024 * 1024)),
 							},
 						},
 					},
@@ -8978,6 +9099,205 @@ func TestLoadIngresses(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{
 						"default-ingress-with-proxy-body-size": {
+							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
+								DialTimeout:     ptypes.Duration(60 * time.Second),
+								ReadTimeout:     ptypes.Duration(60 * time.Second),
+								WriteTimeout:    ptypes.Duration(60 * time.Second),
+								IdleConnTimeout: ptypes.Duration(60 * time.Second),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc: "Proxy request buffering off disables retry",
+			paths: []string{
+				"services.yml",
+				"ingressclasses.yml",
+				"ingresses/ingress-with-proxy-request-buffering-off.yml",
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-ingress-with-proxy-request-buffering-off-rule-0-path-0": {
+							EntryPoints: []string{"http"},
+							Rule:        `Host("hostname.localhost") && Path("/")`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-proxy-request-buffering-off-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-proxy-request-buffering-off",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+						},
+						"default-ingress-with-proxy-request-buffering-off-rule-0-path-0-tls": {
+							EntryPoints: []string{"https"},
+							Rule:        `Host("hostname.localhost") && Path("/")`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-proxy-request-buffering-off-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-proxy-request-buffering-off",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							TLS: &dynamic.RouterTLSConfig{},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"unavailable-service": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+						"default-ingress-with-proxy-request-buffering-off-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+								ServersTransport: "default-ingress-with-proxy-request-buffering-off",
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{
+						"default-ingress-with-proxy-request-buffering-off": {
+							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
+								DialTimeout:     ptypes.Duration(60 * time.Second),
+								ReadTimeout:     ptypes.Duration(60 * time.Second),
+								WriteTimeout:    ptypes.Duration(60 * time.Second),
+								IdleConnTimeout: ptypes.Duration(60 * time.Second),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc: "Proxy body size influences retry max request body bytes",
+			paths: []string{
+				"services.yml",
+				"ingressclasses.yml",
+				"ingresses/ingress-with-proxy-body-size-retry.yml",
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-ingress-with-proxy-body-size-retry-rule-0-path-0": {
+							EntryPoints: []string{"http"},
+							Rule:        `Host("hostname.localhost") && Path("/")`,
+							RuleSyntax:  "default",
+							Middlewares: []string{"default-ingress-with-proxy-body-size-retry-rule-0-path-0-retry"},
+							Service:     "default-ingress-with-proxy-body-size-retry-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-proxy-body-size-retry",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+						},
+						"default-ingress-with-proxy-body-size-retry-rule-0-path-0-tls": {
+							EntryPoints: []string{"https"},
+							Rule:        `Host("hostname.localhost") && Path("/")`,
+							RuleSyntax:  "default",
+							Middlewares: []string{"default-ingress-with-proxy-body-size-retry-rule-0-path-0-tls-retry"},
+							Service:     "default-ingress-with-proxy-body-size-retry-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-proxy-body-size-retry",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							TLS: &dynamic.RouterTLSConfig{},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-ingress-with-proxy-body-size-retry-rule-0-path-0-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(int64(5 * 1024 * 1024)),
+							},
+						},
+						"default-ingress-with-proxy-body-size-retry-rule-0-path-0-tls-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(int64(5 * 1024 * 1024)),
+							},
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"unavailable-service": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+						"default-ingress-with-proxy-body-size-retry-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+								ServersTransport: "default-ingress-with-proxy-body-size-retry",
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{
+						"default-ingress-with-proxy-body-size-retry": {
 							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
 								DialTimeout:     ptypes.Duration(60 * time.Second),
 								ReadTimeout:     ptypes.Duration(60 * time.Second),
@@ -9059,12 +9379,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-client-body-buffer-size-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-client-body-buffer-size-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -9180,12 +9502,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-proxy-body-size-and-client-body-buffer-size-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(int64(10 * 1024 * 1024)),
 							},
 						},
 						"default-ingress-with-proxy-body-size-and-client-body-buffer-size-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(int64(10 * 1024 * 1024)),
 							},
 						},
 					},
@@ -9303,12 +9627,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-proxy-buffer-size-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-proxy-buffer-size-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -9426,12 +9752,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-proxy-buffers-number-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-proxy-buffers-number-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -9549,12 +9877,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-proxy-buffer-size-and-number-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-proxy-buffer-size-and-number-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -9672,12 +10002,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-proxy-max-temp-file-size-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-proxy-max-temp-file-size-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -9794,12 +10126,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-server-snippet-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-server-snippet-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -9912,12 +10246,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-configuration-snippet-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-configuration-snippet-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -10032,12 +10368,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-both-snippets-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-both-snippets-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -10240,12 +10578,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-server-snippet-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-server-snippet-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -10352,12 +10692,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-configuration-snippet-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-configuration-snippet-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -10466,12 +10808,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-both-snippets-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-both-snippets-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -10583,7 +10927,8 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-auth-tls-pass-certificate-to-upstream-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -10752,6 +11097,7 @@ func TestLoadIngresses(t *testing.T) {
 								Attempts:                 3,
 								Status:                   []string{"400"},
 								RetryNonIdempotentMethod: true,
+								MaxRequestBodyBytes:      ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-proxy-next-upstream-rule-0-path-0-tls-retry": {
@@ -10759,6 +11105,7 @@ func TestLoadIngresses(t *testing.T) {
 								Attempts:                 3,
 								Status:                   []string{"400"},
 								RetryNonIdempotentMethod: true,
+								MaxRequestBodyBytes:      ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -10911,22 +11258,26 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-proxy-next-upstream-tries-unlimited-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 2,
+								Attempts:            2,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-proxy-next-upstream-tries-unlimited-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 2,
+								Attempts:            2,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-proxy-next-upstream-tries-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 5,
+								Attempts:            5,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-proxy-next-upstream-tries-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 5,
+								Attempts:            5,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -11044,14 +11395,16 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-proxy-next-upstream-timeout-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
-								Timeout:  ptypes.Duration(30 * time.Second),
+								Attempts:            3,
+								Timeout:             ptypes.Duration(30 * time.Second),
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-proxy-next-upstream-timeout-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
-								Timeout:  ptypes.Duration(30 * time.Second),
+								Attempts:            3,
+								Timeout:             ptypes.Duration(30 * time.Second),
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -11147,12 +11500,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-server-alias-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-server-alias-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -11288,22 +11643,26 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-primary-ingress-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-primary-ingress-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-alias-ingress-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-alias-ingress-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -11456,22 +11815,26 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-first-ingress-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-first-ingress-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-second-ingress-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-second-ingress-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -11589,12 +11952,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-proxy-http-version-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-proxy-http-version-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -11691,12 +12056,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-proxy-http-version-unsupported-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-proxy-http-version-unsupported-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -11792,12 +12159,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-upstream-hash-by-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-upstream-hash-by-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -11894,12 +12263,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-canary-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-canary-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -12031,12 +12402,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-canary-and-sticky-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-canary-and-sticky-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -12204,12 +12577,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-canary-weight-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-canary-weight-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -12376,22 +12751,26 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-canary-by-header-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-canary-by-header-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-canary-by-header-rule-0-path-0-canary-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-canary-by-header-rule-0-path-0-canary-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -12558,22 +12937,26 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-canary-by-header-value-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-canary-by-header-value-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-canary-by-header-value-rule-0-path-0-canary-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-canary-by-header-value-rule-0-path-0-canary-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -12740,22 +13123,26 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-canary-by-header-pattern-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-canary-by-header-pattern-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-canary-by-header-pattern-rule-0-path-0-canary-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-canary-by-header-pattern-rule-0-path-0-canary-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -12887,12 +13274,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-canary-by-header-misconfigured-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-canary-by-header-misconfigured-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -13059,22 +13448,26 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-canary-by-cookie-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-canary-by-cookie-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-canary-by-cookie-rule-0-path-0-canary-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-canary-by-cookie-rule-0-path-0-canary-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -13276,32 +13669,38 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-canary-by-header-and-cookie-and-weight-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-canary-by-header-and-cookie-and-weight-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-canary-by-header-and-cookie-and-weight-rule-0-path-0-canary-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-canary-by-header-and-cookie-and-weight-rule-0-path-0-canary-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-canary-by-header-and-cookie-and-weight-rule-0-path-0-non-canary-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-canary-by-header-and-cookie-and-weight-rule-0-path-0-non-canary-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -13504,22 +13903,26 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-canary-middlewares-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-canary-middlewares-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-canary-middlewares-rule-0-path-0-canary-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-canary-middlewares-rule-0-path-0-canary-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -13651,12 +14054,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-non-matching-canary-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-non-matching-canary-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -13810,7 +14215,8 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-canary-middlewares-and-tls-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-canary-middlewares-and-tls-rule-0-path-0-canary-redirect-scheme": {
@@ -13827,7 +14233,8 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-canary-middlewares-and-tls-rule-0-path-0-canary-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -13989,12 +14396,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-limit-rps-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-limit-rps-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-limit-rps-rule-0-path-0-limit-rps": {
@@ -14013,12 +14422,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-limit-rps-zero-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-limit-rps-zero-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -14171,12 +14582,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-limit-rpm-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-limit-rpm-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-limit-rpm-rule-0-path-0-limit-rpm": {
@@ -14195,12 +14608,14 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-limit-rpm-zero-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-limit-rpm-zero-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -14348,10 +14763,10 @@ func TestLoadIngresses(t *testing.T) {
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{
-						"default-ingress-with-limit-burst-multiplier-rule-0-path-0-retry":          {Retry: &dynamic.Retry{Attempts: 3}},
-						"default-ingress-with-limit-burst-multiplier-rule-0-path-0-tls-retry":      {Retry: &dynamic.Retry{Attempts: 3}},
-						"default-ingress-with-limit-burst-multiplier-zero-rule-0-path-0-retry":     {Retry: &dynamic.Retry{Attempts: 3}},
-						"default-ingress-with-limit-burst-multiplier-zero-rule-0-path-0-tls-retry": {Retry: &dynamic.Retry{Attempts: 3}},
+						"default-ingress-with-limit-burst-multiplier-rule-0-path-0-retry":          {Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)}},
+						"default-ingress-with-limit-burst-multiplier-rule-0-path-0-tls-retry":      {Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)}},
+						"default-ingress-with-limit-burst-multiplier-zero-rule-0-path-0-retry":     {Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)}},
+						"default-ingress-with-limit-burst-multiplier-zero-rule-0-path-0-tls-retry": {Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)}},
 						"default-ingress-with-limit-burst-multiplier-rule-0-path-0-limit-rps": {
 							RateLimit: &dynamic.RateLimit{Average: 10, Burst: 100, Period: ptypes.Duration(time.Second)},
 						},
@@ -14589,10 +15004,10 @@ func TestLoadIngresses(t *testing.T) {
 					},
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-use-regex-rule-0-path-0-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)},
 						},
 						"default-ingress-with-use-regex-rule-0-path-0-tls-retry": {
-							Retry: &dynamic.Retry{Attempts: 3},
+							Retry: &dynamic.Retry{Attempts: 3, MaxRequestBodyBytes: ptr.To(defaultProxyBodySize)},
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -14687,12 +15102,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-wildcard-host-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-wildcard-host-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},
@@ -14795,7 +15212,8 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-wildcard-host-tls-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
-								Attempts: 3,
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
 							},
 						},
 					},

--- a/pkg/provider/kubernetes/ingress-nginx/middleware.go
+++ b/pkg/provider/kubernetes/ingress-nginx/middleware.go
@@ -470,6 +470,7 @@ func (p *Provider) buildRetry(ctx context.Context, loc *location, endpointCount 
 			retry.Status = append(retry.Status, code)
 		}
 	}
+
 	if len(retry.Status) > 0 {
 		disableRequestBuffering := !p.ProxyRequestBuffering
 		if loc.Config.ProxyRequestBuffering != nil {

--- a/pkg/provider/kubernetes/ingress-nginx/middleware.go
+++ b/pkg/provider/kubernetes/ingress-nginx/middleware.go
@@ -40,7 +40,7 @@ func (p *Provider) buildMiddlewares(ctx context.Context, loc *location, hostname
 	p.buildAuthTLSPassCert(loc)
 	p.buildCustomHeaders(loc)
 	p.buildSnippetAuth(loc)
-	p.buildRetry(loc, endpointCount)
+	p.buildRetry(ctx, loc, endpointCount)
 }
 
 func (p *Provider) buildSSLRedirect(loc *location) {
@@ -413,7 +413,7 @@ func (p *Provider) buildSnippetAuth(loc *location) {
 	loc.SnippetAuth = sa
 }
 
-func (p *Provider) buildRetry(loc *location, endpointCount int) {
+func (p *Provider) buildRetry(ctx context.Context, loc *location, endpointCount int) {
 	attempts := ptr.Deref(loc.Config.ProxyNextUpstreamTries, p.ProxyNextUpstreamTries)
 	// Safeguard to deactivate retry when the value is less than 0.
 	if attempts < 0 {
@@ -442,6 +442,23 @@ func (p *Provider) buildRetry(loc *location, endpointCount int) {
 
 	retry := &dynamic.Retry{Attempts: attempts}
 
+	maxRequestBodyBytes := p.ProxyBodySize
+	if proxyBodySize := ptr.Deref(loc.Config.ProxyBodySize, ""); proxyBodySize != "" {
+		if v, err := nginxSizeToBytes(proxyBodySize); err != nil {
+			log.Ctx(ctx).Warn().Err(err).Msg("proxy-body-size invalid, using provider default")
+		} else {
+			maxRequestBodyBytes = v
+		}
+	}
+
+	if maxRequestBodyBytes == 0 {
+		// Zero value means no limit with ingress-nginx.
+		// With the retry middleware, the equivalent configuration is a negative value.
+		maxRequestBodyBytes = -1
+	}
+
+	retry.MaxRequestBodyBytes = &maxRequestBodyBytes
+
 	hasError := slices.Contains(conditions, "error")
 	hasTimeout := slices.Contains(conditions, "timeout")
 	if !hasError && !hasTimeout {
@@ -451,6 +468,20 @@ func (p *Provider) buildRetry(loc *location, endpointCount int) {
 	for _, sc := range conditions {
 		if code, ok := strings.CutPrefix(sc, "http_"); ok {
 			retry.Status = append(retry.Status, code)
+		}
+	}
+	if len(retry.Status) > 0 {
+		disableRequestBuffering := !p.ProxyRequestBuffering
+		if loc.Config.ProxyRequestBuffering != nil {
+			// Without value validation, lean on disabling by checking for "on", which is more likely to satisfy user input.
+			disableRequestBuffering = *loc.Config.ProxyRequestBuffering != "on"
+		}
+
+		// When request buffering is explicitly disabled,
+		// we still want to allow the retry for empty body requests
+		// but disable it for request with bodies.
+		if disableRequestBuffering {
+			retry.MaxRequestBodyBytes = ptr.To(int64(0))
 		}
 	}
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR sets the retry middleware's MaxRequestBodyBytes from the proxy-body-size annotation in the ingress-nginx provider, and disable retry when proxy-request-buffering is off.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

To have a consistent behavior with ingress-nginx.
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
