### PR TITLE
fix: reject multi-label subdomains for Gateway API wildcard hostname listeners

### DIFF
--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -1078,6 +1078,14 @@ func findMatchingHostname(h1, h2 gatev1.Hostname) gatev1.Hostname {
 		return ""
 	}
 
+	// Gateway API spec: wildcard matches exactly one label.
+	// Reject multi-label subdomains (e.g. *.foo.com must not match baz.bar.foo.com).
+	// Wildcard route hostnames (e.g. *.bar.foo.com) are still allowed.
+	prefix := strings.TrimSuffix(string(h2), trimmedH1)
+	if !strings.HasPrefix(prefix, "*.") && strings.Contains(prefix, ".") {
+		return ""
+	}
+
 	// h1 is a wildcard that encompasses h2, so h2 is always
 	// the more specific hostname (the correct intersection).
 	return h2

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -7589,8 +7589,6 @@ func Test_findMatchingHostnames(t *testing.T) {
 			desc:             "Matching subsubdomain with listener wildcard",
 			listenerHostname: ptr.To(gatev1.Hostname("*.foo.com")),
 			routeHostnames:   []gatev1.Hostname{"baz.bar.foo.com"},
-			want:             []gatev1.Hostname{"baz.bar.foo.com"},
-			wantOk:           true,
 		},
 		{
 			desc:             "Matching subdomain with route hostname wildcard",
@@ -7603,8 +7601,6 @@ func Test_findMatchingHostnames(t *testing.T) {
 			desc:             "Matching subsubdomain with route hostname wildcard",
 			listenerHostname: ptr.To(gatev1.Hostname("baz.bar.foo.com")),
 			routeHostnames:   []gatev1.Hostname{"*.foo.com"},
-			want:             []gatev1.Hostname{"baz.bar.foo.com"},
-			wantOk:           true,
 		},
 		{
 			desc:             "Non matching root domain with listener wildcard",


### PR DESCRIPTION
### What does this PR do?

Fixes findMatchingHostname to reject multi-label subdomains when matching against wildcard listener hostnames, aligning with the Gateway API specification.

### Motivation

Fixes #13171

The Gateway API specification states that wildcard hostnames are interpreted as strict one-label DNS wildcards: a listener *.foo.com should accept bar.foo.com and reject baz.bar.foo.com.

The previous implementation used strings.HasSuffix, which allowed baz.bar.foo.com to match *.foo.com because both end with .foo.com.

### How does it work?

After confirming the suffix match, we check that the prefix (the part before the matched suffix) contains no dots — unless it is itself a wildcard pattern. This ensures:
- bar.foo.com matches *.foo.com ✅
- baz.bar.foo.com does NOT match *.foo.com ✅
- *.bar.foo.com still matches *.foo.com ✅ (wildcard route hostnames)

### Testing

- [x] Updated existing unit tests to expect rejection for multi-label subdomains
- [x] Wildcard-wildcard matching test preserved

### Breaking Changes

This is a behavior change that brings Traefik into compliance with the Gateway API spec. Existing deployments relying on the non-conformant behavior (multi-label subdomains matching single-label wildcards) will be affected.
