### PR TITLE
fix: return catch-all rule when nginx ingress buildRule has no host or path

### DIFF
--- a/pkg/provider/kubernetes/ingress-nginx/translator.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator.go
@@ -606,6 +606,10 @@ func buildRule(host string, loc *location) string {
 		}
 	}
 
+	if len(rules) == 0 {
+		return `PathPrefix("/")`
+	}
+
 	return strings.Join(rules, " && ")
 }
 

--- a/pkg/provider/kubernetes/ingress-nginx/translator_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator_test.go
@@ -1,0 +1,56 @@
+package ingressnginx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	netv1 "k8s.io/api/networking/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestBuildRule(t *testing.T) {
+	tests := []struct {
+		desc     string
+		host     string
+		loc      *location
+		expected string
+	}{
+		{
+			desc:     "empty host and path returns catch-all",
+			host:     "",
+			loc:      &location{},
+			expected: `PathPrefix("/")`,
+		},
+		{
+			desc:     "host only",
+			host:     "foo.localhost",
+			loc:      &location{},
+			expected: `Host("foo.localhost")`,
+		},
+		{
+			desc: "path only",
+			host: "",
+			loc: &location{
+				Path:     "/foo",
+				PathType: ptr.To(netv1.PathTypePrefix),
+			},
+			expected: `(Path("/foo") || PathPrefix("/foo/"))`,
+		},
+		{
+			desc: "host and path",
+			host: "foo.localhost",
+			loc: &location{
+				Path:     "/foo",
+				PathType: ptr.To(netv1.PathTypeExact),
+			},
+			expected: `Host("foo.localhost") && Path("/foo")`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.expected, buildRule(test.host, test.loc))
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Ensures buildRule returns a valid catch-all rule (PathPrefix("/")) when both host and path are empty, instead of returning an empty string that crashes the rule parser.

### Motivation

Fixes #13151

When a Kubernetes ingress has both a defaultBackend and rules with no host field, the nginx ingress provider creates fallback default-backend locations for each rule. When buildRule is called with an empty host and empty path, it returned an empty string, causing the rule parser to fail with:
  parsing rule : 1:1: expected operand, found 'EOF'

### How does it work?

Added a guard at the end of buildRule: if the rules slice is empty, return PathPrefix("/") instead of joining an empty slice.

### Testing

- [x] Added unit tests for buildRule covering empty host/path, host-only, path-only, and host+path combinations
- [x] Existing provider tests pass

### Breaking Changes

- [x] None
