### PR TITLE
Make ipAllowList lookup fast for large lists

### DIFF
--- a/pkg/ip/checker.go
+++ b/pkg/ip/checker.go
@@ -5,13 +5,19 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
-	"strings"
+	"slices"
 )
 
 // Checker allows to check that addresses are in a trusted IPs.
 type Checker struct {
-	authorizedIPs    []*net.IP
-	authorizedIPsNet []*net.IPNet
+	authorizedIPs    map[netip.Addr]struct{}
+	authorizedRanges []ipRange
+}
+
+// ipRange represents a contiguous range of IP addresses.
+type ipRange struct {
+	start netip.Addr
+	end   netip.Addr
 }
 
 // NewChecker builds a new Checker given a list of CIDR-Strings to trusted IPs.
@@ -20,28 +26,44 @@ func NewChecker(trustedIPs []string) (*Checker, error) {
 		return nil, errors.New("no trusted IPs provided")
 	}
 
-	checker := &Checker{}
+	checker := &Checker{
+		authorizedIPs: make(map[netip.Addr]struct{}),
+	}
 
 	for _, ipMask := range trustedIPs {
-		if ipAddr := net.ParseIP(ipMask); ipAddr != nil {
-			checker.authorizedIPs = append(checker.authorizedIPs, &ipAddr)
+		if addr, err := netip.ParseAddr(ipMask); err == nil {
+			checker.authorizedIPs[canonicalAddr(addr)] = struct{}{}
 			continue
 		}
 
-		_, ipAddr, err := net.ParseCIDR(ipMask)
+		prefix, err := netip.ParsePrefix(ipMask)
 		if err != nil {
-			return nil, fmt.Errorf("parsing CIDR trusted IPs %s: %w", ipAddr, err)
+			return nil, fmt.Errorf("parsing CIDR trusted IPs %s: %w", ipMask, err)
 		}
-		checker.authorizedIPsNet = append(checker.authorizedIPsNet, ipAddr)
+
+		startAddr := canonicalAddr(prefix.Masked().Addr())
+
+		if prefix.IsSingleIP() {
+			checker.authorizedIPs[startAddr] = struct{}{}
+			continue
+		}
+
+		endAddr := canonicalAddr(networkLastAddress(prefix))
+
+		checker.authorizedRanges = append(checker.authorizedRanges, ipRange{
+			start: startAddr,
+			end:   endAddr,
+		})
 	}
+
+	// Sort and merge overlapping ranges for efficient binary search
+	checker.mergeRanges()
 
 	return checker, nil
 }
 
 // IsAuthorized checks if provided request is authorized by the trusted IPs.
 func (ip *Checker) IsAuthorized(addr string) error {
-	var invalidMatches []string
-
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
 		host = addr
@@ -53,8 +75,7 @@ func (ip *Checker) IsAuthorized(addr string) error {
 	}
 
 	if !ok {
-		invalidMatches = append(invalidMatches, addr)
-		return fmt.Errorf("%q matched none of the trusted IPs", strings.Join(invalidMatches, ", "))
+		return fmt.Errorf("%q matched none of the trusted IPs", addr)
 	}
 
 	return nil
@@ -66,37 +87,110 @@ func (ip *Checker) Contains(addr string) (bool, error) {
 		return false, errors.New("empty IP address")
 	}
 
-	ipAddr, err := parseIP(addr)
+	ipAddr, err := netip.ParseAddr(addr)
 	if err != nil {
-		return false, fmt.Errorf("unable to parse address: %s: %w", addr, err)
+		return false, fmt.Errorf("unable to parse IP from address %s: %w", addr, err)
 	}
 
-	return ip.ContainsIP(ipAddr), nil
+	return ip.containsAddr(ipAddr), nil
 }
 
 // ContainsIP checks if provided address is in the trusted IPs.
 func (ip *Checker) ContainsIP(addr net.IP) bool {
-	for _, authorizedIP := range ip.authorizedIPs {
-		if authorizedIP.Equal(addr) {
-			return true
-		}
+	ipAddr, ok := netip.AddrFromSlice(addr)
+	if !ok {
+		return false
 	}
-
-	for _, authorizedNet := range ip.authorizedIPsNet {
-		if authorizedNet.Contains(addr) {
-			return true
-		}
-	}
-
-	return false
+	return ip.containsAddr(ipAddr)
 }
 
-func parseIP(addr string) (net.IP, error) {
-	parsedAddr, err := netip.ParseAddr(addr)
-	if err != nil {
-		return nil, fmt.Errorf("can't parse IP from address %s", addr)
+// containsAddr checks if the provided netip.Addr is in the trusted IPs.
+func (ip *Checker) containsAddr(addr netip.Addr) bool {
+	addr = canonicalAddr(addr)
+
+	// Check single IPs first (O(1) lookup)
+	if _, exists := ip.authorizedIPs[addr]; exists {
+		return true
 	}
 
-	ip := parsedAddr.As16()
-	return ip[:], nil
+	// Binary search in sorted ranges (O(log n) lookup)
+	return ip.containsInRange(addr)
+}
+
+// containsInRange uses binary search to check if addr falls within any authorized range.
+func (ip *Checker) containsInRange(addr netip.Addr) bool {
+	ranges := ip.authorizedRanges
+	if len(ranges) == 0 {
+		return false
+	}
+
+	// Find the first range where range.end >= addr
+	idx, _ := slices.BinarySearchFunc(ranges, addr, func(r ipRange, target netip.Addr) int {
+		return r.end.Compare(target)
+	})
+
+	// Check if addr >= range.start for the found range
+	return idx < len(ranges) && ranges[idx].start.Compare(addr) <= 0
+}
+
+// canonicalAddr normalizes an address for comparison against the authorized lists.
+// Unmap converts IPv4-mapped IPv6 addresses (e.g. ::ffff:192.168.1.1) to their
+// IPv4 form so they match entries stored as IPv4. WithZone strips link-local zone
+// identifiers (e.g. fe80::1%eth0) so that addresses with and without a zone compare
+// equal, matching the behaviour of the old net.IP-based lookup which had no zones.
+func canonicalAddr(addr netip.Addr) netip.Addr {
+	return addr.Unmap().WithZone("")
+}
+
+// mergeRanges sorts and merges overlapping/adjacent IP ranges in-place.
+func (ip *Checker) mergeRanges() {
+	ranges := ip.authorizedRanges
+	if len(ranges) <= 1 {
+		return
+	}
+
+	// Sort ranges by start address
+	slices.SortFunc(ranges, func(a, b ipRange) int {
+		return a.start.Compare(b.start)
+	})
+
+	// Merge overlapping/adjacent ranges
+	merged := []ipRange{ranges[0]}
+	for _, next := range ranges[1:] {
+		current := &merged[len(merged)-1]
+
+		if current.end.Compare(next.start) >= 0 || isAdjacent(current.end, next.start) {
+			if next.end.Compare(current.end) > 0 {
+				current.end = next.end
+			}
+			continue
+		}
+
+		merged = append(merged, next)
+	}
+
+	ip.authorizedRanges = merged
+}
+
+// isAdjacent reports whether nextStart immediately follows currentEnd in the same address family.
+func isAdjacent(currentEnd, nextStart netip.Addr) bool {
+	if currentEnd.Is4() != nextStart.Is4() {
+		return false
+	}
+	currentEndNext := currentEnd.Next()
+	return currentEndNext.IsValid() && currentEndNext == nextStart
+}
+
+// networkLastAddress calculates the last IP address in a CIDR block.
+func networkLastAddress(prefix netip.Prefix) netip.Addr {
+	addr := prefix.Addr()
+	ipBytes := addr.AsSlice()
+	mask := net.CIDRMask(prefix.Bits(), addr.BitLen())
+
+	for i := range ipBytes {
+		ipBytes[i] |= ^mask[i]
+	}
+
+	res, _ := netip.AddrFromSlice(ipBytes)
+	return res
 }

--- a/pkg/ip/checker_test.go
+++ b/pkg/ip/checker_test.go
@@ -1,7 +1,9 @@
 package ip
 
 import (
+	"fmt"
 	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -77,21 +79,21 @@ func TestNew(t *testing.T) {
 				"fe80::/16",
 			},
 			expectedAuthorizedIPs: nil,
-			errMessage:            "parsing CIDR trusted IPs <nil>: invalid CIDR address: ",
+			errMessage:            `parsing CIDR trusted IPs : netip.ParsePrefix(""): no '/'`,
 		}, {
 			desc: "trusted IPs containing only an empty string",
 			trustedIPs: []string{
 				"",
 			},
 			expectedAuthorizedIPs: nil,
-			errMessage:            "parsing CIDR trusted IPs <nil>: invalid CIDR address: ",
+			errMessage:            `parsing CIDR trusted IPs : netip.ParsePrefix(""): no '/'`,
 		}, {
 			desc: "trusted IPs containing an invalid string",
 			trustedIPs: []string{
 				"foo",
 			},
 			expectedAuthorizedIPs: nil,
-			errMessage:            "parsing CIDR trusted IPs <nil>: invalid CIDR address: foo",
+			errMessage:            `parsing CIDR trusted IPs foo: netip.ParsePrefix("foo"): no '/'`,
 		}, {
 			desc: "IPv4 & IPv6 trusted IPs",
 			trustedIPs: []string{
@@ -124,10 +126,9 @@ func TestNew(t *testing.T) {
 				require.EqualError(t, err, test.errMessage)
 			} else {
 				require.NoError(t, err)
-				for index, actual := range ipChecker.authorizedIPsNet {
-					expected := test.expectedAuthorizedIPs[index]
-					assert.Equal(t, expected.IP, actual.IP)
-					assert.Equal(t, expected.Mask.String(), actual.Mask.String())
+				require.NotNil(t, ipChecker)
+				for _, expected := range test.expectedAuthorizedIPs {
+					assert.True(t, ipChecker.ContainsIP(expected.IP), "expected %s to be authorized", expected.IP)
 				}
 			}
 		})
@@ -328,4 +329,722 @@ func TestContainsBrokenIPs(t *testing.T) {
 		_, err := ipChecker.Contains(testIP)
 		assert.Error(t, err)
 	}
+}
+
+func numToIP4String(n uint32) string {
+	return fmt.Sprintf("%d.%d.%d.%d", byte(n>>24), byte(n>>16), byte(n>>8), byte(n))
+}
+
+func generateNonAdjacentCIDRs(n uint32) (cidrs []string, matchingIP string, nonMatchingIP string, err error) {
+	var maxNumOfAddresses uint32 = 1<<32 - 1
+	var gap uint32 = 512 // gap of 512 (2 /24 blocks) ensures non-overlapping and non-adjacent CIDRs
+	maxNumOfCIDRs := maxNumOfAddresses / gap
+	if n <= 0 || n > maxNumOfCIDRs {
+		return nil, "", "", fmt.Errorf("n must be between 1 and %d", maxNumOfCIDRs)
+	}
+	cidrs = make([]string, n)
+	ip := uint32(0)
+	for i := range n {
+		cidrs[i] = numToIP4String(ip) + "/24"
+		ip += gap
+	}
+	mid := (n/2)&^1*gap + gap/4
+	matchingIP = numToIP4String(mid)
+	nonMatchingIP = numToIP4String(gap / 4 * 3)
+	return
+}
+
+func generateUniqueSingleIPs(n uint32) (ips []string, matchingIP string, nonMatchingIP string, err error) {
+	var maxNumOfAddresses uint32 = 1<<32 - 1
+	if n <= 0 || n > maxNumOfAddresses {
+		return nil, "", "", fmt.Errorf("n must be between 1 and %d", maxNumOfAddresses)
+	}
+	ips = make([]string, n)
+	for i := range n {
+		ips[i] = numToIP4String(i)
+	}
+	matchingIP = numToIP4String(n / 2)
+	nonMatchingIP = numToIP4String(n)
+	return
+}
+
+func newTestChecker(b *testing.B, trustedIPs []string) *Checker {
+	b.Helper()
+	checker, err := NewChecker(trustedIPs)
+	require.NoError(b, err)
+	return checker
+}
+
+func mustParseIP(b *testing.B, s string) net.IP {
+	b.Helper()
+	ip := net.ParseIP(s)
+	require.NotNil(b, ip, "failed to parse IP: %s", s)
+	return ip
+}
+
+func requireContainsIP(b *testing.B, checker *Checker, ip net.IP) {
+	b.Helper()
+	require.True(b, checker.ContainsIP(ip), "test IP should be in the trusted list")
+}
+
+func requireNotContainsIP(b *testing.B, checker *Checker, ip net.IP) {
+	b.Helper()
+	require.False(b, checker.ContainsIP(ip), "test IP should not be in the trusted list")
+}
+
+func BenchmarkContainsIP_MatchInSingleIPList_100k(b *testing.B) {
+	trustedIPs, matchingIP, _, err := generateUniqueSingleIPs(100000)
+	require.NoError(b, err)
+
+	checker := newTestChecker(b, trustedIPs)
+	testIP := mustParseIP(b, matchingIP)
+	requireContainsIP(b, checker, testIP)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		checker.ContainsIP(testIP)
+	}
+}
+
+func BenchmarkContainsIP_NoMatchInSingleIPList_100k(b *testing.B) {
+	trustedIPs, _, nonMatchingIP, err := generateUniqueSingleIPs(100000)
+	require.NoError(b, err)
+
+	checker := newTestChecker(b, trustedIPs)
+	testIP := mustParseIP(b, nonMatchingIP)
+	requireNotContainsIP(b, checker, testIP)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		checker.ContainsIP(testIP)
+	}
+}
+
+func BenchmarkContainsIP_MatchInCIDRList_10k(b *testing.B) {
+	trustedIPs, matchingIP, _, err := generateNonAdjacentCIDRs(10000)
+	require.NoError(b, err)
+
+	checker := newTestChecker(b, trustedIPs)
+	testIP := mustParseIP(b, matchingIP)
+	requireContainsIP(b, checker, testIP)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		checker.ContainsIP(testIP)
+	}
+}
+
+func BenchmarkContainsIP_NoMatchInCIDRList_10k(b *testing.B) {
+	trustedIPs, _, nonMatchingIP, err := generateNonAdjacentCIDRs(10000)
+	require.NoError(b, err)
+
+	checker := newTestChecker(b, trustedIPs)
+	testIP := mustParseIP(b, nonMatchingIP)
+	requireNotContainsIP(b, checker, testIP)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		checker.ContainsIP(testIP)
+	}
+}
+
+func BenchmarkContainsIP_MatchInCIDRList_100k(b *testing.B) {
+	trustedIPs, matchingIP, _, err := generateNonAdjacentCIDRs(100000)
+	require.NoError(b, err)
+
+	checker := newTestChecker(b, trustedIPs)
+	testIP := mustParseIP(b, matchingIP)
+	requireContainsIP(b, checker, testIP)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		checker.ContainsIP(testIP)
+	}
+}
+
+func BenchmarkContainsIP_NoMatchInCIDRList_100k(b *testing.B) {
+	trustedIPs, _, nonMatchingIP, err := generateNonAdjacentCIDRs(100000)
+	require.NoError(b, err)
+
+	checker := newTestChecker(b, trustedIPs)
+	testIP := mustParseIP(b, nonMatchingIP)
+	requireNotContainsIP(b, checker, testIP)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		checker.ContainsIP(testIP)
+	}
+}
+
+func BenchmarkContainsIP_MatchInMixedList_SingleIP_100k(b *testing.B) {
+	cidrs, _, _, err := generateNonAdjacentCIDRs(50000)
+	require.NoError(b, err)
+	singles, matchingSingleIP, _, err := generateUniqueSingleIPs(50000)
+	require.NoError(b, err)
+
+	trustedIPs := append(cidrs, singles...)
+
+	checker := newTestChecker(b, trustedIPs)
+	testIP := mustParseIP(b, matchingSingleIP)
+	requireContainsIP(b, checker, testIP)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		checker.ContainsIP(testIP)
+	}
+}
+
+func BenchmarkContainsIP_MatchInMixedList_CIDR_100k(b *testing.B) {
+	cidrs, matchingCIDRIP, _, err := generateNonAdjacentCIDRs(50000)
+	require.NoError(b, err)
+	singles, _, _, err := generateUniqueSingleIPs(50000)
+	require.NoError(b, err)
+
+	trustedIPs := append(cidrs, singles...)
+
+	checker := newTestChecker(b, trustedIPs)
+	testIP := mustParseIP(b, matchingCIDRIP)
+	requireContainsIP(b, checker, testIP)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		checker.ContainsIP(testIP)
+	}
+}
+
+func BenchmarkContainsIP_NoMatchInMixedList_100k(b *testing.B) {
+	cidrs, _, _, err := generateNonAdjacentCIDRs(50000)
+	require.NoError(b, err)
+	singles, _, _, err := generateUniqueSingleIPs(50000)
+	require.NoError(b, err)
+
+	trustedIPs := append(cidrs, singles...)
+
+	checker := newTestChecker(b, trustedIPs)
+	testIP := mustParseIP(b, numToIP4String(1<<32-1))
+	requireNotContainsIP(b, checker, testIP)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		checker.ContainsIP(testIP)
+	}
+}
+
+func TestNetworkLastAddress(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		prefix   netip.Prefix
+		expected netip.Addr
+	}{
+		{
+			desc:     "IPv4 /24",
+			prefix:   netip.MustParsePrefix("192.168.1.0/24"),
+			expected: netip.MustParseAddr("192.168.1.255"),
+		},
+		{
+			desc:     "IPv4 /0 (all addresses)",
+			prefix:   netip.MustParsePrefix("0.0.0.0/0"),
+			expected: netip.MustParseAddr("255.255.255.255"),
+		},
+		{
+			desc:     "IPv4 /8",
+			prefix:   netip.MustParsePrefix("10.0.0.0/8"),
+			expected: netip.MustParseAddr("10.255.255.255"),
+		},
+		{
+			desc:     "IPv4 /32 single IP",
+			prefix:   netip.MustParsePrefix("10.0.0.1/32"),
+			expected: netip.MustParseAddr("10.0.0.1"),
+		},
+		{
+			desc:     "IPv4 /16",
+			prefix:   netip.MustParsePrefix("172.16.0.0/16"),
+			expected: netip.MustParseAddr("172.16.255.255"),
+		},
+		{
+			desc:     "IPv4 /30",
+			prefix:   netip.MustParsePrefix("192.168.0.0/30"),
+			expected: netip.MustParseAddr("192.168.0.3"),
+		},
+		{
+			desc:     "IPv4 /29",
+			prefix:   netip.MustParsePrefix("10.10.10.16/29"),
+			expected: netip.MustParseAddr("10.10.10.23"),
+		},
+		{
+			desc:     "IPv4 /28 non-aligned",
+			prefix:   netip.MustParsePrefix("10.10.10.20/28"),
+			expected: netip.MustParseAddr("10.10.10.31"),
+		},
+		{
+			desc:     "IPv6 /64",
+			prefix:   netip.MustParsePrefix("2001:db8::/64"),
+			expected: netip.MustParseAddr("2001:db8::ffff:ffff:ffff:ffff"),
+		},
+		{
+			desc:     "IPv6 /16",
+			prefix:   netip.MustParsePrefix("fe80::/16"),
+			expected: netip.MustParseAddr("fe80:ffff:ffff:ffff:ffff:ffff:ffff:ffff"),
+		},
+		{
+			desc:     "IPv6 /128 single IP",
+			prefix:   netip.MustParsePrefix("2001:db8::1/128"),
+			expected: netip.MustParseAddr("2001:db8::1"),
+		},
+		{
+			desc:     "IPv6 /0 (all addresses)",
+			prefix:   netip.MustParsePrefix("::/0"),
+			expected: netip.MustParseAddr("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"),
+		},
+		{
+			desc:     "IPv6 /48",
+			prefix:   netip.MustParsePrefix("2a03:4000:6:d080::/48"),
+			expected: netip.MustParseAddr("2a03:4000:6:ffff:ffff:ffff:ffff:ffff"),
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			result := networkLastAddress(test.prefix)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestMergeRanges(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		trustedIPs     []string
+		expectedRanges int
+		passIPs        []string
+		rejectIPs      []string
+	}{
+		{
+			desc: "overlapping ranges merge",
+			trustedIPs: []string{
+				"10.0.0.0/24",
+				"10.0.0.0/16",
+			},
+			expectedRanges: 1,
+			passIPs: []string{
+				"10.0.0.1",
+				"10.0.255.255",
+			},
+			rejectIPs: []string{
+				"10.1.0.1",
+			},
+		},
+		{
+			desc: "adjacent ranges merge",
+			trustedIPs: []string{
+				"10.0.0.0/25",
+				"10.0.0.128/25",
+			},
+			expectedRanges: 1,
+			passIPs: []string{
+				"10.0.0.1",
+				"10.0.0.128",
+				"10.0.0.255",
+			},
+			rejectIPs: []string{
+				"10.0.1.1",
+			},
+		},
+		{
+			desc: "subset ranges merge",
+			trustedIPs: []string{
+				"10.0.0.0/8",
+				"10.0.0.0/24",
+				"10.0.1.0/24",
+			},
+			expectedRanges: 1,
+			passIPs: []string{
+				"10.0.0.1",
+				"10.255.255.255",
+			},
+			rejectIPs: []string{
+				"11.0.0.1",
+			},
+		},
+		{
+			desc: "non-overlapping ranges stay separate",
+			trustedIPs: []string{
+				"10.0.0.0/24",
+				"192.168.0.0/24",
+			},
+			expectedRanges: 2,
+			passIPs: []string{
+				"10.0.0.1",
+				"192.168.0.1",
+			},
+			rejectIPs: []string{
+				"172.16.0.1",
+			},
+		},
+		{
+			desc: "IPv6 overlapping ranges",
+			trustedIPs: []string{
+				"2001:db8::/48",
+				"2001:db8::/64",
+			},
+			expectedRanges: 1,
+			passIPs: []string{
+				"2001:db8::1",
+				"2001:db8:0:ffff:ffff:ffff:ffff:ffff",
+			},
+			rejectIPs: []string{
+				"2001:db9::1",
+			},
+		},
+		{
+			desc: "mixed IPv4 and IPv6 ranges are not merged across families",
+			trustedIPs: []string{
+				"0.0.0.0/0",
+				"2001:db8::/64",
+			},
+			expectedRanges: 2,
+			passIPs: []string{
+				"10.0.0.1",
+				"255.255.255.255",
+				"2001:db8::1",
+			},
+			rejectIPs: []string{
+				"::1",
+				"fe80::1",
+				"2001:db9::1",
+			},
+		},
+		{
+			desc: "IPv6 /0 covers all IPv6 addresses",
+			trustedIPs: []string{
+				"::/0",
+			},
+			expectedRanges: 1,
+			passIPs: []string{
+				"::1",
+				"2001:db8::1",
+				"fe80::1",
+				"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+			},
+			rejectIPs: []string{
+				"10.0.0.1",
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			checker, err := NewChecker(test.trustedIPs)
+			require.NoError(t, err)
+			require.Len(t, checker.authorizedRanges, test.expectedRanges)
+
+			for _, ip := range test.passIPs {
+				ok, err := checker.Contains(ip)
+				require.NoError(t, err)
+				assert.Truef(t, ok, "%s should have passed", ip)
+			}
+
+			for _, ip := range test.rejectIPs {
+				ok, err := checker.Contains(ip)
+				require.NoError(t, err)
+				assert.Falsef(t, ok, "%s should have been rejected", ip)
+			}
+		})
+	}
+}
+
+func TestContainsRangeBoundaries(t *testing.T) {
+	trustedIPs := []string{
+		"10.0.1.0/24",
+		"10.0.3.0/24",
+		"10.0.5.0/24",
+	}
+
+	checker, err := NewChecker(trustedIPs)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		desc       string
+		addr       string
+		authorized bool
+	}{
+		{
+			desc:       "before first range",
+			addr:       "10.0.0.255",
+			authorized: false,
+		},
+		{
+			desc:       "exact start of first range",
+			addr:       "10.0.1.0",
+			authorized: true,
+		},
+		{
+			desc:       "middle of first range",
+			addr:       "10.0.1.128",
+			authorized: true,
+		},
+		{
+			desc:       "exact end of first range",
+			addr:       "10.0.1.255",
+			authorized: true,
+		},
+		{
+			desc:       "between first and second range",
+			addr:       "10.0.2.0",
+			authorized: false,
+		},
+		{
+			desc:       "exact start of second range",
+			addr:       "10.0.3.0",
+			authorized: true,
+		},
+		{
+			desc:       "exact end of second range",
+			addr:       "10.0.3.255",
+			authorized: true,
+		},
+		{
+			desc:       "between second and third range",
+			addr:       "10.0.4.128",
+			authorized: false,
+		},
+		{
+			desc:       "exact start of third range",
+			addr:       "10.0.5.0",
+			authorized: true,
+		},
+		{
+			desc:       "exact end of third range",
+			addr:       "10.0.5.255",
+			authorized: true,
+		},
+		{
+			desc:       "after last range",
+			addr:       "10.0.6.0",
+			authorized: false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			ok, err := checker.Contains(test.addr)
+			require.NoError(t, err)
+			assert.Equal(t, test.authorized, ok)
+		})
+	}
+}
+
+func TestContainsIP(t *testing.T) {
+	trustedIPs := []string{"10.0.0.0/24", "2001:db8::/64"}
+	checker, err := NewChecker(trustedIPs)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		desc       string
+		ip         net.IP
+		authorized bool
+	}{
+		{
+			desc:       "IPv4 in range",
+			ip:         net.ParseIP("10.0.0.50"),
+			authorized: true,
+		},
+		{
+			desc:       "IPv4 out of range",
+			ip:         net.ParseIP("10.0.1.50"),
+			authorized: false,
+		},
+		{
+			desc:       "IPv6 in range",
+			ip:         net.ParseIP("2001:db8::1"),
+			authorized: true,
+		},
+		{
+			desc:       "IPv6 out of range",
+			ip:         net.ParseIP("2001:db9::1"),
+			authorized: false,
+		},
+		{
+			desc:       "IPv4-mapped IPv6 in range",
+			ip:         net.ParseIP("::ffff:10.0.0.50"),
+			authorized: true,
+		},
+		{
+			desc:       "nil IP",
+			ip:         nil,
+			authorized: false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			result := checker.ContainsIP(test.ip)
+			assert.Equal(t, test.authorized, result)
+		})
+	}
+}
+
+func TestIPv4MappedIPv6(t *testing.T) {
+	trustedIPs := []string{"192.168.1.0/24"}
+	checker, err := NewChecker(trustedIPs)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		desc       string
+		addr       string
+		authorized bool
+	}{
+		{
+			desc:       "IPv4-mapped IPv6 in range",
+			addr:       "::ffff:192.168.1.50",
+			authorized: true,
+		},
+		{
+			desc:       "IPv4-mapped IPv6 out of range",
+			addr:       "::ffff:192.168.2.50",
+			authorized: false,
+		},
+		{
+			desc:       "plain IPv4 in range",
+			addr:       "192.168.1.50",
+			authorized: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			ok, err := checker.Contains(test.addr)
+			require.NoError(t, err)
+			assert.Equal(t, test.authorized, ok)
+		})
+	}
+}
+
+func TestContainsEmptyAddress(t *testing.T) {
+	checker, err := NewChecker([]string{"10.0.0.0/24"})
+	require.NoError(t, err)
+
+	ok, err := checker.Contains("")
+	require.Error(t, err)
+	assert.False(t, ok)
+	assert.Contains(t, err.Error(), "empty IP address")
+}
+
+func TestIsAuthorizedVariations(t *testing.T) {
+	trustedIPs := []string{
+		"10.0.0.0/24",
+		"2001:db8::/64",
+	}
+	checker, err := NewChecker(trustedIPs)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		desc       string
+		addr       string
+		authorized bool
+	}{
+		{
+			desc:       "IP with port",
+			addr:       "10.0.0.50:12345",
+			authorized: true,
+		},
+		{
+			desc:       "IP without port",
+			addr:       "10.0.0.50",
+			authorized: true,
+		},
+		{
+			desc:       "IPv6 with brackets and port",
+			addr:       "[2001:db8::1]:8080",
+			authorized: true,
+		},
+		{
+			desc:       "IPv6 without port",
+			addr:       "2001:db8::1",
+			authorized: true,
+		},
+		{
+			desc:       "IPv4-mapped IPv6 with port",
+			addr:       "[::ffff:10.0.0.50]:443",
+			authorized: true,
+		},
+		{
+			desc:       "IPv6 with zone ID",
+			addr:       "fe80::1%eth0",
+			authorized: false,
+		},
+		{
+			desc:       "unauthorized IP with port",
+			addr:       "192.168.1.1:80",
+			authorized: false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			err := checker.IsAuthorized(test.addr)
+			if test.authorized {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestZoneIDHandling(t *testing.T) {
+	t.Run("zone ID on single IP", func(t *testing.T) {
+		checker, err := NewChecker([]string{"fe80::1"})
+		require.NoError(t, err)
+
+		ok, err := checker.Contains("fe80::1")
+		require.NoError(t, err)
+		assert.True(t, ok, "fe80::1 should match authorized fe80::1")
+
+		ok, err = checker.Contains("fe80::1%eth0")
+		require.NoError(t, err)
+		assert.Truef(t, ok, "%s should match authorized fe80::1", "fe80::1%eth0")
+	})
+
+	t.Run("zone ID in range", func(t *testing.T) {
+		checker, err := NewChecker([]string{"fe80::/16"})
+		require.NoError(t, err)
+
+		ok, err := checker.Contains("fe80::%eth0")
+		require.NoError(t, err)
+		assert.Truef(t, ok, "%s should match fe80::/16", "fe80::%eth0")
+
+		ok, err = checker.Contains("fe80::1%eth0")
+		require.NoError(t, err)
+		assert.Truef(t, ok, "%s should match fe80::/16", "fe80::1%eth0")
+
+		ok, err = checker.Contains("fe80:ffff:ffff:ffff:ffff:ffff:ffff:ffff%eth0")
+		require.NoError(t, err)
+		assert.Truef(t, ok, "%s should match fe80::/16 range end", "fe80:ffff:ffff:ffff:ffff:ffff:ffff:ffff%eth0")
+	})
+
+	t.Run("zone ID in config", func(t *testing.T) {
+		checker, err := NewChecker([]string{"fe80::1%eth0"})
+		require.NoError(t, err)
+
+		ok, err := checker.Contains("fe80::1")
+		require.NoError(t, err)
+		assert.Truef(t, ok, "%s should match authorized %s", "fe80::1", "fe80::1%eth0")
+
+		ok, err = checker.Contains("fe80::1%eth0")
+		require.NoError(t, err)
+		assert.Truef(t, ok, "%s should match authorized %s", "fe80::1%eth0", "fe80::1%eth0")
+	})
 }


### PR DESCRIPTION
Replace O(n) linear scan with O(1) hash map for single IPs and O(log n) binary search for CIDR ranges. Ranges are sorted and merged during initialization to minimize lookup time.

The original linear scan becomes a bottleneck with large allow lists, especially on the no-match path which scans every entry. The optimized lookup is essentially constant time regardless of list size.

Benchmark comparison (10K-100K entries):
```
goos: linux
goarch: amd64
pkg: github.com/traefik/traefik/v3/pkg/ip
cpu: Intel(R) Core(TM) i7-10610U CPU @ 1.80GHz
```

BenchmarkContainsIP Before the change:
```
MatchInSingleIPList_100k-8         4446   248490 ns/op  0 B/op  0 allocs/op
NoMatchInSingleIPList_100k-8       2042   514240 ns/op  0 B/op  0 allocs/op
MatchInCIDRList_10k-8             25490    44886 ns/op  0 B/op  0 allocs/op
NoMatchInCIDRList_10k-8           13095    87495 ns/op  0 B/op  0 allocs/op
MatchInCIDRList_100k-8             2222   549185 ns/op  0 B/op  0 allocs/op
NoMatchInCIDRList_100k-8            777  1534752 ns/op  0 B/op  0 allocs/op
MatchInMixedList_SingleIP_100k-8  10090   123441 ns/op  0 B/op  0 allocs/op
MatchInMixedList_CIDR_100k-8       2258   552287 ns/op  0 B/op  0 allocs/op
NoMatchInMixedList_100k-8          1359   846405 ns/op  0 B/op  0 allocs/op
```

BenchmarkContainsIP After the change:
```
MatchInSingleIPList_100k-8        46649944   25.64 ns/op  0 B/op  0 allocs/op
NoMatchInSingleIPList_100k-8      50158794   23.51 ns/op  0 B/op  0 allocs/op
MatchInCIDRList_10k-8              8956461  121.5  ns/op  0 B/op  0 allocs/op
NoMatchInCIDRList_10k-8            9507897  118.0  ns/op  0 B/op  0 allocs/op
MatchInCIDRList_100k-8             9087830  133.1  ns/op  0 B/op  0 allocs/op
NoMatchInCIDRList_100k-8           8594448  136.2  ns/op  0 B/op  0 allocs/op
MatchInMixedList_SingleIP_100k-8  47374381   24.36 ns/op  0 B/op  0 allocs/op
MatchInMixedList_CIDR_100k-8       8320868  133.4  ns/op  0 B/op  0 allocs/op
NoMatchInMixedList_100k-8          9360322  130.1  ns/op  0 B/op  0 allocs/op
```


<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Improves IP lookup performance when working with large allow lists 


### Motivation

The current (linear lookup) implementation quickly becomes a bottleneck when IP allow lists grow


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
