### PR TITLE
fix(k8s): reduce provider churn from EndpointSlice and node updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,6 @@ require (
 	github.com/mailgun/ttlmap v0.0.0-20170619185759-c1c17f74874f // No tag on the repo.
 	github.com/miekg/dns v1.1.72
 	github.com/mitchellh/copystructure v1.2.0
-	github.com/mitchellh/hashstructure v1.0.0
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c // No tag on the repo.
 	github.com/moby/moby/api v1.54.1
 	github.com/moby/moby/client v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -1605,8 +1605,6 @@ github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJ
 github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
-github.com/mitchellh/hashstructure v1.0.0 h1:ZkRJX1CyOoTkar7p/mLS5TZU4nJ1Rn/F8u9dGS02Q3Y=
-github.com/mitchellh/hashstructure v1.0.0/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/mitchellh/hashstructure"
 	"github.com/rs/zerolog/log"
+	"github.com/traefik/traefik/v3/pkg/config/dynamic/confighash"
 	"github.com/traefik/traefik/v3/pkg/config/static"
 	"github.com/traefik/traefik/v3/pkg/redactor"
 	"github.com/traefik/traefik/v3/pkg/version"
@@ -51,10 +51,7 @@ func createBody(staticConfiguration *static.Configuration) (*bytes.Buffer, error
 
 	log.Debug().Msgf("Anonymous stats sent to %s: %s", collectorURL, anonConfig)
 
-	hashConf, err := hashstructure.Hash(staticConfiguration, nil)
-	if err != nil {
-		return nil, err
-	}
+	hashConf := confighash.Hash(staticConfiguration)
 
 	data := &data{
 		Version:       version.Version,

--- a/pkg/config/dynamic/confighash/hash.go
+++ b/pkg/config/dynamic/confighash/hash.go
@@ -1,0 +1,208 @@
+// Package confighash computes a fast, allocation-light fingerprint of a
+// Traefik configuration value.
+//
+// It replaces github.com/mitchellh/hashstructure on the Kubernetes-provider
+// reload hot-path. The two differ in three ways:
+//
+//   - maps are combined order-independently with XOR over per-entry hashes
+//     instead of sorting keys before hashing (no allocation per call),
+//   - primitives are written straight into hash/maphash via encoding/binary
+//     rather than boxed through reflect.Value.Interface,
+//   - the seed is process-random (hash/maphash.MakeSeed), so the value is
+//     stable within a single Traefik process but not across processes.
+//
+// Callers (provider reload-dedup, anonymous-stats payload) only compare the
+// value to its previous self in the same process, so the per-process seed is
+// the right trade-off: it gives us hash/maphash's AES-NI-accelerated mixing
+// and DoS resistance without any portability concern.
+package confighash
+
+import (
+	"encoding/binary"
+	"hash/maphash"
+	"math"
+	"reflect"
+	"sync"
+)
+
+// seed is shared by every hash computed in this process. Generated once at
+// package init via hash/maphash.MakeSeed.
+var seed = maphash.MakeSeed()
+
+var hashPool = sync.Pool{
+	New: func() any {
+		return &maphash.Hash{}
+	},
+}
+
+func acquire() *maphash.Hash {
+	h := hashPool.Get().(*maphash.Hash)
+	h.SetSeed(seed)
+	h.Reset()
+	return h
+}
+
+func release(h *maphash.Hash) { hashPool.Put(h) }
+
+// Type tags ensure two values of different kinds with identical byte content
+// never collide (e.g. uint64(0) vs nil pointer, []byte{} vs string "").
+const (
+	tagNil byte = iota + 1
+	tagBool
+	tagInt
+	tagUint
+	tagFloat
+	tagComplex
+	tagString
+	tagBytes
+	tagSlice
+	tagArray
+	tagStruct
+	tagMap
+	tagPtr
+	tagInterface
+	tagUnsupported
+)
+
+// Hash returns a 64-bit fingerprint of v.
+//
+// Two structurally-equal values produce the same hash within a single Traefik
+// process. Map iteration order does not affect the result. The function never
+// panics and never returns an error; unsupported kinds (chan, func, unsafe
+// pointer) hash to a constant sentinel so they can appear inside an otherwise
+// hashable struct.
+func Hash(v any) uint64 {
+	h := acquire()
+	defer release(h)
+	hashValue(h, reflect.ValueOf(v))
+	return h.Sum64()
+}
+
+func hashValue(h *maphash.Hash, v reflect.Value) {
+	if !v.IsValid() {
+		_ = h.WriteByte(tagNil)
+		return
+	}
+
+	switch v.Kind() {
+	case reflect.Bool:
+		var buf [2]byte
+		buf[0] = tagBool
+		if v.Bool() {
+			buf[1] = 1
+		}
+		_, _ = h.Write(buf[:])
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		writeTagUint64(h, tagInt, uint64(v.Int()))
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		writeTagUint64(h, tagUint, v.Uint())
+
+	case reflect.Float32, reflect.Float64:
+		writeTagUint64(h, tagFloat, math.Float64bits(v.Float()))
+
+	case reflect.Complex64, reflect.Complex128:
+		c := v.Complex()
+		var buf [17]byte
+		buf[0] = tagComplex
+		binary.LittleEndian.PutUint64(buf[1:9], math.Float64bits(real(c)))
+		binary.LittleEndian.PutUint64(buf[9:17], math.Float64bits(imag(c)))
+		_, _ = h.Write(buf[:])
+
+	case reflect.String:
+		writeTagUint64(h, tagString, uint64(v.Len()))
+		_, _ = h.WriteString(v.String())
+
+	case reflect.Ptr:
+		if v.IsNil() {
+			_ = h.WriteByte(tagNil)
+			return
+		}
+		_ = h.WriteByte(tagPtr)
+		hashValue(h, v.Elem())
+
+	case reflect.Interface:
+		if v.IsNil() {
+			_ = h.WriteByte(tagNil)
+			return
+		}
+		_ = h.WriteByte(tagInterface)
+		hashValue(h, v.Elem())
+
+	case reflect.Slice:
+		if v.IsNil() {
+			_ = h.WriteByte(tagNil)
+			return
+		}
+		// Fast path for []byte: avoids per-element reflection.
+		if v.Type().Elem().Kind() == reflect.Uint8 {
+			writeTagUint64(h, tagBytes, uint64(v.Len()))
+			_, _ = h.Write(v.Bytes())
+			return
+		}
+		writeTagUint64(h, tagSlice, uint64(v.Len()))
+		for i := 0; i < v.Len(); i++ {
+			hashValue(h, v.Index(i))
+		}
+
+	case reflect.Array:
+		writeTagUint64(h, tagArray, uint64(v.Len()))
+		for i := 0; i < v.Len(); i++ {
+			hashValue(h, v.Index(i))
+		}
+
+	case reflect.Struct:
+		_ = h.WriteByte(tagStruct)
+		t := v.Type()
+		n := v.NumField()
+		for i := 0; i < n; i++ {
+			f := t.Field(i)
+			if !f.IsExported() {
+				continue
+			}
+			// Field name is mixed in so renaming or reordering a field
+			// invalidates the hash even if the wire types stay the same.
+			_, _ = h.WriteString(f.Name)
+			hashValue(h, v.Field(i))
+		}
+
+	case reflect.Map:
+		if v.IsNil() {
+			_ = h.WriteByte(tagNil)
+			return
+		}
+		// Combine per-entry hashes with XOR -- commutative and associative,
+		// so iteration order does not matter and we never allocate a
+		// sorted key list. Per-entry hashing borrows a sub-hasher from
+		// the same pool.
+		var combined uint64
+		sub := acquire()
+		iter := v.MapRange()
+		for iter.Next() {
+			sub.Reset()
+			hashValue(sub, iter.Key())
+			hashValue(sub, iter.Value())
+			combined ^= sub.Sum64()
+		}
+		release(sub)
+		// Mixing the map length distinguishes nil / empty / single-nil-entry
+		// maps after the XOR collapses identical sub-hashes.
+		var buf [17]byte
+		buf[0] = tagMap
+		binary.LittleEndian.PutUint64(buf[1:9], uint64(v.Len()))
+		binary.LittleEndian.PutUint64(buf[9:17], combined)
+		_, _ = h.Write(buf[:])
+
+	default:
+		// chan, func, unsafe.Pointer: not meaningful to hash structurally.
+		_ = h.WriteByte(tagUnsupported)
+	}
+}
+
+func writeTagUint64(h *maphash.Hash, tag byte, u uint64) {
+	var buf [9]byte
+	buf[0] = tag
+	binary.LittleEndian.PutUint64(buf[1:], u)
+	_, _ = h.Write(buf[:])
+}

--- a/pkg/config/dynamic/confighash/hash_test.go
+++ b/pkg/config/dynamic/confighash/hash_test.go
@@ -1,0 +1,445 @@
+package confighash
+
+import (
+	"sync"
+	"testing"
+	"unsafe"
+
+	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/traefik/traefik/v3/pkg/config/dynamic"
+	"github.com/traefik/traefik/v3/pkg/tls"
+)
+
+// minimalDynamicConfig returns a hand-built *dynamic.Configuration that
+// exercises HTTP, TCP, UDP and TLS sub-trees with a few representative
+// pointer / map / slice fields. Used as the seed for sensitivity and
+// order-independence tests.
+func minimalDynamicConfig() *dynamic.Configuration {
+	passHostHeader := true
+
+	return &dynamic.Configuration{
+		HTTP: &dynamic.HTTPConfiguration{
+			Routers: map[string]*dynamic.Router{
+				"r1": {
+					EntryPoints: []string{"web"},
+					Middlewares: []string{"m1"},
+					Service:     "s1",
+					Rule:        "Host(`example.com`)",
+					Priority:    10,
+				},
+			},
+			Services: map[string]*dynamic.Service{
+				"s1": {
+					LoadBalancer: &dynamic.ServersLoadBalancer{
+						Servers:        []dynamic.Server{{URL: "http://10.0.0.1:80"}},
+						PassHostHeader: &passHostHeader,
+					},
+				},
+			},
+			Middlewares: map[string]*dynamic.Middleware{
+				"m1": {
+					AddPrefix: &dynamic.AddPrefix{Prefix: "/api"},
+				},
+			},
+		},
+		TCP: &dynamic.TCPConfiguration{
+			Routers: map[string]*dynamic.TCPRouter{
+				"t1": {
+					EntryPoints: []string{"tcp-ep"},
+					Service:     "ts1",
+					Rule:        "HostSNI(`*`)",
+				},
+			},
+			Services: map[string]*dynamic.TCPService{
+				"ts1": {
+					LoadBalancer: &dynamic.TCPServersLoadBalancer{
+						Servers: []dynamic.TCPServer{{Address: "10.0.0.1:443"}},
+					},
+				},
+			},
+		},
+		UDP: &dynamic.UDPConfiguration{
+			Routers: map[string]*dynamic.UDPRouter{
+				"u1": {
+					EntryPoints: []string{"udp-ep"},
+					Service:     "us1",
+				},
+			},
+			Services: map[string]*dynamic.UDPService{
+				"us1": {
+					LoadBalancer: &dynamic.UDPServersLoadBalancer{
+						Servers: []dynamic.UDPServer{{Address: "10.0.0.1:53"}},
+					},
+				},
+			},
+		},
+		TLS: &dynamic.TLSConfiguration{
+			Options: map[string]tls.Options{
+				"default": {MinVersion: "VersionTLS12"},
+			},
+		},
+	}
+}
+
+// Contract 1 — Determinism.
+
+func TestHash_DeterministicAcrossCalls(t *testing.T) {
+	t.Parallel()
+
+	cfg := minimalDynamicConfig()
+	want := Hash(cfg)
+	for i := 0; i < 100; i++ {
+		assert.Equal(t, want, Hash(cfg), "iteration %d", i)
+	}
+}
+
+func TestHash_DeterministicAcrossCopies(t *testing.T) {
+	t.Parallel()
+
+	cfg := &dynamic.Configuration{}
+	_, err := toml.DecodeFile("../fixtures/sample.toml", cfg)
+	require.NoError(t, err)
+
+	cpy := cfg.DeepCopy()
+	assert.Equal(t, Hash(cfg), Hash(cpy))
+}
+
+// Contract 2 — Sensitivity. Any structural change flips the hash.
+
+func TestHash_DetectsMutation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func(*dynamic.Configuration)
+	}{
+		{
+			name: "router rule changes",
+			mutate: func(c *dynamic.Configuration) {
+				c.HTTP.Routers["r1"].Rule = "Host(`other.com`)"
+			},
+		},
+		{
+			name: "router priority changes",
+			mutate: func(c *dynamic.Configuration) {
+				c.HTTP.Routers["r1"].Priority = 20
+			},
+		},
+		{
+			name: "router middlewares slice grows",
+			mutate: func(c *dynamic.Configuration) {
+				c.HTTP.Routers["r1"].Middlewares = append(c.HTTP.Routers["r1"].Middlewares, "m2")
+			},
+		},
+		{
+			name: "service PassHostHeader pointer flips",
+			mutate: func(c *dynamic.Configuration) {
+				b := false
+				c.HTTP.Services["s1"].LoadBalancer.PassHostHeader = &b
+			},
+		},
+		{
+			name: "service PassHostHeader becomes nil",
+			mutate: func(c *dynamic.Configuration) {
+				c.HTTP.Services["s1"].LoadBalancer.PassHostHeader = nil
+			},
+		},
+		{
+			name: "middleware swapped to a different middleware",
+			mutate: func(c *dynamic.Configuration) {
+				c.HTTP.Middlewares["m1"] = &dynamic.Middleware{
+					StripPrefix: &dynamic.StripPrefix{Prefixes: []string{"/api"}},
+				}
+			},
+		},
+		{
+			name: "tcp router rule changes",
+			mutate: func(c *dynamic.Configuration) {
+				c.TCP.Routers["t1"].Rule = "HostSNI(`example.com`)"
+			},
+		},
+		{
+			name: "udp router entry points change",
+			mutate: func(c *dynamic.Configuration) {
+				c.UDP.Routers["u1"].EntryPoints = []string{"udp-ep", "udp-ep-2"}
+			},
+		},
+		{
+			name: "tls option field changes",
+			mutate: func(c *dynamic.Configuration) {
+				opt := c.TLS.Options["default"]
+				opt.MinVersion = "VersionTLS13"
+				c.TLS.Options["default"] = opt
+			},
+		},
+		{
+			name: "map gains an entry",
+			mutate: func(c *dynamic.Configuration) {
+				c.HTTP.Routers["r2"] = &dynamic.Router{Rule: "Host(`b.com`)"}
+			},
+		},
+		{
+			name: "map loses an entry",
+			mutate: func(c *dynamic.Configuration) {
+				delete(c.HTTP.Routers, "r1")
+			},
+		},
+		{
+			name: "server slice element changes",
+			mutate: func(c *dynamic.Configuration) {
+				c.HTTP.Services["s1"].LoadBalancer.Servers[0].URL = "http://10.0.0.2:80"
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			base := minimalDynamicConfig()
+			want := Hash(base)
+
+			mutated := minimalDynamicConfig()
+			test.mutate(mutated)
+
+			assert.NotEqual(t, want, Hash(mutated),
+				"mutation %q produced an identical hash", test.name)
+		})
+	}
+}
+
+func TestHash_NilEmptyZeroDistinct(t *testing.T) {
+	t.Parallel()
+
+	// Each pair must hash to a different value. Picking pairs that share
+	// either the bit-pattern or the underlying zero value but differ in
+	// kind, nil-ness or container shape.
+	type pair struct {
+		name string
+		a, b any
+	}
+
+	zeroInt := 0
+	zeroPtrInt := &zeroInt
+
+	pairs := []pair{
+		{"untyped nil vs empty struct ptr", nil, &dynamic.Configuration{}},
+		{"nil slice vs empty slice", []string(nil), []string{}},
+		{"nil map vs empty map", map[string]int(nil), map[string]int{}},
+		{"empty map vs single zero-key entry", map[string]int{}, map[string]int{"": 0}},
+		{"empty string vs empty bytes", "", []byte{}},
+		{"int64(0) vs uint64(0)", int64(0), uint64(0)},
+		{"int64(0) vs bool false", int64(0), false},
+		{"uint64(0) vs bool false", uint64(0), false},
+		{"int(0) vs *int(0)", 0, zeroPtrInt},
+		{"nil ptr vs &T{}", (*dynamic.Configuration)(nil), &dynamic.Configuration{}},
+	}
+
+	for _, p := range pairs {
+		t.Run(p.name, func(t *testing.T) {
+			t.Parallel()
+			assert.NotEqual(t, Hash(p.a), Hash(p.b),
+				"hash collision between %#v and %#v", p.a, p.b)
+		})
+	}
+}
+
+// Contract 3 — Map-order independence (the XOR design's whole point).
+
+func TestHash_MapOrderIndependent(t *testing.T) {
+	t.Parallel()
+
+	// Primitive-value map.
+	keys := []string{"alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta"}
+	want := Hash(buildIntMap(keys))
+	// Reverse, rotate, and shuffle insertion order; the hash must not move.
+	orders := [][]string{
+		reversed(keys),
+		rotated(keys, 3),
+		{"theta", "alpha", "eta", "beta", "zeta", "gamma", "epsilon", "delta"},
+		{"epsilon", "delta", "alpha", "gamma", "zeta", "beta", "eta", "theta"},
+	}
+	for i, ord := range orders {
+		assert.Equal(t, want, Hash(buildIntMap(ord)), "primitive map order %d", i)
+	}
+
+	// Pointer-value map (the realistic case — routers/services/middlewares
+	// are all map[string]*T).
+	routerKeys := []string{"r1", "r2", "r3", "r4", "r5", "r6"}
+	wantR := Hash(buildRouterMap(routerKeys))
+	for i, ord := range [][]string{
+		reversed(routerKeys),
+		rotated(routerKeys, 2),
+		{"r4", "r1", "r6", "r2", "r5", "r3"},
+	} {
+		assert.Equal(t, wantR, Hash(buildRouterMap(ord)), "router map order %d", i)
+	}
+}
+
+func TestHash_NestedMapOrderIndependent(t *testing.T) {
+	t.Parallel()
+
+	keys := []string{"a", "b", "c", "d", "e", "f", "g"}
+
+	cfg1 := &dynamic.Configuration{
+		HTTP: &dynamic.HTTPConfiguration{
+			Routers:     buildRouterMap(keys),
+			Middlewares: buildMiddlewareMap(keys),
+		},
+	}
+	cfg2 := &dynamic.Configuration{
+		HTTP: &dynamic.HTTPConfiguration{
+			Routers:     buildRouterMap(reversed(keys)),
+			Middlewares: buildMiddlewareMap(reversed(keys)),
+		},
+	}
+
+	assert.Equal(t, Hash(cfg1), Hash(cfg2))
+}
+
+// Contract 4 — Realistic configs hash and stay stable across DeepCopy,
+// then flip on any mutation deep inside the tree.
+
+func TestHash_SampleFixture(t *testing.T) {
+	t.Parallel()
+
+	cfg := &dynamic.Configuration{}
+	_, err := toml.DecodeFile("../fixtures/sample.toml", cfg)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.HTTP)
+	require.NotEmpty(t, cfg.HTTP.Routers, "fixture must populate at least one router")
+
+	before := Hash(cfg)
+
+	// Deep-copy must hash identically — this is the closest in-process
+	// analogue to the provider rebuilding *dynamic.Configuration on every
+	// event.
+	copied := cfg.DeepCopy()
+	assert.Equal(t, before, Hash(copied),
+		"deep copy should hash identically to the original")
+
+	// Mutating a leaf string deep inside HTTP.Routers must flip the hash.
+	for k := range cfg.HTTP.Routers {
+		cfg.HTTP.Routers[k].Rule = "mutated"
+		break
+	}
+	assert.NotEqual(t, before, Hash(cfg),
+		"mutating a nested router rule should change the hash")
+}
+
+// (A dedicated TestHash_StaticConfig was considered but dropped because
+// pkg/config/static transitively imports pkg/config/dynamic/confighash via
+// the CRD provider, which would create a test-time import cycle. The
+// dynamic-configuration cases above already exercise every kind the
+// reflection walker needs to handle.)
+
+// Contract 5 — Resilience: never panics, race-safe.
+
+func TestHash_DoesNotPanicOnUnsupportedKinds(t *testing.T) {
+	t.Parallel()
+
+	type weird struct {
+		Ch      chan int
+		Fn      func()
+		Unsafe  unsafe.Pointer
+		Payload string
+	}
+
+	v := weird{
+		Ch:      make(chan int),
+		Fn:      func() {},
+		Unsafe:  unsafe.Pointer(t),
+		Payload: "ok",
+	}
+
+	assert.NotPanics(t, func() { _ = Hash(v) })
+	// Two values identical-except-for-the-Payload must still hash differently,
+	// proving the unsupported branches don't swallow the payload field.
+	v2 := v
+	v2.Payload = "different"
+	assert.NotEqual(t, Hash(v), Hash(v2))
+}
+
+func TestHash_ConcurrentSafe(t *testing.T) {
+	t.Parallel()
+
+	cfg := minimalDynamicConfig()
+	want := Hash(cfg)
+
+	const goroutines = 200
+	const calls = 50
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	results := make([]uint64, goroutines*calls)
+	for g := 0; g < goroutines; g++ {
+		go func(g int) {
+			defer wg.Done()
+			for c := 0; c < calls; c++ {
+				results[g*calls+c] = Hash(cfg)
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	for i, got := range results {
+		require.Equalf(t, want, got, "goroutine result %d diverged", i)
+	}
+}
+
+// --- helpers ---
+
+// buildIntMap derives the value from the key so the result depends only on
+// the set of keys, not on insertion order.
+func buildIntMap(keys []string) map[string]int {
+	m := make(map[string]int, len(keys))
+	for _, k := range keys {
+		m[k] = len(k)
+	}
+	return m
+}
+
+// buildRouterMap is order-stable for the same reason as buildIntMap.
+func buildRouterMap(keys []string) map[string]*dynamic.Router {
+	m := make(map[string]*dynamic.Router, len(keys))
+	for _, k := range keys {
+		m[k] = &dynamic.Router{
+			Service:  "svc-" + k,
+			Rule:     "Host(`" + k + ".example.com`)",
+			Priority: len(k),
+		}
+	}
+	return m
+}
+
+func buildMiddlewareMap(keys []string) map[string]*dynamic.Middleware {
+	m := make(map[string]*dynamic.Middleware, len(keys))
+	for _, k := range keys {
+		m[k] = &dynamic.Middleware{
+			AddPrefix: &dynamic.AddPrefix{Prefix: "/" + k},
+		}
+	}
+	return m
+}
+
+func reversed(in []string) []string {
+	out := make([]string, len(in))
+	for i, v := range in {
+		out[len(in)-1-i] = v
+	}
+	return out
+}
+
+func rotated(in []string, n int) []string {
+	if len(in) == 0 {
+		return in
+	}
+	n %= len(in)
+	out := make([]string, 0, len(in))
+	out = append(out, in[n:]...)
+	out = append(out, in[:n]...)
+	return out
+}

--- a/pkg/provider/kubernetes/crd/client.go
+++ b/pkg/provider/kubernetes/crd/client.go
@@ -21,7 +21,6 @@ import (
 	kerror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	kinformers "k8s.io/client-go/informers"
 	kclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -224,7 +223,11 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 		if err != nil {
 			return nil, err
 		}
-		_, err = factoryKube.Discovery().V1().EndpointSlices().Informer().AddEventHandler(eventHandler)
+		endpointSlicesInformer := factoryKube.Discovery().V1().EndpointSlices().Informer()
+		if err = endpointSlicesInformer.AddIndexers(k8s.EndpointSliceServiceNameIndexers); err != nil {
+			return nil, fmt.Errorf("adding endpointslice service-name indexer: %w", err)
+		}
+		_, err = endpointSlicesInformer.AddEventHandler(eventHandler)
 		if err != nil {
 			return nil, err
 		}
@@ -462,14 +465,22 @@ func (c *clientWrapper) GetEndpointSlicesForService(namespace, serviceName strin
 		return nil, fmt.Errorf("failed to get endpointslices for service %s/%s: namespace is not within watched namespaces", namespace, serviceName)
 	}
 
-	serviceLabelRequirement, err := labels.NewRequirement(discoveryv1.LabelServiceName, selection.Equals, []string{serviceName})
+	items, err := c.factoriesKube[c.lookupNamespace(namespace)].
+		Discovery().V1().EndpointSlices().Informer().
+		GetIndexer().ByIndex(k8s.EndpointSliceServiceNameIndex, k8s.EndpointSliceServiceNameIndexKey(namespace, serviceName))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create service label selector requirement: %w", err)
+		return nil, fmt.Errorf("failed to get endpointslices for service %s/%s: %w", namespace, serviceName, err)
 	}
-	serviceSelector := labels.NewSelector()
-	serviceSelector = serviceSelector.Add(*serviceLabelRequirement)
 
-	return c.factoriesKube[c.lookupNamespace(namespace)].Discovery().V1().EndpointSlices().Lister().EndpointSlices(namespace).List(serviceSelector)
+	result := make([]*discoveryv1.EndpointSlice, 0, len(items))
+	for _, item := range items {
+		es, ok := item.(*discoveryv1.EndpointSlice)
+		if !ok {
+			continue
+		}
+		result = append(result, es)
+	}
+	return result, nil
 }
 
 // GetSecret returns the named secret from the given namespace.

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -19,10 +19,10 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/mitchellh/hashstructure"
 	"github.com/rs/zerolog/log"
 	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
+	"github.com/traefik/traefik/v3/pkg/config/dynamic/confighash"
 	"github.com/traefik/traefik/v3/pkg/job"
 	"github.com/traefik/traefik/v3/pkg/observability/logs"
 	"github.com/traefik/traefik/v3/pkg/provider"
@@ -128,13 +128,10 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 					// But if we do in the future, we'll need to track more information about the dropped events.
 					conf := p.loadConfigurationFromCRD(ctxLog, k8sClient)
 
-					confHash, err := hashstructure.Hash(conf, nil)
-					switch {
-					case err != nil:
-						logger.Error().Err(err).Msg("Unable to hash the configuration")
-					case p.lastConfiguration.Get() == confHash:
+					confHash := confighash.Hash(conf)
+					if p.lastConfiguration.Get() == confHash {
 						logger.Debug().Msgf("Skipping Kubernetes event kind %T", event)
-					default:
+					} else {
 						p.lastConfiguration.Set(confHash)
 						configurationChan <- dynamic.Message{
 							ProviderName:  ProviderName,

--- a/pkg/provider/kubernetes/gateway/client.go
+++ b/pkg/provider/kubernetes/gateway/client.go
@@ -16,7 +16,6 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	ktypes "k8s.io/apimachinery/pkg/types"
 	kinformers "k8s.io/client-go/informers"
 	kclientset "k8s.io/client-go/kubernetes"
@@ -163,7 +162,11 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 		if err != nil {
 			return nil, err
 		}
-		_, err = factoryKube.Discovery().V1().EndpointSlices().Informer().AddEventHandler(eventHandler)
+		endpointSlicesInformer := factoryKube.Discovery().V1().EndpointSlices().Informer()
+		if err = endpointSlicesInformer.AddIndexers(k8s.EndpointSliceServiceNameIndexers); err != nil {
+			return nil, fmt.Errorf("adding endpointslice service-name indexer: %w", err)
+		}
+		_, err = endpointSlicesInformer.AddEventHandler(eventHandler)
 		if err != nil {
 			return nil, err
 		}
@@ -372,14 +375,22 @@ func (c *clientWrapper) ListEndpointSlicesForService(namespace, serviceName stri
 		return nil, fmt.Errorf("failed to get endpointslices for service %s/%s: namespace is not within watched namespaces", namespace, serviceName)
 	}
 
-	serviceLabelRequirement, err := labels.NewRequirement(discoveryv1.LabelServiceName, selection.Equals, []string{serviceName})
+	items, err := c.factoriesKube[c.lookupNamespace(namespace)].
+		Discovery().V1().EndpointSlices().Informer().
+		GetIndexer().ByIndex(k8s.EndpointSliceServiceNameIndex, k8s.EndpointSliceServiceNameIndexKey(namespace, serviceName))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create service label selector requirement: %w", err)
+		return nil, fmt.Errorf("failed to get endpointslices for service %s/%s: %w", namespace, serviceName, err)
 	}
-	serviceSelector := labels.NewSelector()
-	serviceSelector = serviceSelector.Add(*serviceLabelRequirement)
 
-	return c.factoriesKube[c.lookupNamespace(namespace)].Discovery().V1().EndpointSlices().Lister().EndpointSlices(namespace).List(serviceSelector)
+	result := make([]*discoveryv1.EndpointSlice, 0, len(items))
+	for _, item := range items {
+		es, ok := item.(*discoveryv1.EndpointSlice)
+		if !ok {
+			continue
+		}
+		result = append(result, es)
+	}
+	return result, nil
 }
 
 // ListBackendTLSPoliciesForService returns the BackendTLSPolicy for the given service name in the given namespace.

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -13,10 +13,10 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/mitchellh/hashstructure"
 	"github.com/rs/zerolog/log"
 	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
+	"github.com/traefik/traefik/v3/pkg/config/dynamic/confighash"
 	"github.com/traefik/traefik/v3/pkg/job"
 	"github.com/traefik/traefik/v3/pkg/observability/logs"
 	traefikv1alpha1 "github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/traefikio/v1alpha1"
@@ -217,13 +217,10 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 					// But if we do in the future, we'll need to track more information about the dropped events.
 					conf := p.loadConfigurationFromGateways(ctxLog)
 
-					confHash, err := hashstructure.Hash(conf, nil)
-					switch {
-					case err != nil:
-						logger.Error().Msg("Unable to hash the configuration")
-					case p.lastConfiguration.Get() == confHash:
+					confHash := confighash.Hash(conf)
+					if p.lastConfiguration.Get() == confHash {
 						logger.Debug().Msgf("Skipping Kubernetes event kind %T", event)
-					default:
+					} else {
 						p.lastConfiguration.Set(confHash)
 						configurationChan <- dynamic.Message{
 							ProviderName:  ProviderName,

--- a/pkg/provider/kubernetes/ingress-nginx/client.go
+++ b/pkg/provider/kubernetes/ingress-nginx/client.go
@@ -20,7 +20,6 @@ import (
 	kerror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	kinformers "k8s.io/client-go/informers"
 	kclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -172,7 +171,11 @@ func (c *clientWrapper) WatchAll(ctx context.Context, namespace, namespaceSelect
 		if err != nil {
 			return nil, err
 		}
-		_, err = factoryKube.Discovery().V1().EndpointSlices().Informer().AddEventHandler(eventHandler)
+		endpointSlicesInformer := factoryKube.Discovery().V1().EndpointSlices().Informer()
+		if err = endpointSlicesInformer.AddIndexers(k8s.EndpointSliceServiceNameIndexers); err != nil {
+			return nil, fmt.Errorf("adding endpointslice service-name indexer: %w", err)
+		}
+		_, err = endpointSlicesInformer.AddEventHandler(eventHandler)
 		if err != nil {
 			return nil, err
 		}
@@ -320,14 +323,22 @@ func (c *clientWrapper) GetEndpointSlicesForService(namespace, serviceName strin
 		return nil, fmt.Errorf("failed to get endpointslices for service %s/%s: namespace is not within watched namespaces", namespace, serviceName)
 	}
 
-	serviceLabelRequirement, err := labels.NewRequirement(discoveryv1.LabelServiceName, selection.Equals, []string{serviceName})
+	items, err := c.factoriesKube[c.lookupNamespace(namespace)].
+		Discovery().V1().EndpointSlices().Informer().
+		GetIndexer().ByIndex(k8s.EndpointSliceServiceNameIndex, k8s.EndpointSliceServiceNameIndexKey(namespace, serviceName))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create service label selector requirement: %w", err)
+		return nil, fmt.Errorf("failed to get endpointslices for service %s/%s: %w", namespace, serviceName, err)
 	}
-	serviceSelector := labels.NewSelector()
-	serviceSelector = serviceSelector.Add(*serviceLabelRequirement)
 
-	return c.factoriesKube[c.lookupNamespace(namespace)].Discovery().V1().EndpointSlices().Lister().EndpointSlices(namespace).List(serviceSelector)
+	result := make([]*discoveryv1.EndpointSlice, 0, len(items))
+	for _, item := range items {
+		es, ok := item.(*discoveryv1.EndpointSlice)
+		if !ok {
+			continue
+		}
+		result = append(result, es)
+	}
+	return result, nil
 }
 
 // GetConfigMap returns the named configMap from the given namespace.

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
@@ -10,10 +10,10 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/mitchellh/hashstructure"
 	"github.com/rs/zerolog/log"
 	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
+	"github.com/traefik/traefik/v3/pkg/config/dynamic/confighash"
 	"github.com/traefik/traefik/v3/pkg/job"
 	"github.com/traefik/traefik/v3/pkg/observability/logs"
 	"github.com/traefik/traefik/v3/pkg/safe"
@@ -221,13 +221,10 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 					// track more information about the dropped events.
 					conf := p.loadConfiguration(ctxLog)
 
-					confHash, err := hashstructure.Hash(conf, nil)
-					switch {
-					case err != nil:
-						logger.Error().Msg("Unable to hash the configuration")
-					case p.lastConfiguration.Get() == confHash:
+					confHash := confighash.Hash(conf)
+					if p.lastConfiguration.Get() == confHash {
 						logger.Debug().Msgf("Skipping Kubernetes event kind %T", event)
-					default:
+					} else {
 						p.lastConfiguration.Set(confHash)
 						configurationChan <- dynamic.Message{
 							ProviderName:  ProviderName,

--- a/pkg/provider/kubernetes/ingress/client.go
+++ b/pkg/provider/kubernetes/ingress/client.go
@@ -20,7 +20,6 @@ import (
 	kerror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	kinformers "k8s.io/client-go/informers"
 	kclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -172,7 +171,11 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 		if err != nil {
 			return nil, err
 		}
-		_, err = factoryKube.Discovery().V1().EndpointSlices().Informer().AddEventHandler(eventHandler)
+		endpointSlicesInformer := factoryKube.Discovery().V1().EndpointSlices().Informer()
+		if err = endpointSlicesInformer.AddIndexers(k8s.EndpointSliceServiceNameIndexers); err != nil {
+			return nil, fmt.Errorf("adding endpointslice service-name indexer: %w", err)
+		}
+		_, err = endpointSlicesInformer.AddEventHandler(eventHandler)
 		if err != nil {
 			return nil, err
 		}
@@ -327,14 +330,22 @@ func (c *clientWrapper) GetEndpointSlicesForService(namespace, serviceName strin
 		return nil, fmt.Errorf("failed to get endpointslices for service %s/%s: namespace is not within watched namespaces", namespace, serviceName)
 	}
 
-	serviceLabelRequirement, err := labels.NewRequirement(discoveryv1.LabelServiceName, selection.Equals, []string{serviceName})
+	items, err := c.factoriesKube[c.lookupNamespace(namespace)].
+		Discovery().V1().EndpointSlices().Informer().
+		GetIndexer().ByIndex(k8s.EndpointSliceServiceNameIndex, k8s.EndpointSliceServiceNameIndexKey(namespace, serviceName))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create service label selector requirement: %w", err)
+		return nil, fmt.Errorf("failed to get endpointslices for service %s/%s: %w", namespace, serviceName, err)
 	}
-	serviceSelector := labels.NewSelector()
-	serviceSelector = serviceSelector.Add(*serviceLabelRequirement)
 
-	return c.factoriesKube[c.lookupNamespace(namespace)].Discovery().V1().EndpointSlices().Lister().EndpointSlices(namespace).List(serviceSelector)
+	result := make([]*discoveryv1.EndpointSlice, 0, len(items))
+	for _, item := range items {
+		es, ok := item.(*discoveryv1.EndpointSlice)
+		if !ok {
+			continue
+		}
+		result = append(result, es)
+	}
+	return result, nil
 }
 
 // GetSecret returns the named secret from the given namespace.

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -15,10 +15,10 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/mitchellh/hashstructure"
 	"github.com/rs/zerolog/log"
 	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
+	"github.com/traefik/traefik/v3/pkg/config/dynamic/confighash"
 	"github.com/traefik/traefik/v3/pkg/job"
 	"github.com/traefik/traefik/v3/pkg/observability/logs"
 	"github.com/traefik/traefik/v3/pkg/provider"
@@ -129,13 +129,10 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 					// track more information about the dropped events.
 					conf := p.loadConfigurationFromIngresses(ctxLog, k8sClient)
 
-					confHash, err := hashstructure.Hash(conf, nil)
-					switch {
-					case err != nil:
-						logger.Error().Msg("Unable to hash the configuration")
-					case p.lastConfiguration.Get() == confHash:
+					confHash := confighash.Hash(conf)
+					if p.lastConfiguration.Get() == confHash {
 						logger.Debug().Msgf("Skipping Kubernetes event kind %T", event)
-					default:
+					} else {
 						p.lastConfiguration.Set(confHash)
 						configurationChan <- dynamic.Message{
 							ProviderName:  ProviderName,

--- a/pkg/provider/kubernetes/k8s/event_handler.go
+++ b/pkg/provider/kubernetes/k8s/event_handler.go
@@ -1,8 +1,10 @@
 package k8s
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 // ResourceEventHandler handles Add, Update or Delete Events for resources.
@@ -47,17 +49,28 @@ func objChanged(oldObj, newObj any) bool {
 		return false
 	}
 
-	if _, ok := oldObj.(*discoveryv1.EndpointSlice); ok {
-		return endpointSliceChanged(oldObj.(*discoveryv1.EndpointSlice), newObj.(*discoveryv1.EndpointSlice))
+	switch old := oldObj.(type) {
+	case *discoveryv1.EndpointSlice:
+		return endpointSliceChanged(old, newObj.(*discoveryv1.EndpointSlice))
+	case *corev1.Node:
+		return nodeChanged(old, newObj.(*corev1.Node))
 	}
 
 	return true
 }
 
-// In some Kubernetes versions leader election is done by updating an endpoint annotation every second,
-// if there are no changes to the endpoints addresses, ports, and there are no addresses defined for an endpoint
-// the event can safely be ignored and won't cause unnecessary config reloads.
-// TODO: check if Kubernetes is still using EndpointSlice for leader election, which seems to not be the case anymore.
+// endpointSliceChanged reports whether two EndpointSlices differ in fields that
+// Traefik consumes: ports, endpoint addresses, and per-endpoint readiness
+// conditions. Metadata-only updates (ResourceVersion bumps, label/annotation
+// churn, managedFields edits) are intentionally ignored to avoid spurious
+// configuration rebuilds.
+//
+// Conditions.Ready is consumed by the TCP/UDP/Gateway providers, while
+// Conditions.Serving and Conditions.Terminating are consumed by the HTTP
+// provider (server filtering and the Fenced behaviour); all three are compared
+// with nil / true / false treated as distinct values, since a nil value
+// defaults to "true" per the Kubernetes API spec but a downgrade to false is
+// load-bearing.
 func endpointSliceChanged(a, b *discoveryv1.EndpointSlice) bool {
 	if len(a.Ports) != len(b.Ports) {
 		return true
@@ -65,10 +78,10 @@ func endpointSliceChanged(a, b *discoveryv1.EndpointSlice) bool {
 
 	for i, aport := range a.Ports {
 		bport := b.Ports[i]
-		if aport.Name != bport.Name {
+		if !ptr.Equal(aport.Name, bport.Name) {
 			return true
 		}
-		if aport.Port != bport.Port {
+		if !ptr.Equal(aport.Port, bport.Port) {
 			return true
 		}
 	}
@@ -99,5 +112,58 @@ func endpointChanged(a, b discoveryv1.Endpoint) bool {
 		}
 	}
 
+	if !ptr.Equal(a.Conditions.Ready, b.Conditions.Ready) {
+		return true
+	}
+	if !ptr.Equal(a.Conditions.Serving, b.Conditions.Serving) {
+		return true
+	}
+	if !ptr.Equal(a.Conditions.Terminating, b.Conditions.Terminating) {
+		return true
+	}
+
 	return false
+}
+
+// nodeChanged reports whether two Node objects differ in any field Traefik
+// reads. Traefik only consumes Status.Addresses entries of type InternalIP and
+// ExternalIP (for NodePort load-balancer servers and IngressLoadBalancer
+// status), so kubelet status heartbeats (~10s) that rewrite conditions,
+// capacity, images, allocatable etc. without touching those addresses must not
+// drive a full configuration rebuild.
+//
+// Comparison is allocation-free: Nodes typically report 2-3 relevant
+// addresses, so an O(N*M) pairwise walk beats building two maps per call and
+// avoids the per-heartbeat GC churn that the map approach incurred under
+// kubelet's ~10s status cadence.
+func nodeChanged(a, b *corev1.Node) bool {
+	if relevantNodeAddressCount(a) != relevantNodeAddressCount(b) {
+		return true
+	}
+	for _, aa := range a.Status.Addresses {
+		if aa.Type != corev1.NodeInternalIP && aa.Type != corev1.NodeExternalIP {
+			continue
+		}
+		found := false
+		for _, ba := range b.Status.Addresses {
+			if ba.Type == aa.Type && ba.Address == aa.Address {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return true
+		}
+	}
+	return false
+}
+
+func relevantNodeAddressCount(n *corev1.Node) int {
+	c := 0
+	for _, addr := range n.Status.Addresses {
+		if addr.Type == corev1.NodeInternalIP || addr.Type == corev1.NodeExternalIP {
+			c++
+		}
+	}
+	return c
 }

--- a/pkg/provider/kubernetes/k8s/event_handler_test.go
+++ b/pkg/provider/kubernetes/k8s/event_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -223,6 +224,325 @@ func Test_detectChanges(t *testing.T) {
 			t.Parallel()
 
 			assert.Equal(t, test.want, objChanged(test.oldObj, test.newObj))
+		})
+	}
+}
+
+func Test_endpointSliceChanged_conditions(t *testing.T) {
+	bTrue := true
+	bFalse := false
+
+	makeSlice := func(ready, serving, terminating *bool) *discoveryv1.EndpointSlice {
+		return &discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"},
+			Endpoints: []discoveryv1.Endpoint{{
+				Addresses: []string{"10.0.0.1"},
+				Conditions: discoveryv1.EndpointConditions{
+					Ready:       ready,
+					Serving:     serving,
+					Terminating: terminating,
+				},
+			}},
+		}
+	}
+
+	tests := []struct {
+		name string
+		a    *discoveryv1.EndpointSlice
+		b    *discoveryv1.EndpointSlice
+		want bool
+	}{
+		{
+			name: "Identical conditions (all nil)",
+			a:    makeSlice(nil, nil, nil),
+			b:    makeSlice(nil, nil, nil),
+			want: false,
+		},
+		{
+			name: "Identical conditions (all true)",
+			a:    makeSlice(&bTrue, &bTrue, &bFalse),
+			b:    makeSlice(&bTrue, &bTrue, &bFalse),
+			want: false,
+		},
+		{
+			name: "Ready transitions nil -> true",
+			a:    makeSlice(nil, &bTrue, &bFalse),
+			b:    makeSlice(&bTrue, &bTrue, &bFalse),
+			want: true,
+		},
+		{
+			name: "Ready transitions true -> false",
+			a:    makeSlice(&bTrue, &bTrue, &bFalse),
+			b:    makeSlice(&bFalse, &bTrue, &bFalse),
+			want: true,
+		},
+		{
+			name: "Serving transitions true -> false",
+			a:    makeSlice(&bTrue, &bTrue, &bFalse),
+			b:    makeSlice(&bTrue, &bFalse, &bFalse),
+			want: true,
+		},
+		{
+			name: "Terminating transitions false -> true",
+			a:    makeSlice(&bTrue, &bTrue, &bFalse),
+			b:    makeSlice(&bTrue, &bTrue, &bTrue),
+			want: true,
+		},
+		{
+			name: "Terminating transitions nil -> false (distinct)",
+			a:    makeSlice(&bTrue, &bTrue, nil),
+			b:    makeSlice(&bTrue, &bTrue, &bFalse),
+			want: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.want, endpointSliceChanged(test.a, test.b))
+		})
+	}
+}
+
+func Test_endpointSliceChanged_ports(t *testing.T) {
+	port80 := int32(80)
+	port80bis := int32(80)
+	port8080 := int32(8080)
+	nameA := "http"
+	nameAbis := "http"
+	nameB := "metrics"
+
+	makeSlice := func(ports []discoveryv1.EndpointPort) *discoveryv1.EndpointSlice {
+		return &discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"},
+			Ports:      ports,
+		}
+	}
+
+	tests := []struct {
+		name string
+		a    *discoveryv1.EndpointSlice
+		b    *discoveryv1.EndpointSlice
+		want bool
+	}{
+		{
+			name: "Identical port values but distinct pointers",
+			a:    makeSlice([]discoveryv1.EndpointPort{{Name: &nameA, Port: &port80}}),
+			b:    makeSlice([]discoveryv1.EndpointPort{{Name: &nameAbis, Port: &port80bis}}),
+			want: false,
+		},
+		{
+			name: "Different port number",
+			a:    makeSlice([]discoveryv1.EndpointPort{{Name: &nameA, Port: &port80}}),
+			b:    makeSlice([]discoveryv1.EndpointPort{{Name: &nameA, Port: &port8080}}),
+			want: true,
+		},
+		{
+			name: "Different port name",
+			a:    makeSlice([]discoveryv1.EndpointPort{{Name: &nameA, Port: &port80}}),
+			b:    makeSlice([]discoveryv1.EndpointPort{{Name: &nameB, Port: &port80}}),
+			want: true,
+		},
+		{
+			name: "Port name nil vs set",
+			a:    makeSlice([]discoveryv1.EndpointPort{{Port: &port80}}),
+			b:    makeSlice([]discoveryv1.EndpointPort{{Name: &nameA, Port: &port80}}),
+			want: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.want, endpointSliceChanged(test.a, test.b))
+		})
+	}
+}
+
+func Test_nodeChanged(t *testing.T) {
+	mkNode := func(addrs ...corev1.NodeAddress) *corev1.Node {
+		return &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1", Name: "n"},
+			Status: corev1.NodeStatus{
+				Addresses: addrs,
+			},
+		}
+	}
+
+	tests := []struct {
+		name string
+		a    *corev1.Node
+		b    *corev1.Node
+		want bool
+	}{
+		{
+			name: "Identical InternalIP",
+			a:    mkNode(corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}),
+			b:    mkNode(corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}),
+			want: false,
+		},
+		{
+			name: "Heartbeat-only change (hostname order, capacity, etc.)",
+			a: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{
+						{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+						{Type: corev1.NodeHostName, Address: "old-host"},
+					},
+					Capacity: corev1.ResourceList{},
+				},
+			},
+			b: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{
+						{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+						{Type: corev1.NodeHostName, Address: "new-host"},
+					},
+					Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "InternalIP changed",
+			a:    mkNode(corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}),
+			b:    mkNode(corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.2"}),
+			want: true,
+		},
+		{
+			name: "InternalIP added",
+			a:    mkNode(corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}),
+			b: mkNode(
+				corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+				corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.2"},
+			),
+			want: true,
+		},
+		{
+			name: "ExternalIP added",
+			a:    mkNode(corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}),
+			b: mkNode(
+				corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+				corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: "203.0.113.1"},
+			),
+			want: true,
+		},
+		{
+			name: "ExternalIP value changed",
+			a: mkNode(
+				corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+				corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: "203.0.113.1"},
+			),
+			b: mkNode(
+				corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+				corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: "203.0.113.2"},
+			),
+			want: true,
+		},
+		{
+			name: "Same addresses but reordered",
+			a: mkNode(
+				corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+				corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: "203.0.113.1"},
+			),
+			b: mkNode(
+				corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: "203.0.113.1"},
+				corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+			),
+			want: false,
+		},
+		{
+			name: "Hostname-only change (irrelevant address type)",
+			a: mkNode(
+				corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+				corev1.NodeAddress{Type: corev1.NodeHostName, Address: "old-host"},
+			),
+			b: mkNode(
+				corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+				corev1.NodeAddress{Type: corev1.NodeHostName, Address: "new-host"},
+			),
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.want, nodeChanged(test.a, test.b))
+		})
+	}
+}
+
+func Test_objChanged_dispatchesNode(t *testing.T) {
+	a := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}},
+		},
+	}
+	b := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"}, // heartbeat bumps RV
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}},
+		},
+	}
+	// Same Internal/ExternalIPs even though RV changed - must not fire.
+	assert.False(t, objChanged(a, b))
+}
+
+func Test_endpointSliceServiceNameIndexFunc(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  any
+		want []string
+	}{
+		{
+			name: "EndpointSlice with service-name label",
+			obj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "es-1",
+					Labels: map[string]string{
+						discoveryv1.LabelServiceName: "svc",
+					},
+				},
+			},
+			want: []string{"ns/svc"},
+		},
+		{
+			name: "EndpointSlice missing service-name label",
+			obj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "es-1"},
+			},
+		},
+		{
+			name: "EndpointSlice with empty service-name label",
+			obj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "es-1",
+					Labels:    map[string]string{discoveryv1.LabelServiceName: ""},
+				},
+			},
+		},
+		{
+			name: "Non-EndpointSlice object",
+			obj:  &corev1.Node{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := endpointSliceServiceNameIndexFunc(test.obj)
+			assert.NoError(t, err)
+			assert.Equal(t, test.want, got)
 		})
 	}
 }

--- a/pkg/provider/kubernetes/k8s/indexers.go
+++ b/pkg/provider/kubernetes/k8s/indexers.go
@@ -1,0 +1,37 @@
+package k8s
+
+import (
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// EndpointSliceServiceNameIndex is the name of the informer indexer that maps
+// EndpointSlices to their owning Service via the kubernetes.io/service-name
+// label. The index key has the form "namespace/serviceName".
+const EndpointSliceServiceNameIndex = "EndpointSliceServiceName"
+
+// EndpointSliceServiceNameIndexers is the cache.Indexers value to register on
+// a Discovery/V1/EndpointSlices SharedIndexInformer so that callers can look
+// up slices for a given Service in O(1) instead of doing a namespace-wide
+// label-selector scan.
+var EndpointSliceServiceNameIndexers = cache.Indexers{
+	EndpointSliceServiceNameIndex: endpointSliceServiceNameIndexFunc,
+}
+
+func endpointSliceServiceNameIndexFunc(obj any) ([]string, error) {
+	es, ok := obj.(*discoveryv1.EndpointSlice)
+	if !ok {
+		return nil, nil
+	}
+	svc, ok := es.Labels[discoveryv1.LabelServiceName]
+	if !ok || svc == "" {
+		return nil, nil
+	}
+	return []string{es.Namespace + "/" + svc}, nil
+}
+
+// EndpointSliceServiceNameIndexKey builds the index key used by
+// EndpointSliceServiceNameIndex for a given namespace/serviceName pair.
+func EndpointSliceServiceNameIndexKey(namespace, serviceName string) string {
+	return namespace + "/" + serviceName
+}

--- a/pkg/provider/kubernetes/knative/kubernetes.go
+++ b/pkg/provider/kubernetes/knative/kubernetes.go
@@ -13,10 +13,10 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/mitchellh/hashstructure"
 	"github.com/rs/zerolog/log"
 	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
+	"github.com/traefik/traefik/v3/pkg/config/dynamic/confighash"
 	"github.com/traefik/traefik/v3/pkg/job"
 	"github.com/traefik/traefik/v3/pkg/observability/logs"
 	"github.com/traefik/traefik/v3/pkg/safe"
@@ -109,13 +109,10 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 					// But if we do in the future, we'll need to track more information about the dropped events.
 					conf, ingressStatuses := p.loadConfiguration(ctxLog)
 
-					confHash, err := hashstructure.Hash(conf, nil)
-					switch {
-					case err != nil:
-						logger.Error().Msg("Unable to hash the configuration")
-					case p.lastConfiguration.Get() == confHash:
+					confHash := confighash.Hash(conf)
+					if p.lastConfiguration.Get() == confHash {
 						logger.Debug().Msgf("Skipping Kubernetes event kind %T", event)
-					default:
+					} else {
 						p.lastConfiguration.Set(confHash)
 						configurationChan <- dynamic.Message{
 							ProviderName:  ProviderName,

--- a/pkg/provider/nomad/nomad.go
+++ b/pkg/provider/nomad/nomad.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/nomad/api"
-	"github.com/mitchellh/hashstructure"
 	"github.com/rs/zerolog/log"
 	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
+	"github.com/traefik/traefik/v3/pkg/config/dynamic/confighash"
 	"github.com/traefik/traefik/v3/pkg/job"
 	"github.com/traefik/traefik/v3/pkg/observability/logs"
 	"github.com/traefik/traefik/v3/pkg/provider"
@@ -207,9 +207,7 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 			if err != nil {
 				return fmt.Errorf("loading configuration: %w", err)
 			}
-			if _, err := p.updateLastConfiguration(conf); err != nil {
-				return fmt.Errorf("updating last configuration: %w", err)
-			}
+			p.updateLastConfiguration(conf)
 
 			configurationChan <- dynamic.Message{
 				ProviderName:  p.name,
@@ -225,11 +223,7 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 					if err != nil {
 						return fmt.Errorf("loading configuration: %w", err)
 					}
-					updated, err := p.updateLastConfiguration(conf)
-					if err != nil {
-						return fmt.Errorf("updating last configuration: %w", err)
-					}
-					if !updated {
+					if !p.updateLastConfiguration(conf) {
 						logger.Debug().Msgf("Skipping Nomad event %d with no changes", event.Index)
 						continue
 					}
@@ -320,18 +314,13 @@ func (p *Provider) loadConfiguration(ctx context.Context) (*dynamic.Configuratio
 	return p.buildConfig(ctx, items), nil
 }
 
-func (p *Provider) updateLastConfiguration(conf *dynamic.Configuration) (bool, error) {
-	confHash, err := hashstructure.Hash(conf, nil)
-	if err != nil {
-		return false, fmt.Errorf("hashing the configuration: %w", err)
-	}
-
+func (p *Provider) updateLastConfiguration(conf *dynamic.Configuration) bool {
+	confHash := confighash.Hash(conf)
 	if p.lastConfiguration.Get() == confHash {
-		return false, nil
+		return false
 	}
-
 	p.lastConfiguration.Set(confHash)
-	return true, nil
+	return true
 }
 
 func (p *Provider) getNomadServiceData(ctx context.Context) ([]item, error) {


### PR DESCRIPTION
## Summary

Fixes the Kubernetes provider CPU regression reported in https://github.com/traefik/traefik/issues/13011 by reducing unnecessary config rebuild churn and hot-path cost during informer updates.

## What changed

- Added a fast internal configuration hashing implementation in `pkg/config/dynamic/confighash` and switched Kubernetes providers, collector, and nomad provider hashing call sites to it.
- Added EndpointSlice service-name index support in `pkg/provider/kubernetes/k8s/indexers.go` and integrated it in provider clients to avoid repeated selector scans.
- Improved Kubernetes event filtering in `pkg/provider/kubernetes/k8s/event_handler.go`:
  - Added `nodeChanged()` to ignore non-load-bearing Node updates.
  - Expanded EndpointSlice change detection to only react to data relevant for routing/service resolution.
- Added/extended tests for hash determinism/safety and event change detection behavior.

## Benchmark evidence

Source files:
[summary-churn.txt](https://github.com/user-attachments/files/28390790/summary-churn.txt)
[summary-no-churn.txt](https://github.com/user-attachments/files/28390746/summary-no-churn.txt)

Benchmark files: https://github.com/jaygridley/traefik/tree/bench-issue-13011/bench/issue-13011

### Churn scenario (node + EndpointSlice churn)

- Mean CPU: `209.6 mCPU` -> `119.6 mCPU` (**-43%**)
- P95 CPU: `431 mCPU` -> `246 mCPU`
- Max CPU: `477 mCPU` -> `268 mCPU`

### No-churn scenario

- Mean CPU: `1.5 mCPU` -> `1.4 mCPU` (**-7%**)

## Testing

```
go test ./pkg/config/dynamic/confighash ./pkg/provider/kubernetes/... ./pkg/provider/nomad ./pkg/collector           
ok      github.com/traefik/traefik/v3/pkg/config/dynamic/confighash     0.606s
ok      github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd       5.496s
?       github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/generated/applyconfiguration  [no test files]
?       github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/generated/applyconfiguration/internal [no test files]
?       github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/generated/applyconfiguration/traefikio/v1alpha1       [no test files]
?       github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/generated/clientset/versioned [no test files]
?       github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/generated/clientset/versioned/fake    [no test files]
?       github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/generated/clientset/versioned/scheme  [no test files]
?       github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/generated/clientset/versioned/typed/traefikio/v1alpha1        [no test files]
?       github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/generated/clientset/versioned/typed/traefikio/v1alpha1/fake   [no test files]
?       github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/generated/informers/externalversions  [no test files]
?       github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/generated/informers/externalversions/internalinterfaces       [no test files]
?       github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/generated/informers/externalversions/traefikio        [no test files]
?       github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/generated/informers/externalversions/traefikio/v1alpha1       [no test files]
?       github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/generated/listers/traefikio/v1alpha1  [no test files]
?       github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/traefikio/v1alpha1    [no test files]
ok      github.com/traefik/traefik/v3/pkg/provider/kubernetes/gateway   3.492s
ok      github.com/traefik/traefik/v3/pkg/provider/kubernetes/ingress   3.289s
ok      github.com/traefik/traefik/v3/pkg/provider/kubernetes/ingress-nginx     6.312s
ok      github.com/traefik/traefik/v3/pkg/provider/kubernetes/k8s       0.979s
ok      github.com/traefik/traefik/v3/pkg/provider/kubernetes/knative   2.977s
ok      github.com/traefik/traefik/v3/pkg/provider/nomad        3.295s
ok      github.com/traefik/traefik/v3/pkg/collector     1.313s
```