### PR TITLE
docs: add 3.7 to the release documentation

### DIFF
--- a/docs/content/deprecation/releases.md
+++ b/docs/content/deprecation/releases.md
@@ -4,16 +4,17 @@
 
 Below is a non-exhaustive list of versions and their maintenance status:
 
-| Version | Release Date | Active Support     | Security Support  |
-|---------|--------------|--------------------|-------------------|
-| 3.6     | Nov 07, 2025 | Yes                | Yes               |
-| 3.5     | Jul 23, 2025 | Ended Nov 07, 2025 | No                |
-| 3.4     | May 05, 2025 | Ended Jul 23, 2025 | No                |
-| 3.3     | Jan 06, 2025 | Ended May 05, 2025 | No                |
-| 3.2     | Oct 28, 2024 | Ended Jan 06, 2025 | No                |
-| 3.1     | Jul 15, 2024 | Ended Oct 28, 2024 | No                |
-| 3.0     | Apr 29, 2024 | Ended Jul 15, 2024 | No                |
-| 2.11    | Feb 12, 2024 | Ended Apr 29, 2025 | Ends Feb 01, 2026 |
+| Version | Release Date | Active Support     | Security Support   |
+|---------|--------------|--------------------|--------------------|
+| 3.7     | May 05, 2026 | Yes                | Yes                |
+| 3.6     | Nov 07, 2025 | Ended May 05, 2026 | Yes                |
+| 3.5     | Jul 23, 2025 | Ended Nov 07, 2025 | No                 |
+| 3.4     | May 05, 2025 | Ended Jul 23, 2025 | No                 |
+| 3.3     | Jan 06, 2025 | Ended May 05, 2025 | No                 |
+| 3.2     | Oct 28, 2024 | Ended Jan 06, 2025 | No                 |
+| 3.1     | Jul 15, 2024 | Ended Oct 28, 2024 | No                 |
+| 3.0     | Apr 29, 2024 | Ended Jul 15, 2024 | No                 |
+| 2.11    | Feb 12, 2024 | Ended Apr 29, 2025 | Ended Feb 01, 2026 |
 
 ??? example "Active Support / Security Support"
 


### PR DESCRIPTION
### What does this PR do?

Add 3.7 to the release documentation.

### Motivation

Also note that 3.6 has no longer an active support. Don't put a security support end date as I am not sure if the 1-year support is enforced.

Note that https://endoflife.date/traefik information seems incorrect, hence this update.

Also, the PR template says 3.6 and 2.11. I think it should be updated too?

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
