### PR TITLE
fix: suppress unmatched internal service entrypoint requests from access log

### DIFF
--- a/pkg/server/middleware/observability.go
+++ b/pkg/server/middleware/observability.go
@@ -136,6 +136,17 @@ func (o *ObservabilityMgr) observabilityContextHandler(next http.Handler, intern
 	})
 }
 
+// IsInternalServiceEntryPoint reports whether the given entry point is dedicated to an internal service
+// (ping or internal services). This is used to treat unmatched requests on those entry points as
+// internal, so that addInternals=false suppresses them (e.g. plain HTTP hitting a TLS entry point).
+func (o *ObservabilityMgr) IsInternalServiceEntryPoint(entryPointName string) bool {
+	if o == nil || o.config.Ping == nil {
+		return false
+	}
+
+	return o.config.Ping.EntryPoint == entryPointName
+}
+
 // shouldAccessLog returns whether the access logs should be enabled for the given serviceName and the observability config.
 func (o *ObservabilityMgr) shouldAccessLog(internal bool, observabilityConfig dynamic.RouterObservabilityConfig) bool {
 	if o == nil {

--- a/pkg/server/router/router.go
+++ b/pkg/server/router/router.go
@@ -208,7 +208,7 @@ func (m *Manager) BuildHandlers(rootCtx context.Context, entryPoints []string, t
 			epObsConfig = model.Observability
 		}
 
-		defaultHandler, err := m.observabilityMgr.BuildEPChain(ctx, entryPointName, false, epObsConfig).Then(http.NotFoundHandler())
+		defaultHandler, err := m.observabilityMgr.BuildEPChain(ctx, entryPointName, m.observabilityMgr.IsInternalServiceEntryPoint(entryPointName), epObsConfig).Then(http.NotFoundHandler())
 		if err != nil {
 			logger.Error().Err(err).Send()
 			continue
@@ -230,7 +230,7 @@ func (m *Manager) getHTTPRouters(ctx context.Context, entryPoints []string, tls 
 func (m *Manager) buildEntryPointHandler(ctx context.Context, entryPointName string, configs map[string]*runtime.RouterInfo, config dynamic.RouterObservabilityConfig) (http.Handler, error) {
 	muxer := httpmuxer.NewMuxer(m.parser, m.providersPrecedence)
 
-	defaultHandler, err := m.observabilityMgr.BuildEPChain(ctx, entryPointName, false, config).Then(http.NotFoundHandler())
+	defaultHandler, err := m.observabilityMgr.BuildEPChain(ctx, entryPointName, m.observabilityMgr.IsInternalServiceEntryPoint(entryPointName), config).Then(http.NotFoundHandler())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What this fixes

Fixes #12751

When `ping.entryPoint` points to a TLS entrypoint with `manualRouting: true`, plain HTTP requests to that port match no router — the ping/metrics router requires `tls: {}`. The fallback 404 handler was built with `internal=false`, so `addInternals: false` in `accessLog` had no effect and these requests were logged as noise.

## Root cause

In `router.go`, the muxer's default (unmatched) handler always hardcoded `internal=false`:


// Before
BuildEPChain(ctx, entryPointName, false, config).Then(http.NotFoundHandler())


When no router matches, this handler fires. Since `internal=false`, `shouldAccessLog` never suppresses it regardless of `addInternals`.

For matched routers, `internal` is correctly derived from the service name:

BuildEPChain(ctx, entryPointName, strings.HasSuffix(routerConfig.Service, "@internal"), config)

So matched internal routers get suppressed fine — only the unmatched fallback was broken.

## Fix

Added `IsInternalServiceEntryPoint(entryPointName string) bool` to `ObservabilityMgr`. It checks whether the given entrypoint is configured as the ping or Prometheus metrics entrypoint. Both services expose `entryPoint` + `manualRouting` and are susceptible to the same issue.

The two default handler build sites in `router.go` now use this instead of hardcoding `false`:

// After
BuildEPChain(ctx, entryPointName, m.observabilityMgr.IsInternalServiceEntryPoint(entryPointName), config).Then(http.NotFoundHandler())


Matched router handlers are unaffected — they continue to derive `internal` from the service name suffix as before.

## Testing

# HTTPS ping → 200, not logged
curl --location 'https://localhost:9543/ping'

# Plain HTTP to TLS port → 404, not logged
curl --location 'http://localhost:9543/ping'

# Confirm access log stays empty
cat access.log