### PR TITLE
ci: declare workflow-level `contents: read` on the 9 build/test workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,9 @@ on:
 env:
   CGO_ENABLED: 0
 
+permissions:
+  contents: read
+
 jobs:
 
   build-webui:

--- a/.github/workflows/check_doc.yaml
+++ b/.github/workflows/check_doc.yaml
@@ -8,6 +8,9 @@ on:
       - '.github/workflows/check_doc.yaml'
       - 'docs/**'
 
+permissions:
+  contents: read
+
 jobs:
 
   docs:

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -11,6 +11,9 @@ env:
   STRUCTOR_VERSION: v1.13.2
   MIXTUS_VERSION: v0.4.1
 
+permissions:
+  contents: read
+
 jobs:
 
   docs:

--- a/.github/workflows/experimental.yaml
+++ b/.github/workflows/experimental.yaml
@@ -9,6 +9,9 @@ on:
 env:
   CGO_ENABLED: 0
 
+permissions:
+  contents: read
+
 jobs:
 
   build-webui:

--- a/.github/workflows/test-gateway-api-conformance.yaml
+++ b/.github/workflows/test-gateway-api-conformance.yaml
@@ -14,6 +14,9 @@ on:
 env:
   CGO_ENABLED: 0
 
+permissions:
+  contents: read
+
 jobs:
 
   test-gateway-api-conformance:

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -12,6 +12,9 @@ on:
 env:
   CGO_ENABLED: 0
 
+permissions:
+  contents: read
+
 jobs:
 
   build:

--- a/.github/workflows/test-knative-conformance.yaml
+++ b/.github/workflows/test-knative-conformance.yaml
@@ -14,6 +14,9 @@ on:
 env:
   CGO_ENABLED: 0
 
+permissions:
+  contents: read
+
 jobs:
 
   test-knative-conformance:

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -9,6 +9,9 @@ on:
       - '**.md'
       - 'script/gcg/**'
 
+permissions:
+  contents: read
+
 jobs:
   generate-packages:
     name: List Go Packages

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -9,6 +9,9 @@ env:
   GOLANGCI_LINT_VERSION: v2.10.1
   MISSPELL_VERSION: v0.7.0
 
+permissions:
+  contents: read
+
 jobs:
 
   lint:


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on the 9 workflows in `.github/workflows/` that don't actually need any write scope:

- `build.yaml`: Go build matrix.
- `check_doc.yaml`, `documentation.yaml`: docs build/lint.
- `experimental.yaml`: experimental feature CI.
- `test-gateway-api-conformance.yaml`, `test-knative-conformance.yaml`, `test-integration.yaml`, `test-unit.yaml`: test suites.
- `validate.yaml`: linting + format validation.

None call a GitHub API beyond the initial checkout, so `contents: read` is sufficient for each.

`release.yaml` is intentionally left implicit; it needs write scopes that are best declared by maintainers who own the release flow.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs and the leaked token retained whatever scope was issued at the workflow level. Pinning per workflow caps that runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.