### PR TITLE
Increase timeout for Docker image sync job to 30 minutes

### DIFF
--- a/.github/workflows/sync-docker-images.yaml
+++ b/.github/workflows/sync-docker-images.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Increase the timeout on the Docker image sync (GitHub) job.

### Motivation

<!-- What inspired you to submit this pull request? -->
Seeing #13317 caused by a recent sync job timing out: https://github.com/traefik/traefik/actions/runs/27047058215/job/79835019788.

When multiple (re-)releases happen on the same day, the current value may not suffice as observed. The result is impartial synchronization, which may cause consumer confusion.

As the risk and impact of increasing this value seem relatively minor, I'd say it would be preferable to err on the side of increasing this value rather than keeping it really tight.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
