### PR TITLE
kubernetes: detect EndpointSlice condition changes

### DIFF
--- a/pkg/provider/kubernetes/k8s/event_handler.go
+++ b/pkg/provider/kubernetes/k8s/event_handler.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 // ResourceEventHandler handles Add, Update or Delete Events for resources.
@@ -97,6 +98,15 @@ func endpointChanged(a, b discoveryv1.Endpoint) bool {
 		if aaddr != baddr {
 			return true
 		}
+	}
+
+	// A nil condition has a defined meaning that consumers resolve with the same defaults
+	// (Ready and Serving default to true, Terminating to false), so comparison must use those
+	// defaults to avoid reporting a nil-to-default transition as a change.
+	if ptr.Deref(a.Conditions.Ready, true) != ptr.Deref(b.Conditions.Ready, true) ||
+		ptr.Deref(a.Conditions.Serving, true) != ptr.Deref(b.Conditions.Serving, true) ||
+		ptr.Deref(a.Conditions.Terminating, false) != ptr.Deref(b.Conditions.Terminating, false) {
+		return true
 	}
 
 	return false

--- a/pkg/provider/kubernetes/k8s/event_handler_test.go
+++ b/pkg/provider/kubernetes/k8s/event_handler_test.go
@@ -12,6 +12,8 @@ import (
 func Test_detectChanges(t *testing.T) {
 	portA := int32(80)
 	portB := int32(8080)
+	trueValue := true
+	falseValue := false
 	tests := []struct {
 		name   string
 		oldObj any
@@ -177,6 +179,154 @@ func Test_detectChanges(t *testing.T) {
 				},
 				Endpoints: []discoveryv1.Endpoint{{
 					Addresses: []string{"10.10.10.11"},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "With different endpoint ready condition",
+			oldObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses:  []string{"10.10.10.10"},
+					Conditions: discoveryv1.EndpointConditions{Ready: &trueValue},
+				}},
+			},
+			newObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "2",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses:  []string{"10.10.10.10"},
+					Conditions: discoveryv1.EndpointConditions{Ready: &falseValue},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "With different endpoint serving condition",
+			oldObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses:  []string{"10.10.10.10"},
+					Conditions: discoveryv1.EndpointConditions{Serving: &trueValue},
+				}},
+			},
+			newObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "2",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses:  []string{"10.10.10.10"},
+					Conditions: discoveryv1.EndpointConditions{Serving: &falseValue},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "With different endpoint terminating condition",
+			oldObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses:  []string{"10.10.10.10"},
+					Conditions: discoveryv1.EndpointConditions{Terminating: &falseValue},
+				}},
+			},
+			newObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "2",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses:  []string{"10.10.10.10"},
+					Conditions: discoveryv1.EndpointConditions{Terminating: &trueValue},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "With endpoint serving condition nil then explicitly true",
+			oldObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses: []string{"10.10.10.10"},
+				}},
+			},
+			newObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "2",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses:  []string{"10.10.10.10"},
+					Conditions: discoveryv1.EndpointConditions{Serving: &trueValue},
+				}},
+			},
+		},
+		{
+			name: "With endpoint serving condition nil then explicitly false",
+			oldObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses: []string{"10.10.10.10"},
+				}},
+			},
+			newObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "2",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses:  []string{"10.10.10.10"},
+					Conditions: discoveryv1.EndpointConditions{Serving: &falseValue},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "With endpoint terminating condition nil then explicitly false",
+			oldObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses: []string{"10.10.10.10"},
+				}},
+			},
+			newObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "2",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses:  []string{"10.10.10.10"},
+					Conditions: discoveryv1.EndpointConditions{Terminating: &falseValue},
+				}},
+			},
+		},
+		{
+			name: "With endpoint terminating condition nil then explicitly true",
+			oldObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses: []string{"10.10.10.10"},
+				}},
+			},
+			newObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "2",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses:  []string{"10.10.10.10"},
+					Conditions: discoveryv1.EndpointConditions{Terminating: &trueValue},
 				}},
 			},
 			want: true,


### PR DESCRIPTION
### What does this PR do?

Adds content-aware change detection for EndpointSlice update events, so a rebuild only fires when fields Traefik consumes change (ports, endpoint addresses, and the Ready/Serving/Terminating tri-state) — ignoring updates that only bump metadata/resourceVersion.

### Motivation

Part of #13011. Without this, any EndpointSlice update (annotation ticks from co-resident controllers, condition transitions with no address change) triggers a full O(Ingresses × paths) rebuild. The condition comparison treats nil/true/false as distinct, because Serving/Terminating drive server filtering + `Fenced` and Ready drives TCP/UDP/Gateway — dropping a condition-only transition would be a correctness bug.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation <!-- no user-facing configuration surface -->

### Additional Notes

Overlaps #13255, which also expands EndpointSlice change detection. Opening for comparison; happy to defer to #13255, fold in, or close — whichever you prefer. Targeting v3.7.
