### PR TITLE
Fix regressions after refacto of the ingress-nginx provider

### DIFF
--- a/pkg/provider/kubernetes/ingress-nginx/build.go
+++ b/pkg/provider/kubernetes/ingress-nginx/build.go
@@ -55,7 +55,7 @@ func (p *Provider) build(ctx context.Context, ingressClasses []*netv1.IngressCla
 	mc := &model{
 		Backends: make(map[string]*backend),
 		Servers:  make(map[string]*server),
-		Certs:    make(map[string]string),
+		Certs:    make(map[string]certPair),
 	}
 
 	// Builder-local cache of TLS options resolved per ingress. Each Location
@@ -255,6 +255,14 @@ func (p *Provider) build(ctx context.Context, ingressClasses []*netv1.IngressCla
 
 		// ssl-passthrough: handled per-rule. serversTransport is not needed for passthrough.
 		if ptr.Deref(ing.config.SSLPassthrough, false) {
+			// Even with ssl-passthrough, the Spec.TLS section's certificates are
+			// still loaded so they remain available as the default certificate
+			// (mirrors ingress-nginx behavior pre-metamodel).
+			if len(ing.Spec.TLS) > 0 {
+				if err := p.loadCertificates(ctxIng, ing.Ingress, mc.Certs, loadedSecrets); err != nil {
+					logger.Warn().Err(err).Msg("Error loading TLS certificates for ssl-passthrough ingress")
+				}
+			}
 			for _, rule := range ing.Spec.Rules {
 				if rule.Host == "" {
 					logger.Error().Msg("Cannot process ssl-passthrough: rule has no host")
@@ -763,16 +771,19 @@ func (p *Provider) certificateBlocks(namespace, name string) (*certBlocks, error
 	return &blocks, nil
 }
 
-// loadCertificates loads TLS certificates for an ingress into mcCerts (keyed by cert PEM).
-// The loaded set is shared across ingresses to avoid re-reading the same secret multiple times.
-func (p *Provider) loadCertificates(ctx context.Context, ing *netv1.Ingress, mcCerts map[string]string, loaded map[string]bool) error {
+// loadCertificates loads TLS certificates for an ingress into mcCerts.
+// The map is keyed by "<namespace>/<secretName>" so each Secret stays as a
+// distinct certificate entry even if multiple Secrets carry identical PEM
+// content, matching ingress-nginx behavior. The loaded set is shared across
+// ingresses to avoid re-reading the same secret multiple times.
+func (p *Provider) loadCertificates(ctx context.Context, ing *netv1.Ingress, mcCerts map[string]certPair, loaded map[string]bool) error {
 	for _, t := range ing.Spec.TLS {
 		if t.SecretName == "" {
 			log.Ctx(ctx).Debug().Msg("Skipping TLS section: no secret name")
 			continue
 		}
 
-		secretKey := ing.Namespace + "-" + t.SecretName
+		secretKey := ing.Namespace + "/" + t.SecretName
 		if loaded[secretKey] {
 			continue
 		}
@@ -787,7 +798,7 @@ func (p *Provider) loadCertificates(ctx context.Context, ing *netv1.Ingress, mcC
 			return fmt.Errorf("no keypair found in secret %s/%s", ing.Namespace, t.SecretName)
 		}
 
-		mcCerts[string(blocks.cert)] = string(blocks.key)
+		mcCerts[secretKey] = certPair{Cert: string(blocks.cert), Key: string(blocks.key)}
 	}
 
 	return nil

--- a/pkg/provider/kubernetes/ingress-nginx/build.go
+++ b/pkg/provider/kubernetes/ingress-nginx/build.go
@@ -317,6 +317,18 @@ func (p *Provider) build(ctx context.Context, ingressClasses []*netv1.IngressCla
 			logger.Error().Err(err).Msg("Cannot build serversTransport, skipping ingress")
 			continue
 		}
+		// Load TLS certificates into the shared mc.Certs map first. They are kept
+		// even when the rest of the ingress is later skipped (e.g. when an
+		// auth-tls-secret fails to resolve), so the default certificate pool stays
+		// consistent. When loading fails, hasTLS still signals that the ingress has
+		// a TLS section so the translator can fall back to the default cert.
+		hasTLS := len(ing.Spec.TLS) > 0
+		if hasTLS {
+			if err := p.loadCertificates(ctxIng, ing.Ingress, mc.Certs, loadedSecrets); err != nil {
+				logger.Warn().Err(err).Msg("Error loading TLS certificates, defaulting to default certificate")
+			}
+		}
+
 		// Resolve TLS option (auth-tls-secret).
 		var tlsOptionName string
 		var tlsOption *tls.Options
@@ -328,23 +340,15 @@ func (p *Provider) build(ctx context.Context, ingressClasses []*netv1.IngressCla
 			} else {
 				tlsOpt, err := p.buildClientAuthTLSOption(ing.Namespace, ing.config)
 				if err != nil {
-					logger.Error().Err(err).Msg("Cannot build client auth TLS option")
-				} else {
-					tlsOptionName = optName
-					tlsOption = tlsOpt
-					tlsOptionCache[optName] = tlsOption
+					logger.Error().Err(err).Msg("Cannot build client auth TLS option, skipping ingress")
+					// Skipping the ingress entirely matches ingress-nginx behavior:
+					// when the configured client-auth secret cannot be resolved, no
+					// router/middleware/service should be exposed for the ingress.
+					continue
 				}
-			}
-		}
-
-		// Load TLS certificates into the shared mc.Certs map (keyed by cert PEM,
-		// which naturally deduplicates certs reused across ingresses). When loading
-		// fails, hasTLS still signals that the ingress has a TLS section so the
-		// translator can fall back to the default cert.
-		hasTLS := len(ing.Spec.TLS) > 0
-		if hasTLS {
-			if err := p.loadCertificates(ctxIng, ing.Ingress, mc.Certs, loadedSecrets); err != nil {
-				logger.Warn().Err(err).Msg("Error loading TLS certificates, defaulting to default certificate")
+				tlsOptionName = optName
+				tlsOption = tlsOpt
+				tlsOptionCache[optName] = tlsOption
 			}
 		}
 

--- a/pkg/provider/kubernetes/ingress-nginx/build.go
+++ b/pkg/provider/kubernetes/ingress-nginx/build.go
@@ -255,9 +255,7 @@ func (p *Provider) build(ctx context.Context, ingressClasses []*netv1.IngressCla
 
 		// ssl-passthrough: handled per-rule. serversTransport is not needed for passthrough.
 		if ptr.Deref(ing.config.SSLPassthrough, false) {
-			// Even with ssl-passthrough, the Spec.TLS section's certificates are
-			// still loaded so they remain available as the default certificate
-			// (mirrors ingress-nginx behavior pre-metamodel).
+			// Even with ssl-passthrough, the Spec.TLS section's certificates are still loaded so they remain available as the default certificate.
 			if len(ing.Spec.TLS) > 0 {
 				if err := p.loadCertificates(ctxIng, ing.Ingress, mc.Certs, loadedSecrets); err != nil {
 					logger.Warn().Err(err).Msg("Error loading TLS certificates for ssl-passthrough ingress")

--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-auth-tls-pass-certificate-to-upstream-optional-no-ca.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-auth-tls-pass-certificate-to-upstream-optional-no-ca.yml
@@ -1,0 +1,28 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-with-auth-tls-pass-certificate-to-upstream-optional-no-ca
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/auth-tls-secret: "default/ca-secret"
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: "optional_no_ca"
+    nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
+
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - auth-tls-pass-cert-optional-no-ca.localhost
+      secretName: whoami-tls
+  rules:
+    - host: auth-tls-pass-cert-optional-no-ca.localhost
+      http:
+        paths:
+          - path: /
+            pathType: Exact
+            backend:
+              service:
+                name: whoami
+                port:
+                  number: 80

--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-auth-tls-secret-missing.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-auth-tls-secret-missing.yml
@@ -1,0 +1,26 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-with-auth-tls-secret-missing
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/auth-tls-secret: "default/nonexistent-secret"
+
+spec:
+  ingressClassName: nginx
+  tls:
+    - secretName: whoami-tls
+      hosts:
+        - auth-tls-secret-missing.localhost
+  rules:
+    - host: auth-tls-secret-missing.localhost
+      http:
+        paths:
+          - path: /
+            pathType: Exact
+            backend:
+              service:
+                name: whoami
+                port:
+                  number: 80

--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-custom-http-errors-and-upstream-hash-by.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-custom-http-errors-and-upstream-hash-by.yml
@@ -1,0 +1,24 @@
+---
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: ingress-with-custom-http-errors-and-upstream-hash-by
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/default-backend: whoami-b
+    nginx.ingress.kubernetes.io/custom-http-errors: "404,500"
+    nginx.ingress.kubernetes.io/upstream-hash-by: "$request_uri"
+
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: whoami.localhost
+      http:
+        paths:
+          - path: /
+            pathType: Exact
+            backend:
+              service:
+                name: whoami
+                port:
+                  number: 80

--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-default-backend-no-rules.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-default-backend-no-rules.yml
@@ -4,6 +4,8 @@ apiVersion: networking.k8s.io/v1
 metadata:
   name: ingress-with-default-backend-no-rules
   namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/enable-cors: "true"
 
 spec:
   ingressClassName: nginx

--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-ssl-passthrough-and-tls-section.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-ssl-passthrough-and-tls-section.yml
@@ -1,0 +1,26 @@
+---
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: ingress-with-ssl-passthrough-and-tls-section
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - passthrough-tls.whoami.localhost
+      secretName: whoami-tls
+  rules:
+    - host: passthrough-tls.whoami.localhost
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-tls
+                port:
+                  number: 443

--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-tls-multi-secrets.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-tls-multi-secrets.yml
@@ -1,0 +1,48 @@
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  namespace: default
+  name: whoami-tls-extra
+
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t
+  tls.key: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t
+
+---
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: ingress-with-tls-multi-secrets
+  namespace: default
+
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - first.localhost
+      secretName: whoami-tls
+    - hosts:
+        - second.localhost
+      secretName: whoami-tls-extra
+  rules:
+    - host: first.localhost
+      http:
+        paths:
+          - path: /
+            pathType: Exact
+            backend:
+              service:
+                name: whoami
+                port:
+                  number: 80
+    - host: second.localhost
+      http:
+        paths:
+          - path: /
+            pathType: Exact
+            backend:
+              service:
+                name: whoami
+                port:
+                  number: 80

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -15109,6 +15109,544 @@ func TestLoadIngresses(t *testing.T) {
 				TLS: &dynamic.TLSConfiguration{},
 			},
 		},
+		{
+			// Regression test for the metamodel refactor: two TLS sections that
+			// reference distinct Secrets must produce two TLS certificate entries,
+			// even when the Secrets carry identical PEM content. The fix in build.go
+			// keys the certs map by "<namespace>/<secretName>" rather than by the
+			// certificate PEM, so the second entry is no longer dropped.
+			desc: "TLS multiple secrets are not deduplicated by PEM content",
+			paths: []string{
+				"services.yml",
+				"secrets.yml",
+				"ingressclasses.yml",
+				"ingresses/ingress-with-tls-multi-secrets.yml",
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-ingress-with-tls-multi-secrets-rule-0-path-0": {
+							EntryPoints: []string{"http"},
+							Rule:        `Host("first.localhost") && Path("/")`,
+							RuleSyntax:  "default",
+							Middlewares: []string{"default-ingress-with-tls-multi-secrets-rule-0-path-0-redirect-scheme"},
+							Service:     "noop@internal",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-tls-multi-secrets",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+						},
+						"default-ingress-with-tls-multi-secrets-rule-0-path-0-tls": {
+							EntryPoints: []string{"https"},
+							Rule:        `Host("first.localhost") && Path("/")`,
+							RuleSyntax:  "default",
+							Middlewares: []string{"default-ingress-with-tls-multi-secrets-rule-0-path-0-tls-retry"},
+							Service:     "default-ingress-with-tls-multi-secrets-whoami-80",
+							TLS:         &dynamic.RouterTLSConfig{},
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-tls-multi-secrets",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+						},
+						"default-ingress-with-tls-multi-secrets-rule-1-path-0": {
+							EntryPoints: []string{"http"},
+							Rule:        `Host("second.localhost") && Path("/")`,
+							RuleSyntax:  "default",
+							Middlewares: []string{"default-ingress-with-tls-multi-secrets-rule-1-path-0-redirect-scheme"},
+							Service:     "noop@internal",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-tls-multi-secrets",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+						},
+						"default-ingress-with-tls-multi-secrets-rule-1-path-0-tls": {
+							EntryPoints: []string{"https"},
+							Rule:        `Host("second.localhost") && Path("/")`,
+							RuleSyntax:  "default",
+							Middlewares: []string{"default-ingress-with-tls-multi-secrets-rule-1-path-0-tls-retry"},
+							Service:     "default-ingress-with-tls-multi-secrets-whoami-80",
+							TLS:         &dynamic.RouterTLSConfig{},
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-tls-multi-secrets",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-ingress-with-tls-multi-secrets-rule-0-path-0-redirect-scheme": {
+							RedirectScheme: &dynamic.RedirectScheme{
+								Scheme:                 "https",
+								ForcePermanentRedirect: true,
+							},
+						},
+						"default-ingress-with-tls-multi-secrets-rule-0-path-0-tls-retry": {
+							Retry: &dynamic.Retry{Attempts: 3},
+						},
+						"default-ingress-with-tls-multi-secrets-rule-1-path-0-redirect-scheme": {
+							RedirectScheme: &dynamic.RedirectScheme{
+								Scheme:                 "https",
+								ForcePermanentRedirect: true,
+							},
+						},
+						"default-ingress-with-tls-multi-secrets-rule-1-path-0-tls-retry": {
+							Retry: &dynamic.Retry{Attempts: 3},
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"unavailable-service": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+						"default-ingress-with-tls-multi-secrets-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{URL: "http://10.10.0.1:80"},
+									{URL: "http://10.10.0.2:80"},
+								},
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+								ServersTransport: "default-ingress-with-tls-multi-secrets",
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{
+						"default-ingress-with-tls-multi-secrets": {
+							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
+								DialTimeout:     ptypes.Duration(60 * time.Second),
+								ReadTimeout:     ptypes.Duration(60 * time.Second),
+								WriteTimeout:    ptypes.Duration(60 * time.Second),
+								IdleConnTimeout: ptypes.Duration(60 * time.Second),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{
+					Certificates: []*tls.CertAndStores{
+						{
+							Certificate: tls.Certificate{
+								CertFile: "-----BEGIN CERTIFICATE-----",
+								KeyFile:  "-----BEGIN CERTIFICATE-----",
+							},
+						},
+						{
+							Certificate: tls.Certificate{
+								CertFile: "-----BEGIN CERTIFICATE-----",
+								KeyFile:  "-----BEGIN CERTIFICATE-----",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			// Regression test for the metamodel refactor: an ingress with
+			// ssl-passthrough must still load TLS certificates from its Spec.TLS
+			// section, so the certificate is registered as a default cert even
+			// though TCP passthrough takes over the actual routing.
+			desc: "SSL Passthrough still loads TLS section certificates",
+			paths: []string{
+				"services.yml",
+				"secrets.yml",
+				"ingressclasses.yml",
+				"ingresses/ingress-with-ssl-passthrough-and-tls-section.yml",
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers: map[string]*dynamic.TCPRouter{
+						"default-ingress-with-ssl-passthrough-and-tls-section-passthrough-tls-whoami-localhost": {
+							EntryPoints: []string{"https"},
+							Rule:        `HostSNI("passthrough-tls.whoami.localhost")`,
+							RuleSyntax:  "default",
+							TLS: &dynamic.RouterTCPTLSConfig{
+								Passthrough: true,
+							},
+							Service: "default-whoami-tls-443",
+						},
+					},
+					Services: map[string]*dynamic.TCPService{
+						"default-whoami-tls-443": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{Address: "10.10.0.3:8443"},
+									{Address: "10.10.0.4:8443"},
+								},
+							},
+						},
+					},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:     map[string]*dynamic.Router{},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"unavailable-service": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{
+					Certificates: []*tls.CertAndStores{
+						{
+							Certificate: tls.Certificate{
+								CertFile: "-----BEGIN CERTIFICATE-----",
+								KeyFile:  "-----BEGIN CERTIFICATE-----",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			// Regression test for the metamodel refactor: when
+			// auth-tls-pass-certificate-to-upstream is enabled together with
+			// auth-tls-verify-client=optional_no_ca (RequestClientCert), the
+			// auth-tls-secret's CA bytes must be forwarded to the upstream via
+			// the AuthTLSPassCertificateToUpstream middleware's CAFiles field.
+			desc: "Auth TLS pass certificate to upstream with optional_no_ca populates CAFiles",
+			paths: []string{
+				"services.yml",
+				"secrets.yml",
+				"ingressclasses.yml",
+				"ingresses/ingress-with-auth-tls-pass-certificate-to-upstream-optional-no-ca.yml",
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-ingress-with-auth-tls-pass-certificate-to-upstream-optional-no-ca-rule-0-path-0": {
+							EntryPoints: []string{"http"},
+							Rule:        `Host("auth-tls-pass-cert-optional-no-ca.localhost") && Path("/")`,
+							RuleSyntax:  "default",
+							Middlewares: []string{"default-ingress-with-auth-tls-pass-certificate-to-upstream-optional-no-ca-rule-0-path-0-redirect-scheme"},
+							Service:     "noop@internal",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-auth-tls-pass-certificate-to-upstream-optional-no-ca",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+						},
+						"default-ingress-with-auth-tls-pass-certificate-to-upstream-optional-no-ca-rule-0-path-0-tls": {
+							EntryPoints: []string{"https"},
+							Rule:        `Host("auth-tls-pass-cert-optional-no-ca.localhost") && Path("/")`,
+							RuleSyntax:  "default",
+							Middlewares: []string{"default-ingress-with-auth-tls-pass-certificate-to-upstream-optional-no-ca-rule-0-path-0-tls-pass-certificate-to-upstream", "default-ingress-with-auth-tls-pass-certificate-to-upstream-optional-no-ca-rule-0-path-0-tls-retry"},
+							Service:     "default-ingress-with-auth-tls-pass-certificate-to-upstream-optional-no-ca-whoami-80",
+							TLS: &dynamic.RouterTLSConfig{
+								Options: "default-ingress-with-auth-tls-pass-certificate-to-upstream-optional-no-ca-default-ca-secret",
+							},
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-auth-tls-pass-certificate-to-upstream-optional-no-ca",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-ingress-with-auth-tls-pass-certificate-to-upstream-optional-no-ca-rule-0-path-0-redirect-scheme": {
+							RedirectScheme: &dynamic.RedirectScheme{
+								Scheme:                 "https",
+								ForcePermanentRedirect: true,
+							},
+						},
+						"default-ingress-with-auth-tls-pass-certificate-to-upstream-optional-no-ca-rule-0-path-0-tls-pass-certificate-to-upstream": {
+							AuthTLSPassCertificateToUpstream: &dynamic.AuthTLSPassCertificateToUpstream{
+								ClientAuthType: tls.RequestClientCert,
+								CAFiles:        []types.FileOrContent{"-----BEGIN CERTIFICATE-----"},
+							},
+						},
+						"default-ingress-with-auth-tls-pass-certificate-to-upstream-optional-no-ca-rule-0-path-0-tls-retry": {
+							Retry: &dynamic.Retry{Attempts: 3},
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"unavailable-service": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+						"default-ingress-with-auth-tls-pass-certificate-to-upstream-optional-no-ca-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{URL: "http://10.10.0.1:80"},
+									{URL: "http://10.10.0.2:80"},
+								},
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+								ServersTransport: "default-ingress-with-auth-tls-pass-certificate-to-upstream-optional-no-ca",
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{
+						"default-ingress-with-auth-tls-pass-certificate-to-upstream-optional-no-ca": {
+							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
+								DialTimeout:     ptypes.Duration(60 * time.Second),
+								ReadTimeout:     ptypes.Duration(60 * time.Second),
+								WriteTimeout:    ptypes.Duration(60 * time.Second),
+								IdleConnTimeout: ptypes.Duration(60 * time.Second),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{
+					Certificates: []*tls.CertAndStores{
+						{
+							Certificate: tls.Certificate{
+								CertFile: "-----BEGIN CERTIFICATE-----",
+								KeyFile:  "-----BEGIN CERTIFICATE-----",
+							},
+						},
+					},
+					Options: map[string]tls.Options{
+						"default-ingress-with-auth-tls-pass-certificate-to-upstream-optional-no-ca-default-ca-secret": {
+							ClientAuth: tls.ClientAuth{
+								CAFiles:        []types.FileOrContent{"-----BEGIN CERTIFICATE-----"},
+								ClientAuthType: tls.RequestClientCert,
+							},
+							CipherSuites: []string{
+								"TLS_AES_128_GCM_SHA256",
+								"TLS_AES_256_GCM_SHA384",
+								"TLS_CHACHA20_POLY1305_SHA256",
+								"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+								"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+								"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+								"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+								"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+								"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+								"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+								"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+								"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+								"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+							},
+							ALPNProtocols: []string{"h2", "http/1.1", tlsalpn01.ACMETLS1Protocol},
+						},
+					},
+				},
+			},
+		},
+		{
+			// Regression test for the metamodel refactor: when an ingress combines
+			// custom-http-errors + a per-ingress default-backend annotation +
+			// upstream-hash-by, the per-router error-backend service must inherit
+			// the upstream-hash-by configuration (HRW strategy + NginxUpstreamHashBy)
+			// from the ingress location config — not fall back to the default WRR
+			// strategy.
+			desc: "Custom HTTP errors error-backend service inherits upstream-hash-by",
+			paths: []string{
+				"services.yml",
+				"ingressclasses.yml",
+				"ingresses/ingress-with-custom-http-errors-and-upstream-hash-by.yml",
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-ingress-with-custom-http-errors-and-upstream-hash-by-rule-0-path-0": {
+							EntryPoints: []string{"http"},
+							Rule:        `Host("whoami.localhost") && Path("/")`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-custom-http-errors-and-upstream-hash-by-whoami-80",
+							Middlewares: []string{
+								"default-ingress-with-custom-http-errors-and-upstream-hash-by-rule-0-path-0-custom-http-errors",
+								"default-ingress-with-custom-http-errors-and-upstream-hash-by-rule-0-path-0-retry",
+							},
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-custom-http-errors-and-upstream-hash-by",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+						},
+						"default-ingress-with-custom-http-errors-and-upstream-hash-by-rule-0-path-0-tls": {
+							EntryPoints: []string{"https"},
+							Rule:        `Host("whoami.localhost") && Path("/")`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-custom-http-errors-and-upstream-hash-by-whoami-80",
+							TLS:         &dynamic.RouterTLSConfig{},
+							Middlewares: []string{
+								"default-ingress-with-custom-http-errors-and-upstream-hash-by-rule-0-path-0-tls-custom-http-errors",
+								"default-ingress-with-custom-http-errors-and-upstream-hash-by-rule-0-path-0-tls-retry",
+							},
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-custom-http-errors-and-upstream-hash-by",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-ingress-with-custom-http-errors-and-upstream-hash-by-rule-0-path-0-custom-http-errors": {
+							Errors: &dynamic.ErrorPage{
+								Status:  []string{"404", "500"},
+								Service: "default-backend-default-ingress-with-custom-http-errors-and-upstream-hash-by-rule-0-path-0",
+								NginxHeaders: &http.Header{
+									"X-Namespaces":   {"default"},
+									"X-Ingress-Name": {"ingress-with-custom-http-errors-and-upstream-hash-by"},
+									"X-Service-Name": {"whoami"},
+									"X-Service-Port": {"80"},
+								},
+							},
+						},
+						"default-ingress-with-custom-http-errors-and-upstream-hash-by-rule-0-path-0-tls-custom-http-errors": {
+							Errors: &dynamic.ErrorPage{
+								Status:  []string{"404", "500"},
+								Service: "default-backend-default-ingress-with-custom-http-errors-and-upstream-hash-by-rule-0-path-0-tls",
+								NginxHeaders: &http.Header{
+									"X-Namespaces":   {"default"},
+									"X-Ingress-Name": {"ingress-with-custom-http-errors-and-upstream-hash-by"},
+									"X-Service-Name": {"whoami"},
+									"X-Service-Port": {"80"},
+								},
+							},
+						},
+						"default-ingress-with-custom-http-errors-and-upstream-hash-by-rule-0-path-0-retry": {
+							Retry: &dynamic.Retry{Attempts: 3},
+						},
+						"default-ingress-with-custom-http-errors-and-upstream-hash-by-rule-0-path-0-tls-retry": {
+							Retry: &dynamic.Retry{Attempts: 3},
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"unavailable-service": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+						"default-ingress-with-custom-http-errors-and-upstream-hash-by-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{URL: "http://10.10.0.1:80"},
+									{URL: "http://10.10.0.2:80"},
+								},
+								Strategy:            dynamic.BalancerStrategyHRW,
+								NginxUpstreamHashBy: "$request_uri",
+								PassHostHeader:      ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+								ServersTransport: "default-ingress-with-custom-http-errors-and-upstream-hash-by",
+							},
+						},
+						"default-backend-default-ingress-with-custom-http-errors-and-upstream-hash-by-rule-0-path-0": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{URL: "http://10.10.0.5:8000"},
+									{URL: "http://10.10.0.6:8000"},
+								},
+								Strategy:            dynamic.BalancerStrategyHRW,
+								NginxUpstreamHashBy: "$request_uri",
+								PassHostHeader:      ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+						"default-backend-default-ingress-with-custom-http-errors-and-upstream-hash-by-rule-0-path-0-tls": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{URL: "http://10.10.0.5:8000"},
+									{URL: "http://10.10.0.6:8000"},
+								},
+								Strategy:            dynamic.BalancerStrategyHRW,
+								NginxUpstreamHashBy: "$request_uri",
+								PassHostHeader:      ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{
+						"default-ingress-with-custom-http-errors-and-upstream-hash-by": {
+							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
+								DialTimeout:     ptypes.Duration(60 * time.Second),
+								ReadTimeout:     ptypes.Duration(60 * time.Second),
+								WriteTimeout:    ptypes.Duration(60 * time.Second),
+								IdleConnTimeout: ptypes.Duration(60 * time.Second),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
 	}
 
 	for _, test := range testCases {

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -5338,7 +5338,7 @@ func TestLoadIngresses(t *testing.T) {
 			},
 		},
 		{
-			desc: "Ingress default backend without rules emits catch-all routers",
+			desc: "Ingress default backend without rules emits catch-all routers with middleware annotations applied",
 			paths: []string{
 				"services.yml",
 				"ingressclasses.yml",
@@ -5357,7 +5357,7 @@ func TestLoadIngresses(t *testing.T) {
 							RuleSyntax:  "default",
 							Priority:    math.MinInt32,
 							Service:     "default-backend",
-							Middlewares: []string{"default-backend-retry"},
+							Middlewares: []string{"default-backend-cors", "default-backend-retry"},
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
 									Ingress: &dynamic.KubernetesIngressMetadata{
@@ -5375,7 +5375,7 @@ func TestLoadIngresses(t *testing.T) {
 							RuleSyntax:  "default",
 							Priority:    math.MinInt32,
 							Service:     "default-backend",
-							Middlewares: []string{"default-backend-tls-retry"},
+							Middlewares: []string{"default-backend-tls-cors", "default-backend-tls-retry"},
 							TLS:         &dynamic.RouterTLSConfig{},
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
@@ -5390,6 +5390,26 @@ func TestLoadIngresses(t *testing.T) {
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{
+						"default-backend-cors": {
+							Headers: &dynamic.Headers{
+								AccessControlAllowCredentials: true,
+								AccessControlExposeHeaders:    []string{},
+								AccessControlAllowHeaders:     []string{"DNT", "Keep-Alive", "User-Agent", "X-Requested-With", "If-Modified-Since", "Cache-Control", "Content-Type", "Range,Authorization"},
+								AccessControlAllowMethods:     []string{"GET", "PUT", "POST", "DELETE", "PATCH", "OPTIONS"},
+								AccessControlAllowOriginList:  []string{"*"},
+								AccessControlMaxAge:           1728000,
+							},
+						},
+						"default-backend-tls-cors": {
+							Headers: &dynamic.Headers{
+								AccessControlAllowCredentials: true,
+								AccessControlExposeHeaders:    []string{},
+								AccessControlAllowHeaders:     []string{"DNT", "Keep-Alive", "User-Agent", "X-Requested-With", "If-Modified-Since", "Cache-Control", "Content-Type", "Range,Authorization"},
+								AccessControlAllowMethods:     []string{"GET", "PUT", "POST", "DELETE", "PATCH", "OPTIONS"},
+								AccessControlAllowOriginList:  []string{"*"},
+								AccessControlMaxAge:           1728000,
+							},
+						},
 						"default-backend-retry": {
 							Retry: &dynamic.Retry{
 								Attempts: 3,
@@ -15645,6 +15665,47 @@ func TestLoadIngresses(t *testing.T) {
 					},
 				},
 				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc: "Auth TLS secret missing — ingress is skipped entirely",
+			paths: []string{
+				"services.yml",
+				"secrets.yml",
+				"ingressclasses.yml",
+				"ingresses/ingress-with-auth-tls-secret-missing.yml",
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:     map[string]*dynamic.Router{},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"unavailable-service": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{
+					Certificates: []*tls.CertAndStores{
+						{
+							Certificate: tls.Certificate{
+								CertFile: "-----BEGIN CERTIFICATE-----",
+								KeyFile:  "-----BEGIN CERTIFICATE-----",
+							},
+						},
+					},
+				},
 			},
 		},
 	}

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -15130,11 +15130,8 @@ func TestLoadIngresses(t *testing.T) {
 			},
 		},
 		{
-			// Regression test for the metamodel refactor: two TLS sections that
-			// reference distinct Secrets must produce two TLS certificate entries,
-			// even when the Secrets carry identical PEM content. The fix in build.go
-			// keys the certs map by "<namespace>/<secretName>" rather than by the
-			// certificate PEM, so the second entry is no longer dropped.
+			// Two TLS sections that reference distinct Secrets must produce two TLS certificate entries,
+			// even when the Secrets carry identical PEM content.
 			desc: "TLS multiple secrets are not deduplicated by PEM content",
 			paths: []string{
 				"services.yml",
@@ -15295,10 +15292,8 @@ func TestLoadIngresses(t *testing.T) {
 			},
 		},
 		{
-			// Regression test for the metamodel refactor: an ingress with
-			// ssl-passthrough must still load TLS certificates from its Spec.TLS
-			// section, so the certificate is registered as a default cert even
-			// though TCP passthrough takes over the actual routing.
+			// An ingress with ssl-passthrough must still load TLS certificates from its Spec.TLS section,
+			// so the certificate is registered as a default cert even though TCP passthrough takes over the actual routing.
 			desc: "SSL Passthrough still loads TLS section certificates",
 			paths: []string{
 				"services.yml",
@@ -15359,11 +15354,8 @@ func TestLoadIngresses(t *testing.T) {
 			},
 		},
 		{
-			// Regression test for the metamodel refactor: when
-			// auth-tls-pass-certificate-to-upstream is enabled together with
-			// auth-tls-verify-client=optional_no_ca (RequestClientCert), the
-			// auth-tls-secret's CA bytes must be forwarded to the upstream via
-			// the AuthTLSPassCertificateToUpstream middleware's CAFiles field.
+			// When auth-tls-pass-certificate-to-upstream is enabled together with auth-tls-verify-client=optional_no_ca (RequestClientCert),
+			// the auth-tls-secret's CA bytes must be forwarded to the upstream via the AuthTLSPassCertificateToUpstream middleware's CAFiles field.
 			desc: "Auth TLS pass certificate to upstream with optional_no_ca populates CAFiles",
 			paths: []string{
 				"services.yml",
@@ -15506,12 +15498,9 @@ func TestLoadIngresses(t *testing.T) {
 			},
 		},
 		{
-			// Regression test for the metamodel refactor: when an ingress combines
-			// custom-http-errors + a per-ingress default-backend annotation +
-			// upstream-hash-by, the per-router error-backend service must inherit
-			// the upstream-hash-by configuration (HRW strategy + NginxUpstreamHashBy)
-			// from the ingress location config — not fall back to the default WRR
-			// strategy.
+			// When an ingress combines custom-http-errors + a per-ingress default-backend annotation + upstream-hash-by,
+			// the per-router error-backend service must inherit the upstream-hash-by configuration (HRW strategy + NginxUpstreamHashBy)
+			// from the ingress location config — not fall back to the default WRR strategy.
 			desc: "Custom HTTP errors error-backend service inherits upstream-hash-by",
 			paths: []string{
 				"services.yml",

--- a/pkg/provider/kubernetes/ingress-nginx/middleware.go
+++ b/pkg/provider/kubernetes/ingress-nginx/middleware.go
@@ -12,6 +12,8 @@ import (
 	"github.com/rs/zerolog/log"
 	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
+	"github.com/traefik/traefik/v3/pkg/tls"
+	"github.com/traefik/traefik/v3/pkg/types"
 	"k8s.io/utils/ptr"
 )
 
@@ -333,8 +335,27 @@ func (p *Provider) buildAuthTLSPassCert(loc *location) {
 		return
 	}
 
+	verifyClient := clientAuthTypeFromString(loc.Config.AuthTLSVerifyClient)
+
+	var caFiles []types.FileOrContent
+	// When auth-tls-verify-client is "optional_no_ca" (RequestClientCert), the CA
+	// certificate from the auth-tls-secret is forwarded to the upstream so the
+	// upstream can verify the client certificate it receives.
+	if verifyClient == tls.RequestClientCert {
+		parts := strings.SplitN(ptr.Deref(loc.Config.AuthTLSSecret, ""), "/", 2)
+		if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+			secretNamespace, secretName := parts[0], parts[1]
+			if p.AllowCrossNamespaceResources || secretNamespace == loc.Namespace {
+				if blocks, err := p.certificateBlocks(secretNamespace, secretName); err == nil && blocks.ca != nil {
+					caFiles = []types.FileOrContent{types.FileOrContent(blocks.ca)}
+				}
+			}
+		}
+	}
+
 	loc.AuthTLSPassCert = &dynamic.AuthTLSPassCertificateToUpstream{
-		ClientAuthType: clientAuthTypeFromString(loc.Config.AuthTLSVerifyClient),
+		ClientAuthType: verifyClient,
+		CAFiles:        caFiles,
 	}
 }
 

--- a/pkg/provider/kubernetes/ingress-nginx/model.go
+++ b/pkg/provider/kubernetes/ingress-nginx/model.go
@@ -29,9 +29,17 @@ type model struct {
 	DefaultBackendLocation *location
 
 	// Certs holds all TLS certificates resolved from Kubernetes Secrets across all ingresses.
-	// The map key is the certificate PEM, the value is the matching private key PEM.
-	// Using the cert PEM as the key naturally deduplicates certificates that appear in multiple ingresses.
-	Certs map[string]string
+	// The map key is "<namespace>/<secretName>", which deduplicates by Secret identity
+	// rather than by certificate PEM (so two distinct Secrets with the same cert
+	// content remain separate entries, matching ingress-nginx behavior).
+	Certs map[string]certPair
+}
+
+// certPair holds the certificate and private key PEM bytes for a single
+// Kubernetes Secret resolved from a TLS section.
+type certPair struct {
+	Cert string
+	Key  string
 }
 
 // backend represents a resolved upstream service.

--- a/pkg/provider/kubernetes/ingress-nginx/translator.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator.go
@@ -92,7 +92,7 @@ func (p *Provider) translate(ctx context.Context, mc *model) *dynamic.Configurat
 		// Apply the full middleware stack from the ingress location annotations to
 		// both catch-all routers, so options like enable-cors, custom-headers,
 		// rate-limits, redirects, etc. configured on a "spec.defaultBackend only"
-		// ingress reach its catch-all routers (and not just retry).
+		// ingress reach its catch-all routers.
 		if loc := mc.DefaultBackendLocation; loc != nil {
 			p.applyMiddlewares(mc, loc, defaultBackendName, rt, conf)
 			p.applyMiddlewares(mc, loc, defaultBackendTLSName, rtTLS, conf)

--- a/pkg/provider/kubernetes/ingress-nginx/translator.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator.go
@@ -89,13 +89,13 @@ func (p *Provider) translate(ctx context.Context, mc *model) *dynamic.Configurat
 			Observability: obs,
 		}
 
-		if loc := mc.DefaultBackendLocation; loc != nil && loc.Retry != nil {
-			retryName := defaultBackendName + "-retry"
-			retryTLSName := defaultBackendTLSName + "-retry"
-			conf.HTTP.Middlewares[retryName] = &dynamic.Middleware{Retry: loc.Retry}
-			conf.HTTP.Middlewares[retryTLSName] = &dynamic.Middleware{Retry: loc.Retry}
-			rt.Middlewares = []string{retryName}
-			rtTLS.Middlewares = []string{retryTLSName}
+		// Apply the full middleware stack from the ingress location annotations to
+		// both catch-all routers, so options like enable-cors, custom-headers,
+		// rate-limits, redirects, etc. configured on a "spec.defaultBackend only"
+		// ingress reach its catch-all routers (and not just retry).
+		if loc := mc.DefaultBackendLocation; loc != nil {
+			p.applyMiddlewares(mc, loc, defaultBackendName, rt, conf)
+			p.applyMiddlewares(mc, loc, defaultBackendTLSName, rtTLS, conf)
 		}
 
 		conf.HTTP.Routers[defaultBackendName] = rt

--- a/pkg/provider/kubernetes/ingress-nginx/translator.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator.go
@@ -3,9 +3,11 @@ package ingressnginx
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math"
 	"net/http"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -37,11 +39,12 @@ func (p *Provider) translate(ctx context.Context, mc *model) *dynamic.Configurat
 	lb.SetDefaults()
 	conf.HTTP.Services[unavailableServiceName] = &dynamic.Service{LoadBalancer: lb}
 
-	for cert, key := range mc.Certs {
+	for _, k := range slices.Sorted(maps.Keys(mc.Certs)) {
+		cp := mc.Certs[k]
 		conf.TLS.Certificates = append(conf.TLS.Certificates, &tls.CertAndStores{
 			Certificate: tls.Certificate{
-				CertFile: types.FileOrContent(cert),
-				KeyFile:  types.FileOrContent(key),
+				CertFile: types.FileOrContent(cp.Cert),
+				KeyFile:  types.FileOrContent(cp.Key),
 			},
 		})
 	}
@@ -411,7 +414,7 @@ func (p *Provider) applyMiddlewares(mc *model, loc *location, routerKey string, 
 		if e.ErrorBackendName != "" {
 			errorSvcName = "default-backend-" + routerKey
 			if errBackend, ok := mc.Backends[e.ErrorBackendName]; ok {
-				conf.HTTP.Services[errorSvcName] = buildService(errBackend, "")
+				conf.HTTP.Services[errorSvcName] = buildServiceWithLocConfig(errBackend, "", loc.Config)
 			}
 		}
 		headers := http.Header{


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes some regression we introduced after the refacto.


### More

 - Remove certificate deduplication ( should be reintroduce later )
 - Add CAFiles in AuthPassTLSCert
 - Handle annotation on backend for error pages