### PR TITLE
kubernetes: index EndpointSlices by service name

### DIFF
--- a/pkg/provider/kubernetes/crd/client.go
+++ b/pkg/provider/kubernetes/crd/client.go
@@ -21,7 +21,6 @@ import (
 	kerror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	kinformers "k8s.io/client-go/informers"
 	kclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -224,7 +223,11 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 		if err != nil {
 			return nil, err
 		}
-		_, err = factoryKube.Discovery().V1().EndpointSlices().Informer().AddEventHandler(eventHandler)
+		endpointSliceInformer := factoryKube.Discovery().V1().EndpointSlices().Informer()
+		if err = endpointSliceInformer.AddIndexers(k8s.EndpointSliceServiceNameIndexers); err != nil {
+			return nil, err
+		}
+		_, err = endpointSliceInformer.AddEventHandler(eventHandler)
 		if err != nil {
 			return nil, err
 		}
@@ -462,14 +465,11 @@ func (c *clientWrapper) GetEndpointSlicesForService(namespace, serviceName strin
 		return nil, fmt.Errorf("failed to get endpointslices for service %s/%s: namespace is not within watched namespaces", namespace, serviceName)
 	}
 
-	serviceLabelRequirement, err := labels.NewRequirement(discoveryv1.LabelServiceName, selection.Equals, []string{serviceName})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create service label selector requirement: %w", err)
-	}
-	serviceSelector := labels.NewSelector()
-	serviceSelector = serviceSelector.Add(*serviceLabelRequirement)
-
-	return c.factoriesKube[c.lookupNamespace(namespace)].Discovery().V1().EndpointSlices().Lister().EndpointSlices(namespace).List(serviceSelector)
+	return k8s.EndpointSlicesByServiceName(
+		c.factoriesKube[c.lookupNamespace(namespace)].Discovery().V1().EndpointSlices().Informer().GetIndexer(),
+		namespace,
+		serviceName,
+	)
 }
 
 // GetSecret returns the named secret from the given namespace.

--- a/pkg/provider/kubernetes/gateway/client.go
+++ b/pkg/provider/kubernetes/gateway/client.go
@@ -16,7 +16,6 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	ktypes "k8s.io/apimachinery/pkg/types"
 	kinformers "k8s.io/client-go/informers"
 	kclientset "k8s.io/client-go/kubernetes"
@@ -166,7 +165,11 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 		if err != nil {
 			return nil, err
 		}
-		_, err = factoryKube.Discovery().V1().EndpointSlices().Informer().AddEventHandler(eventHandler)
+		endpointSliceInformer := factoryKube.Discovery().V1().EndpointSlices().Informer()
+		if err = endpointSliceInformer.AddIndexers(k8s.EndpointSliceServiceNameIndexers); err != nil {
+			return nil, err
+		}
+		_, err = endpointSliceInformer.AddEventHandler(eventHandler)
 		if err != nil {
 			return nil, err
 		}
@@ -375,14 +378,11 @@ func (c *clientWrapper) ListEndpointSlicesForService(namespace, serviceName stri
 		return nil, fmt.Errorf("failed to get endpointslices for service %s/%s: namespace is not within watched namespaces", namespace, serviceName)
 	}
 
-	serviceLabelRequirement, err := labels.NewRequirement(discoveryv1.LabelServiceName, selection.Equals, []string{serviceName})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create service label selector requirement: %w", err)
-	}
-	serviceSelector := labels.NewSelector()
-	serviceSelector = serviceSelector.Add(*serviceLabelRequirement)
-
-	return c.factoriesKube[c.lookupNamespace(namespace)].Discovery().V1().EndpointSlices().Lister().EndpointSlices(namespace).List(serviceSelector)
+	return k8s.EndpointSlicesByServiceName(
+		c.factoriesKube[c.lookupNamespace(namespace)].Discovery().V1().EndpointSlices().Informer().GetIndexer(),
+		namespace,
+		serviceName,
+	)
 }
 
 // ListBackendTLSPoliciesForService returns the BackendTLSPolicy for the given service name in the given namespace.

--- a/pkg/provider/kubernetes/ingress-nginx/client.go
+++ b/pkg/provider/kubernetes/ingress-nginx/client.go
@@ -20,7 +20,6 @@ import (
 	kerror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	kinformers "k8s.io/client-go/informers"
 	kclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -172,7 +171,11 @@ func (c *clientWrapper) WatchAll(ctx context.Context, namespace, namespaceSelect
 		if err != nil {
 			return nil, err
 		}
-		_, err = factoryKube.Discovery().V1().EndpointSlices().Informer().AddEventHandler(eventHandler)
+		endpointSliceInformer := factoryKube.Discovery().V1().EndpointSlices().Informer()
+		if err = endpointSliceInformer.AddIndexers(k8s.EndpointSliceServiceNameIndexers); err != nil {
+			return nil, err
+		}
+		_, err = endpointSliceInformer.AddEventHandler(eventHandler)
 		if err != nil {
 			return nil, err
 		}
@@ -320,14 +323,11 @@ func (c *clientWrapper) GetEndpointSlicesForService(namespace, serviceName strin
 		return nil, fmt.Errorf("failed to get endpointslices for service %s/%s: namespace is not within watched namespaces", namespace, serviceName)
 	}
 
-	serviceLabelRequirement, err := labels.NewRequirement(discoveryv1.LabelServiceName, selection.Equals, []string{serviceName})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create service label selector requirement: %w", err)
-	}
-	serviceSelector := labels.NewSelector()
-	serviceSelector = serviceSelector.Add(*serviceLabelRequirement)
-
-	return c.factoriesKube[c.lookupNamespace(namespace)].Discovery().V1().EndpointSlices().Lister().EndpointSlices(namespace).List(serviceSelector)
+	return k8s.EndpointSlicesByServiceName(
+		c.factoriesKube[c.lookupNamespace(namespace)].Discovery().V1().EndpointSlices().Informer().GetIndexer(),
+		namespace,
+		serviceName,
+	)
 }
 
 // GetConfigMap returns the named configMap from the given namespace.

--- a/pkg/provider/kubernetes/ingress/client.go
+++ b/pkg/provider/kubernetes/ingress/client.go
@@ -20,7 +20,6 @@ import (
 	kerror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	kinformers "k8s.io/client-go/informers"
 	kclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -172,7 +171,11 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 		if err != nil {
 			return nil, err
 		}
-		_, err = factoryKube.Discovery().V1().EndpointSlices().Informer().AddEventHandler(eventHandler)
+		endpointSliceInformer := factoryKube.Discovery().V1().EndpointSlices().Informer()
+		if err = endpointSliceInformer.AddIndexers(k8s.EndpointSliceServiceNameIndexers); err != nil {
+			return nil, err
+		}
+		_, err = endpointSliceInformer.AddEventHandler(eventHandler)
 		if err != nil {
 			return nil, err
 		}
@@ -327,14 +330,11 @@ func (c *clientWrapper) GetEndpointSlicesForService(namespace, serviceName strin
 		return nil, fmt.Errorf("failed to get endpointslices for service %s/%s: namespace is not within watched namespaces", namespace, serviceName)
 	}
 
-	serviceLabelRequirement, err := labels.NewRequirement(discoveryv1.LabelServiceName, selection.Equals, []string{serviceName})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create service label selector requirement: %w", err)
-	}
-	serviceSelector := labels.NewSelector()
-	serviceSelector = serviceSelector.Add(*serviceLabelRequirement)
-
-	return c.factoriesKube[c.lookupNamespace(namespace)].Discovery().V1().EndpointSlices().Lister().EndpointSlices(namespace).List(serviceSelector)
+	return k8s.EndpointSlicesByServiceName(
+		c.factoriesKube[c.lookupNamespace(namespace)].Discovery().V1().EndpointSlices().Informer().GetIndexer(),
+		namespace,
+		serviceName,
+	)
 }
 
 // GetSecret returns the named secret from the given namespace.

--- a/pkg/provider/kubernetes/k8s/endpointslice_indexer.go
+++ b/pkg/provider/kubernetes/k8s/endpointslice_indexer.go
@@ -1,0 +1,51 @@
+package k8s
+
+import (
+	"fmt"
+
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+const EndpointSliceServiceNameIndex = "endpointSliceServiceName"
+
+var EndpointSliceServiceNameIndexers = cache.Indexers{
+	EndpointSliceServiceNameIndex: endpointSliceServiceNameIndexFunc,
+}
+
+func EndpointSlicesByServiceName(indexer cache.Indexer, namespace, serviceName string) ([]*discoveryv1.EndpointSlice, error) {
+	objects, err := indexer.ByIndex(EndpointSliceServiceNameIndex, endpointSliceServiceNameIndexKey(namespace, serviceName))
+	if err != nil {
+		return nil, fmt.Errorf("listing endpoint slices by service name index: %w", err)
+	}
+
+	endpointSlices := make([]*discoveryv1.EndpointSlice, 0, len(objects))
+	for _, object := range objects {
+		endpointSlice, ok := object.(*discoveryv1.EndpointSlice)
+		if !ok {
+			return nil, fmt.Errorf("unexpected endpoint slice object type %T", object)
+		}
+
+		endpointSlices = append(endpointSlices, endpointSlice)
+	}
+
+	return endpointSlices, nil
+}
+
+func endpointSliceServiceNameIndexFunc(obj any) ([]string, error) {
+	endpointSlice, ok := obj.(*discoveryv1.EndpointSlice)
+	if !ok {
+		return nil, fmt.Errorf("unexpected endpoint slice object type %T", obj)
+	}
+
+	serviceName := endpointSlice.Labels[discoveryv1.LabelServiceName]
+	if serviceName == "" {
+		return nil, nil
+	}
+
+	return []string{endpointSliceServiceNameIndexKey(endpointSlice.Namespace, serviceName)}, nil
+}
+
+func endpointSliceServiceNameIndexKey(namespace, serviceName string) string {
+	return namespace + "/" + serviceName
+}

--- a/pkg/provider/kubernetes/k8s/endpointslice_indexer_test.go
+++ b/pkg/provider/kubernetes/k8s/endpointslice_indexer_test.go
@@ -1,0 +1,66 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestEndpointSlicesByServiceName(t *testing.T) {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, EndpointSliceServiceNameIndexers)
+
+	matching := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "matching",
+			Namespace: "default",
+			Labels: map[string]string{
+				discoveryv1.LabelServiceName: "app",
+			},
+		},
+	}
+	require.NoError(t, indexer.Add(matching))
+
+	// A service routinely has more than one EndpointSlice, so the lookup must return all of them.
+	matchingSecond := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "matching-second",
+			Namespace: "default",
+			Labels: map[string]string{
+				discoveryv1.LabelServiceName: "app",
+			},
+		},
+	}
+	require.NoError(t, indexer.Add(matchingSecond))
+
+	require.NoError(t, indexer.Add(&discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "other-service",
+			Namespace: "default",
+			Labels: map[string]string{
+				discoveryv1.LabelServiceName: "other",
+			},
+		},
+	}))
+
+	require.NoError(t, indexer.Add(&discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "other-namespace",
+			Namespace: "other",
+			Labels: map[string]string{
+				discoveryv1.LabelServiceName: "app",
+			},
+		},
+	}))
+
+	endpointSlices, err := EndpointSlicesByServiceName(indexer, "default", "app")
+	require.NoError(t, err)
+	// ByIndex returns objects in map-iteration order, so the result is not ordered.
+	require.ElementsMatch(t, []*discoveryv1.EndpointSlice{matching, matchingSecond}, endpointSlices)
+
+	unknown, err := EndpointSlicesByServiceName(indexer, "default", "unknown")
+	require.NoError(t, err)
+	require.Empty(t, unknown)
+}


### PR DESCRIPTION
### What does this PR do?

Adds an informer indexer on `discoveryv1.LabelServiceName` and replaces the per-call `EndpointSlices(ns).List(serviceSelector)` label-selector scan with an indexed `GetIndexer().ByIndex(...)` lookup, across the ingress, crd, gateway, and ingress-nginx providers.

### Motivation

The primary root-cause fix for #13011: the EndpointSlice migration in v3.1 (`a8a92eb2a`) replaced an O(1) Endpoints lookup with an O(N) scan of every EndpointSlice in the namespace on every `loadService` call, which dominates CPU during reconfig bursts.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation <!-- no user-facing configuration surface -->

### Additional Notes

Heads-up: this overlaps #13255, which implements the same indexer. We're mainly opening it so there's a concrete diff to compare — ours benchmarks a little lighter in our runs, but we're entirely happy to defer to #13255, fold our version in, or close this, whichever is least work for review. Targeting v3.7 (regression present there).
