### PR TITLE
Polish grammar in migration guides

### DIFF
--- a/docs/content/migrate/v1-to-v2.md
+++ b/docs/content/migrate/v1-to-v2.md
@@ -17,7 +17,7 @@ For more information about the changes in Traefik v2, please refer to the [v2 do
 
     We created a tool to help during the migration: [traefik-migration-tool](https://github.com/traefik/traefik-migration-tool)
 
-    This tool allows to:
+    This tool lets you:
 
     - convert `Ingress` to Traefik `IngressRoute` resources.
     - convert `acme.json` file from v1 to v2 format.

--- a/docs/content/migrate/v2-to-v3-details.md
+++ b/docs/content/migrate/v2-to-v3-details.md
@@ -680,7 +680,7 @@ It can be configured in the install configuration.
 ##### Configure the Syntax Per Router
 
 The rule syntax can also be configured on a per-router basis.
-This allows to have heterogeneous router configurations and ease migration.
+This allows you to have heterogeneous router configurations and ease migration.
 
 ??? example "An example router with syntax configuration"
 


### PR DESCRIPTION
Polishes 'allows to' grammar in migration guide text. Documentation-only change.