### PR TITLE
Fix: Return error if specified configuration file is not found

### DIFF
--- a/pkg/cli/loader_file.go
+++ b/pkg/cli/loader_file.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -74,6 +75,9 @@ func loadConfigFiles(configFile string, element any) (string, error) {
 	}
 
 	if len(filePath) == 0 {
+		if configFile != "" {
+			return "", fmt.Errorf("configuration file not found: %s", configFile)
+		}
 		return "", nil
 	}
 


### PR DESCRIPTION
### Description

When starting Traefik with the `--configfile` option, it previously failed silently and loaded the default configuration if the specified file was missing. This PR ensures that Traefik returns an error when an explicitly specified configuration file is not found, providing better feedback to the user.

Fixes #13045