### PR TITLE
feat: fallback to RemoteAddr in PoolStrategy when X-Forwarded-For is absent

### DIFF
--- a/docs/content/reference/routing-configuration/http/middlewares/ipallowlist.md
+++ b/docs/content/reference/routing-configuration/http/middlewares/ipallowlist.md
@@ -5,7 +5,9 @@ description: "Learn how to use IPAllowList in HTTP middleware for limiting clien
 
 `ipAllowList` accepts / refuses requests based on the client IP.
 
-## Configuration Example
+## Configuration Examples
+
+### Allowing Defined IPs
 
 ```yaml tab="Structured (YAML)"
 # Accepts request from defined IP
@@ -52,11 +54,63 @@ spec:
       - 192.168.1.7
 ```
 
+### Customizing the Rejection Status Code
+
+```yaml tab="Structured (YAML)"
+# Rejects requests with a 404 instead of 403
+http:
+  middlewares:
+    test-ipallowlist:
+      ipAllowList:
+        sourceRange:
+          - "127.0.0.1/32"
+        rejectStatusCode: 404
+```
+
+```toml tab="Structured (TOML)"
+# Rejects requests with a 404 instead of 403
+[http.middlewares]
+  [http.middlewares.test-ipallowlist.ipAllowList]
+    sourceRange = ["127.0.0.1/32"]
+    rejectStatusCode = 404
+```
+
+```yaml tab="Labels"
+# Rejects requests with a 404 instead of 403
+labels:
+  - "traefik.http.middlewares.test-ipallowlist.ipallowlist.sourcerange=127.0.0.1/32"
+  - "traefik.http.middlewares.test-ipallowlist.ipallowlist.rejectstatuscode=404"
+```
+
+```json tab="Tags"
+// Rejects requests with a 404 instead of 403
+{
+  "Tags" : [
+    "traefik.http.middlewares.test-ipallowlist.ipallowlist.sourcerange=127.0.0.1/32",
+    "traefik.http.middlewares.test-ipallowlist.ipallowlist.rejectstatuscode=404"
+  ]
+}
+```
+
+```yaml tab="Kubernetes"
+# Rejects requests with a 404 instead of 403
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: test-ipallowlist
+spec:
+  ipAllowList:
+    sourceRange:
+      - 127.0.0.1/32
+    rejectStatusCode: 404
+```
+
 ## Configuration Options
 
 | Field      | Description     | Default | Required |
 |:-----------|:------------------------------|:--------|:---------|
 | <a id="opt-sourceRange" href="#opt-sourceRange" title="#opt-sourceRange">`sourceRange`</a> | List of allowed IPs (or ranges of allowed IPs by using CIDR notation). |      | Yes      |
+| <a id="opt-rejectStatusCode" href="#opt-rejectStatusCode" title="#opt-rejectStatusCode">`rejectStatusCode`</a> | HTTP status code used for refused requests. | 403      | No      |
 | <a id="opt-ipStrategy-depth" href="#opt-ipStrategy-depth" title="#opt-ipStrategy-depth">`ipStrategy.depth`</a> | Depth position of the IP to select in the `X-Forwarded-For` header (starting from the right).<br />0 means no depth.<br />If greater than the total number of IPs in `X-Forwarded-For`, then the client IP is empty<br /> If higher than 0, the `excludedIPs` options is not evaluated.<br /> More information about [`ipStrategy](#ipstrategy), and [`depth`](#example-of-depth--x-forwarded-for) below. | 0      | No      |
 | <a id="opt-ipStrategy-excludedIPs" href="#opt-ipStrategy-excludedIPs" title="#opt-ipStrategy-excludedIPs">`ipStrategy.excludedIPs`</a> | Allows Traefik to scan the `X-Forwarded-For` header and select the first IP not in the list.<br />If `depth` is specified, `excludedIPs` is ignored.<br /> More information about [`ipStrategy](#ipstrategy), and [`excludedIPs`](#example-of-excludedips--x-forwarded-for) below. |       | No      |
 | <a id="opt-ipStrategy-ipv6Subnet" href="#opt-ipStrategy-ipv6Subnet" title="#opt-ipStrategy-ipv6Subnet">`ipStrategy.ipv6Subnet`</a> |  If `ipv6Subnet` is provided and the selected IP is IPv6, the IP is transformed into the first IP of the subnet it belongs to. <br />More information about [`ipStrategy.ipv6Subnet`](#ipstrategyipv6subnet), and [`excludedIPs`](#example-of-excludedips--x-forwarded-for) below. |       | No      |

--- a/docs/content/reference/routing-configuration/kubernetes/crd/tcp/ingressroutetcp.md
+++ b/docs/content/reference/routing-configuration/kubernetes/crd/tcp/ingressroutetcp.md
@@ -12,9 +12,97 @@ This registers the `IngressRouteTCP` kind and other Traefik-specific resources.
 !!! note "General"
     If both HTTP routers and TCP routers are connected to the same EntryPoint, the TCP routers will apply before the HTTP routers. If no matching route is found for the TCP routers, then the HTTP routers will take over.
 
-## Configuration Example
+## Configuration Examples
 
-You can declare an `IngressRouteTCP` as detailed below:
+### Basic TCP Routing
+
+The following example demonstrates a minimal `IngressRouteTCP` that routes all incoming TCP connections on the `footcp` entry point to a Kubernetes Service named `foo` on port `8080`.
+
+```yaml tab="IngressRouteTCP"
+apiVersion: traefik.io/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: mytcproute
+  namespace: apps
+
+spec:
+  entryPoints:
+    - footcp
+  routes:
+  - match: HostSNI(`*`)
+    services:
+    - name: foo
+      port: 8080
+```
+
+```yaml tab="Service"
+apiVersion: v1
+kind: Service
+metadata:
+  name: foo
+  namespace: apps
+
+spec:
+  ports:
+    - port: 8080
+  selector:
+    app: foo
+```
+
+### TCP Routing with TLS Termination
+
+The following example shows an `IngressRouteTCP` that terminates TLS on the entry point before forwarding the decrypted traffic to the backend service.
+
+```yaml tab="IngressRouteTCP"
+apiVersion: traefik.io/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: mytcproute-tls
+  namespace: apps
+
+spec:
+  entryPoints:
+    - footcp
+  routes:
+  - match: HostSNI(`example.com`)
+    services:
+    - name: foo
+      port: 8080
+
+  tls:
+    secretName: mytlscert
+```
+
+```yaml tab="Service"
+apiVersion: v1
+kind: Service
+metadata:
+  name: foo
+  namespace: apps
+
+spec:
+  ports:
+    - port: 8080
+  selector:
+    app: foo
+```
+
+```yaml tab="Secret"
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mytlscert
+  namespace: apps
+
+type: kubernetes.io/tls
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t...
+  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQ==...
+```
+
+### Complete Configuration Reference
+
+You can declare an `IngressRouteTCP` with all available options as detailed below:
 
 ```yaml tab="IngressRouteTCP"
 apiVersion: traefik.io/v1alpha1
@@ -49,7 +137,7 @@ spec:
     certResolver: foo
     domains:
     - main: example.net
-      sans:                       
+      sans:
       - a.example.net
       - b.example.net
     passthrough: false

--- a/pkg/ip/strategy.go
+++ b/pkg/ip/strategy.go
@@ -70,22 +70,37 @@ type PoolStrategy struct {
 // GetIP checks the list of Forwarded IPs (most recent first) against the
 // Checker pool of IPs. It returns the first IP that is not in the pool, or the
 // empty string otherwise.
+// If the X-Forwarded-For header is absent, it falls back to the request's
+// RemoteAddr.
 func (s *PoolStrategy) GetIP(req *http.Request) string {
 	if s.Checker == nil {
 		return ""
 	}
 
 	xff := req.Header.Get(xForwardedFor)
-	xffs := strings.Split(xff, ",")
+	if xff != "" {
+		xffs := strings.Split(xff, ",")
 
-	for i := len(xffs) - 1; i >= 0; i-- {
-		xffTrimmed := strings.TrimSpace(xffs[i])
-		if len(xffTrimmed) == 0 {
-			continue
+		for i := len(xffs) - 1; i >= 0; i-- {
+			xffTrimmed := strings.TrimSpace(xffs[i])
+			if len(xffTrimmed) == 0 {
+				continue
+			}
+			if contain, _ := s.Checker.Contains(xffTrimmed); !contain {
+				return xffTrimmed
+			}
 		}
-		if contain, _ := s.Checker.Contains(xffTrimmed); !contain {
-			return xffTrimmed
-		}
+
+		return ""
+	}
+
+	ip, _, err := net.SplitHostPort(req.RemoteAddr)
+	if err != nil {
+		ip = req.RemoteAddr
+	}
+
+	if contain, _ := s.Checker.Contains(ip); !contain {
+		return ip
 	}
 
 	return ""

--- a/pkg/ip/strategy_test.go
+++ b/pkg/ip/strategy_test.go
@@ -148,13 +148,13 @@ func TestDepthStrategy_GetIP(t *testing.T) {
 	}
 }
 
-func TestTrustedIPsStrategy_GetIP(t *testing.T) {
+func TestPoolStrategy_GetIP(t *testing.T) {
 	testCases := []struct {
 		desc          string
 		trustedIPs    []string
 		xForwardedFor string
+		remoteAddr    string
 		expected      string
-		useRemote     bool
 	}{
 		{
 			desc:          "Trust all IPs",
@@ -180,6 +180,37 @@ func TestTrustedIPsStrategy_GetIP(t *testing.T) {
 			xForwardedFor: "10.0.0.4,10.0.0.3,10.0.0.2,10.0.0.1",
 			expected:      "",
 		},
+		{
+			desc:       "X-Forwarded-For absent, RemoteAddr not in pool",
+			trustedIPs: []string{"10.0.0.2", "10.0.0.1"},
+			remoteAddr: "10.2.3.1:123",
+			expected:   "10.2.3.1",
+		},
+		{
+			desc:       "X-Forwarded-For absent, RemoteAddr in pool",
+			trustedIPs: []string{"10.0.0.2", "10.0.0.1"},
+			remoteAddr: "10.0.0.1:123",
+			expected:   "",
+		},
+		{
+			desc:       "X-Forwarded-For absent, RemoteAddr not in pool with CIDR",
+			trustedIPs: []string{"10.0.0.1/24"},
+			remoteAddr: "10.2.3.1:123",
+			expected:   "10.2.3.1",
+		},
+		{
+			desc:       "X-Forwarded-For absent, RemoteAddr in pool with CIDR",
+			trustedIPs: []string{"10.0.0.1/24"},
+			remoteAddr: "10.0.0.5:123",
+			expected:   "",
+		},
+		{
+			desc:          "X-Forwarded-For present but all IPs in pool, do not fallback",
+			trustedIPs:    []string{"10.0.0.2", "10.0.0.1"},
+			xForwardedFor: "10.0.0.2,10.0.0.1",
+			remoteAddr:    "10.2.3.1:123",
+			expected:      "",
+		},
 	}
 
 	for _, test := range testCases {
@@ -191,7 +222,12 @@ func TestTrustedIPsStrategy_GetIP(t *testing.T) {
 
 			strategy := PoolStrategy{Checker: checker}
 			req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1", nil)
-			req.Header.Set(xForwardedFor, test.xForwardedFor)
+			if test.xForwardedFor != "" {
+				req.Header.Set(xForwardedFor, test.xForwardedFor)
+			}
+			if test.remoteAddr != "" {
+				req.RemoteAddr = test.remoteAddr
+			}
 			actual := strategy.GetIP(req)
 			assert.Equal(t, test.expected, actual)
 		})


### PR DESCRIPTION
### What does this PR do?

When the `X-Forwarded-For` header is not present, `PoolStrategy` now falls back to checking the request's `RemoteAddr` against the configured IP pool.

### Motivation

This improves the `IPAllowList` middleware usability for traffic paths that do not set the `X-Forwarded-For` header (e.g., internal traffic, VPNs). Previously, the middleware would return an empty client IP when `X-Forwarded-For` was absent, causing allow-listing to fail for legitimate direct connections.

- `PoolStrategy.GetIP` falls back to `RemoteAddr` when XFF is absent
- `RemoteAddr` IP is checked against the `Checker` pool before returning
- Existing XFF behavior is preserved: fallback only happens when the XFF header is completely absent, not when all XFF IPs are in the pool

Fixes #7884

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

This is a non-breaking change. The fallback only activates when `X-Forwarded-For` is absent. When the header is present (even if all IPs are in the excluded pool), the existing behavior is preserved.