### PR TITLE
kubernetes ingress: cache parsed router annotations

### DIFF
--- a/pkg/provider/kubernetes/ingress/annotations.go
+++ b/pkg/provider/kubernetes/ingress/annotations.go
@@ -2,6 +2,7 @@ package ingress
 
 import (
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
@@ -29,6 +30,33 @@ type RouterIng struct {
 	RuleSyntax    string                             `json:"ruleSyntax,omitempty"`
 	TLS           *dynamic.RouterTLSConfig           `json:"tls,omitempty" label:"allowEmpty"`
 	Observability *dynamic.RouterObservabilityConfig `json:"observability,omitempty" label:"allowEmpty"`
+}
+
+func (r *RouterConfig) DeepCopy() *RouterConfig {
+	if r == nil {
+		return nil
+	}
+
+	out := new(RouterConfig)
+	if r.Router != nil {
+		out.Router = r.Router.DeepCopy()
+	}
+
+	return out
+}
+
+func (r *RouterIng) DeepCopy() *RouterIng {
+	if r == nil {
+		return nil
+	}
+
+	out := *r
+	out.EntryPoints = slices.Clone(r.EntryPoints)
+	out.Middlewares = slices.Clone(r.Middlewares)
+	out.TLS = r.TLS.DeepCopy()
+	out.Observability = r.Observability.DeepCopy()
+
+	return &out
 }
 
 // SetDefaults sets the default values.

--- a/pkg/provider/kubernetes/ingress/annotations_test.go
+++ b/pkg/provider/kubernetes/ingress/annotations_test.go
@@ -103,6 +103,38 @@ func Test_parseRouterConfig(t *testing.T) {
 	}
 }
 
+func TestRouterConfigDeepCopy(t *testing.T) {
+	cfg := &RouterConfig{
+		Router: &RouterIng{
+			EntryPoints: []string{"web"},
+			Middlewares: []string{"auth"},
+			TLS: &dynamic.RouterTLSConfig{
+				Options: "default",
+				Domains: []types.Domain{
+					{Main: "example.com", SANs: []string{"www.example.com"}},
+				},
+			},
+			Observability: &dynamic.RouterObservabilityConfig{
+				AccessLogs: pointer(true),
+			},
+		},
+	}
+
+	got := cfg.DeepCopy()
+
+	got.Router.EntryPoints[0] = "websecure"
+	got.Router.Middlewares[0] = "ratelimit"
+	got.Router.TLS.Options = "custom"
+	got.Router.TLS.Domains[0].SANs[0] = "api.example.com"
+	*got.Router.Observability.AccessLogs = false
+
+	assert.Equal(t, []string{"web"}, cfg.Router.EntryPoints)
+	assert.Equal(t, []string{"auth"}, cfg.Router.Middlewares)
+	assert.Equal(t, "default", cfg.Router.TLS.Options)
+	assert.Equal(t, []string{"www.example.com"}, cfg.Router.TLS.Domains[0].SANs)
+	assert.True(t, *cfg.Router.Observability.AccessLogs)
+}
+
 func Test_parseServiceConfig(t *testing.T) {
 	testCases := []struct {
 		desc        string

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -62,8 +62,14 @@ type Provider struct {
 	DefaultRuleSyntax string `json:"-" toml:"-" yaml:"-" label:"-" file:"-"`
 
 	lastConfiguration safe.Safe
+	routerConfigCache map[string]routerConfigCacheEntry
 
 	routerTransform k8s.RouterTransform
+}
+
+type routerConfigCacheEntry struct {
+	config *RouterConfig
+	err    error
 }
 
 func (p *Provider) SetRouterTransform(routerTransform k8s.RouterTransform) {
@@ -245,6 +251,7 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 	}
 
 	ingresses := client.GetIngresses()
+	seenRouterConfigKeys := make(map[string]struct{}, len(ingresses))
 
 	certConfigs := make(map[string]*tls.CertAndStores)
 	for _, ingress := range ingresses {
@@ -259,7 +266,7 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 			logger.Error().Err(err).Msg("Error while updating ingress status")
 		}
 
-		rtConfig, err := parseRouterConfig(ingress.Annotations)
+		rtConfig, err := p.getRouterConfig(ingress, seenRouterConfigKeys)
 		if err != nil {
 			logger.Error().Err(err).Msg("Failed to parse annotations")
 			continue
@@ -439,7 +446,46 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 		}
 	}
 
+	p.pruneRouterConfigCache(seenRouterConfigKeys)
+
 	return conf
+}
+
+func (p *Provider) getRouterConfig(ingress *netv1.Ingress, seen map[string]struct{}) (*RouterConfig, error) {
+	key := routerConfigCacheKey(ingress)
+	if key == "" {
+		return parseRouterConfig(ingress.Annotations)
+	}
+
+	seen[key] = struct{}{}
+
+	if entry, ok := p.routerConfigCache[key]; ok {
+		return entry.config.DeepCopy(), entry.err
+	}
+
+	config, err := parseRouterConfig(ingress.Annotations)
+	if p.routerConfigCache == nil {
+		p.routerConfigCache = map[string]routerConfigCacheEntry{}
+	}
+
+	p.routerConfigCache[key] = routerConfigCacheEntry{config: config.DeepCopy(), err: err}
+	return config, err
+}
+
+func (p *Provider) pruneRouterConfigCache(seen map[string]struct{}) {
+	for key := range p.routerConfigCache {
+		if _, ok := seen[key]; !ok {
+			delete(p.routerConfigCache, key)
+		}
+	}
+}
+
+func routerConfigCacheKey(ingress *netv1.Ingress) string {
+	if ingress.ResourceVersion == "" {
+		return ""
+	}
+
+	return ingress.Namespace + "/" + ingress.Name + "/" + ingress.ResourceVersion
 }
 
 func (p *Provider) updateIngressStatus(ing *netv1.Ingress, k8sClient Client) error {

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -33,6 +33,97 @@ var _ provider.Provider = (*Provider)(nil)
 
 func pointer[T any](v T) *T { return &v }
 
+func TestGetRouterConfigUsesResourceVersionCache(t *testing.T) {
+	p := &Provider{}
+	ing := &netv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "testing",
+			Name:            "ingress",
+			ResourceVersion: "1",
+			Annotations: map[string]string{
+				"traefik.ingress.kubernetes.io/router.entrypoints": "web",
+				"traefik.ingress.kubernetes.io/router.tls.options": "default",
+			},
+		},
+	}
+
+	seen := map[string]struct{}{}
+	cfg, err := p.getRouterConfig(ing, seen)
+	require.NoError(t, err)
+
+	cfg.Router.EntryPoints[0] = "websecure"
+	cfg.Router.TLS.Options = "custom"
+
+	cfg, err = p.getRouterConfig(ing, seen)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"web"}, cfg.Router.EntryPoints)
+	assert.Equal(t, "default", cfg.Router.TLS.Options)
+	assert.Len(t, p.routerConfigCache, 1)
+
+	p.pruneRouterConfigCache(map[string]struct{}{})
+
+	assert.Empty(t, p.routerConfigCache)
+}
+
+func TestGetRouterConfigInvalidatesOnResourceVersionChange(t *testing.T) {
+	p := &Provider{}
+	ing := &netv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "testing",
+			Name:            "ingress",
+			ResourceVersion: "1",
+			Annotations: map[string]string{
+				"traefik.ingress.kubernetes.io/router.entrypoints": "web",
+			},
+		},
+	}
+
+	// First rebuild caches the parsed annotations under the resourceVersion key.
+	seen := map[string]struct{}{}
+	cfg, err := p.getRouterConfig(ing, seen)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"web"}, cfg.Router.EntryPoints)
+	p.pruneRouterConfigCache(seen)
+
+	// A spec change bumps the resourceVersion, which must yield a cache miss and re-parse.
+	ing.ResourceVersion = "2"
+	ing.Annotations["traefik.ingress.kubernetes.io/router.entrypoints"] = "websecure"
+
+	seen = map[string]struct{}{}
+	cfg, err = p.getRouterConfig(ing, seen)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"websecure"}, cfg.Router.EntryPoints)
+
+	// The stale entry for resourceVersion "1" is pruned, leaving only the current one.
+	p.pruneRouterConfigCache(seen)
+	assert.Len(t, p.routerConfigCache, 1)
+	_, ok := p.routerConfigCache["testing/ingress/2"]
+	assert.True(t, ok)
+}
+
+func TestGetRouterConfigCachesNilConfig(t *testing.T) {
+	p := &Provider{}
+	ing := &netv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "testing",
+			Name:            "ingress",
+			ResourceVersion: "1",
+		},
+	}
+
+	seen := map[string]struct{}{}
+	cfg, err := p.getRouterConfig(ing, seen)
+	require.NoError(t, err)
+	assert.Nil(t, cfg)
+
+	// The nil result (no router annotations) is cached and the DeepCopy on read stays nil-safe.
+	cfg, err = p.getRouterConfig(ing, seen)
+	require.NoError(t, err)
+	assert.Nil(t, cfg)
+	assert.Len(t, p.routerConfigCache, 1)
+}
+
 func TestLoadConfigurationFromIngresses(t *testing.T) {
 	testCases := []struct {
 		desc                         string


### PR DESCRIPTION
### What does this PR do?

Caches the parsed router-annotation config (`parseRouterConfig`) per Ingress, keyed by `(namespace, name, resourceVersion)`, pruning entries not seen during a rebuild. Cached entries are deep-copied on read so each rebuild gets independent values.

### Motivation

Part of #13011. The pprof in that issue attributes ~19% of rebuild CPU to `ingress.parseRouterConfig` — `paerser`'s reflection-based `label.Decode` runs for every Ingress on every rebuild even when annotations are unchanged. Keying on `resourceVersion` lets unchanged Ingresses skip the decode entirely on subsequent rebuilds.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation <!-- no user-facing configuration surface -->

### Additional Notes

Independent follow-up to a tertiary hotspot in #13011, complementary to #13255. The deep copy on read preserves the pre-cache semantics (each rebuild gets fresh slices/pointers, which are aliased into the emitted dynamic config). Targeting v3.7 (regression present there, labeled `kind/bug`).
