### PR TITLE
Fix request scheme derivation when Gateway API RequestRedirect omits scheme

### DIFF
--- a/pkg/middlewares/gatewayapi/redirect/request_redirect.go
+++ b/pkg/middlewares/gatewayapi/redirect/request_redirect.go
@@ -59,8 +59,14 @@ func (r redirect) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	redirectURL := *req.URL
 	redirectURL.Host = req.Host
 
+	// req.URL.Scheme is always empty for server requests (Go net/http, RFC 7230 section 5.3).
+	// Per the Gateway API spec, when no scheme is configured the request scheme must be used.
+	// https://github.com/kubernetes-sigs/gateway-api/blob/v1.4.0/apis/v1/httproute_types.go#L1194-L1195
+	redirectURL.Scheme = "http"
 	if r.scheme != nil {
 		redirectURL.Scheme = *r.scheme
+	} else if req.TLS != nil {
+		redirectURL.Scheme = "https"
 	}
 
 	host := redirectURL.Hostname()

--- a/pkg/middlewares/gatewayapi/redirect/request_redirect_test.go
+++ b/pkg/middlewares/gatewayapi/redirect/request_redirect_test.go
@@ -3,6 +3,7 @@ package redirect
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +11,71 @@ import (
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
 	"k8s.io/utils/ptr"
 )
+
+func TestRequestRedirectHandlerSchemeFromRequest(t *testing.T) {
+	testCases := []struct {
+		desc       string
+		config     dynamic.RequestRedirect
+		tls        bool
+		wantScheme string
+	}{
+		{
+			desc:       "no scheme configured derives http from plain request",
+			config:     dynamic.RequestRedirect{Path: ptr.To("/baz")},
+			wantScheme: "http",
+		},
+		{
+			desc:       "no scheme configured derives https from TLS request",
+			config:     dynamic.RequestRedirect{Path: ptr.To("/baz")},
+			tls:        true,
+			wantScheme: "https",
+		},
+		{
+			desc:       "explicit scheme overrides request scheme",
+			config:     dynamic.RequestRedirect{Scheme: ptr.To("https"), Path: ptr.To("/baz")},
+			wantScheme: "https",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+			handler, err := NewRequestRedirect(t.Context(), next, test.config, "traefikTest")
+			require.NoError(t, err)
+
+			var ts *httptest.Server
+			if test.tls {
+				ts = httptest.NewTLSServer(handler)
+			} else {
+				ts = httptest.NewServer(handler)
+			}
+			t.Cleanup(ts.Close)
+
+			client := ts.Client()
+			client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			}
+
+			resp, err := client.Get(ts.URL + "/foo/bar")
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = resp.Body.Close() })
+
+			// Use the raw header value instead of resp.Location(), which resolves
+			// scheme-relative URLs against the request URL and would mask an empty scheme.
+			locationStr := resp.Header.Get("Location")
+			require.NotEmpty(t, locationStr)
+
+			locationURL, err := url.Parse(locationStr)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.wantScheme, locationURL.Scheme)
+			assert.Equal(t, "/baz", locationURL.Path)
+		})
+	}
+}
 
 func TestRequestRedirectHandler(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
### What does this PR do?

Fix `RequestRedirect` middleware producing scheme-relative `Location` headers (e.g. `//example.com/baz`) when no scheme is configured in the Gateway API `HTTPRequestRedirectFilter`.

In Go's `net/http`, real server requests always have `req.URL.Scheme = ""` because clients send requests in origin-form (`GET /path HTTP/1.1`), which carries no scheme on the wire ([RFC 7230, section 5.3](https://datatracker.ietf.org/doc/html/rfc7230#section-5.3)).

The fix is to derive the scheme from `req.TLS`, which is the reliable indicator of the transport-layer protocol in a Go HTTP handler.

### Motivation

To be inline with Gateway API spec.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

