### PR TITLE
refactor: use prefix trie for IP authorization checks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/moby/moby/api v1.54.1
 	github.com/moby/moby/client v0.4.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
+	github.com/phemmer/go-iptrie v0.0.0-20240326174613-ba542f5282c9 // No tag on the repo.
 	github.com/pires/go-proxyproto v0.8.1
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // No tag on the repo.
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -1742,6 +1742,8 @@ github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8
 github.com/performancecopilot/speed/v4 v4.0.0/go.mod h1:qxrSyuDGrTOWfV+uKRFhfxw6h/4HXRGUiZiufxo49BM=
 github.com/peterhellberg/link v1.2.0 h1:UA5pg3Gp/E0F2WdX7GERiNrPQrM1K6CVJUUWfHa4t6c=
 github.com/peterhellberg/link v1.2.0/go.mod h1:gYfAh+oJgQu2SrZHg5hROVRQe1ICoK0/HHJTcE0edxc=
+github.com/phemmer/go-iptrie v0.0.0-20240326174613-ba542f5282c9 h1:C8IqpV7kfAyZDRCnAVNi//l1mWlpyPmq1N6DjVvYEnY=
+github.com/phemmer/go-iptrie v0.0.0-20240326174613-ba542f5282c9/go.mod h1:dDLiSjNqdp8VjphLdGTx19OeAUsHOzhtc1FFJqpzWMU=
 github.com/phpdave11/gofpdf v1.4.2/go.mod h1:zpO6xFn9yxo3YLyMvW8HcKWVdbNqgIfOOp2dXMnm1mY=
 github.com/phpdave11/gofpdi v1.0.12/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
 github.com/phpdave11/gofpdi v1.0.13/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=

--- a/pkg/ip/checker.go
+++ b/pkg/ip/checker.go
@@ -6,12 +6,13 @@ import (
 	"net"
 	"net/netip"
 	"strings"
+
+	"github.com/phemmer/go-iptrie"
 )
 
 // Checker allows to check that addresses are in a trusted IPs.
 type Checker struct {
-	authorizedIPs    []*net.IP
-	authorizedIPsNet []*net.IPNet
+	trie *iptrie.Trie
 }
 
 // NewChecker builds a new Checker given a list of CIDR-Strings to trusted IPs.
@@ -20,19 +21,24 @@ func NewChecker(trustedIPs []string) (*Checker, error) {
 		return nil, errors.New("no trusted IPs provided")
 	}
 
-	checker := &Checker{}
+	checker := &Checker{trie: iptrie.NewTrie()}
 
 	for _, ipMask := range trustedIPs {
 		if ipAddr := net.ParseIP(ipMask); ipAddr != nil {
-			checker.authorizedIPs = append(checker.authorizedIPs, &ipAddr)
-			continue
+			addr, ok := netip.AddrFromSlice(ipAddr)
+			if !ok {
+				return nil, fmt.Errorf("parsing trusted IPs %s", ipAddr)
+			}
+			checker.trie.Insert(netip.PrefixFrom(addr, 32*(len(ipAddr)/4)), struct{}{})
+		} else {
+			_, ipAddr, err := net.ParseCIDR(ipMask)
+			if err != nil {
+				return nil, fmt.Errorf("parsing CIDR trusted IPs %s: %w", ipAddr, err)
+			}
+			addr, _ := netip.AddrFromSlice(ipAddr.IP)
+			ones, _ := ipAddr.Mask.Size()
+			checker.trie.Insert(netip.PrefixFrom(addr, ones), struct{}{})
 		}
-
-		_, ipAddr, err := net.ParseCIDR(ipMask)
-		if err != nil {
-			return nil, fmt.Errorf("parsing CIDR trusted IPs %s: %w", ipAddr, err)
-		}
-		checker.authorizedIPsNet = append(checker.authorizedIPsNet, ipAddr)
 	}
 
 	return checker, nil
@@ -76,19 +82,11 @@ func (ip *Checker) Contains(addr string) (bool, error) {
 
 // ContainsIP checks if provided address is in the trusted IPs.
 func (ip *Checker) ContainsIP(addr net.IP) bool {
-	for _, authorizedIP := range ip.authorizedIPs {
-		if authorizedIP.Equal(addr) {
-			return true
-		}
+	a, ok := netip.AddrFromSlice(addr)
+	if !ok {
+		return false
 	}
-
-	for _, authorizedNet := range ip.authorizedIPsNet {
-		if authorizedNet.Contains(addr) {
-			return true
-		}
-	}
-
-	return false
+	return ip.trie.Contains(a)
 }
 
 func parseIP(addr string) (net.IP, error) {

--- a/pkg/ip/checker_test.go
+++ b/pkg/ip/checker_test.go
@@ -1,8 +1,11 @@
 package ip
 
 import (
+	"math/rand"
 	"net"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -124,10 +127,11 @@ func TestNew(t *testing.T) {
 				require.EqualError(t, err, test.errMessage)
 			} else {
 				require.NoError(t, err)
-				for index, actual := range ipChecker.authorizedIPsNet {
-					expected := test.expectedAuthorizedIPs[index]
-					assert.Equal(t, expected.IP, actual.IP)
-					assert.Equal(t, expected.Mask.String(), actual.Mask.String())
+				// Verify the checker works by testing ContainsIP against known CIDR ranges
+				for _, cidrStr := range test.trustedIPs {
+					_, expectedNet, cidrErr := net.ParseCIDR(cidrStr)
+					require.NoError(t, cidrErr)
+					assert.True(t, ipChecker.ContainsIP(expectedNet.IP))
 				}
 			}
 		})
@@ -328,4 +332,57 @@ func TestContainsBrokenIPs(t *testing.T) {
 		_, err := ipChecker.Contains(testIP)
 		assert.Error(t, err)
 	}
+}
+
+func TestCheckerLargeNumberOfIPs(t *testing.T) {
+	t.Parallel()
+
+	rng := rand.New(rand.NewSource(42))
+
+	// Build large list: 10k CIDRs + 1k single IPs
+	var trustedIPs []string
+	var singleIPs []string
+	subnetPrefixes := []int{8, 16, 24}
+	for i := 0; i < 10000; i++ {
+		pl := subnetPrefixes[rng.Intn(len(subnetPrefixes))]
+		var base net.IP
+		if pl <= 16 {
+			base = net.IPv4(byte(rng.Intn(256)), byte(rng.Intn(256)), byte(rng.Intn(256)), byte(rng.Intn(256)))
+		} else {
+			base = net.IPv4(byte(rng.Intn(256)), byte(rng.Intn(256)), byte(rng.Intn(256)), 0)
+		}
+		trustedIPs = append(trustedIPs, base.String()+"/"+strconv.Itoa(pl))
+	}
+	for i := 0; i < 1000; i++ {
+		ip := net.IPv4(byte(rng.Intn(256)), byte(rng.Intn(256)), byte(rng.Intn(256)), byte(rng.Intn(256)))
+		s := ip.String()
+		trustedIPs = append(trustedIPs, s)
+		singleIPs = append(singleIPs, s)
+	}
+
+	start := time.Now()
+	checker, err := NewChecker(trustedIPs)
+	require.NoError(t, err)
+	t.Logf("Built checker with %d entries in %v", len(trustedIPs), time.Since(start))
+
+	// Verify a sample of single IPs are found
+	foundCount := 0
+	for _, ipStr := range singleIPs {
+		if ok, _ := checker.Contains(ipStr); ok {
+			foundCount++
+		}
+	}
+	assert.Equal(t, 1000, foundCount)
+
+	// Performance: 100k lookups
+	var addrs []string
+	for i := 0; i < 100000; i++ {
+		addrs = append(addrs, net.IPv4(byte(rng.Intn(256)), byte(rng.Intn(256)), byte(rng.Intn(256)), byte(rng.Intn(256))).String())
+	}
+	start = time.Now()
+	for _, addr := range addrs {
+		_, err := checker.Contains(addr)
+		require.NoError(t, err)
+	}
+	t.Logf("100k lookups in %v", time.Since(start))
 }


### PR DESCRIPTION

### What does this PR do?

Switch the IP set checker from a list that is O(n)  in number of entries to a prefix trie that is O(k) in number of bytes of the IP (4 or 16), effectively constant.

### Motivation

For very large IP allowlists or blocklists, the lookup time per request can in practice grow to larger than the request servicing time. This change caps the lookup time in the IP checker.

### More

- Added a new unit test demonstrating a large number of IPs in the set, and showing impact on lookup time.

### Additional Notes

There are several Go prefix trie implementations, I chose the one that looked best (code quality, then performance). I am open to suggestions for alternatives.
