### PR TITLE
kubernetes ingress-nginx: deduplicate status updates per rebuild

### DIFF
--- a/docs/content/migrate/v3.md
+++ b/docs/content/migrate/v3.md
@@ -80,7 +80,7 @@ kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/downloa
 
 ### Kubernetes CRD Provider
 
-To use the new options of the `retry` middleware with the Kubernetes CRD provider, you need to update your CRDs.
+To use the new options of the `retry` middleware or the new `ingressClassName` field with the Kubernetes CRD provider, you need to update your CRDs.
 
 **Apply Updated CRDs:**
 

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
@@ -281,7 +281,7 @@ func (p *Provider) updateIngressStatuses(ctx context.Context, mc *model) {
 	ingresses := p.k8sClient.ListIngresses()
 	ingressesByKey := make(map[string]*netv1.Ingress, len(ingresses))
 	for _, ing := range ingresses {
-		ingressesByKey[ingressKey(ing.Namespace, ing.Name)] = ing
+		ingressesByKey[ing.Namespace+"/"+ing.Name] = ing
 	}
 
 	processed := make(map[string]struct{})
@@ -291,7 +291,7 @@ func (p *Provider) updateIngressStatuses(ctx context.Context, mc *model) {
 				continue
 			}
 
-			key := ingressKey(loc.Namespace, loc.IngressName)
+			key := loc.Namespace + "/" + loc.IngressName
 			if _, ok := processed[key]; ok {
 				continue
 			}
@@ -310,10 +310,6 @@ func (p *Provider) updateIngressStatuses(ctx context.Context, mc *model) {
 			}
 		}
 	}
-}
-
-func ingressKey(namespace, name string) string {
-	return namespace + "/" + name
 }
 
 func (p *Provider) validateConfiguration() error {

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
@@ -267,29 +267,53 @@ func (p *Provider) loadConfiguration(ctx context.Context) *dynamic.Configuration
 	// Phase 1: build the metamodel from k8s resources.
 	mc := p.build(ctx, ingressClasses)
 
-	// Update ingress statuses (requires k8s access, must happen in Phase 1 context).
+	p.updateIngressStatuses(ctx, mc)
+
+	// Phase 2: translate the metamodel into a Traefik dynamic.Configuration.
+	return p.translate(ctx, mc)
+}
+
+func (p *Provider) updateIngressStatuses(ctx context.Context, mc *model) {
+	if p.PublishService == "" && len(p.PublishStatusAddress) == 0 {
+		return
+	}
+
+	ingresses := p.k8sClient.ListIngresses()
+	ingressesByKey := make(map[string]*netv1.Ingress, len(ingresses))
+	for _, ing := range ingresses {
+		ingressesByKey[ingressKey(ing.Namespace, ing.Name)] = ing
+	}
+
+	processed := make(map[string]struct{})
 	for _, server := range mc.Servers {
 		for _, loc := range server.Locations {
 			if loc.IngressName == "" {
 				continue
 			}
-			// Retrieve the original ingress to update its status.
-			for _, ing := range p.k8sClient.ListIngresses() {
-				if ing.Namespace == loc.Namespace && ing.Name == loc.IngressName {
-					if err := p.updateIngressStatus(ing); err != nil {
-						log.Ctx(ctx).Error().Err(err).
-							Str("namespace", ing.Namespace).
-							Str("ingress", ing.Name).
-							Msg("Error while updating ingress status")
-					}
-					break
-				}
+
+			key := ingressKey(loc.Namespace, loc.IngressName)
+			if _, ok := processed[key]; ok {
+				continue
+			}
+			processed[key] = struct{}{}
+
+			ing, ok := ingressesByKey[key]
+			if !ok {
+				continue
+			}
+
+			if err := p.updateIngressStatus(ing); err != nil {
+				log.Ctx(ctx).Error().Err(err).
+					Str("namespace", ing.Namespace).
+					Str("ingress", ing.Name).
+					Msg("Error while updating ingress status")
 			}
 		}
 	}
+}
 
-	// Phase 2: translate the metamodel into a Traefik dynamic.Configuration.
-	return p.translate(ctx, mc)
+func ingressKey(namespace, name string) string {
+	return namespace + "/" + name
 }
 
 func (p *Provider) validateConfiguration() error {

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -17,7 +17,12 @@ import (
 	"github.com/traefik/traefik/v3/pkg/provider/kubernetes/k8s"
 	"github.com/traefik/traefik/v3/pkg/tls"
 	"github.com/traefik/traefik/v3/pkg/types"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/utils/ptr"
 )
@@ -15736,6 +15741,112 @@ func TestLoadIngresses(t *testing.T) {
 			assert.Equal(t, test.expected, conf)
 		})
 	}
+}
+
+func TestLoadConfigurationUpdatesIngressStatusOncePerIngress(t *testing.T) {
+	pathType := netv1.PathTypePrefix
+	kubeClient := kubefake.NewClientset(
+		&netv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "multi-path",
+				Namespace: "default",
+			},
+			Spec: netv1.IngressSpec{
+				Rules: []netv1.IngressRule{
+					{
+						Host: "example.com",
+						IngressRuleValue: netv1.IngressRuleValue{
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{
+									{
+										Path:     "/one",
+										PathType: &pathType,
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
+												Name: "whoami",
+												Port: netv1.ServiceBackendPort{Number: 80},
+											},
+										},
+									},
+									{
+										Path:     "/two",
+										PathType: &pathType,
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
+												Name: "whoami",
+												Port: netv1.ServiceBackendPort{Number: 80},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "whoami",
+				Namespace: "default",
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "http",
+						Port:       80,
+						TargetPort: intstr.FromInt32(8080),
+					},
+				},
+			},
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "whoami",
+				Namespace: "default",
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: "whoami",
+				},
+			},
+			Ports: []discoveryv1.EndpointPort{
+				{
+					Name: ptr.To("http"),
+					Port: ptr.To[int32](8080),
+				},
+			},
+			Endpoints: []discoveryv1.Endpoint{
+				{Addresses: []string{"10.0.0.1"}},
+			},
+		},
+	)
+
+	client := newClient(kubeClient)
+	_, err := client.WatchAll(t.Context(), "", "")
+	require.NoError(t, err)
+	kubeClient.ClearActions()
+
+	p := Provider{
+		k8sClient:                client,
+		NonTLSEntryPoints:        []string{"http"},
+		TLSEntryPoints:           []string{"https"},
+		PublishStatusAddress:     []string{"203.0.113.10"},
+		WatchIngressWithoutClass: true,
+	}
+	p.SetDefaults()
+
+	conf := p.loadConfiguration(t.Context())
+	require.NotNil(t, conf)
+
+	var statusUpdates int
+	for _, action := range kubeClient.Actions() {
+		if action.GetVerb() == "update" &&
+			action.GetResource().Resource == "ingresses" &&
+			action.GetSubresource() == "status" {
+			statusUpdates++
+		}
+	}
+
+	assert.Equal(t, 1, statusUpdates)
 }
 
 func TestNginxSizeToBytes(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Deduplicates Kubernetes Ingress NGINX status updates during each provider rebuild.

Before this PR, status publishing walked every generated model location and scanned all watched Ingresses for each location. Multiple locations can originate from the same Ingress, so Traefik repeated the same lookup and unchanged-status check several times in one rebuild.

With this change, the provider builds an Ingress index once and updates each distinct Ingress at most once per rebuild. It also skips the status phase when neither `publishService` nor `publishStatusAddress` is configured.

### Motivation

The Kubernetes Ingress NGINX provider can rebuild frequently in large clusters. Repeating the status lookup/update path for every generated location adds avoidable work and can amplify provider reconcile cost without changing status output.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Added a regression test with one Ingress containing two paths that asserts only one `ingresses/status` update is attempted.

This PR keeps existing status semantics; it only deduplicates repeated status work for Ingresses that already appear in the built model.
