### PR TITLE
fix(middleware): add CORS headers to regular responses

### DIFF
--- a/pkg/middlewares/headers/header.go
+++ b/pkg/middlewares/headers/header.go
@@ -95,6 +95,20 @@ func (s *Header) PostRequestModifyResponseHeaders(res *http.Response) error {
 		res.Header.Set("Access-Control-Expose-Headers", exposeHeaders)
 	}
 
+	allowHeaders := strings.Join(s.headers.AccessControlAllowHeaders, ",")
+	if allowHeaders != "" {
+		res.Header.Set("Access-Control-Allow-Headers", allowHeaders)
+	}
+
+	allowMethods := strings.Join(s.headers.AccessControlAllowMethods, ",")
+	if allowMethods != "" {
+		res.Header.Set("Access-Control-Allow-Methods", allowMethods)
+	}
+
+	if s.headers.AccessControlMaxAge != 0 {
+		res.Header.Set("Access-Control-Max-Age", strconv.Itoa(int(s.headers.AccessControlMaxAge)))
+	}
+
 	if !s.headers.AddVaryHeader {
 		return nil
 	}

--- a/pkg/middlewares/headers/header_test.go
+++ b/pkg/middlewares/headers/header_test.go
@@ -472,6 +472,27 @@ func TestNewHeader_CORSResponses(t *testing.T) {
 			},
 			expected: map[string][]string{},
 		},
+		{
+			desc: "Regular GET includes Allow-Headers, Allow-Methods, Max-Age",
+			next: emptyHandler,
+			cfg: dynamic.Headers{
+				AccessControlAllowOriginList:  []string{"*"},
+				AccessControlAllowMethods:     []string{"GET", "POST", "OPTIONS"},
+				AccessControlAllowHeaders:     []string{"X-Foo", "Content-Type"},
+				AccessControlMaxAge:           1728000,
+				AccessControlAllowCredentials: true,
+			},
+			requestHeaders: map[string][]string{
+				"Origin": {"http://example.com"},
+			},
+			expected: map[string][]string{
+				"Access-Control-Allow-Origin":      {"*"},
+				"Access-Control-Allow-Credentials": {"true"},
+				"Access-Control-Allow-Headers":     {"X-Foo,Content-Type"},
+				"Access-Control-Allow-Methods":     {"GET,POST,OPTIONS"},
+				"Access-Control-Max-Age":           {"1728000"},
+			},
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Adds configured CORS headers to regular non-preflight responses in the headers middleware.

Currently:

1.  preflight `OPTIONS` responses include:  `Access-Control-Allow-Headers`, `Access-Control-Allow-Methods` and `Access-Control-Max-Age`

2. regular `GET/POST` responses only include: `Access-Control-Allow-Origin` and  `Access-Control-Allow-Credentials`

This change makes regular responses include the missing configured CORS headers as well, matching nginx-ingress behavior more closely.

### Motivation

<!-- What inspired you to submit this pull request? -->

Related to #13090.

I investigated the issue and found the behavior comes from the core headers middleware rather than the ingress-nginx provider translation itself.

This aligns Traefik behavior more closely with nginx-ingress, which returns the configured CORS headers on regular responses as well.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
The existing preflight behavior is unchanged. This only adds the configured CORS headers to regular non-preflight responses.

This PR is opened mainly for discussion and feedback first, as I am not fully sure whether this behavior change is desired globally or if there is a better approach for nginx-ingress compatibility.