### PR TITLE
Capitalize NGINX in kubernetesIngressNGINX

### DIFF
--- a/docs/content/migrate/nginx-to-traefik.md
+++ b/docs/content/migrate/nginx-to-traefik.md
@@ -170,7 +170,7 @@ helm repo update
 ```bash
 helm upgrade --install traefik traefik/traefik \
   --namespace traefik --create-namespace \
-  --set providers.kubernetesIngressNginx.enabled=true
+  --set providers.kubernetesIngressNGINX.enabled=true
 ```
 
 Or using a [values file](https://github.com/traefik/traefik-helm-chart/blob/master/traefik/VALUES.md) for more configuration:
@@ -178,7 +178,7 @@ Or using a [values file](https://github.com/traefik/traefik-helm-chart/blob/mast
 ```yaml tab="traefik-values.yaml"
 ...
 providers:
-  kubernetesIngressNginx:
+  kubernetesIngressNGINX:
     enabled: true
  ...
 ```


### PR DESCRIPTION
Documentation update for Nginx to Traefik migration.

Using kubernetesIngressNginx no longer works with the latest version of the Helm Chart (40.2.0).
The Values need to use kubernetesIngressNGINX, with capital NGINX

## Error

```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
traefik:
- at '/providers': additional properties 'kubernetesIngressNginx' not allowed
```

