### PR TITLE
kubernetes: ignore Node updates that do not affect addresses

### DIFF
--- a/pkg/provider/kubernetes/k8s/event_handler.go
+++ b/pkg/provider/kubernetes/k8s/event_handler.go
@@ -1,6 +1,9 @@
 package k8s
 
 import (
+	"maps"
+
+	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -50,6 +53,9 @@ func objChanged(oldObj, newObj any) bool {
 	if _, ok := oldObj.(*discoveryv1.EndpointSlice); ok {
 		return endpointSliceChanged(oldObj.(*discoveryv1.EndpointSlice), newObj.(*discoveryv1.EndpointSlice))
 	}
+	if _, ok := oldObj.(*corev1.Node); ok {
+		return nodeChanged(oldObj.(*corev1.Node), newObj.(*corev1.Node))
+	}
 
 	return true
 }
@@ -85,6 +91,23 @@ func endpointSliceChanged(a, b *discoveryv1.EndpointSlice) bool {
 	}
 
 	return false
+}
+
+func nodeChanged(a, b *corev1.Node) bool {
+	return !maps.Equal(nodeAddressSet(a.Status.Addresses), nodeAddressSet(b.Status.Addresses))
+}
+
+func nodeAddressSet(addresses []corev1.NodeAddress) map[corev1.NodeAddress]struct{} {
+	result := make(map[corev1.NodeAddress]struct{})
+	for _, address := range addresses {
+		if address.Type != corev1.NodeInternalIP && address.Type != corev1.NodeExternalIP {
+			continue
+		}
+
+		result[address] = struct{}{}
+	}
+
+	return result
 }
 
 func endpointChanged(a, b discoveryv1.Endpoint) bool {

--- a/pkg/provider/kubernetes/k8s/event_handler_test.go
+++ b/pkg/provider/kubernetes/k8s/event_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -216,6 +217,60 @@ func Test_detectChanges(t *testing.T) {
 				}},
 			},
 			want: true,
+		},
+		{
+			name: "Node with heartbeat-only status update",
+			oldObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+					Addresses:  []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}},
+				},
+			},
+			newObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionFalse}},
+					Addresses:  []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}},
+				},
+			},
+		},
+		{
+			name: "Node with different internal IP",
+			oldObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}},
+				},
+			},
+			newObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.2"}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Node with different hostname only",
+			oldObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{
+						{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+						{Type: corev1.NodeHostName, Address: "node-a"},
+					},
+				},
+			},
+			newObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{
+						{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+						{Type: corev1.NodeHostName, Address: "node-b"},
+					},
+				},
+			},
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
### What does this PR do?

Adds `nodeChanged()` so Node updates only trigger a rebuild when the set of `InternalIP`/`ExternalIP` addresses changes, ignoring the ~10s kubelet status heartbeat (conditions/images/capacity/allocatable) that Traefik never reads.

### Motivation

Part of #13011. With cluster-scope resources enabled (default, needed for NodePortLB), kubelet rewrites `Node.Status` on a heartbeat; each rewrite currently triggers a full rebuild even though Traefik only reads `Node.Status.Addresses` of type `InternalIP`/`ExternalIP`.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation <!-- no user-facing configuration surface -->

### Additional Notes

Overlaps #13255, which also adds `nodeChanged`. Opening for comparison; fully open to deferring to #13255, folding in, or closing. Targeting v3.7.
