### PR TITLE
Escape double quotes in quoted log fields

### DIFF
--- a/pkg/middlewares/accesslog/logger_formatters.go
+++ b/pkg/middlewares/accesslog/logger_formatters.go
@@ -3,6 +3,7 @@ package accesslog
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -108,7 +109,7 @@ func toLogEntry(s, defaultValue string, quote bool) string {
 	}
 
 	if quote {
-		return `"` + s + `"`
+		return `"` + strings.ReplaceAll(s, `"`, `\"`) + `"`
 	}
 	return s
 }

--- a/pkg/middlewares/accesslog/logger_formatters_test.go
+++ b/pkg/middlewares/accesslog/logger_formatters_test.go
@@ -81,6 +81,27 @@ func TestCommonLogFormatter_Format(t *testing.T) {
 			expectedLog: `10.0.0.1 - Client [10/Nov/2009:14:00:00 -0900] "GET /foo http" 123 132 "referer" "agent" - "foo" "http://10.0.0.2/toto" 123000ms
 `,
 		},
+		{
+			name: "user-agent with double quote is escaped",
+			data: map[string]any{
+				StartUTC:               time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+				Duration:               1 * time.Millisecond,
+				ClientHost:             "10.0.0.1",
+				ClientUsername:         "-",
+				RequestMethod:          http.MethodGet,
+				RequestPath:            "/",
+				RequestProtocol:        "HTTP/1.1",
+				DownstreamStatus:       200,
+				DownstreamContentSize:  0,
+				RequestRefererHeader:   "-",
+				RequestUserAgentHeader: `foo " bar`,
+				RequestCount:           1,
+				RouterName:             "test@file",
+				ServiceURL:             "http://127.0.0.1:8080",
+			},
+			expectedLog: `10.0.0.1 - - [10/Nov/2009:23:00:00 +0000] "GET / HTTP/1.1" 200 0 "-" "foo \" bar" 1 "test@file" "http://127.0.0.1:8080" 1ms
+`,
+		},
 	}
 
 	var err error
@@ -220,6 +241,16 @@ func Test_toLog(t *testing.T) {
 			defaultValue: defaultValue,
 			quoted:       true,
 			expectedLog:  `"foo"`,
+		},
+		{
+			desc: "Should escape double quotes in quoted string",
+			fields: logrus.Fields{
+				"Powpow": `foo " bar`,
+			},
+			fieldName:    "Powpow",
+			defaultValue: defaultValue,
+			quoted:       true,
+			expectedLog:  `"foo \" bar"`,
 		},
 		{
 			desc: "Should return defaultValue if fieldName does not exist",


### PR DESCRIPTION
### What does this PR do?

Escapes double quotes inside quoted access log fields (User-Agent, Referer, etc.) to produce valid log entries.

### Motivation

Closes #11722. When a header value such as User-Agent contained a double quote character, it was written unescaped into the access log, breaking the CLF format and any parser consuming the logs.


### More

- [x ] Added/updated tests
- [ ] Added/updated documentation
