### PR TITLE
Escape exact gRPC method matches

### DIFF
--- a/pkg/provider/kubernetes/gateway/grpcroute.go
+++ b/pkg/provider/kubernetes/gateway/grpcroute.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -394,14 +395,25 @@ func buildGRPCMethodRule(method *gatev1.GRPCMethodMatch) string {
 		return `PathPrefix("/")`
 	}
 
+	// Determine if we should treat values as literals or regex patterns.
+	isExact := method.Type == nil || *method.Type == gatev1.GRPCMethodMatchExact
+
 	sExpr := "[^/]+"
 	if s := ptr.Deref(method.Service, ""); s != "" {
-		sExpr = s
+		if isExact {
+			sExpr = regexp.QuoteMeta(s)
+		} else {
+			sExpr = s
+		}
 	}
 
 	mExpr := "[^/]+"
 	if m := ptr.Deref(method.Method, ""); m != "" {
-		mExpr = m
+		if isExact {
+			mExpr = regexp.QuoteMeta(m)
+		} else {
+			mExpr = m
+		}
 	}
 
 	return fmt.Sprintf("PathRegexp(%q)", fmt.Sprintf("/%s/%s", sExpr, mExpr))

--- a/pkg/provider/kubernetes/gateway/grpcroute.go
+++ b/pkg/provider/kubernetes/gateway/grpcroute.go
@@ -395,7 +395,6 @@ func buildGRPCMethodRule(method *gatev1.GRPCMethodMatch) string {
 		return `PathPrefix("/")`
 	}
 
-	// Determine if we should treat values as literals or regex patterns.
 	isExact := method.Type == nil || *method.Type == gatev1.GRPCMethodMatchExact
 
 	sExpr := "[^/]+"

--- a/pkg/provider/kubernetes/gateway/grpcroute_test.go
+++ b/pkg/provider/kubernetes/gateway/grpcroute_test.go
@@ -182,6 +182,7 @@ func Test_buildGRPCMethodRule(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
+
 			rule := buildGRPCMethodRule(test.method)
 			assert.Equal(t, test.expectedRule, rule)
 		})

--- a/pkg/provider/kubernetes/gateway/grpcroute_test.go
+++ b/pkg/provider/kubernetes/gateway/grpcroute_test.go
@@ -119,15 +119,6 @@ func Test_buildGRPCMethodRule(t *testing.T) {
 			expectedRule: `PathRegexp("/[^/]+/bar")`,
 		},
 		{
-			desc: "Exact service and method matching",
-			method: &gatev1.GRPCMethodMatch{
-				Type:    ptr.To(gatev1.GRPCMethodMatchExact),
-				Service: ptr.To("foo"),
-				Method:  ptr.To("bar"),
-			},
-			expectedRule: `PathRegexp("/foo/bar")`,
-		},
-		{
 			desc: "Regexp service matching",
 			method: &gatev1.GRPCMethodMatch{
 				Type:    ptr.To(gatev1.GRPCMethodMatchRegularExpression),
@@ -152,12 +143,45 @@ func Test_buildGRPCMethodRule(t *testing.T) {
 			},
 			expectedRule: `PathRegexp("/[^1-9/]/[^1-9/]")`,
 		},
+		{
+			desc: "Exact type with dot in service name escapes dot",
+			method: &gatev1.GRPCMethodMatch{
+				Type:    ptr.To(gatev1.GRPCMethodMatchExact),
+				Service: ptr.To("foo.bar"),
+				Method:  ptr.To("Method"),
+			},
+			expectedRule: `PathRegexp("/foo\\.bar/Method")`,
+		},
+		{
+			desc: "Nil type defaults to exact and escapes dot",
+			method: &gatev1.GRPCMethodMatch{
+				Type:    nil,
+				Service: ptr.To("auth.api"),
+				Method:  ptr.To("Login"),
+			},
+			expectedRule: `PathRegexp("/auth\\.api/Login")`,
+		},
+		{
+			desc: "RegularExpression type preserves dot as regex wildcard",
+			method: &gatev1.GRPCMethodMatch{
+				Type:    ptr.To(gatev1.GRPCMethodMatchRegularExpression),
+				Service: ptr.To("foo.bar"),
+				Method:  ptr.To(".*"),
+			},
+			expectedRule: `PathRegexp("/foo.bar/.*")`,
+		},
+		{
+			desc: "Exact type with neither service nor method uses full wildcard",
+			method: &gatev1.GRPCMethodMatch{
+				Type: ptr.To(gatev1.GRPCMethodMatchExact),
+			},
+			expectedRule: `PathRegexp("/[^/]+/[^/]+")`,
+		},
 	}
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
-
 			rule := buildGRPCMethodRule(test.method)
 			assert.Equal(t, test.expectedRule, rule)
 		})


### PR DESCRIPTION
### What does this PR do?

Fixes `buildGRPCMethodRule` so exact gRPC service and method matches are escaped before building the route rule.

Previously, exact values were inserted into `PathRegexp` without escaping, so `.` in service names was treated as a regex wildcard.

This PR preserves regex behavior for `RegularExpression` matches and adds tests for exact escaping.

### Motivation

Fixes the behavior reported in #13172.

Gateway API allows `.` in exact gRPC service names, and those dots should be matched literally. Without escaping, route matching can be broader than intended.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

Closes #13172.