### PR TITLE
Bugfix/13287 fix ingress nginx endpointslice fencing

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,37 +1,16 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772963539,
-        "narHash": "sha256-9jVDGZnvCckTGdYT53d/EfznygLskyLQXYwJLKMPsZs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "9dcb002ca1690658be4a04645215baea8b95f31d",
-        "type": "github"
+        "lastModified": 1778036283,
+        "narHash": "sha256-GW2cEd/cLcVbbCes8iQuoY2qGIeCA7UiaD351hpkXfI=",
+        "rev": "ed67bc86e84e51d4a88e73c7fd36006dc876476f",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre993032.ed67bc86e84e/nixexprs.tar.xz"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz"
       }
     },
     "nixpkgs-golangci": {
@@ -68,25 +47,9 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "nixpkgs-golangci": "nixpkgs-golangci",
         "nixpkgs-kct": "nixpkgs-kct"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     # Main nixpkgs (used for gnused)
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
 
     # Pinned nixpkgs for kubernetes-controller-tools
     # Search: https://www.nixhub.io/packages/kubernetes-controller-tools
@@ -12,33 +12,34 @@
     # Pinned nixpkgs for golangci-lint
     # Search: https://www.nixhub.io/packages/golangci-lint
     nixpkgs-golangci.url = "github:NixOS/nixpkgs/80d901ec0377e19ac3f7bb8c035201e2e098cc97";
-
-    flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, nixpkgs-kct, nixpkgs-golangci, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs {
-          inherit system;
-        };
+  outputs =
+    {
+      nixpkgs,
+      nixpkgs-kct,
+      nixpkgs-golangci,
+      ...
+    }:
+    let
+      inherit (nixpkgs.lib) genAttrs;
+      forEachSystem = genAttrs nixpkgs.lib.systems.flakeExposed;
 
-        pkgs-kct = import nixpkgs-kct {
-          inherit system;
-        };
-
-        pkgs-golangci = import nixpkgs-golangci {
-          inherit system;
-        };
-      in
-      {
-        devShells.default = pkgs.mkShell {
+      pkgsForEach = nixpkgs.legacyPackages;
+      pkgsKctForEach = nixpkgs-kct.legacyPackages;
+      pkgsGolangCiForEach = nixpkgs-golangci.legacyPackages;
+    in
+    {
+      devShells = forEachSystem (system: {
+        default = pkgsForEach.${system}.mkShell {
           packages = [
-            pkgs-kct.kubernetes-controller-tools
-            pkgs.gnused
-            pkgs-golangci.golangci-lint
+            pkgsForEach.${system}.gnused
+            pkgsKctForEach.${system}.kubernetes-controller-tools
+            pkgsGolangCiForEach.${system}.golangci-lint
           ];
         };
-      }
-    );
+      });
+
+      formatter = forEachSystem (system: pkgsForEach.${system}.nixfmt);
+    };
 }

--- a/pkg/provider/kubernetes/ingress-nginx/translator.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator.go
@@ -294,7 +294,8 @@ func buildService(backend *backend, serversTransportName string) *dynamic.Servic
 	svc := &dynamic.Service{LoadBalancer: lb}
 	for _, ep := range backend.Endpoints {
 		svc.LoadBalancer.Servers = append(svc.LoadBalancer.Servers, dynamic.Server{
-			URL: fmt.Sprintf("http://%s", ep.Address),
+			URL:    fmt.Sprintf("http://%s", ep.Address),
+			Fenced: ep.Fenced,
 		})
 	}
 
@@ -320,7 +321,8 @@ func buildServiceWithLocConfig(backend *backend, serversTransportName string, lo
 	svc := &dynamic.Service{LoadBalancer: lb}
 	for _, ep := range backend.Endpoints {
 		svc.LoadBalancer.Servers = append(svc.LoadBalancer.Servers, dynamic.Server{
-			URL: fmt.Sprintf("%s://%s", scheme, ep.Address),
+			URL:    fmt.Sprintf("%s://%s", scheme, ep.Address),
+			Fenced: ep.Fenced,
 		})
 	}
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Fixes when endpointslice is updated, marking an endpoint as `ready: false` and `terminating: true`, Traefik's ingress-nginx provider marks the server as fenced and stops sending new traffic to it.


### Motivation

We want our pods to be able to gracefully terminate, and to do so, they should stop receiving new requests and be able to handle existing requests, until done and then stop. Right now, they get traffic when they are in Terminating state, until they are fully stopped, which sometimes results in requests being sent to a pod which is already stopped, resulting in HTTP timeouts towards the client.


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Fixes #13287 
