### PR TITLE
kubernetes: deduplicate backend service loads per rebuild

### DIFF
--- a/pkg/provider/kubernetes/ingress-nginx/build.go
+++ b/pkg/provider/kubernetes/ingress-nginx/build.go
@@ -48,6 +48,11 @@ type certBlocks struct {
 	key  []byte
 }
 
+type backendEndpointsCacheEntry struct {
+	endpoints []endpoint
+	err       error
+}
+
 // build reads all Ingress resources visible to the client and produces a model.
 //
 //nolint:funlen // multi-phase ingress processing kept inline for readability
@@ -62,6 +67,7 @@ func (p *Provider) build(ctx context.Context, ingressClasses []*netv1.IngressCla
 	// that needs an option carries a pointer to the cached entry; the translator
 	// registers each unique option once in conf.TLS.Options.
 	tlsOptionCache := make(map[string]*tls.Options)
+	backendEndpointsCache := make(map[string]backendEndpointsCacheEntry)
 
 	allHosts := make(map[string]bool)
 	hostsWithUseRegex := make(map[string]bool)
@@ -73,6 +79,7 @@ func (p *Provider) build(ctx context.Context, ingressClasses []*netv1.IngressCla
 			p.defaultBackendServiceNamespace,
 			netv1.IngressBackend{Service: &netv1.IngressServiceBackend{Name: p.defaultBackendServiceName}},
 			IngressConfig{},
+			backendEndpointsCache,
 		)
 		if err != nil {
 			log.Ctx(ctx).Error().Err(err).Msg("Cannot resolve default backend service")
@@ -208,7 +215,7 @@ func (p *Provider) build(ctx context.Context, ingressClasses []*netv1.IngressCla
 				}
 
 				// The canary backend's addresses are checked using the original ingress config.
-				endpoints, err := p.getBackendEndpoints(canaryIngress.Namespace, pa.Backend, prodIngressPath.config)
+				endpoints, err := p.getBackendEndpointsCached(canaryIngress.Namespace, pa.Backend, prodIngressPath.config, backendEndpointsCache)
 				if err != nil || len(endpoints) == 0 {
 					continue
 				}
@@ -284,7 +291,7 @@ func (p *Provider) build(ctx context.Context, ingressClasses []*netv1.IngressCla
 					continue
 				}
 
-				endpoints, err := p.getBackendEndpoints(ing.Namespace, *ingBackend, ing.config)
+				endpoints, err := p.getBackendEndpointsCached(ing.Namespace, *ingBackend, ing.config, backendEndpointsCache)
 				if err != nil {
 					logger.Error().Err(err).Msgf("Cannot resolve passthrough backend for host %q", rule.Host)
 					continue
@@ -365,7 +372,7 @@ func (p *Provider) build(ctx context.Context, ingressClasses []*netv1.IngressCla
 				// the location is still emitted with an empty backend so the router
 				// (and its middlewares) exist, mirroring ingress-nginx's 503-on-no-servers
 				// behavior.
-				endpoints, err := p.getBackendEndpoints(ing.Namespace, pa.Backend, ing.config)
+				endpoints, err := p.getBackendEndpointsCached(ing.Namespace, pa.Backend, ing.config, backendEndpointsCache)
 				if err != nil {
 					logger.Warn().
 						Str("service", pa.Backend.Service.Name).
@@ -442,9 +449,10 @@ func (p *Provider) build(ctx context.Context, ingressClasses []*netv1.IngressCla
 							// Build the error backend using defaultBackend annotation or provider default.
 							defaultSvcName := ptr.Deref(ing.config.DefaultBackend, "")
 							if defaultSvcName != "" {
-								endpoints, err := p.getBackendEndpoints(ing.Namespace,
+								endpoints, err := p.getBackendEndpointsCached(ing.Namespace,
 									netv1.IngressBackend{Service: &netv1.IngressServiceBackend{Name: defaultSvcName}},
-									ing.config)
+									ing.config,
+									backendEndpointsCache)
 								if err == nil {
 									mc.Backends[errBackendName] = &backend{
 										Name:      errBackendName,
@@ -478,7 +486,7 @@ func (p *Provider) build(ctx context.Context, ingressClasses []*netv1.IngressCla
 		// (default-backend / default-backend-tls routers) so it still serves traffic.
 		if ing.Spec.DefaultBackend != nil && ing.Spec.DefaultBackend.Service != nil {
 			db := ing.Spec.DefaultBackend
-			endpoints, err := p.getBackendEndpoints(ing.Namespace, *db, ing.config)
+			endpoints, err := p.getBackendEndpointsCached(ing.Namespace, *db, ing.config, backendEndpointsCache)
 			if err != nil {
 				logger.Warn().
 					Str("service", db.Service.Name).
@@ -722,8 +730,38 @@ func (p *Provider) getEndpointsFromEndpointSlices(namespace, name, portName stri
 	return endpoints, nil
 }
 
-func (p *Provider) resolveBackend(namespace string, ingBackend netv1.IngressBackend, cfg IngressConfig) (*backend, error) {
-	endpoints, err := p.getBackendEndpoints(namespace, ingBackend, cfg)
+func (p *Provider) getBackendEndpointsCached(namespace string, backend netv1.IngressBackend, cfg IngressConfig, cache map[string]backendEndpointsCacheEntry) ([]endpoint, error) {
+	key := backendEndpointsCacheKey(namespace, backend, cfg)
+	if key == "" {
+		return p.getBackendEndpoints(namespace, backend, cfg)
+	}
+
+	if entry, ok := cache[key]; ok {
+		return slices.Clone(entry.endpoints), entry.err
+	}
+
+	endpoints, err := p.getBackendEndpoints(namespace, backend, cfg)
+	cache[key] = backendEndpointsCacheEntry{endpoints: slices.Clone(endpoints), err: err}
+
+	return endpoints, err
+}
+
+func backendEndpointsCacheKey(namespace string, backend netv1.IngressBackend, cfg IngressConfig) string {
+	if backend.Service == nil {
+		return ""
+	}
+
+	return strings.Join([]string{
+		namespace,
+		backend.Service.Name,
+		portString(backend.Service.Port),
+		strconv.FormatBool(ptr.Deref(cfg.ServiceUpstream, false)),
+		ptr.Deref(cfg.DefaultBackend, ""),
+	}, "/")
+}
+
+func (p *Provider) resolveBackend(namespace string, ingBackend netv1.IngressBackend, cfg IngressConfig, cache map[string]backendEndpointsCacheEntry) (*backend, error) {
+	endpoints, err := p.getBackendEndpointsCached(namespace, ingBackend, cfg, cache)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/kubernetes/ingress-nginx/build_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/build_test.go
@@ -1,0 +1,40 @@
+package ingressnginx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	netv1 "k8s.io/api/networking/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestBackendEndpointsCacheKey(t *testing.T) {
+	backend := netv1.IngressBackend{
+		Service: &netv1.IngressServiceBackend{
+			Name: "whoami",
+			Port: netv1.ServiceBackendPort{Name: "http"},
+		},
+	}
+
+	base := backendEndpointsCacheKey("testing", backend, IngressConfig{})
+
+	// The same service and config must reuse the same cache entry.
+	assert.Equal(t, base, backendEndpointsCacheKey("testing", backend, IngressConfig{}))
+
+	// getBackendEndpoints branches on ServiceUpstream and DefaultBackend, so those must not
+	// collide with the base entry for the same service.
+	assert.NotEqual(t, base, backendEndpointsCacheKey("testing", backend, IngressConfig{ServiceUpstream: ptr.To(true)}))
+	assert.NotEqual(t, base, backendEndpointsCacheKey("testing", backend, IngressConfig{DefaultBackend: ptr.To("fallback")}))
+
+	// A different port of the same service is a distinct backend.
+	otherPort := netv1.IngressBackend{
+		Service: &netv1.IngressServiceBackend{
+			Name: "whoami",
+			Port: netv1.ServiceBackendPort{Name: "https"},
+		},
+	}
+	assert.NotEqual(t, base, backendEndpointsCacheKey("testing", otherPort, IngressConfig{}))
+
+	// A backend without a Service cannot be keyed and must bypass the cache.
+	assert.Empty(t, backendEndpointsCacheKey("testing", netv1.IngressBackend{}, IngressConfig{}))
+}

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -66,6 +66,11 @@ type Provider struct {
 	routerTransform k8s.RouterTransform
 }
 
+type serviceCacheEntry struct {
+	service *dynamic.Service
+	err     error
+}
+
 func (p *Provider) SetRouterTransform(routerTransform k8s.RouterTransform) {
 	p.routerTransform = routerTransform
 }
@@ -245,6 +250,7 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 	}
 
 	ingresses := client.GetIngresses()
+	serviceCache := make(map[string]serviceCacheEntry)
 
 	certConfigs := make(map[string]*tls.CertAndStores)
 	for _, ingress := range ingresses {
@@ -300,7 +306,7 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 				continue
 			}
 
-			service, err := p.loadService(client, ingress.Namespace, *ingress.Spec.DefaultBackend)
+			service, err := p.loadServiceCached(client, ingress.Namespace, *ingress.Spec.DefaultBackend, serviceCache)
 			if err != nil {
 				logger.Error().
 					Str("serviceName", ingress.Spec.DefaultBackend.Service.Name).
@@ -374,7 +380,7 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 					continue
 				}
 
-				service, err := p.loadService(client, ingress.Namespace, pa.Backend)
+				service, err := p.loadServiceCached(client, ingress.Namespace, pa.Backend, serviceCache)
 				if err != nil {
 					logger.Error().
 						Str("serviceName", pa.Backend.Service.Name).
@@ -440,6 +446,30 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 	}
 
 	return conf
+}
+
+func (p *Provider) loadServiceCached(client Client, namespace string, backend netv1.IngressBackend, cache map[string]serviceCacheEntry) (*dynamic.Service, error) {
+	key := serviceCacheKey(namespace, backend)
+	if key == "" {
+		return p.loadService(client, namespace, backend)
+	}
+
+	if entry, ok := cache[key]; ok {
+		return entry.service.DeepCopy(), entry.err
+	}
+
+	service, err := p.loadService(client, namespace, backend)
+	cache[key] = serviceCacheEntry{service: service.DeepCopy(), err: err}
+
+	return service, err
+}
+
+func serviceCacheKey(namespace string, backend netv1.IngressBackend) string {
+	if backend.Service == nil {
+		return ""
+	}
+
+	return namespace + "/" + backend.Service.Name + "/" + portString(backend.Service.Port)
 }
 
 func (p *Provider) updateIngressStatus(ing *netv1.Ingress, k8sClient Client) error {

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -23,15 +23,91 @@ import (
 	"github.com/traefik/traefik/v3/pkg/tls"
 	"github.com/traefik/traefik/v3/pkg/types"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
 )
 
 var _ provider.Provider = (*Provider)(nil)
 
 func pointer[T any](v T) *T { return &v }
+
+func TestLoadServiceCachedDeduplicatesBackendLoads(t *testing.T) {
+	client := &countingClient{
+		clientMock: clientMock{
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "testing", Name: "whoami"},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "http",
+								Port:       80,
+								TargetPort: intstr.FromInt32(8080),
+							},
+						},
+					},
+				},
+			},
+			endpointSlices: []*discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "testing",
+						Labels: map[string]string{
+							discoveryv1.LabelServiceName: "whoami",
+						},
+					},
+					Ports: []discoveryv1.EndpointPort{
+						{Name: ptr.To("http"), Port: ptr.To[int32](8080)},
+					},
+					Endpoints: []discoveryv1.Endpoint{
+						{Addresses: []string{"10.0.0.1"}},
+					},
+				},
+			},
+		},
+	}
+	backend := netv1.IngressBackend{
+		Service: &netv1.IngressServiceBackend{
+			Name: "whoami",
+			Port: netv1.ServiceBackendPort{Name: "http"},
+		},
+	}
+	cache := map[string]serviceCacheEntry{}
+
+	p := &Provider{}
+	service, err := p.loadServiceCached(client, "testing", backend, cache)
+	require.NoError(t, err)
+	service.LoadBalancer.Servers[0].URL = "http://mutated"
+
+	service, err = p.loadServiceCached(client, "testing", backend, cache)
+	require.NoError(t, err)
+
+	assert.Equal(t, "http://10.0.0.1:8080", service.LoadBalancer.Servers[0].URL)
+	assert.Equal(t, 1, client.getServiceCalls)
+	assert.Equal(t, 1, client.getEndpointSlicesCalls)
+}
+
+type countingClient struct {
+	clientMock
+
+	getServiceCalls        int
+	getEndpointSlicesCalls int
+}
+
+func (c *countingClient) GetService(namespace, name string) (*corev1.Service, bool, error) {
+	c.getServiceCalls++
+	return c.clientMock.GetService(namespace, name)
+}
+
+func (c *countingClient) GetEndpointSlicesForService(namespace, serviceName string) ([]*discoveryv1.EndpointSlice, error) {
+	c.getEndpointSlicesCalls++
+	return c.clientMock.GetEndpointSlicesForService(namespace, serviceName)
+}
 
 func TestLoadConfigurationFromIngresses(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
### What does this PR do?

Deduplicates backend service resolution within a single provider rebuild. Many routes reference the same backend; this caches the resolved result keyed on the inputs that determine it (namespace, service name, port — plus `service-upstream`/`default-backend` for ingress-nginx), so the Service lookup, EndpointSlice lookup, annotation parsing, and endpoint iteration run once per unique backend instead of once per route. Applied to the Ingress and ingress-nginx providers.

### Motivation

Part of #13011. The pprof shows `loadService`/`loadServers` (and the equivalent `getBackendEndpoints` in ingress-nginx) called per path rather than per unique Service, repeating identical work across routes that share a backend. A per-rebuild cache collapses these.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation <!-- no user-facing configuration surface -->

### Additional Notes

Independent follow-up to a tertiary hotspot in #13011, complementary to #13255. The cache lives for a single rebuild (created fresh each time) and returns cloned/deep-copied values so callers can't corrupt it. This touches two providers with the same optimization — happy to split into two PRs if maintainers prefer. Targeting v3.7.
