### PR TITLE
Reject requests with different paths after StripPrefix and StripPrefixRegex normalisation

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -856,3 +856,20 @@ and [Kubernetes Gateway](../providers/kubernetes-gateway.md#crossprovidernamespa
 From version `v2.11.47` onwards, the BasicAuth middleware requires a non-empty users configuration in order to be built successfully.
 Previously, the middleware would be built successfully but always return a 401 status code for any request.
 Now, an error occurs and any routers using it will be unmounted. For the same request, a 404 status code is served instead of a 401 status code.
+
+### StripPrefix and StripPrefixRegex Middleware
+
+From version `v2.11.47` onwards, the StripPrefix middleware and the StripPrefixRegex middleware reject requests (`400 Bad Request`)
+when stripping the configured prefix produces a path that differs from its normalised form
+(i.e. a path containing `.` or `..` segments that would be collapsed by normalisation).
+
+This prevents the stripped path from being interpreted as a different resource by the upstream service.
+
+Examples with a configured prefix of `/api`:
+
+| Request path | Path after strip | Normalised path | Result       |
+|--------------|------------------|-----------------|--------------|
+| `/api/foo`   | `/foo`           | `/foo`          | `200` (sent) |
+| `/api/`      | `/`              | `/`             | `200` (sent) |
+| `/api./foo`  | `/./foo`         | `/foo`          | `400`        |
+| `/api../foo` | `/../foo`        | `/foo`          | `400`        |

--- a/pkg/middlewares/stripprefix/strip_prefix.go
+++ b/pkg/middlewares/stripprefix/strip_prefix.go
@@ -63,9 +63,6 @@ func (s *stripPrefix) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 				req.URL = req.URL.JoinPath()
 			}
 
-			if path == "" && s.forceSlash || path != "" && !strings.HasPrefix(path, "/") {
-				path = "/" + path
-			}
 			// Stop here if the normalization of the path produces a different path.
 			if path != req.URL.Path {
 				http.Error(rw, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)

--- a/pkg/middlewares/stripprefix/strip_prefix.go
+++ b/pkg/middlewares/stripprefix/strip_prefix.go
@@ -58,8 +58,18 @@ func (s *stripPrefix) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			// Here we are sanitizing the URL when the path is not empty,
 			// as the JoinPath method is adding a leading slash if the path is empty
 			// to be aligned with ensureLeadingSlash behavior.
-			if req.URL.Path != "" {
+			path := req.URL.Path
+			if path != "" {
 				req.URL = req.URL.JoinPath()
+			}
+
+			if path == "" && s.forceSlash || path != "" && !strings.HasPrefix(path, "/") {
+				path = "/" + path
+			}
+			// Stop here if the normalization of the path produces a different path.
+			if path != req.URL.Path {
+				http.Error(rw, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+				return
 			}
 
 			req.Header.Add(ForwardedPrefixHeader, prefix)

--- a/pkg/middlewares/stripprefix/strip_prefix.go
+++ b/pkg/middlewares/stripprefix/strip_prefix.go
@@ -48,6 +48,8 @@ func (s *stripPrefix) GetTracingInformation() (string, ext.SpanKindEnum) {
 }
 
 func (s *stripPrefix) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	logger := log.FromContext(middlewares.GetLoggerCtx(req.Context(), s.name, typeName))
+
 	for _, prefix := range s.prefixes {
 		if strings.HasPrefix(req.URL.Path, prefix) {
 			req.URL.Path = s.getPathStripped(req.URL.Path, prefix)
@@ -65,6 +67,7 @@ func (s *stripPrefix) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 			// Stop here if the normalization of the path produces a different path.
 			if path != req.URL.Path {
+				logger.Debugf("Rejecting request, sanitized path: %q is not equivalent to stripped path: %q", path, req.URL.Path)
 				http.Error(rw, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 				return
 			}

--- a/pkg/middlewares/stripprefix/strip_prefix_test.go
+++ b/pkg/middlewares/stripprefix/strip_prefix_test.go
@@ -191,10 +191,7 @@ func TestStripPrefix(t *testing.T) {
 				Prefixes: []string{"/api"},
 			},
 			path:               "/api./foo",
-			expectedStatusCode: http.StatusOK,
-			expectedPath:       "/foo",
-			expectedRawPath:    "",
-			expectedHeader:     "/api",
+			expectedStatusCode: http.StatusBadRequest,
 		},
 		{
 			desc: "multiple dots in the path not stripped by the prefix",
@@ -202,10 +199,7 @@ func TestStripPrefix(t *testing.T) {
 				Prefixes: []string{"/api"},
 			},
 			path:               "/api../foo",
-			expectedStatusCode: http.StatusOK,
-			expectedPath:       "/foo",
-			expectedRawPath:    "",
-			expectedHeader:     "/api",
+			expectedStatusCode: http.StatusBadRequest,
 		},
 		{
 			desc: "multiple dots in the path not stripped by the prefix with forceSlash",
@@ -214,10 +208,7 @@ func TestStripPrefix(t *testing.T) {
 				ForceSlash: true,
 			},
 			path:               "/api../foo",
-			expectedStatusCode: http.StatusOK,
-			expectedPath:       "/foo",
-			expectedRawPath:    "",
-			expectedHeader:     "/api",
+			expectedStatusCode: http.StatusBadRequest,
 		},
 	}
 

--- a/pkg/middlewares/stripprefix/strip_prefix_test.go
+++ b/pkg/middlewares/stripprefix/strip_prefix_test.go
@@ -235,6 +235,10 @@ func TestStripPrefix(t *testing.T) {
 			handler.ServeHTTP(resp, req)
 
 			assert.Equal(t, test.expectedStatusCode, resp.Code, "Unexpected status code.")
+			if test.expectedStatusCode != http.StatusOK {
+				return
+			}
+
 			assert.Equal(t, test.expectedPath, actualPath, "Unexpected path.")
 			assert.Equal(t, test.expectedRawPath, actualRawPath, "Unexpected raw path.")
 			assert.Equal(t, test.expectedHeader, actualHeader, "Unexpected '%s' header.", ForwardedPrefixHeader)

--- a/pkg/middlewares/stripprefixregex/strip_prefix_regex.go
+++ b/pkg/middlewares/stripprefixregex/strip_prefix_regex.go
@@ -73,9 +73,6 @@ func (s *stripPrefixRegex) ServeHTTP(rw http.ResponseWriter, req *http.Request) 
 				req.URL = req.URL.JoinPath()
 			}
 
-			if path != "" && !strings.HasPrefix(path, "/") {
-				path = "/" + path
-			}
 			// Stop here if the normalization of the path produces a different path.
 			if path != req.URL.Path {
 				http.Error(rw, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)

--- a/pkg/middlewares/stripprefixregex/strip_prefix_regex.go
+++ b/pkg/middlewares/stripprefixregex/strip_prefix_regex.go
@@ -68,8 +68,18 @@ func (s *stripPrefixRegex) ServeHTTP(rw http.ResponseWriter, req *http.Request) 
 			// Here we are sanitizing the URL when the path is not empty,
 			// as the JoinPath method is adding a leading slash if the path is empty
 			// to be aligned with ensureLeadingSlash behavior.
-			if req.URL.Path != "" {
+			path := req.URL.Path
+			if path != "" {
 				req.URL = req.URL.JoinPath()
+			}
+
+			if path != "" && !strings.HasPrefix(path, "/") {
+				path = "/" + path
+			}
+			// Stop here if the normalization of the path produces a different path.
+			if path != req.URL.Path {
+				http.Error(rw, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+				return
 			}
 
 			req.RequestURI = req.URL.RequestURI()

--- a/pkg/middlewares/stripprefixregex/strip_prefix_regex.go
+++ b/pkg/middlewares/stripprefixregex/strip_prefix_regex.go
@@ -50,6 +50,8 @@ func (s *stripPrefixRegex) GetTracingInformation() (string, ext.SpanKindEnum) {
 }
 
 func (s *stripPrefixRegex) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	logger := log.FromContext(middlewares.GetLoggerCtx(req.Context(), s.name, typeName))
+
 	for _, exp := range s.expressions {
 		parts := exp.FindStringSubmatch(req.URL.Path)
 		if len(parts) > 0 && len(parts[0]) > 0 {
@@ -75,6 +77,7 @@ func (s *stripPrefixRegex) ServeHTTP(rw http.ResponseWriter, req *http.Request) 
 
 			// Stop here if the normalization of the path produces a different path.
 			if path != req.URL.Path {
+				logger.Debugf("Rejecting request, sanitized path: %q is not equivalent to stripped path: %q", path, req.URL.Path)
 				http.Error(rw, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 				return
 			}

--- a/pkg/middlewares/stripprefixregex/strip_prefix_regex_test.go
+++ b/pkg/middlewares/stripprefixregex/strip_prefix_regex_test.go
@@ -201,21 +201,13 @@ func TestStripPrefixRegex(t *testing.T) {
 			desc:               "/api./foo",
 			config:             dynamic.StripPrefixRegex{Regex: []string{"/api"}},
 			path:               "/api./foo",
-			expectedStatusCode: http.StatusOK,
-			expectedPath:       "/foo",
-			expectedRawPath:    "",
-			expectedRequestURI: "/foo",
-			expectedHeader:     "/api",
+			expectedStatusCode: http.StatusBadRequest,
 		},
 		{
 			desc:               "/api../foo",
 			config:             dynamic.StripPrefixRegex{Regex: []string{"/api"}},
 			path:               "/api../foo",
-			expectedStatusCode: http.StatusOK,
-			expectedPath:       "/foo",
-			expectedRawPath:    "",
-			expectedRequestURI: "/foo",
-			expectedHeader:     "/api",
+			expectedStatusCode: http.StatusBadRequest,
 		},
 	}
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adds the rejection of requests with different paths after the StripPrefix and StripPrefixRegex normalisation.
<!-- A brief description of the change being made with this pull request. -->

### Motivation

To avoid the stripped path from being interpreted as a different resource by the upstream service.
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
