### PR TITLE
Trim quotes from proxy_set_header header name

### DIFF
--- a/pkg/middlewares/ingressnginx/snippet/action.go
+++ b/pkg/middlewares/ingressnginx/snippet/action.go
@@ -393,7 +393,7 @@ func createProxySetHeaderAction(d config.IDirective) (action, error) {
 		return nil, errors.New("proxy_set_header directive requires 2 parameters (header and value)")
 	}
 
-	key := params[0].String()
+	key := trimQuote(params[0].String())
 	val := trimQuote(params[1].String())
 
 	return func(rw http.ResponseWriter, req *http.Request, ctx *actionContext) (bool, error) {

--- a/pkg/middlewares/ingressnginx/snippet/snippet_test.go
+++ b/pkg/middlewares/ingressnginx/snippet/snippet_test.go
@@ -400,6 +400,15 @@ proxy_set_header Accept-Encoding "";
 			},
 		},
 		{
+			desc: "proxy_set_header with quoted header name",
+			configurationSnippet: `
+proxy_set_header "X-Custom-Header" "my-value";
+`,
+			expectedRequestHeaders: map[string]string{
+				"X-Custom-Header": "my-value",
+			},
+		},
+		{
 			desc: "set directive creates variable",
 			configurationSnippet: `
 set $my_var "hello";


### PR DESCRIPTION
### What does this PR do?

Apply `trimQuote` to the header name parameter in the `proxy_set_header` directive, so that quoted header names (e.g. `proxy_set_header "X-Custom-Header" "my-value"`) are handled correctly.

### Motivation

* Previously, the quotes were stripped from the value but not from the header name, causing the header to be set with literal quote characters in its name.
* This could lead to errors like: `net/http: invalid header field name "\"Authorization\""`
* `ingress-nginx` support quotes in `proxy_set_header` header names. [Reference 1](https://github.com/kubernetes/ingress-nginx/blob/main/test/e2e/annotations/auth.go#L311) [Reference 2](https://github.com/kubernetes/ingress-nginx/blob/main/internal/ingress/controller/template/template_test.go#L561)

### More

- [x] Added/updated tests
- [ ] Added/updated documentation