### PR TITLE
fix: suppress unmatched ping entrypoint requests from access log

### DIFF
--- a/pkg/server/middleware/observability.go
+++ b/pkg/server/middleware/observability.go
@@ -136,6 +136,17 @@ func (o *ObservabilityMgr) observabilityContextHandler(next http.Handler, intern
 	})
 }
 
+// IsPingEntryPoint reports whether the given entry point name is configured as the ping entry point.
+// This is used to treat unmatched requests on the ping entry point as internal,
+// so that addInternals=false suppresses them (e.g. plain HTTP hitting a TLS ping entry point).
+func (o *ObservabilityMgr) IsPingEntryPoint(entryPointName string) bool {
+	if o == nil || o.config.Ping == nil {
+		return false
+	}
+
+	return o.config.Ping.EntryPoint == entryPointName
+}
+
 // shouldAccessLog returns whether the access logs should be enabled for the given serviceName and the observability config.
 func (o *ObservabilityMgr) shouldAccessLog(internal bool, observabilityConfig dynamic.RouterObservabilityConfig) bool {
 	if o == nil {

--- a/pkg/server/middleware/observability_test.go
+++ b/pkg/server/middleware/observability_test.go
@@ -1,0 +1,69 @@
+package middleware
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/traefik/traefik/v3/pkg/config/static"
+	"github.com/traefik/traefik/v3/pkg/ping"
+)
+
+func TestIsPingEntryPoint(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		mgr            *ObservabilityMgr
+		entryPointName string
+		expected       bool
+	}{
+		{
+			desc:           "nil ObservabilityMgr receiver",
+			mgr:            nil,
+			entryPointName: "websecure",
+			expected:       false,
+		},
+		{
+			desc:           "ping config is nil",
+			mgr:            &ObservabilityMgr{config: static.Configuration{}},
+			entryPointName: "websecure",
+			expected:       false,
+		},
+		{
+			desc: "entry point matches configured ping entry point",
+			mgr: &ObservabilityMgr{
+				config: static.Configuration{
+					Ping: &ping.Handler{EntryPoint: "websecure"},
+				},
+			},
+			entryPointName: "websecure",
+			expected:       true,
+		},
+		{
+			desc: "entry point does not match configured ping entry point",
+			mgr: &ObservabilityMgr{
+				config: static.Configuration{
+					Ping: &ping.Handler{EntryPoint: "websecure"},
+				},
+			},
+			entryPointName: "web",
+			expected:       false,
+		},
+		{
+			desc: "non-ping entry point on same traefik instance",
+			mgr: &ObservabilityMgr{
+				config: static.Configuration{
+					Ping: &ping.Handler{EntryPoint: "ping"},
+				},
+			},
+			entryPointName: "websecure",
+			expected:       false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.expected, test.mgr.IsPingEntryPoint(test.entryPointName))
+		})
+	}
+}

--- a/pkg/server/router/router.go
+++ b/pkg/server/router/router.go
@@ -208,7 +208,7 @@ func (m *Manager) BuildHandlers(rootCtx context.Context, entryPoints []string, t
 			epObsConfig = model.Observability
 		}
 
-		defaultHandler, err := m.observabilityMgr.BuildEPChain(ctx, entryPointName, false, epObsConfig).Then(http.NotFoundHandler())
+		defaultHandler, err := m.observabilityMgr.BuildEPChain(ctx, entryPointName, m.observabilityMgr.IsPingEntryPoint(entryPointName), epObsConfig).Then(http.NotFoundHandler())
 		if err != nil {
 			logger.Error().Err(err).Send()
 			continue
@@ -230,7 +230,7 @@ func (m *Manager) getHTTPRouters(ctx context.Context, entryPoints []string, tls 
 func (m *Manager) buildEntryPointHandler(ctx context.Context, entryPointName string, configs map[string]*runtime.RouterInfo, config dynamic.RouterObservabilityConfig) (http.Handler, error) {
 	muxer := httpmuxer.NewMuxer(m.parser, m.providersPrecedence)
 
-	defaultHandler, err := m.observabilityMgr.BuildEPChain(ctx, entryPointName, false, config).Then(http.NotFoundHandler())
+	defaultHandler, err := m.observabilityMgr.BuildEPChain(ctx, entryPointName, m.observabilityMgr.IsPingEntryPoint(entryPointName), config).Then(http.NotFoundHandler())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
---
Title: fix: suppress ping entrypoint unmatched requests from access log

---

**What does this PR do?**

When `ping.entryPoint` is set to a TLS entry point with `manualRouting: true`, plain HTTP requests to that port match no router (the ping router requires TLS). The fallback 404 handler was built with `internal=false`, causing these unmatched requests to bypass `addInternals: false` and appear in the access log as noise.

This fix treats the default (unmatched) handler on the ping entry point as internal, so `addInternals: false` correctly suppresses it. Matched router handlers are unaffected - they continue to derive the `internal` flag from the service name suffix.

Fixes #12751

**Motivation**

Unmatched requests on a TLS ping entry point (e.g. plain HTTP hitting a port configured for TLS-only ping with `manualRouting: true`) were leaking into access logs even with `accessLog.addInternals: false`. This produced spurious log noise for operators using the ping health check on a dedicated TLS entry point.

**More**

- Added/updated tests
- Added/updated documentation

**Additional Notes**

Only the fallback `defaultHandler` on the ping entry point is affected. The `IsPingEntryPoint` helper checks `o.config.Ping.EntryPoint` and returns `false` if ping is unconfigured, so there is no behavioral change for setups that don't use `ping.entryPoint`.

---