### PR TITLE
Fix race condition in tests accessing global variables in parallel

### DIFF
--- a/pkg/middlewares/observability/semconv_test.go
+++ b/pkg/middlewares/observability/semconv_test.go
@@ -52,8 +52,6 @@ func TestSemConvServerMetrics(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			t.Parallel()
-
 			var cfg otypes.OTLP
 			(&cfg).SetDefaults()
 			cfg.AddRoutersLabels = true

--- a/pkg/proxy/httputil/observability_test.go
+++ b/pkg/proxy/httputil/observability_test.go
@@ -57,8 +57,6 @@ func TestObservabilityRoundTripper_metrics(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			t.Parallel()
-
 			var cfg otypes.OTLP
 			(&cfg).SetDefaults()
 			cfg.AddRoutersLabels = true


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes two similar race conditions in tests. Two of the tests are each running two cases in parallel which are both accessing the same global variable. Removing the Parallel setting fixes the tests.

The tests are quick enough, that making this change does not cause a noticeable slowdown in testing.

### Motivation

I've noticed that there are two tests in the test suite for Traefik that randomly fails when the tests are running on a machine with high load.

I looked into it, and figured out what the issue is, and I thought it would be nice to fix it.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Here is how I reproduced and tested the issue:

Before the fix, running the same test over and over should cause it to fail eventually:
```
λ ~ > go test -run ^TestSemConvServerMetrics$ github.com/traefik/traefik/v3/pkg/middlewares/observability -count=10000 -failfast
--- FAIL: TestSemConvServerMetrics (0.00s)
    --- FAIL: TestSemConvServerMetrics/not_found_status (0.00s)
        semconv_test.go:97: 
                Error Trace:    /home/marcsello/work/traefik/pkg/middlewares/observability/semconv_test.go:97
                Error:          "[]" should have 1 item(s), but has 0
                Test:           TestSemConvServerMetrics/not_found_status
FAIL
FAIL    github.com/traefik/traefik/v3/pkg/middlewares/observability     0.026s
FAIL

λ ~ > go test -run ^TestObservabilityRoundTripper_metrics$ github.com/traefik/traefik/v3/pkg/proxy/httputil -count=10000 -failfast
--- FAIL: TestObservabilityRoundTripper_metrics (0.00s)
    --- FAIL: TestObservabilityRoundTripper_metrics/not_found_status (0.00s)
        observability_test.go:94: 
                Error Trace:    /home/marcsello/work/traefik/pkg/proxy/httputil/observability_test.go:94
                Error:          "[]" should have 1 item(s), but has 0
                Test:           TestObservabilityRoundTripper_metrics/not_found_status
FAIL
FAIL    github.com/traefik/traefik/v3/pkg/proxy/httputil        0.048s
FAIL

```

After the fix, the same tests no longer fail:

```
λ ~ > go test -run ^TestObservabilityRoundTripper_metrics$ github.com/traefik/traefik/v3/pkg/proxy/httputil -count=10000 -failfast
ok      github.com/traefik/traefik/v3/pkg/proxy/httputil        1.078s
λ ~ > go test -run ^TestSemConvServerMetrics$ github.com/traefik/traefik/v3/pkg/middlewares/observability -count=10000 -failfast  
ok      github.com/traefik/traefik/v3/pkg/middlewares/observability     1.082s
```

---

I opened this PR against the master branch, because while it's a bug fix, it is not tied to any specific release, this issue has been present for at least two years seemingly.