### PR TITLE
fix(ingress-nginx): make trailing slash optional in rewrite-target regex

### DIFF
--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
@@ -73,6 +73,10 @@ var (
 	strictPathTypeRegexp = regexp.MustCompile(`(?i)^/[[:alnum:]._\-/]*$`)
 	// The same regexp used in ingress-nginx: https://github.com/kubernetes/ingress-nginx/blob/main/internal/ingress/annotations/parser/validators.go#L77
 	regexPathWithCapture = regexp.MustCompile(`^/?[-._~a-zA-Z0-9/$:]*$`)
+	// trailingSlashCaptureRegex matches a trailing /(...) at the end of a path regex.
+	// Used to make the slash optional so "/original/(.*)" also matches "/original".
+	// See https://github.com/traefik/traefik/issues/12982
+	trailingSlashCaptureRegex = regexp.MustCompile(`/\(([^)]*)\)$`)
 )
 
 // Provider holds configurations of the provider.

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -3164,14 +3164,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-x-forwarded-prefix-three-groups-rule-0-path-0-rewrite-target": {
 							RewriteTarget: &dynamic.RewriteTarget{
-								Regex:            "/(prefix)/(sub)/(.*)",
+								Regex:            "/(prefix)/(sub)/?(.*)",
 								Replacement:      "/$3",
 								XForwardedPrefix: "/$1/$2",
 							},
 						},
 						"default-ingress-with-x-forwarded-prefix-three-groups-rule-0-path-0-tls-rewrite-target": {
 							RewriteTarget: &dynamic.RewriteTarget{
-								Regex:            "/(prefix)/(sub)/(.*)",
+								Regex:            "/(prefix)/(sub)/?(.*)",
 								Replacement:      "/$3",
 								XForwardedPrefix: "/$1/$2",
 							},

--- a/pkg/provider/kubernetes/ingress-nginx/middleware.go
+++ b/pkg/provider/kubernetes/ingress-nginx/middleware.go
@@ -256,7 +256,13 @@ func (p *Provider) buildRewriteTarget(loc *location) {
 		return
 	}
 
-	regex := loc.Path
+	// When the path ends with a trailing slash + capture group like "/(.*)"
+	// or "/(.+)", make the slash optional so the regex also matches the bare
+	// prefix without a trailing slash. nginx handles this by doing a prefix
+	// match before the regex; Traefik only does regex, so the slash must be
+	// optional to get equivalent behavior.
+	// See https://github.com/traefik/traefik/issues/12982
+	regex := trailingSlashCaptureRegex.ReplaceAllString(loc.Path, "/?($1)")
 
 	xfp := ""
 	if loc.Config.XForwardedPrefix != nil && regexPathWithCapture.MatchString(*loc.Config.XForwardedPrefix) {


### PR DESCRIPTION
Rebased onto v3.7 per @kevinpollet's request in #13065.

## What does this PR do?

When `pathType: ImplementationSpecific` with a regex capture path like `/original/(.*)` is used alongside `rewrite-target: https://bar.example.org/$1`, requests to the base path `/original` (without trailing slash) return 404.

nginx handles this because it does a prefix match before the regex. Traefik only does regex matching, so `/original/(.*)` requires the trailing slash to match.

### Fix

Detect path regexes ending with a literal slash followed by a capture group (e.g. `/(.*)`), and make the slash optional: `/original/(.*)` becomes `/original/?(.*)`. A compiled regex (`trailingSlashCaptureRegex`) ensures only the trailing `/(...)` is affected.

| Request | Before (404) | After |
|---|---|---|
| `/original` | 404 (regex doesn't match) | 302 to `https://bar.example.org/` |
| `/original/other` | 302 (unchanged) | 302 (unchanged) |

Fixes #12982