### PR TITLE
Clear Ssl-Client-* headers when no client certificate is present

### DIFF
--- a/pkg/middlewares/ingressnginx/authtlspasscertificatetoupstream/auth_tls_pass_certificate_to_upstream.go
+++ b/pkg/middlewares/ingressnginx/authtlspasscertificatetoupstream/auth_tls_pass_certificate_to_upstream.go
@@ -65,6 +65,10 @@ func (p *authTLSPassCertificateToUpstream) ServeHTTP(rw http.ResponseWriter, req
 	if req.TLS == nil || len(req.TLS.PeerCertificates) == 0 {
 		logger.Debug().Msg("Tried to extract a certificate on a request without mutual TLS")
 		req.Header.Set(sslClientVerify, "NONE")
+		// Prevent client-supplied values from reaching the upstream on the no-mTLS path.
+		req.Header.Del(sslClientCert)
+		req.Header.Del(sslClientSubjectDN)
+		req.Header.Del(sslClientIssuerDN)
 		p.next.ServeHTTP(rw, req)
 		return
 	}

--- a/pkg/middlewares/ingressnginx/authtlspasscertificatetoupstream/auth_tls_pass_certificate_to_upstream_test.go
+++ b/pkg/middlewares/ingressnginx/authtlspasscertificatetoupstream/auth_tls_pass_certificate_to_upstream_test.go
@@ -360,6 +360,26 @@ func TestAuthTLSPassCertificateToUpstream(t *testing.T) {
 	}
 }
 
+func TestAuthTLSNoMTLSClearsCertHeaders(t *testing.T) {
+	config := dynamic.AuthTLSPassCertificateToUpstream{
+		ClientAuthType: tls.VerifyClientCertIfGiven,
+	}
+	handler, err := NewAuthTLSPassCertificateToUpstream(t.Context(), next, config, "test")
+	require.NoError(t, err)
+
+	req := testhelpers.MustNewRequest(http.MethodGet, "http://example.com/foo", nil)
+	req.Header.Set(sslClientCert, "client-cert")
+	req.Header.Set(sslClientSubjectDN, "CN=client")
+	req.Header.Set(sslClientIssuerDN, "CN=client-CA")
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.Equal(t, "NONE", req.Header.Get(sslClientVerify))
+	assert.Empty(t, req.Header.Get(sslClientCert))
+	assert.Empty(t, req.Header.Get(sslClientSubjectDN))
+	assert.Empty(t, req.Header.Get(sslClientIssuerDN))
+}
+
 func buildTLSWith(certContents []string) *cryptoTLS.ConnectionState {
 	var peerCertificates []*x509.Certificate
 


### PR DESCRIPTION
### What does this PR do?

As a hardening improvement, this PR clears `Ssl-Client-Cert`, `Ssl-Client-Subject-Dn`, and `Ssl-Client-Issuer-Dn` headers on `AuthTLSPassCertificateToUpstream` middleware for ingress-nginx provider when no client certificate is provided, mirroring the behaviour of the mTLS branch which already overwrites all four headers from the verified peer certificate.

### Motivation

Ensures client-supplied values for those headers never reach the upstream when no certificate is present.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation
