### PR TITLE
Return an error when an explicit config file is not found

### DIFF
--- a/pkg/cli/loader_file.go
+++ b/pkg/cli/loader_file.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -74,6 +75,9 @@ func loadConfigFiles(configFile string, element any) (string, error) {
 	}
 
 	if len(filePath) == 0 {
+		if configFile != "" {
+			return "", fmt.Errorf("configuration file not found: %s", configFile)
+		}
 		return "", nil
 	}
 

--- a/pkg/cli/loader_file_test.go
+++ b/pkg/cli/loader_file_test.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/traefik/traefik/v3/cmd"
+)
+
+func TestLoadConfigFiles(t *testing.T) {
+	dir := t.TempDir()
+	existingFile := filepath.Join(dir, "traefik.toml")
+	require.NoError(t, os.WriteFile(existingFile, []byte("[log]\n  level = \"DEBUG\"\n"), 0o600))
+
+	tests := []struct {
+		desc       string
+		configFile string
+		wantErr    bool
+	}{
+		{
+			desc:       "existing file",
+			configFile: existingFile,
+		},
+		{
+			desc:       "non-existent explicit file",
+			configFile: filepath.Join(dir, "does-not-exist.toml"),
+			wantErr:    true,
+		},
+		{
+			desc:       "no file specified",
+			configFile: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			tconfig := cmd.NewTraefikConfiguration()
+			got, err := loadConfigFiles(test.configFile, tconfig)
+			if test.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "not found")
+				return
+			}
+			require.NoError(t, err)
+			if test.configFile != "" {
+				assert.Equal(t, test.configFile, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

When `--configfile` points at a path that does not exist, `loadConfigFiles` calls `finder.Find`, which walks the search list and silently skips missing paths, then returns `("", nil)`. The caller treats that as "no config file specified" and starts Traefik with built-in defaults — no error, no warning, nothing in the logs.

This PR adds a guard: if the caller supplied an explicit file path and the finder came back empty, we now return an error immediately so startup fails loudly.

### Motivation

A missing volume mount in Kubernetes, a path typo, or a stale env var can silently discard the operator's entire configuration. Traefik boots and serves traffic, but with none of the routing rules, TLS config, or middleware the operator intended. There is no way to detect this until traffic starts misbehaving.

Failing fast with a clear error message is the right call here.

Note: the underlying `finder.Find` in `traefik/paerser` doesn't distinguish between "user-specified file not found" and "no default file found" — it returns `("", nil)` for both. This fix handles it at the `loadConfigFiles` layer in traefik rather than requiring a paerser change.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation (no doc change needed — this makes an implicit behaviour explicit via a startup error)

### Additional Notes

The existing behaviour for the no-file-specified case (`configFile == ""`) is unchanged. Traefik continues to start normally with defaults when the flag is not passed.

Tested locally against the reproduction case from #13045:
```
$ go test ./pkg/cli/... -v -count=1
--- PASS: TestLoadConfigFiles/existing_file
--- PASS: TestLoadConfigFiles/non-existent_explicit_file
--- PASS: TestLoadConfigFiles/no_file_specified
PASS
```

Fixes #13045