### PR TITLE
fix: handle lowercase percent-encoded reserved characters in muxer routing path

### DIFF
--- a/pkg/muxer/http/mux.go
+++ b/pkg/muxer/http/mux.go
@@ -152,7 +152,7 @@ func withRoutingPath(req *http.Request) (*http.Request, error) {
 		}
 
 		encodedCharacter := escapedPath[i : i+3]
-		if _, reserved := reservedCharacters[encodedCharacter]; reserved {
+		if _, reserved := reservedCharacters[strings.ToUpper(encodedCharacter)]; reserved {
 			routingPathBuilder.WriteString(encodedCharacter)
 		} else {
 			// This should never happen as the standard library will reject requests containing invalid percent-encodings.

--- a/pkg/muxer/http/mux_test.go
+++ b/pkg/muxer/http/mux_test.go
@@ -694,6 +694,16 @@ func TestRoutingPath(t *testing.T) {
 			path:                "/foo%20bar%2Fbaz%23qux",
 			expectedRoutingPath: "/foo bar%2Fbaz%23qux",
 		},
+		{
+			desc:                "lowercase reserved percent-encoded slash is kept encoded",
+			path:                "/foo%2fbar",
+			expectedRoutingPath: "/foo%2fbar",
+		},
+		{
+			desc:                "lowercase reserved percent-encoded asterisk is kept encoded",
+			path:                "/foo%2abar",
+			expectedRoutingPath: "/foo%2abar",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
### What does this PR do?

Normalizes percent-encoded character lookups in the HTTP muxer to be case-insensitive for reserved characters.

### Motivation

Fixes #13173

The reservedCharacters map in pkg/muxer/http/mux.go only contained uppercase hex entries (e.g. %2F). Per RFC 3986, %2f and %2F are equivalent, but Go's url.URL.EscapedPath() preserves the original case. This caused lowercase percent-encoded reserved characters to fall through to url.PathUnescape and get decoded into the routing path, while uppercase variants stayed encoded.

### How does it work?

A single-line change: strings.ToUpper(encodedCharacter) before looking up reservedCharacters.

### Testing

- [x] Unit tests added for lowercase reserved characters (%2f, %2a)
- [x] Existing tests pass

### Breaking Changes

- [x] None
