### PR TITLE
Add error log deduplication for Kubernetes providers

### DIFF
--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/mitchellh/hashstructure"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
@@ -67,11 +68,49 @@ type Provider struct {
 	lastConfiguration safe.Safe
 
 	routerTransform k8s.RouterTransform
+
+	errorDeduper *k8s.ErrorDeduper
 }
 
 // Init the provider.
 func (p *Provider) Init() error {
+	p.errorDeduper = k8s.NewErrorDeduper()
 	return nil
+}
+
+func (p *Provider) logIngressError(logger zerolog.Logger, namespace, ingress, msg string, err error) {
+	if p.errorDeduper == nil {
+		p.errorDeduper = k8s.NewErrorDeduper()
+	}
+	key := fmt.Sprintf("%s:%s:%s:%s", ProviderName, namespace, ingress, err.Error())
+	shouldLog, suppressed := p.errorDeduper.ShouldLog(key)
+	if !shouldLog {
+		return
+	}
+	event := logger.Error().Err(err)
+	if suppressed > 0 {
+		event = event.Int("suppressed", suppressed)
+	}
+	event.Msg(msg)
+}
+
+func (p *Provider) logIngressServiceError(logger zerolog.Logger, namespace, ingress, serviceName, servicePort, msg string, err error) {
+	if p.errorDeduper == nil {
+		p.errorDeduper = k8s.NewErrorDeduper()
+	}
+	key := fmt.Sprintf("%s:%s:%s:%s:%s:%s", ProviderName, namespace, ingress, serviceName, servicePort, err.Error())
+	shouldLog, suppressed := p.errorDeduper.ShouldLog(key)
+	if !shouldLog {
+		return
+	}
+	event := logger.Error().
+		Str("serviceName", serviceName).
+		Str("servicePort", servicePort).
+		Err(err)
+	if suppressed > 0 {
+		event = event.Int("suppressed", suppressed)
+	}
+	event.Msg(msg)
 }
 
 // Provide allows the k8s provider to provide configurations to traefik

--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -101,13 +101,13 @@ func (p *Provider) loadIngressRouteConfiguration(ctx context.Context, client Cli
 
 				errBuild := cb.buildServicesLB(ctx, ingressRoute.Namespace, spec, serviceName, conf.Services)
 				if errBuild != nil {
-					logger.Error().Err(errBuild).Send()
+					p.logIngressError(logger, ingressRoute.Namespace, ingressRoute.Name, "", errBuild)
 					continue
 				}
 			case len(route.Services) == 1:
 				fullName, serversLB, err := cb.nameAndService(ctx, ingressRoute.Namespace, route.Services[0].LoadBalancerSpec)
 				if err != nil {
-					logger.Error().Err(err).Send()
+					p.logIngressError(logger, ingressRoute.Namespace, ingressRoute.Name, "", err)
 					continue
 				}
 

--- a/pkg/provider/kubernetes/crd/kubernetes_tcp.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_tcp.go
@@ -67,11 +67,9 @@ func (p *Provider) loadIngressRouteTCPConfiguration(ctx context.Context, client 
 			for _, service := range route.Services {
 				balancerServerTCP, err := p.createLoadBalancerServerTCP(client, ingressRouteTCP.Namespace, service)
 				if err != nil {
-					logger.Error().
-						Str("serviceName", service.Name).
-						Stringer("servicePort", &service.Port).
-						Err(err).
-						Msg("Cannot create service")
+					p.logIngressServiceError(logger, ingressRouteTCP.Namespace, ingressRouteTCP.Name,
+						service.Name, service.Port.String(),
+						"Cannot create service", err)
 					continue
 				}
 

--- a/pkg/provider/kubernetes/crd/kubernetes_udp.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_udp.go
@@ -42,11 +42,9 @@ func (p *Provider) loadIngressRouteUDPConfiguration(ctx context.Context, client 
 			for _, service := range route.Services {
 				balancerServerUDP, err := p.createLoadBalancerServerUDP(client, ingressRouteUDP.Namespace, service)
 				if err != nil {
-					logger.Error().
-						Str("serviceName", service.Name).
-						Stringer("servicePort", &service.Port).
-						Err(err).
-						Msg("Cannot create service")
+					p.logIngressServiceError(logger, ingressRouteUDP.Namespace, ingressRouteUDP.Name,
+						service.Name, service.Port.String(),
+						"Cannot create service", err)
 					continue
 				}
 

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/mitchellh/hashstructure"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
@@ -63,6 +64,8 @@ type Provider struct {
 	lastConfiguration safe.Safe
 
 	routerTransform k8s.RouterTransform
+
+	errorDeduper *k8s.ErrorDeduper
 }
 
 func (p *Provider) SetRouterTransform(routerTransform k8s.RouterTransform) {
@@ -71,7 +74,27 @@ func (p *Provider) SetRouterTransform(routerTransform k8s.RouterTransform) {
 
 // Init the provider.
 func (p *Provider) Init() error {
+	p.errorDeduper = k8s.NewErrorDeduper()
 	return nil
+}
+
+func (p *Provider) logServiceError(logger zerolog.Logger, namespace, ingress, serviceName, servicePort, msg string, err error) {
+	if p.errorDeduper == nil {
+		p.errorDeduper = k8s.NewErrorDeduper()
+	}
+	key := fmt.Sprintf("%s:%s:%s:%s:%s:%s", ProviderName, namespace, ingress, serviceName, servicePort, err.Error())
+	shouldLog, suppressed := p.errorDeduper.ShouldLog(key)
+	if !shouldLog {
+		return
+	}
+	event := logger.Error().
+		Str("serviceName", serviceName).
+		Str("servicePort", servicePort).
+		Err(err)
+	if suppressed > 0 {
+		event = event.Int("suppressed", suppressed)
+	}
+	event.Msg(msg)
 }
 
 // ProviderName is the Kubernetes Ingress provider name.
@@ -284,19 +307,18 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 
 			service, err := p.loadService(client, ingress.Namespace, *ingress.Spec.DefaultBackend)
 			if err != nil {
-				logger.Error().
-					Str("serviceName", ingress.Spec.DefaultBackend.Service.Name).
-					Str("servicePort", ingress.Spec.DefaultBackend.Service.Port.String()).
-					Err(err).
-					Msg("Cannot create service")
+				p.logServiceError(logger, ingress.Namespace, ingress.Name,
+					ingress.Spec.DefaultBackend.Service.Name,
+					ingress.Spec.DefaultBackend.Service.Port.String(),
+					"Cannot create service", err)
 				continue
 			}
 
 			if len(service.LoadBalancer.Servers) == 0 && !p.AllowEmptyServices {
-				logger.Error().
-					Str("serviceName", ingress.Spec.DefaultBackend.Service.Name).
-					Str("servicePort", ingress.Spec.DefaultBackend.Service.Port.String()).
-					Msg("Skipping service: no endpoints found")
+				p.logServiceError(logger, ingress.Namespace, ingress.Name,
+					ingress.Spec.DefaultBackend.Service.Name,
+					ingress.Spec.DefaultBackend.Service.Port.String(),
+					"Skipping service: no endpoints found", errors.New("no endpoints found"))
 				continue
 			}
 
@@ -358,19 +380,18 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 
 				service, err := p.loadService(client, ingress.Namespace, pa.Backend)
 				if err != nil {
-					logger.Error().
-						Str("serviceName", pa.Backend.Service.Name).
-						Str("servicePort", pa.Backend.Service.Port.String()).
-						Err(err).
-						Msg("Cannot create service")
+					p.logServiceError(logger, ingress.Namespace, ingress.Name,
+						pa.Backend.Service.Name,
+						pa.Backend.Service.Port.String(),
+						"Cannot create service", err)
 					continue
 				}
 
 				if len(service.LoadBalancer.Servers) == 0 && !p.AllowEmptyServices {
-					logger.Error().
-						Str("serviceName", pa.Backend.Service.Name).
-						Str("servicePort", pa.Backend.Service.Port.String()).
-						Msg("Skipping service: no endpoints found")
+					p.logServiceError(logger, ingress.Namespace, ingress.Name,
+						pa.Backend.Service.Name,
+						pa.Backend.Service.Port.String(),
+						"Skipping service: no endpoints found", errors.New("no endpoints found"))
 					continue
 				}
 

--- a/pkg/provider/kubernetes/k8s/log_dedup.go
+++ b/pkg/provider/kubernetes/k8s/log_dedup.go
@@ -1,0 +1,58 @@
+package k8s
+
+import (
+	"sync"
+	"time"
+)
+
+const defaultDedupTTL = 1 * time.Minute
+
+type dedupEntry struct {
+	lastSeen time.Time
+	count    int
+}
+
+// ErrorDeduper suppresses repeated identical error logs within a TTL window.
+type ErrorDeduper struct {
+	mu      sync.Mutex
+	entries map[string]dedupEntry
+	ttl     time.Duration
+}
+
+// NewErrorDeduper creates an ErrorDeduper with the default 1-minute TTL.
+func NewErrorDeduper() *ErrorDeduper {
+	return &ErrorDeduper{
+		entries: make(map[string]dedupEntry),
+		ttl:     defaultDedupTTL,
+	}
+}
+
+// ShouldLog returns true if the error should be logged, and the number of
+// suppressed occurrences since the last time it was logged.
+func (d *ErrorDeduper) ShouldLog(key string) (bool, int) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	now := time.Now()
+	entry, exists := d.entries[key]
+
+	if exists && now.Sub(entry.lastSeen) < d.ttl {
+		// Within TTL: suppress and increment count.
+		d.entries[key] = dedupEntry{
+			lastSeen: entry.lastSeen,
+			count:    entry.count + 1,
+		}
+		return false, 0
+	}
+
+	// Either first time or TTL expired: allow log.
+	suppressed := 0
+	if exists {
+		suppressed = entry.count
+	}
+	d.entries[key] = dedupEntry{
+		lastSeen: now,
+		count:    0,
+	}
+	return true, suppressed
+}

--- a/pkg/provider/kubernetes/k8s/log_dedup_test.go
+++ b/pkg/provider/kubernetes/k8s/log_dedup_test.go
@@ -1,0 +1,58 @@
+package k8s
+
+import (
+	"testing"
+	"time"
+)
+
+func TestErrorDeduper_ShouldLog(t *testing.T) {
+	d := NewErrorDeduper()
+
+	// First occurrence should always be logged.
+	shouldLog, suppressed := d.ShouldLog("key1")
+	if !shouldLog {
+		t.Error("expected first occurrence to be logged")
+	}
+	if suppressed != 0 {
+		t.Errorf("expected suppressed=0, got %d", suppressed)
+	}
+
+	// Duplicate within TTL should be suppressed.
+	shouldLog, suppressed = d.ShouldLog("key1")
+	if shouldLog {
+		t.Error("expected duplicate within TTL to be suppressed")
+	}
+	if suppressed != 0 {
+		t.Errorf("expected suppressed=0 for suppressed entry, got %d", suppressed)
+	}
+
+	// Multiple suppressions should accumulate.
+	for i := 0; i < 3; i++ {
+		d.ShouldLog("key1")
+	}
+
+	// Expire the TTL manually.
+	d.mu.Lock()
+	entry := d.entries["key1"]
+	entry.lastSeen = time.Now().Add(-2 * time.Minute)
+	d.entries["key1"] = entry
+	d.mu.Unlock()
+
+	// After TTL expires, should log again with suppressed count.
+	shouldLog, suppressed = d.ShouldLog("key1")
+	if !shouldLog {
+		t.Error("expected log after TTL expiry")
+	}
+	if suppressed != 4 {
+		t.Errorf("expected suppressed=4, got %d", suppressed)
+	}
+
+	// Different key should log independently.
+	shouldLog, suppressed = d.ShouldLog("key2")
+	if !shouldLog {
+		t.Error("expected different key to be logged")
+	}
+	if suppressed != 0 {
+		t.Errorf("expected suppressed=0 for new key, got %d", suppressed)
+	}
+}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

When broken IngressRoute or Ingress resources reference missing services or services without endpoints, Traefik emits the same error logs on every configuration refresh cycle. This creates noise and can overwhelm log rate limiting.

Introduce a shared ErrorDeduper with a hardcoded 1-minute TTL. Duplicate errors within the window are suppressed. When the TTL expires and the error is allowed through again, a suppressed=N field indicates how many occurrences were skipped.

This covers:
- Ingress provider: Cannot create service, Skipping service
- CRD provider (HTTP/TCP/UDP): Cannot create service, kubernetes service not found, no servers found


### Motivation

<!-- What inspired you to submit this pull request? -->

I want to get a feel for appetite for this change. We run heavily multi-tenant cluster. A lot of business teams that self-manage Namespaces.

We don't care about broken Service / Ingress config until a team comes looking to debug. Currently there is a lot of noise that is not very useful, we strive for correct config but inevitably we run invalid config and this can be costly logs wise.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

This is a first light stab, I wan to mainly see if this is something you would consider. Thanks!