### PR TITLE
Allow query parameters to be dropped from the access log

### DIFF
--- a/docs/content/observe/logs-and-access-logs.md
+++ b/docs/content/observe/logs-and-access-logs.md
@@ -175,6 +175,7 @@ When using the `json` format, you can customize which fields are included in you
 
 - **Request Fields:** You can choose to `keep`, `drop`, or `redact` any of the standard request fields. A complete list of available fields like `ClientHost`, `RequestMethod`, and `Duration` can be found in the [reference documentation](../reference/install-configuration/observability/logs-and-accesslogs.md#json-format-fields).
 - **Request Headers:** You can also specify which request headers should be included in the logs, and whether their values should be `kept`, `dropped`, or `redacted`.
+- **Request Query Parameters:** You can choose to `keep` or `drop` the query parameters for a request.
 
 !!! info
     For detailed configuration options, refer to the [reference documentation](../reference/install-configuration/observability/logs-and-accesslogs.md).

--- a/docs/content/reference/install-configuration/observability/logs-and-accesslogs.md
+++ b/docs/content/reference/install-configuration/observability/logs-and-accesslogs.md
@@ -171,6 +171,9 @@ accessLog:
         User-Agent: redact
         # Drop the Authorization header value
         Authorization: drop
+    queryParameters:
+      # Drop all query parameters
+      defaultMode: drop
 ```
 
 ```toml tab="File (TOML)"
@@ -194,6 +197,9 @@ accessLog:
       [accessLog.fields.headers.names]
         User-Agent = "redact"
         Authorization = "drop"
+
+    [accessLog.fields.queryParameters]
+      defaultMode = "drop
 ```
 
 ```sh tab="CLI"
@@ -208,6 +214,7 @@ accessLog:
 --accesslog.fields.headers.defaultmode=keep
 --accesslog.fields.headers.names.User-Agent=redact
 --accesslog.fields.headers.names.Authorization=drop
+--accesslog.fields.queryparameters.defaultmode=drop
 ```
 
 ### Configuration Options
@@ -228,6 +235,7 @@ The section below describes how to configure Traefik access logs using the stati
 | <a id="opt-accesslog-fields-names" href="#opt-accesslog-fields-names" title="#opt-accesslog-fields-names">`accesslog.fields.names`</a> | Set the fields list to display in the access logs (format `name:mode`).<br /> Available fields list [here](#json-format-fields). |  [ ]    | No      |
 | <a id="opt-accesslog-fields-headers-defaultMode" href="#opt-accesslog-fields-headers-defaultMode" title="#opt-accesslog-fields-headers-defaultMode">`accesslog.fields.headers.defaultMode`</a> | Mode to apply by default to the access logs headers (`keep`, `redact` or `drop`).  | drop | No      |
 | <a id="opt-accesslog-fields-headers-names" href="#opt-accesslog-fields-headers-names" title="#opt-accesslog-fields-headers-names">`accesslog.fields.headers.names`</a> | Set the headers list to display in the access logs (format `name:mode`). |   [ ]   | No      |
+| <a id="opt-accesslog-fields-queryParameters-defaultMode" href="#opt-accesslog-fields-queryParameters-defaultMode" title="#opt-accesslog-fields-queryParameters-defaultMode">`accesslog.fields.queryParameters.defaultMode`</a> | Mode to apply by default to the access logs query parameters (`keep` or `drop`) | keep | No      |
 
 ### OpenTelemetry
 

--- a/pkg/middlewares/accesslog/logger.go
+++ b/pkg/middlewares/accesslog/logger.go
@@ -230,11 +230,17 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request, next http
 		core[RequestAddr] = req.Host
 		core[RequestHost], core[RequestPort] = silentSplitHostPort(req.Host)
 	}
+
+	queryParameters := ""
+	if h.config.Fields.KeepQueryParameters() {
+		queryParameters = req.URL.RawQuery
+	}
+
 	// copy the URL without the scheme, hostname etc
 	urlCopy := &url.URL{
 		Path:       req.URL.Path,
 		RawPath:    req.URL.RawPath,
-		RawQuery:   req.URL.RawQuery,
+		RawQuery:   queryParameters,
 		ForceQuery: req.URL.ForceQuery,
 		Fragment:   req.URL.Fragment,
 	}

--- a/pkg/middlewares/accesslog/logger_test.go
+++ b/pkg/middlewares/accesslog/logger_test.go
@@ -39,23 +39,25 @@ import (
 const delta float64 = 1e-10
 
 var (
-	logFileNameSuffix       = "/traefik/logger/test.log"
-	testContent             = "Hello, World"
-	testServiceName         = "http://127.0.0.1/testService"
-	testRouterName          = "testRouter"
-	testStatus              = 123
-	testContentSize   int64 = 12
-	testHostname            = "TestHost"
-	testUsername            = "TestUser"
-	testPath                = "testpath"
-	testPort                = 8181
-	testProto               = "HTTP/0.0"
-	testScheme              = "http"
-	testMethod              = http.MethodPost
-	testReferer             = "testReferer"
-	testUserAgent           = "testUserAgent"
-	testRetryAttempts       = 2
-	testStart               = time.Now()
+	logFileNameSuffix             = "/traefik/logger/test.log"
+	testContent                   = "Hello, World"
+	testServiceName               = "http://127.0.0.1/testService"
+	testRouterName                = "testRouter"
+	testStatus                    = 123
+	testContentSize         int64 = 12
+	testHostname                  = "TestHost"
+	testUsername                  = "TestUser"
+	testPath                      = "testpath"
+	testQueryParams               = "param1=test1&param2=test2"
+	testPathWithQueryParams       = testPath + "?" + testQueryParams
+	testPort                      = 8181
+	testProto                     = "HTTP/0.0"
+	testScheme                    = "http"
+	testMethod                    = http.MethodPost
+	testReferer                   = "testReferer"
+	testUserAgent                 = "testUserAgent"
+	testRetryAttempts             = 2
+	testStart                     = time.Now()
 )
 
 func TestOTelAccessLogWithBodyAndDualOutput(t *testing.T) {
@@ -458,7 +460,7 @@ func TestCommonLogger(t *testing.T) {
 	logData, err := os.ReadFile(logFilePath)
 	require.NoError(t, err)
 
-	expectedLog := ` TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath HTTP/0.0" 123 12 "testReferer" "testUserAgent" 1 "testRouter" "http://127.0.0.1/testService" 1ms`
+	expectedLog := ` TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath?param1=test1&param2=test2 HTTP/0.0" 123 12 "testReferer" "testUserAgent" 1 "testRouter" "http://127.0.0.1/testService" 1ms`
 	assertValidCommonLogData(t, expectedLog, logData)
 }
 
@@ -473,7 +475,7 @@ func TestCommonLoggerWithBufferingSize(t *testing.T) {
 	logData, err := os.ReadFile(logFilePath)
 	require.NoError(t, err)
 
-	expectedLog := ` TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath HTTP/0.0" 123 12 "testReferer" "testUserAgent" 1 "testRouter" "http://127.0.0.1/testService" 1ms`
+	expectedLog := ` TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath?param1=test1&param2=test2 HTTP/0.0" 123 12 "testReferer" "testUserAgent" 1 "testRouter" "http://127.0.0.1/testService" 1ms`
 	assertValidCommonLogData(t, expectedLog, logData)
 }
 
@@ -556,7 +558,7 @@ func TestLoggerJSON(t *testing.T) {
 				RequestHost:               assertString(testHostname),
 				RequestAddr:               assertString(testHostname),
 				RequestMethod:             assertString(testMethod),
-				RequestPath:               assertString(testPath),
+				RequestPath:               assertString(testPathWithQueryParams),
 				RequestProtocol:           assertString(testProto),
 				RequestScheme:             assertString(testScheme),
 				RequestPort:               assertString("-"),
@@ -596,7 +598,7 @@ func TestLoggerJSON(t *testing.T) {
 				RequestHost:               assertString(testHostname),
 				RequestAddr:               assertString(testHostname),
 				RequestMethod:             assertString(testMethod),
-				RequestPath:               assertString(testPath),
+				RequestPath:               assertString(testPathWithQueryParams),
 				RequestProtocol:           assertString(testProto),
 				RequestScheme:             assertString(testScheme),
 				RequestPort:               assertString("-"),
@@ -640,7 +642,7 @@ func TestLoggerJSON(t *testing.T) {
 				RequestHost:                assertString(testHostname),
 				RequestAddr:                assertString(testHostname),
 				RequestMethod:              assertString(testMethod),
-				RequestPath:                assertString(testPath),
+				RequestPath:                assertString(testPathWithQueryParams),
 				RequestProtocol:            assertString(testProto),
 				RequestScheme:              assertString(testScheme),
 				RequestPort:                assertString("-"),
@@ -684,7 +686,7 @@ func TestLoggerJSON(t *testing.T) {
 				RequestHost:               assertString(testHostname),
 				RequestAddr:               assertString(testHostname),
 				RequestMethod:             assertString(testMethod),
-				RequestPath:               assertString(testPath),
+				RequestPath:               assertString(testPathWithQueryParams),
 				RequestProtocol:           assertString(testProto),
 				RequestScheme:             assertString("https"),
 				RequestPort:               assertString("-"),
@@ -824,6 +826,94 @@ func TestLoggerJSON(t *testing.T) {
 				RequestRefererHeader: assertString(testReferer),
 			},
 		},
+		{
+			desc: "default config, drop query parameters",
+			config: &otypes.AccessLog{
+				FilePath: "",
+				Format:   JSONFormat,
+				Fields: &otypes.AccessLogFields{
+					QueryParameters: &otypes.FieldQueryParameters{
+						DefaultMode: "drop",
+					},
+				},
+			},
+			expected: map[string]func(t *testing.T, value any){
+				RequestContentSize:        assertFloat64(0),
+				RequestHost:               assertString(testHostname),
+				RequestAddr:               assertString(testHostname),
+				RequestMethod:             assertString(testMethod),
+				RequestPath:               assertString(testPath),
+				RequestProtocol:           assertString(testProto),
+				RequestScheme:             assertString(testScheme),
+				RequestPort:               assertString("-"),
+				DownstreamStatus:          assertFloat64(float64(testStatus)),
+				DownstreamContentSize:     assertFloat64(float64(len(testContent))),
+				OriginContentSize:         assertFloat64(float64(len(testContent))),
+				OriginStatus:              assertFloat64(float64(testStatus)),
+				RequestRefererHeader:      assertString(testReferer),
+				RequestUserAgentHeader:    assertString(testUserAgent),
+				RouterName:                assertString(testRouterName),
+				ServiceURL:                assertString(testServiceName),
+				ClientUsername:            assertString(testUsername),
+				ClientHost:                assertString(testHostname),
+				ClientPort:                assertString(strconv.Itoa(testPort)),
+				ClientAddr:                assertString(fmt.Sprintf("%s:%d", testHostname, testPort)),
+				"level":                   assertString("info"),
+				"msg":                     assertString(""),
+				"downstream_Content-Type": assertString("text/plain; charset=utf-8"),
+				RequestCount:              assertFloat64NotZero(),
+				Duration:                  assertFloat64NotZero(),
+				Overhead:                  assertFloat64NotZero(),
+				RetryAttempts:             assertFloat64(float64(testRetryAttempts)),
+				"time":                    assertNotEmpty(),
+				"StartLocal":              assertNotEmpty(),
+				"StartUTC":                assertNotEmpty(),
+			},
+		},
+		{
+			desc: "default config, keep query parameters",
+			config: &otypes.AccessLog{
+				FilePath: "",
+				Format:   JSONFormat,
+				Fields: &otypes.AccessLogFields{
+					QueryParameters: &otypes.FieldQueryParameters{
+						DefaultMode: "keep",
+					},
+				},
+			},
+			expected: map[string]func(t *testing.T, value any){
+				RequestContentSize:        assertFloat64(0),
+				RequestHost:               assertString(testHostname),
+				RequestAddr:               assertString(testHostname),
+				RequestMethod:             assertString(testMethod),
+				RequestPath:               assertString(testPathWithQueryParams),
+				RequestProtocol:           assertString(testProto),
+				RequestScheme:             assertString(testScheme),
+				RequestPort:               assertString("-"),
+				DownstreamStatus:          assertFloat64(float64(testStatus)),
+				DownstreamContentSize:     assertFloat64(float64(len(testContent))),
+				OriginContentSize:         assertFloat64(float64(len(testContent))),
+				OriginStatus:              assertFloat64(float64(testStatus)),
+				RequestRefererHeader:      assertString(testReferer),
+				RequestUserAgentHeader:    assertString(testUserAgent),
+				RouterName:                assertString(testRouterName),
+				ServiceURL:                assertString(testServiceName),
+				ClientUsername:            assertString(testUsername),
+				ClientHost:                assertString(testHostname),
+				ClientPort:                assertString(strconv.Itoa(testPort)),
+				ClientAddr:                assertString(fmt.Sprintf("%s:%d", testHostname, testPort)),
+				"level":                   assertString("info"),
+				"msg":                     assertString(""),
+				"downstream_Content-Type": assertString("text/plain; charset=utf-8"),
+				RequestCount:              assertFloat64NotZero(),
+				Duration:                  assertFloat64NotZero(),
+				Overhead:                  assertFloat64NotZero(),
+				RetryAttempts:             assertFloat64(float64(testRetryAttempts)),
+				"time":                    assertNotEmpty(),
+				"StartLocal":              assertNotEmpty(),
+				"StartUTC":                assertNotEmpty(),
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -925,7 +1015,7 @@ func TestNewLogHandlerOutputStdout(t *testing.T) {
 				FilePath: "",
 				Format:   CommonFormat,
 			},
-			expectedLog: `TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testRouter" "http://127.0.0.1/testService" 1ms`,
+			expectedLog: `TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath?param1=test1&param2=test2 HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testRouter" "http://127.0.0.1/testService" 1ms`,
 		},
 		{
 			desc: "default config with empty filters",
@@ -934,7 +1024,7 @@ func TestNewLogHandlerOutputStdout(t *testing.T) {
 				Format:   CommonFormat,
 				Filters:  &otypes.AccessLogFilters{},
 			},
-			expectedLog: `TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testRouter" "http://127.0.0.1/testService" 1ms`,
+			expectedLog: `TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath?param1=test1&param2=test2 HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testRouter" "http://127.0.0.1/testService" 1ms`,
 		},
 		{
 			desc: "Status code filter not matching",
@@ -956,7 +1046,7 @@ func TestNewLogHandlerOutputStdout(t *testing.T) {
 					StatusCodes: []string{"123"},
 				},
 			},
-			expectedLog: `TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testRouter" "http://127.0.0.1/testService" 1ms`,
+			expectedLog: `TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath?param1=test1&param2=test2 HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testRouter" "http://127.0.0.1/testService" 1ms`,
 		},
 		{
 			desc: "Duration filter not matching",
@@ -978,7 +1068,7 @@ func TestNewLogHandlerOutputStdout(t *testing.T) {
 					MinDuration: ptypes.Duration(1 * time.Millisecond),
 				},
 			},
-			expectedLog: `TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testRouter" "http://127.0.0.1/testService" 1ms`,
+			expectedLog: `TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath?param1=test1&param2=test2 HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testRouter" "http://127.0.0.1/testService" 1ms`,
 		},
 		{
 			desc: "Retry attempts filter matching",
@@ -989,7 +1079,7 @@ func TestNewLogHandlerOutputStdout(t *testing.T) {
 					RetryAttempts: true,
 				},
 			},
-			expectedLog: `TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testRouter" "http://127.0.0.1/testService" 1ms`,
+			expectedLog: `TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath?param1=test1&param2=test2 HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testRouter" "http://127.0.0.1/testService" 1ms`,
 		},
 		{
 			desc: "Default mode keep",
@@ -1000,7 +1090,7 @@ func TestNewLogHandlerOutputStdout(t *testing.T) {
 					DefaultMode: "keep",
 				},
 			},
-			expectedLog: `TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testRouter" "http://127.0.0.1/testService" 1ms`,
+			expectedLog: `TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath?param1=test1&param2=test2 HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testRouter" "http://127.0.0.1/testService" 1ms`,
 		},
 		{
 			desc: "Default mode keep with override",
@@ -1014,7 +1104,7 @@ func TestNewLogHandlerOutputStdout(t *testing.T) {
 					},
 				},
 			},
-			expectedLog: `- - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testRouter" "http://127.0.0.1/testService" 1ms`,
+			expectedLog: `- - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath?param1=test1&param2=test2 HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testRouter" "http://127.0.0.1/testService" 1ms`,
 		},
 		{
 			desc: "Default mode drop",
@@ -1220,8 +1310,9 @@ func doLoggingTLSOpt(t *testing.T, config *otypes.AccessLog, enableTLS, tracing,
 		Method:     testMethod,
 		RemoteAddr: fmt.Sprintf("%s:%d", testHostname, testPort),
 		URL: &url.URL{
-			User: url.UserPassword(testUsername, ""),
-			Path: testPath,
+			User:     url.UserPassword(testUsername, ""),
+			Path:     testPath,
+			RawQuery: testQueryParams,
 		},
 		Body: io.NopCloser(bytes.NewReader([]byte("bar"))),
 	}

--- a/pkg/observability/types/logs.go
+++ b/pkg/observability/types/logs.go
@@ -93,9 +93,15 @@ type FieldHeaders struct {
 
 // AccessLogFields holds configuration for access log fields.
 type AccessLogFields struct {
-	DefaultMode string            `description:"Default mode for fields: keep | drop" json:"defaultMode,omitempty" toml:"defaultMode,omitempty" yaml:"defaultMode,omitempty"  export:"true"`
-	Names       map[string]string `description:"Override mode for fields" json:"names,omitempty" toml:"names,omitempty" yaml:"names,omitempty" export:"true"`
-	Headers     *FieldHeaders     `description:"Headers to keep, drop or redact" json:"headers,omitempty" toml:"headers,omitempty" yaml:"headers,omitempty" export:"true"`
+	DefaultMode     string                `description:"Default mode for fields: keep | drop" json:"defaultMode,omitempty" toml:"defaultMode,omitempty" yaml:"defaultMode,omitempty"  export:"true"`
+	Names           map[string]string     `description:"Override mode for fields" json:"names,omitempty" toml:"names,omitempty" yaml:"names,omitempty" export:"true"`
+	Headers         *FieldHeaders         `description:"Headers to keep, drop or redact" json:"headers,omitempty" toml:"headers,omitempty" yaml:"headers,omitempty" export:"true"`
+	QueryParameters *FieldQueryParameters `description:"Keep or drop all query parameters" json:"queryParameters,omitempty" toml:"queryParameters,omitempty" yaml:"queryParameters,omitempty" export:"true"`
+}
+
+// FieldHeaders holds configuration for access log query parameters.
+type FieldQueryParameters struct {
+	DefaultMode string `description:"Default mode for query parameters: keep | drop" json:"defaultMode,omitempty" toml:"defaultMode,omitempty" yaml:"defaultMode,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values.
@@ -103,6 +109,9 @@ func (f *AccessLogFields) SetDefaults() {
 	f.DefaultMode = AccessLogKeep
 	f.Headers = &FieldHeaders{
 		DefaultMode: AccessLogDrop,
+	}
+	f.QueryParameters = &FieldQueryParameters{
+		DefaultMode: AccessLogKeep,
 	}
 }
 
@@ -130,6 +139,14 @@ func (f *AccessLogFields) KeepHeader(header string) string {
 		}
 	}
 	return defaultValue
+}
+
+func (f *AccessLogFields) KeepQueryParameters() bool {
+	defaultKeep := true
+	if f == nil || f.QueryParameters == nil {
+		return defaultKeep
+	}
+	return checkFieldValue(f.QueryParameters.DefaultMode, defaultKeep)
 }
 
 func checkFieldValue(value string, defaultKeep bool) bool {


### PR DESCRIPTION
### What does this PR do?
Allows for all query parameters to be dropped or kept from the RequestPath field in the access log. 

### Motivation
My team and I are looking to migrate to Traefik from Ingress Nginx. For security reasons, we cannot have any request parameters appear in the access logs. Ingress Nginx allowed us to drop those parameters and still log the rest of the request path, but the only way to prevent query parameters from appearing in the access logs in Traefik is to drop the entire RequestPath which is not ideal. We are looking specifically to provide feature parity for this with Ingress Nginx at this time.


### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes
This accomplishes part of #10735.  I've read through the previous conversation in the MR linked to that issue, https://github.com/traefik/traefik/pull/11140, where the desire seemed to be to allow for fine grained control on a parameter by parameter basis. However, my current goal is to provide feature parity to Ingress Nginx to unblock our (and anyone else with this issue) migration, and fine grain control would be a larger and more involved change. I believe I have implemented this in such a way that fine grained control could be added later on without having to rewrite the default behavior portion and this should be a good incremental step towards that goal.
