### PR TITLE
Fix nginx.ingress.kubernetes.io/app-root annotation not preserving query parameters

### DIFF
--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -4635,14 +4635,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-app-root-rule-0-path-0-app-root": {
 							RedirectRegex: &dynamic.RedirectRegex{
-								Regex:       `^(https?://[^/]+)/(\?.*)?$`,
-								Replacement: "$1/foo",
+								Regex:       `^(https?://[^/?]+)/?(\?.*)?$`,
+								Replacement: "$1/foo$2",
 							},
 						},
 						"default-ingress-with-app-root-rule-0-path-0-tls-app-root": {
 							RedirectRegex: &dynamic.RedirectRegex{
-								Regex:       `^(https?://[^/]+)/(\?.*)?$`,
-								Replacement: "$1/foo",
+								Regex:       `^(https?://[^/?]+)/?(\?.*)?$`,
+								Replacement: "$1/foo$2",
 							},
 						},
 						"default-ingress-with-app-root-rule-0-path-0-retry": {
@@ -13480,26 +13480,26 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-canary-middlewares-rule-0-path-0-app-root": {
 							RedirectRegex: &dynamic.RedirectRegex{
-								Regex:       `^(https?://[^/]+)/(\?.*)?$`,
-								Replacement: "$1/foo",
+								Regex:       `^(https?://[^/?]+)/?(\?.*)?$`,
+								Replacement: "$1/foo$2",
 							},
 						},
 						"default-ingress-with-canary-middlewares-rule-0-path-0-tls-app-root": {
 							RedirectRegex: &dynamic.RedirectRegex{
-								Regex:       `^(https?://[^/]+)/(\?.*)?$`,
-								Replacement: "$1/foo",
+								Regex:       `^(https?://[^/?]+)/?(\?.*)?$`,
+								Replacement: "$1/foo$2",
 							},
 						},
 						"default-ingress-with-canary-middlewares-rule-0-path-0-canary-app-root": {
 							RedirectRegex: &dynamic.RedirectRegex{
-								Regex:       `^(https?://[^/]+)/(\?.*)?$`,
-								Replacement: "$1/foo",
+								Regex:       `^(https?://[^/?]+)/?(\?.*)?$`,
+								Replacement: "$1/foo$2",
 							},
 						},
 						"default-ingress-with-canary-middlewares-rule-0-path-0-canary-tls-app-root": {
 							RedirectRegex: &dynamic.RedirectRegex{
-								Regex:       `^(https?://[^/]+)/(\?.*)?$`,
-								Replacement: "$1/foo",
+								Regex:       `^(https?://[^/?]+)/?(\?.*)?$`,
+								Replacement: "$1/foo$2",
 							},
 						},
 						"default-ingress-with-canary-middlewares-rule-0-path-0-retry": {
@@ -13804,8 +13804,8 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-canary-middlewares-and-tls-rule-0-path-0-tls-app-root": {
 							RedirectRegex: &dynamic.RedirectRegex{
-								Regex:       `^(https?://[^/]+)/(\?.*)?$`,
-								Replacement: "$1/foo",
+								Regex:       `^(https?://[^/?]+)/?(\?.*)?$`,
+								Replacement: "$1/foo$2",
 							},
 						},
 						"default-ingress-with-canary-middlewares-and-tls-rule-0-path-0-tls-retry": {
@@ -13821,8 +13821,8 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-canary-middlewares-and-tls-rule-0-path-0-canary-tls-app-root": {
 							RedirectRegex: &dynamic.RedirectRegex{
-								Regex:       `^(https?://[^/]+)/(\?.*)?$`,
-								Replacement: "$1/foo",
+								Regex:       `^(https?://[^/?]+)/?(\?.*)?$`,
+								Replacement: "$1/foo$2",
 							},
 						},
 						"default-ingress-with-canary-middlewares-and-tls-rule-0-path-0-canary-tls-retry": {

--- a/pkg/provider/kubernetes/ingress-nginx/translator.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator.go
@@ -440,8 +440,8 @@ func (p *Provider) applyMiddlewares(mc *model, loc *location, routerKey string, 
 		name := routerKey + "-app-root"
 		conf.HTTP.Middlewares[name] = &dynamic.Middleware{
 			RedirectRegex: &dynamic.RedirectRegex{
-				Regex:       `^(https?://[^/]+)/(\?.*)?$`,
-				Replacement: "$1" + *loc.AppRoot,
+				Regex:       `^(https?://[^/?]+)/?(\?.*)?$`,
+				Replacement: "$1" + *loc.AppRoot + "$2",
 			},
 		}
 		rt.Middlewares = append(rt.Middlewares, name)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?
Ingress Nginx provider bug fix for `nginx.ingress.kubernetes.io/app-root` annotation to include the captured query parameters in the redirect replacement so that requests to the root with query parameters are preserved in the redirect to the app-root path. PR #12986 updated the regex to capture query parameters, but did not update the `Replacement` to include them, causing query parameters to be dropped on redirect.

### Motivation
Fixes #13315 

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes
Support for `nginx.ingress.kubernetes.io/app-root` annotation was added in v3.7, so targeting v3.7 rather than v3.6