### PR TITLE
Return an error when an explicit config file is not found

### DIFF
--- a/pkg/cli/loader_file.go
+++ b/pkg/cli/loader_file.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -74,6 +75,9 @@ func loadConfigFiles(configFile string, element any) (string, error) {
 	}
 
 	if len(filePath) == 0 {
+		if configFile != "" {
+			return "", fmt.Errorf("configuration file not found: %s", configFile)
+		}
 		return "", nil
 	}
 

--- a/pkg/cli/loader_file_test.go
+++ b/pkg/cli/loader_file_test.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/traefik/traefik/v3/cmd"
+)
+
+func TestLoadConfigFiles(t *testing.T) {
+	dir := t.TempDir()
+	existingFile := filepath.Join(dir, "traefik.toml")
+	require.NoError(t, os.WriteFile(existingFile, []byte("[log]\n  level = \"DEBUG\"\n"), 0o600))
+
+	tests := []struct {
+		desc       string
+		configFile string
+		wantErr    bool
+	}{
+		{
+			desc:       "existing file",
+			configFile: existingFile,
+		},
+		{
+			desc:       "non-existent explicit file",
+			configFile: filepath.Join(dir, "does-not-exist.toml"),
+			wantErr:    true,
+		},
+		{
+			desc:       "no file specified",
+			configFile: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			tconfig := cmd.NewTraefikConfiguration()
+			got, err := loadConfigFiles(test.configFile, tconfig)
+			if test.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "not found")
+				return
+			}
+			require.NoError(t, err)
+			if test.configFile != "" {
+				assert.Equal(t, test.configFile, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #13045

Right now if you pass `--configfile=/some/path` and that file doesn't exist, Traefik quietly starts up with its defaults. No error, no warning, nothing in the logs. You'd never know your config was ignored.

This is pretty dangerous in real deployments. If a Kubernetes ConfigMap mount fails, or there's a typo in the path, Traefik boots up serving traffic with zero configuration. The operator has no idea until something breaks.

The fix is in `loadConfigFiles` — after `finder.Find` returns empty, we now check whether the caller actually specified a file. If they did, we return an error instead of falling through silently. If no file was specified, the existing behavior (start with defaults) is unchanged.

I added a table-driven test covering the three cases: file exists, file was explicitly specified but missing (the bug), and no file given at all.

Tested locally:
```
$ go test ./pkg/cli/... -v -count=1
--- PASS: TestLoadConfigFiles/existing_file
--- PASS: TestLoadConfigFiles/non-existent_explicit_file
--- PASS: TestLoadConfigFiles/no_file_specified
PASS
```

`go vet` is clean too.