### PR TITLE
flake.nix: cleanup, refactor

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,37 +1,16 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772963539,
-        "narHash": "sha256-9jVDGZnvCckTGdYT53d/EfznygLskyLQXYwJLKMPsZs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "9dcb002ca1690658be4a04645215baea8b95f31d",
-        "type": "github"
+        "lastModified": 1778036283,
+        "narHash": "sha256-GW2cEd/cLcVbbCes8iQuoY2qGIeCA7UiaD351hpkXfI=",
+        "rev": "ed67bc86e84e51d4a88e73c7fd36006dc876476f",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre993032.ed67bc86e84e/nixexprs.tar.xz"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz"
       }
     },
     "nixpkgs-golangci": {
@@ -68,25 +47,9 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "nixpkgs-golangci": "nixpkgs-golangci",
         "nixpkgs-kct": "nixpkgs-kct"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,8 @@
             pkgs-golangci.golangci-lint
           ];
         };
+
+        formatter = pkgs.nixfmt;
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -16,8 +16,16 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, nixpkgs-kct, nixpkgs-golangci, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      nixpkgs-kct,
+      nixpkgs-golangci,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = import nixpkgs {
           inherit system;

--- a/flake.nix
+++ b/flake.nix
@@ -12,43 +12,34 @@
     # Pinned nixpkgs for golangci-lint
     # Search: https://www.nixhub.io/packages/golangci-lint
     nixpkgs-golangci.url = "github:NixOS/nixpkgs/80d901ec0377e19ac3f7bb8c035201e2e098cc97";
-
-    flake-utils.url = "github:numtide/flake-utils";
   };
 
   outputs =
     {
-      self,
       nixpkgs,
       nixpkgs-kct,
       nixpkgs-golangci,
-      flake-utils,
+      ...
     }:
-    flake-utils.lib.eachDefaultSystem (
-      system:
-      let
-        pkgs = import nixpkgs {
-          inherit system;
-        };
+    let
+      inherit (nixpkgs.lib) genAttrs;
+      forEachSystem = genAttrs nixpkgs.lib.systems.flakeExposed;
 
-        pkgs-kct = import nixpkgs-kct {
-          inherit system;
-        };
-
-        pkgs-golangci = import nixpkgs-golangci {
-          inherit system;
-        };
-      in
-      {
-        devShells.default = pkgs.mkShell {
+      pkgsForEach = nixpkgs.legacyPackages;
+      pkgsKctForEach = nixpkgs-kct.legacyPackages;
+      pkgsGolangCiForEach = nixpkgs-golangci.legacyPackages;
+    in
+    {
+      devShells = forEachSystem (system: {
+        default = pkgsForEach.${system}.mkShell {
           packages = [
-            pkgs-kct.kubernetes-controller-tools
-            pkgs.gnused
-            pkgs-golangci.golangci-lint
+            pkgsForEach.${system}.gnused
+            pkgsKctForEach.${system}.kubernetes-controller-tools
+            pkgsGolangCiForEach.${system}.golangci-lint
           ];
         };
+      });
 
-        formatter = pkgs.nixfmt;
-      }
-    );
+      formatter = forEachSystem (system: pkgsForEach.${system}.nixfmt);
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     # Main nixpkgs (used for gnused)
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
 
     # Pinned nixpkgs for kubernetes-controller-tools
     # Search: https://www.nixhub.io/packages/kubernetes-controller-tools


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This is a set of patches cleaning up and refactoring the `flake.nix` in the project root. 
The patches do the following, in order:
1. Add `nixfmt` as a default formatter
2. Format the `flake.nix` using `nixfmt`
3. Drop `flake-utils` as a dependency, opting for a few trivial lines of Nix code instead.
4. Update the `nixpkgs` flake input, making use of the tarball from `nixos.org`, which is smaller than the standard `nixpkgs` flake input from GitHub, but otherwise just the same. 


I would advise going through the commits in order to follow my process and make reviewing easier.

### Motivation

<!-- What inspired you to submit this pull request? -->
Using `flake-utils` here introduces it as a dependency for all downstream consumers of this flake and is not very useful as it can be replaced by a few lines of `nixpkgs` standard library code.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

<sup><sub>No large language models were used in the creation of these changes; everything is human-made. <3</sub></sup>