### PR TITLE
Fix x-forwarded-port in forward-auth

### DIFF
--- a/pkg/middlewares/auth/forward.go
+++ b/pkg/middlewares/auth/forward.go
@@ -270,7 +270,7 @@ func writeHeader(req, forwardReq *http.Request, trustForwardHeader bool, allowed
 	}
 
 	if _, ok := forwardReq.Header[forwardedheaders.XForwardedPort]; !ok {
-		forwardReq.Header.Set(forwardedheaders.XForwardedPort, forwardedPort(req))
+		forwardReq.Header.Set(forwardedheaders.XForwardedPort, forwardedPort(req, forwardReq))
 	}
 
 	if _, ok := forwardReq.Header[forwardedheaders.XForwardedHost]; !ok {
@@ -322,7 +322,7 @@ func filterForwardRequestHeaders(forwardRequestHeaders http.Header, allowedHeade
 	return filteredHeaders
 }
 
-func forwardedPort(req *http.Request) string {
+func forwardedPort(req, forwardReq *http.Request) string {
 	if req == nil {
 		return ""
 	}
@@ -331,7 +331,7 @@ func forwardedPort(req *http.Request) string {
 		return port
 	}
 
-	if req.Header.Get(forwardedheaders.XForwardedProto) == "https" || req.Header.Get(forwardedheaders.XForwardedProto) == "wss" {
+	if forwardReq.Header.Get(forwardedheaders.XForwardedProto) == "https" || forwardReq.Header.Get(forwardedheaders.XForwardedProto) == "wss" {
 		return "443"
 	}
 

--- a/pkg/middlewares/auth/forward_test.go
+++ b/pkg/middlewares/auth/forward_test.go
@@ -456,6 +456,21 @@ func TestForwardAuth_writeHeader(t *testing.T) {
 				"X-Forwarded-Port":   "80",
 			},
 		},
+		{
+			desc: "X-Forwarded-Proto is not used to calculate X-Forwarded-Port if trustForwardHeader=false",
+			headers: map[string]string{
+				"X-CustomHeader":    "CustomHeader",
+				"X-Forwarded-Proto": "https",
+			},
+			trustForwardHeader: false,
+			expectedHeaders: map[string]string{
+				"X-Forwarded-Proto":  "http",
+				"X-Forwarded-Host":   "foo.bar",
+				"X-Forwarded-Uri":    "/path?q=1",
+				"X-Forwarded-Method": "GET",
+				"X-Forwarded-Port":   "80",
+			},
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes X-Forwarded-Port in forward-auth middleware when X-Forwarded-Proto was sent by the client.

### Motivation

Fix the bug!

### More

- [x] Added/updated tests
- [ ] Added/updated documentation
