### PR TITLE
fix(ingress-nginx): make trailing slash optional in rewrite-target regex

### DIFF
--- a/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target_test.go
+++ b/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target_test.go
@@ -220,6 +220,26 @@ func TestRewriteTarget(t *testing.T) {
 			expectedStatusCode:  http.StatusFound,
 			expectedRedirectURL: "https://portal.example.org/site/foo/bar?tenant=acme&id=42",
 		},
+		{
+			desc: "regex with optional slash matches base path without trailing slash",
+			path: "/original",
+			config: dynamic.RewriteTarget{
+				Regex:       `/original/?(.*)`,
+				Replacement: "https://bar.example.org/$1",
+			},
+			expectedStatusCode:  http.StatusFound,
+			expectedRedirectURL: "https://bar.example.org/",
+		},
+		{
+			desc: "regex with optional slash matches path with suffix",
+			path: "/original/other",
+			config: dynamic.RewriteTarget{
+				Regex:       `/original/?(.*)`,
+				Replacement: "https://bar.example.org/$1",
+			},
+			expectedStatusCode:  http.StatusFound,
+			expectedRedirectURL: "https://bar.example.org/other",
+		},
 	}
 
 	for _, test := range testCases {

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
@@ -83,6 +83,10 @@ var (
 	strictPathTypeRegexp = regexp.MustCompile(`(?i)^/[[:alnum:]._\-/]*$`)
 	// The same regexp used in ingress-nginx: https://github.com/kubernetes/ingress-nginx/blob/main/internal/ingress/annotations/parser/validators.go#L77
 	regexPathWithCapture = regexp.MustCompile(`^/?[-._~a-zA-Z0-9/$:]*$`)
+	// trailingSlashCaptureRegex matches a trailing /(...) at the end of a path regex.
+	// Used to make the slash optional so "/original/(.*)" also matches "/original".
+	// See https://github.com/traefik/traefik/issues/12982
+	trailingSlashCaptureRegex = regexp.MustCompile(`/\(([^)]*)\)$`)
 )
 
 type unavailableError struct {
@@ -1714,8 +1718,17 @@ func applyRewriteTargetConfiguration(rulePath, routerName string, ingressConfig 
 	}
 
 	// The usage of rewrite-target annotation implies the usage of regex.
+	//
+	// When the path ends with a trailing slash + capture group like "/(.*)"
+	// or "/(.+)", make the slash optional so the regex also matches the bare
+	// prefix without a trailing slash. nginx handles this by doing a prefix
+	// match before the regex; Traefik only does regex, so the slash must be
+	// optional to get equivalent behavior.
+	// See https://github.com/traefik/traefik/issues/12982
+	regex := trailingSlashCaptureRegex.ReplaceAllString(rulePath, "/?($1)")
+
 	rewriteTarget := &dynamic.RewriteTarget{
-		Regex:       rulePath,
+		Regex:       regex,
 		Replacement: rewrite,
 	}
 

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -3071,14 +3071,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-x-forwarded-prefix-three-groups-rule-0-path-0-rewrite-target": {
 							RewriteTarget: &dynamic.RewriteTarget{
-								Regex:            "/(prefix)/(sub)/(.*)",
+								Regex:            "/(prefix)/(sub)/?(.*)",
 								Replacement:      "/$3",
 								XForwardedPrefix: "/$1/$2",
 							},
 						},
 						"default-ingress-with-x-forwarded-prefix-three-groups-rule-0-path-0-tls-rewrite-target": {
 							RewriteTarget: &dynamic.RewriteTarget{
-								Regex:            "/(prefix)/(sub)/(.*)",
+								Regex:            "/(prefix)/(sub)/?(.*)",
 								Replacement:      "/$3",
 								XForwardedPrefix: "/$1/$2",
 							},


### PR DESCRIPTION
## What does this PR do?

When `pathType: ImplementationSpecific` with a regex capture path like `/original/(.*)` is used alongside `rewrite-target: https://bar.example.org/$1`, requests to the base path `/original` (without trailing slash) return 404. Requests to `/original/other` work correctly.

nginx handles this because it does a prefix match before the regex. Traefik only does regex matching, so the regex `/original/(.*)` requires the trailing slash to match, and `/original` doesn't have one.

### Root cause

In `applyRewriteTargetConfiguration`, `rulePath` (the raw ingress path) is passed directly as `Regex`. For `/original/(.*)`, the regex is strict about the slash before the capture group.

### Fix

Detect path regexes that end with a literal slash followed by a capture group (e.g. `/(.*)`), and make the slash optional: `/original/(.*)` becomes `/original/?(.*)`.

A compiled regex (`trailingSlashCaptureRegex`) matches only the trailing `/(...)` pattern, so interior path segments like `/(prefix)/(sub)` and alternation groups like `(/|$)(.*)` are not affected.

### Reproduction from #12982

| Request | Before (404) | After |
|---|---|---|
| `/original` | 404 (regex doesn't match) | 302 to `https://bar.example.org/` |
| `/original/other` | 302 to `https://bar.example.org/other` | 302 to `https://bar.example.org/other` (unchanged) |

Fixes #12982