### PR TITLE
muxer: normalise percent-encoding case before reservedCharacters lookup

### DIFF
--- a/pkg/muxer/http/mux.go
+++ b/pkg/muxer/http/mux.go
@@ -152,7 +152,10 @@ func withRoutingPath(req *http.Request) (*http.Request, error) {
 		}
 
 		encodedCharacter := escapedPath[i : i+3]
-		if _, reserved := reservedCharacters[encodedCharacter]; reserved {
+		// Per RFC 3986 section 2.1, %2A and %2a are equivalent. The map
+		// is keyed in uppercase, so normalise before lookup or two
+		// RFC-equivalent paths would route differently.
+		if _, reserved := reservedCharacters[strings.ToUpper(encodedCharacter)]; reserved {
 			routingPathBuilder.WriteString(encodedCharacter)
 		} else {
 			// This should never happen as the standard library will reject requests containing invalid percent-encodings.

--- a/pkg/muxer/http/mux_test.go
+++ b/pkg/muxer/http/mux_test.go
@@ -694,6 +694,13 @@ func TestRoutingPath(t *testing.T) {
 			path:                "/foo%20bar%2Fbaz%23qux",
 			expectedRoutingPath: "/foo bar%2Fbaz%23qux",
 		},
+		// #13173: lowercase percent-encoding of a reserved character is
+		// equivalent to uppercase per RFC 3986 section 2.1.
+		{
+			desc:                "lowercase reserved percent-encoded character is kept encoded",
+			path:                "/foo%2fbar",
+			expectedRoutingPath: "/foo%2fbar",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Closes #13173.

`reservedCharacters` is keyed in uppercase, but `url.URL.EscapedPath` preserves the case the client sent, so `%2f` slips past the reserved check while `%2F` doesn't. Per RFC 3986 2.1 those two are equivalent. Uppercase `encodedCharacter` before the map lookup so two RFC-equivalent paths route to the same router.