### PR TITLE
Fix TCP router service resolution in dashboard flow diagram

### DIFF
--- a/webui/src/components/routers/RouterFlowDiagram.tsx
+++ b/webui/src/components/routers/RouterFlowDiagram.tsx
@@ -112,7 +112,7 @@ const RouterFlowDiagram = ({ data, protocol }: RouterFlowDiagramProps) => {
     ? data.service
     : `${data.service ?? 'unknown'}@${data.provider ?? 'unknown'}`
 
-  const { data: serviceData, error: serviceDataError } = useResourceDetail(serviceSlug ?? '', 'services')
+  const { data: serviceData, error: serviceDataError } = useResourceDetail(serviceSlug ?? '', 'services', protocol)
 
   return (
     <Flex gap={2} data-testid="router-structure">


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Fixes incorrect service lookup in TCP router detail view in the dashboard by ensuring the correct protocol context is used when resolving services. This prevents the UI from calling HTTP service endpoints for TCP routers.


### Motivation

<!-- What inspired you to submit this pull request? -->

After upgrading to Traefik v3.7.0, TCP router detail pages displayed "Service not found" even though the service existed and was correctly exposed via `/api/tcp/services`.  

Root cause was missing protocol context in `useResourceDetail`, causing fallback to HTTP service API instead of TCP.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
Minimal fix. Only updates service resolution to respect router protocol (TCP vs HTTP). No backend changes required. Verified locally with reproduction from issue #13111