### PR TITLE
feat: add uid options pass tls client cert

### DIFF
--- a/docs/content/reference/dynamic-configuration/docker-labels.yml
+++ b/docs/content/reference/dynamic-configuration/docker-labels.yml
@@ -126,6 +126,7 @@
 - "traefik.http.middlewares.middleware16.passtlsclientcert.info.subject.organizationalunit=true"
 - "traefik.http.middlewares.middleware16.passtlsclientcert.info.subject.province=true"
 - "traefik.http.middlewares.middleware16.passtlsclientcert.info.subject.serialnumber=true"
+- "traefik.http.middlewares.middleware16.passtlsclientcert.info.subject.uid=true"
 - "traefik.http.middlewares.middleware16.passtlsclientcert.pem=true"
 - "traefik.http.middlewares.middleware17.plugin.pluginconf0.name0=foobar"
 - "traefik.http.middlewares.middleware17.plugin.pluginconf0.name1=foobar"

--- a/docs/content/reference/dynamic-configuration/file.toml
+++ b/docs/content/reference/dynamic-configuration/file.toml
@@ -303,6 +303,7 @@
             commonName = true
             serialNumber = true
             domainComponent = true
+            uid = true
           [http.middlewares.Middleware16.passTLSClientCert.info.issuer]
             country = true
             province = true

--- a/docs/content/reference/dynamic-configuration/file.yaml
+++ b/docs/content/reference/dynamic-configuration/file.yaml
@@ -349,6 +349,7 @@ http:
             commonName: true
             serialNumber: true
             domainComponent: true
+            uid: true
           issuer:
             country: true
             province: true

--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
@@ -1950,6 +1950,10 @@ spec:
                             description: SerialNumber defines whether to add the serialNumber
                               information into the subject.
                             type: boolean
+                          uid:
+                            description: UID defines whether to add the UID information
+                              into the subject.
+                            type: boolean
                         type: object
                     type: object
                   pem:

--- a/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
@@ -1083,6 +1083,10 @@ spec:
                             description: SerialNumber defines whether to add the serialNumber
                               information into the subject.
                             type: boolean
+                          uid:
+                            description: UID defines whether to add the UID information
+                              into the subject.
+                            type: boolean
                         type: object
                     type: object
                   pem:

--- a/docs/content/reference/routing-configuration/http/middlewares/passtlsclientcert.md
+++ b/docs/content/reference/routing-configuration/http/middlewares/passtlsclientcert.md
@@ -71,6 +71,7 @@ spec:
                 commonName: true
                 serialNumber: true
                 domainComponent: true
+                uid: true
               issuer:
                 country: true
                 province: true
@@ -98,6 +99,7 @@ spec:
             commonName = true
             serialNumber = true
             domainComponent = true
+            uid = true
           [http.middlewares.test-passtlsclientcert.passTLSClientCert.info.issuer]
             country = true
             province = true
@@ -123,6 +125,7 @@ spec:
       - "traefik.http.middlewares.test-passtlsclientcert.passtlsclientcert.info.subject.organizationalunit=true"
       - "traefik.http.middlewares.test-passtlsclientcert.passtlsclientcert.info.subject.province=true"
       - "traefik.http.middlewares.test-passtlsclientcert.passtlsclientcert.info.subject.serialnumber=true"
+      - "traefik.http.middlewares.test-passtlsclientcert.passtlsclientcert.info.subject.uid=true"
       - "traefik.http.middlewares.test-passtlsclientcert.passtlsclientcert.info.issuer.commonname=true"
       - "traefik.http.middlewares.test-passtlsclientcert.passtlsclientcert.info.issuer.country=true"
       - "traefik.http.middlewares.test-passtlsclientcert.passtlsclientcert.info.issuer.domaincomponent=true"
@@ -148,6 +151,7 @@ spec:
         "traefik.http.middlewares.test-passtlsclientcert.passtlsclientcert.info.subject.organizationalunit=true",
         "traefik.http.middlewares.test-passtlsclientcert.passtlsclientcert.info.subject.province=true",
         "traefik.http.middlewares.test-passtlsclientcert.passtlsclientcert.info.subject.serialnumber=true",
+        "traefik.http.middlewares.test-passtlsclientcert.passtlsclientcert.info.subject.uid=true",
         "traefik.http.middlewares.test-passtlsclientcert.passtlsclientcert.info.issuer.commonname=true",
         "traefik.http.middlewares.test-passtlsclientcert.passtlsclientcert.info.issuer.country=true",
         "traefik.http.middlewares.test-passtlsclientcert.passtlsclientcert.info.issuer.domaincomponent=true",
@@ -180,6 +184,7 @@ spec:
             commonName: true
             serialNumber: true
             domainComponent: true
+            uid: true
           issuer:
             country: true
             province: true
@@ -220,6 +225,7 @@ spec:
 | <a id="opt-info-subject-commonName" href="#opt-info-subject-commonName" title="#opt-info-subject-commonName">`info.subject.commonName`</a> | Add the `commonName` information into the subject.<br /> The data is taken from the subject part with the `CN` key.| false      | No      |
 | <a id="opt-info-subject-serialNumber" href="#opt-info-subject-serialNumber" title="#opt-info-subject-serialNumber">`info.subject.serialNumber`</a> | Add the `serialNumber` information into the subject.<br /> The data is taken from the subject part with the `SN` key.| false      | No      |
 | <a id="opt-info-subject-domainComponent" href="#opt-info-subject-domainComponent" title="#opt-info-subject-domainComponent">`info.subject.domainComponent`</a> | Add the `domainComponent` information into the subject.<br />The data is taken from the subject part with the `DC` key. <br />More information about `info` [here](#info). | false      | No      |
+| <a id="opt-info-subject-uid" href="#opt-info-subject-uid" title="#opt-info-subject-uid">`info.subject.uid`</a> | Add the `UID` information into the subject.<br />The data is taken from the subject part with the `UID` key. <br />More information about `info` [here](#info). | false      | No      |
 | <a id="opt-info-issuer" href="#opt-info-issuer" title="#opt-info-issuer">`info.issuer`</a> | The `info.issuer` selects the specific client certificate issuer details you want to add to the `X-Forwarded-Tls-Client-Cert-Info` header. <br />More information about `info` [here](#info). | false      | No      |
 | <a id="opt-info-issuer-country" href="#opt-info-issuer-country" title="#opt-info-issuer-country">`info.issuer.country`</a> | Add the `country` information into the issuer.<br /> The data is taken from the issuer part with the `C` key. <br />More information about `info` [here](#info). | false      | No      |
 | <a id="opt-info-issuer-province" href="#opt-info-issuer-province" title="#opt-info-issuer-province">`info.issuer.province`</a> | Add the `province` information into the issuer.<br />The data is taken from the issuer part with the `ST` key. <br />More information about `info` [here](#info). | false      | No      |

--- a/docs/content/reference/routing-configuration/other-providers/file.toml
+++ b/docs/content/reference/routing-configuration/other-providers/file.toml
@@ -320,6 +320,7 @@
             commonName = true
             serialNumber = true
             domainComponent = true
+            uid = true
           [http.middlewares.Middleware17.passTLSClientCert.info.issuer]
             country = true
             province = true

--- a/docs/content/reference/routing-configuration/other-providers/file.yaml
+++ b/docs/content/reference/routing-configuration/other-providers/file.yaml
@@ -374,6 +374,7 @@ http:
             commonName: true
             serialNumber: true
             domainComponent: true
+            uid: true
           issuer:
             country: true
             province: true

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -1951,6 +1951,10 @@ spec:
                             description: SerialNumber defines whether to add the serialNumber
                               information into the subject.
                             type: boolean
+                          uid:
+                            description: UID defines whether to add the UID information
+                              into the subject.
+                            type: boolean
                         type: object
                     type: object
                   pem:

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -865,6 +865,8 @@ type TLSClientCertificateSubjectDNInfo struct {
 	SerialNumber bool `json:"serialNumber,omitempty" toml:"serialNumber,omitempty" yaml:"serialNumber,omitempty" export:"true"`
 	// DomainComponent defines whether to add the domainComponent information into the subject.
 	DomainComponent bool `json:"domainComponent,omitempty" toml:"domainComponent,omitempty" yaml:"domainComponent,omitempty" export:"true"`
+	// UID defines whether to add the UID information into the subject.
+	UID bool `json:"uid,omitempty" toml:"uid,omitempty" yaml:"uid,omitempty" export:"true"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/config/label/label_test.go
+++ b/pkg/config/label/label_test.go
@@ -1439,6 +1439,7 @@ func TestEncodeConfiguration(t *testing.T) {
 		"traefik.HTTP.Middlewares.Middleware11.PassTLSClientCert.Info.Subject.CommonName":          "true",
 		"traefik.HTTP.Middlewares.Middleware11.PassTLSClientCert.Info.Subject.SerialNumber":        "true",
 		"traefik.HTTP.Middlewares.Middleware11.PassTLSClientCert.Info.Subject.DomainComponent":     "true",
+		"traefik.HTTP.Middlewares.Middleware11.PassTLSClientCert.Info.Subject.UID":                 "false",
 		"traefik.HTTP.Middlewares.Middleware11.PassTLSClientCert.Info.Issuer.Country":              "true",
 		"traefik.HTTP.Middlewares.Middleware11.PassTLSClientCert.Info.Issuer.Province":             "true",
 		"traefik.HTTP.Middlewares.Middleware11.PassTLSClientCert.Info.Issuer.Locality":             "true",

--- a/pkg/middlewares/passtlsclientcert/pass_tls_client_cert.go
+++ b/pkg/middlewares/passtlsclientcert/pass_tls_client_cert.go
@@ -30,7 +30,8 @@ const (
 )
 
 var attributeTypeNames = map[string]string{
-	"0.9.2342.19200300.100.1.25": "DC", // Domain component OID - RFC 2247
+	"0.9.2342.19200300.100.1.25": "DC",  // Domain component OID - RFC 2247
+	"0.9.2342.19200300.100.1.1":  "UID", // User ID OID
 }
 
 // IssuerDistinguishedNameOptions is a struct for specifying the configuration
@@ -74,6 +75,7 @@ type SubjectDistinguishedNameOptions struct {
 	OrganizationalUnitName bool
 	SerialNumber           bool
 	StateOrProvinceName    bool
+	UID                    bool
 }
 
 func newSubjectDistinguishedNameOptions(info *dynamic.TLSClientCertificateSubjectDNInfo) *SubjectDistinguishedNameOptions {
@@ -90,6 +92,7 @@ func newSubjectDistinguishedNameOptions(info *dynamic.TLSClientCertificateSubjec
 		OrganizationalUnitName: info.OrganizationalUnit,
 		SerialNumber:           info.SerialNumber,
 		StateOrProvinceName:    info.Province,
+		UID:                    info.UID,
 	}
 }
 
@@ -269,9 +272,18 @@ func getSubjectDNInfo(ctx context.Context, options *SubjectDistinguishedNameOpti
 
 	// Manage non standard attributes
 	for _, name := range cs.Names {
+
+		switch attributeTypeNames[name.Type.String()] {
 		// Domain Component - RFC 2247
-		if options.DomainComponent && attributeTypeNames[name.Type.String()] == "DC" {
-			_, _ = fmt.Fprintf(content, "DC=%s%s", name.Value, subFieldSeparator)
+		case "DC":
+			if options.DomainComponent {
+				_, _ = fmt.Fprintf(content, "DC=%s%s", name.Value, subFieldSeparator)
+			}
+		// User ID
+		case "UID":
+			if options.UID {
+				_, _ = fmt.Fprintf(content, "UID=%s%s", name.Value, subFieldSeparator)
+			}
 		}
 	}
 

--- a/pkg/middlewares/passtlsclientcert/pass_tls_client_cert_test.go
+++ b/pkg/middlewares/passtlsclientcert/pass_tls_client_cert_test.go
@@ -1,8 +1,11 @@
 package passtlsclientcert
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
 	"encoding/pem"
 	"net"
 	"net/http"
@@ -655,6 +658,30 @@ func Test_getSANs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetSubjectDNInfoWithUID(t *testing.T) {
+	t.Parallel()
+
+	subject := &pkix.Name{
+		CommonName: "client.example.com",
+		Names: []pkix.AttributeTypeAndValue{
+			{
+				Type:  asn1.ObjectIdentifier{0, 9, 2342, 19200300, 100, 1, 1},
+				Value: "user-001",
+			},
+		},
+	}
+
+	options := &SubjectDistinguishedNameOptions{
+		UID:        true,
+		CommonName: true,
+	}
+
+	got := getSubjectDNInfo(context.Background(), options, subject)
+	expected := "UID=user-001,CN=client.example.com,"
+
+	assert.Equal(t, expected, got)
 }
 
 func getCleanCertContents(certContents []string) string {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

This PR adds support for forwarding the UID attribute from the client certificate Subject DN in the `passTLSClientCert` middleware.

The UID attribute is mapped from OID `0.9.2342.19200300.100.1.1` and can be enabled with the following configuration:
```yaml
http:
  middlewares:
    pass-client-cert:
      passTLSClientCert:
        info:
          subject:
            uid: true
```

When enabled, the UID attribute is included in the X-Forwarded-Tls-Client-Cert-Info header.
Example decoded header value:
```text
Subject="UID=user-001,C=JP,O=Client Org,OU=Engineering,CN=test-client"
```

### Motivation

<!-- What inspired you to submit this pull request? -->

Currently, users who need the UID attribute from the client certificate Subject DN have to enable pem: true and parse the full client certificate downstream.

This has a few drawbacks:

* The full PEM certificate increases the forwarded header size.
* Downstream services need to parse the certificate again.
* Users cannot selectively forward only the UID attribute through X-Forwarded-Tls-Client-Cert-Info.

This change allows users to forward only the selected UID attribute directly from Traefik, similar to other supported Subject DN attributes.

Closes #13104

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Unit tests were added to verify that the UID attribute is included only when info.subject.uid is enabled.
Manual verification was also performed with an mTLS client certificate containing UID=user-001.
Forwarded header:
```text
X-Forwarded-Tls-Client-Cert-Info: Subject%3D%22UID%3Duser-001%2CC%3DJP%2CO%3DClient+Org%2COU%3DEngineering%2CCN%3Dtest-client%22
```

Decoded value:
```text
Subject="UID=user-001,C=JP,O=Client Org,OU=Engineering,CN=test-client"
```

Tests run:
```text
go test -v ./pkg/middlewares/passtlsclientcert
make test-unit
make binary
```