### PR TITLE
Update Helm chart values link for Kubernetes Gateway

### DIFF
--- a/docs/content/reference/install-configuration/providers/kubernetes/kubernetes-gateway.md
+++ b/docs/content/reference/install-configuration/providers/kubernetes/kubernetes-gateway.md
@@ -17,7 +17,7 @@ For more details, check out the conformance [report](https://github.com/kubernet
 !!! info "Using The Helm Chart"
 
     When using the Traefik [Helm Chart](../../../../getting-started/kubernetes.md#install-traefik), the CRDs (Custom Resource Definitions) and RBAC (Role-Based Access Control) are automatically managed for you.
-    The only remaining task is to enable the `kubernetesGateway` in the chart [values](https://github.com/traefik/traefik-helm-chart/blob/master/traefik/values.yaml#L323).
+    The only remaining task is to enable the `kubernetesGateway` in the chart [values](https://github.com/traefik/traefik-helm-chart/blob/master/traefik/values.yaml#L354).
 
 ## Requirements
 

--- a/docs/content/reference/install-configuration/providers/kubernetes/kubernetes-gateway.md
+++ b/docs/content/reference/install-configuration/providers/kubernetes/kubernetes-gateway.md
@@ -17,7 +17,7 @@ For more details, check out the conformance [report](https://github.com/kubernet
 !!! info "Using The Helm Chart"
 
     When using the Traefik [Helm Chart](../../../../getting-started/kubernetes.md#install-traefik), the CRDs (Custom Resource Definitions) and RBAC (Role-Based Access Control) are automatically managed for you.
-    The only remaining task is to enable the `kubernetesGateway` in the chart [values](https://github.com/traefik/traefik-helm-chart/blob/master/traefik/values.yaml#L354).
+    The only remaining task is to enable the `kubernetesGateway` in the chart [values](https://github.com/traefik/traefik-helm-chart/blob/master/traefik/values.yaml).
 
 ## Requirements
 


### PR DESCRIPTION
### What does this PR do?

This PR updates the Helm Chart values link in the Kubernetes Gateway API documentation.

### Motivation

The documentation explains that users need to enable `kubernetesGateway` in the chart values when using the Traefik Helm Chart.

This change makes the related link more accurate and easier to follow.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

This is a documentation-only change.