### PR TITLE
Fix redis write timeout option configuration

### DIFF
--- a/pkg/middlewares/ratelimiter/redis_limiter.go
+++ b/pkg/middlewares/ratelimiter/redis_limiter.go
@@ -49,7 +49,7 @@ func newRedisLimiter(ctx context.Context, rate rate.Limit, burst int64, maxDelay
 	}
 
 	if config.Redis.WriteTimeout != nil {
-		if *config.Redis.ReadTimeout > 0 {
+		if *config.Redis.WriteTimeout > 0 {
 			options.WriteTimeout = time.Duration(*config.Redis.WriteTimeout)
 		} else {
 			options.WriteTimeout = -1


### PR DESCRIPTION
### What does this PR do?

Fixes a copy-paste bug in Redis rate limiter configuration where the 
WriteTimeout condition incorrectly checks `*config.Redis.ReadTimeout` 
instead of `*config.Redis.WriteTimeout`.

When `ReadTimeout` is set to `0` (disabled) and `WriteTimeout` is set to 
a positive value (e.g. `5s`), the configured WriteTimeout is silently 
ignored and set to `-1` (disabled).

### Motivation

Found while reading the code. The ReadTimeout block directly above uses 
the correct variable, indicating this is a copy-paste error.

