### PR TITLE
Reduce Kubernetes provider CPU churn

### DIFF
--- a/pkg/provider/kubernetes/crd/client.go
+++ b/pkg/provider/kubernetes/crd/client.go
@@ -21,7 +21,6 @@ import (
 	kerror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	kinformers "k8s.io/client-go/informers"
 	kclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -224,7 +223,11 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 		if err != nil {
 			return nil, err
 		}
-		_, err = factoryKube.Discovery().V1().EndpointSlices().Informer().AddEventHandler(eventHandler)
+		endpointSliceInformer := factoryKube.Discovery().V1().EndpointSlices().Informer()
+		if err = endpointSliceInformer.AddIndexers(k8s.EndpointSliceServiceNameIndexers); err != nil {
+			return nil, err
+		}
+		_, err = endpointSliceInformer.AddEventHandler(eventHandler)
 		if err != nil {
 			return nil, err
 		}
@@ -462,14 +465,7 @@ func (c *clientWrapper) GetEndpointSlicesForService(namespace, serviceName strin
 		return nil, fmt.Errorf("failed to get endpointslices for service %s/%s: namespace is not within watched namespaces", namespace, serviceName)
 	}
 
-	serviceLabelRequirement, err := labels.NewRequirement(discoveryv1.LabelServiceName, selection.Equals, []string{serviceName})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create service label selector requirement: %w", err)
-	}
-	serviceSelector := labels.NewSelector()
-	serviceSelector = serviceSelector.Add(*serviceLabelRequirement)
-
-	return c.factoriesKube[c.lookupNamespace(namespace)].Discovery().V1().EndpointSlices().Lister().EndpointSlices(namespace).List(serviceSelector)
+	return k8s.EndpointSlicesByServiceName(c.factoriesKube[c.lookupNamespace(namespace)].Discovery().V1().EndpointSlices().Informer().GetIndexer(), namespace, serviceName)
 }
 
 // GetSecret returns the named secret from the given namespace.

--- a/pkg/provider/kubernetes/gateway/client.go
+++ b/pkg/provider/kubernetes/gateway/client.go
@@ -16,7 +16,6 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	ktypes "k8s.io/apimachinery/pkg/types"
 	kinformers "k8s.io/client-go/informers"
 	kclientset "k8s.io/client-go/kubernetes"
@@ -166,7 +165,11 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 		if err != nil {
 			return nil, err
 		}
-		_, err = factoryKube.Discovery().V1().EndpointSlices().Informer().AddEventHandler(eventHandler)
+		endpointSliceInformer := factoryKube.Discovery().V1().EndpointSlices().Informer()
+		if err = endpointSliceInformer.AddIndexers(k8s.EndpointSliceServiceNameIndexers); err != nil {
+			return nil, err
+		}
+		_, err = endpointSliceInformer.AddEventHandler(eventHandler)
 		if err != nil {
 			return nil, err
 		}
@@ -375,14 +378,7 @@ func (c *clientWrapper) ListEndpointSlicesForService(namespace, serviceName stri
 		return nil, fmt.Errorf("failed to get endpointslices for service %s/%s: namespace is not within watched namespaces", namespace, serviceName)
 	}
 
-	serviceLabelRequirement, err := labels.NewRequirement(discoveryv1.LabelServiceName, selection.Equals, []string{serviceName})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create service label selector requirement: %w", err)
-	}
-	serviceSelector := labels.NewSelector()
-	serviceSelector = serviceSelector.Add(*serviceLabelRequirement)
-
-	return c.factoriesKube[c.lookupNamespace(namespace)].Discovery().V1().EndpointSlices().Lister().EndpointSlices(namespace).List(serviceSelector)
+	return k8s.EndpointSlicesByServiceName(c.factoriesKube[c.lookupNamespace(namespace)].Discovery().V1().EndpointSlices().Informer().GetIndexer(), namespace, serviceName)
 }
 
 // ListBackendTLSPoliciesForService returns the BackendTLSPolicy for the given service name in the given namespace.

--- a/pkg/provider/kubernetes/gateway/grpcroute.go
+++ b/pkg/provider/kubernetes/gateway/grpcroute.go
@@ -22,20 +22,21 @@ import (
 )
 
 // TODO: as described in the specification https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.GRPCRoute, we should check for hostname conflicts between HTTP and GRPC routes.
-func (p *Provider) loadGRPCRoutes(ctx context.Context, gatewayListeners []gatewayListener, conf *dynamic.Configuration, statusReport *statusReport) {
+func (p *Provider) loadGRPCRoutes(ctx context.Context, listenerIndex gatewayListenerIndex, conf *dynamic.Configuration, statusReport *statusReport) {
 	routes, err := p.client.ListGRPCRoutes()
 	if err != nil {
 		log.Ctx(ctx).Error().Err(err).Msg("Unable to list GRPCRoutes")
 		return
 	}
 
+	var routeListeners []gatewayListener
 	for _, route := range routes {
 		logger := log.Ctx(ctx).With().
 			Str("grpc_route", route.Name).
 			Str("namespace", route.Namespace).
 			Logger()
 
-		routeListeners := matchingGatewayListeners(gatewayListeners, route.Namespace, route.Spec.ParentRefs)
+		routeListeners = listenerIndex.matchingInto(routeListeners[:0], route.Namespace, route.Spec.ParentRefs)
 		if len(routeListeners) == 0 {
 			continue
 		}

--- a/pkg/provider/kubernetes/gateway/httproute.go
+++ b/pkg/provider/kubernetes/gateway/httproute.go
@@ -23,20 +23,21 @@ import (
 	gatev1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-func (p *Provider) loadHTTPRoutes(ctx context.Context, gatewayListeners []gatewayListener, conf *dynamic.Configuration, statusReport *statusReport) {
+func (p *Provider) loadHTTPRoutes(ctx context.Context, listenerIndex gatewayListenerIndex, conf *dynamic.Configuration, statusReport *statusReport) {
 	routes, err := p.client.ListHTTPRoutes()
 	if err != nil {
 		log.Ctx(ctx).Error().Err(err).Msg("Unable to list HTTPRoutes")
 		return
 	}
 
+	var routeListeners []gatewayListener
 	for _, route := range routes {
 		logger := log.Ctx(ctx).With().
 			Str("http_route", route.Name).
 			Str("namespace", route.Namespace).
 			Logger()
 
-		routeListeners := matchingGatewayListeners(gatewayListeners, route.Namespace, route.Spec.ParentRefs)
+		routeListeners = listenerIndex.matchingInto(routeListeners[:0], route.Namespace, route.Spec.ParentRefs)
 		if len(routeListeners) == 0 {
 			continue
 		}

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -144,6 +144,44 @@ type gatewayListener struct {
 	EPName       string
 }
 
+type gatewayListenerIndex struct {
+	byGateway map[ktypes.NamespacedName][]gatewayListener
+}
+
+func newGatewayListenerIndex(listeners []gatewayListener) gatewayListenerIndex {
+	index := gatewayListenerIndex{byGateway: map[ktypes.NamespacedName][]gatewayListener{}}
+	for _, listener := range listeners {
+		key := ktypes.NamespacedName{Namespace: listener.GWNamespace, Name: listener.GWName}
+		index.byGateway[key] = append(index.byGateway[key], listener)
+	}
+
+	return index
+}
+
+func (i gatewayListenerIndex) matching(routeNamespace string, parentRefs []gatev1.ParentReference) []gatewayListener {
+	return i.matchingInto(nil, routeNamespace, parentRefs)
+}
+
+func (i gatewayListenerIndex) matchingInto(listeners []gatewayListener, routeNamespace string, parentRefs []gatev1.ParentReference) []gatewayListener {
+	for _, parentRef := range parentRefs {
+		if ptr.Deref(parentRef.Group, gatev1.GroupName) != gatev1.GroupName {
+			continue
+		}
+
+		if ptr.Deref(parentRef.Kind, kindGateway) != kindGateway {
+			continue
+		}
+
+		key := ktypes.NamespacedName{
+			Namespace: string(ptr.Deref(parentRef.Namespace, gatev1.Namespace(routeNamespace))),
+			Name:      string(parentRef.Name),
+		}
+		listeners = append(listeners, i.byGateway[key]...)
+	}
+
+	return listeners
+}
+
 // RegisterFilterFuncs registers an allowed Group, Kind, and builder for the Filter ExtensionRef objects.
 func (p *Provider) RegisterFilterFuncs(group, kind string, builderFunc BuildFilterFunc) {
 	if p.groupKindFilterFuncs == nil {
@@ -394,14 +432,16 @@ func (p *Provider) loadConfigurationFromGateways(ctx context.Context) (*dynamic.
 		gatewayListeners = append(gatewayListeners, p.loadGatewayListeners(logger.WithContext(ctx), gateway, conf)...)
 	}
 
-	p.loadHTTPRoutes(ctx, gatewayListeners, conf, statusReport)
+	listenerIndex := newGatewayListenerIndex(gatewayListeners)
 
-	p.loadGRPCRoutes(ctx, gatewayListeners, conf, statusReport)
+	p.loadHTTPRoutes(ctx, listenerIndex, conf, statusReport)
 
-	p.loadTLSRoutes(ctx, gatewayListeners, conf, statusReport)
+	p.loadGRPCRoutes(ctx, listenerIndex, conf, statusReport)
+
+	p.loadTLSRoutes(ctx, listenerIndex, conf, statusReport)
 
 	if p.ExperimentalChannel {
-		p.loadTCPRoutes(ctx, gatewayListeners, conf, statusReport)
+		p.loadTCPRoutes(ctx, listenerIndex, conf, statusReport)
 	}
 
 	for _, gateway := range gateways {
@@ -410,12 +450,7 @@ func (p *Provider) loadConfigurationFromGateways(ctx context.Context) (*dynamic.
 			Str("namespace", gateway.Namespace).
 			Logger()
 
-		var listeners []gatewayListener
-		for _, listener := range gatewayListeners {
-			if listener.GWName == gateway.Name && listener.GWNamespace == gateway.Namespace {
-				listeners = append(listeners, listener)
-			}
-		}
+		listeners := listenerIndex.byGateway[ktypes.NamespacedName{Name: gateway.Name, Namespace: gateway.Namespace}]
 
 		gatewayStatus, errConditions := p.makeGatewayStatus(gateway, listeners, addresses)
 		if len(errConditions) > 0 {
@@ -1105,32 +1140,7 @@ func allowRoute(listener gatewayListener, routeNamespace, routeKind string) bool
 }
 
 func matchingGatewayListeners(gatewayListeners []gatewayListener, routeNamespace string, parentRefs []gatev1.ParentReference) []gatewayListener {
-	var listeners []gatewayListener
-
-	for _, listener := range gatewayListeners {
-		for _, parentRef := range parentRefs {
-			if ptr.Deref(parentRef.Group, gatev1.GroupName) != gatev1.GroupName {
-				continue
-			}
-
-			if ptr.Deref(parentRef.Kind, kindGateway) != kindGateway {
-				continue
-			}
-
-			parentRefNamespace := string(ptr.Deref(parentRef.Namespace, gatev1.Namespace(routeNamespace)))
-			if listener.GWNamespace != parentRefNamespace {
-				continue
-			}
-
-			if string(parentRef.Name) != listener.GWName {
-				continue
-			}
-
-			listeners = append(listeners, listener)
-		}
-	}
-
-	return listeners
+	return newGatewayListenerIndex(gatewayListeners).matching(routeNamespace, parentRefs)
 }
 
 func matchListener(listener gatewayListener, parentRef gatev1.ParentReference) bool {

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -7793,6 +7793,51 @@ func Test_matchingGatewayListener(t *testing.T) {
 	}
 }
 
+func BenchmarkGatewayListenerIndexMatching(b *testing.B) {
+	const (
+		gatewayCount       = 500
+		listenerPerGateway = 4
+		routeCount         = 10000
+	)
+
+	var gatewayListeners []gatewayListener
+	for gi := range gatewayCount {
+		for li := range listenerPerGateway {
+			gatewayListeners = append(gatewayListeners, gatewayListener{
+				Name:        fmt.Sprintf("listener-%d", li),
+				GWName:      fmt.Sprintf("gateway-%d", gi),
+				GWNamespace: "default",
+			})
+		}
+	}
+
+	parentRefs := make([][]gatev1.ParentReference, routeCount)
+	for i := range routeCount {
+		parentRefs[i] = []gatev1.ParentReference{{
+			Name: gatev1.ObjectName(fmt.Sprintf("gateway-%d", i%gatewayCount)),
+		}}
+	}
+
+	listenerIndex := newGatewayListenerIndex(gatewayListeners)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	var total int
+	var listeners []gatewayListener
+	for range b.N {
+		total = 0
+		for _, routeParentRefs := range parentRefs {
+			listeners = listenerIndex.matchingInto(listeners[:0], "default", routeParentRefs)
+			total += len(listeners)
+		}
+	}
+
+	if total != routeCount*listenerPerGateway {
+		b.Fatalf("unexpected listener count: %d", total)
+	}
+}
+
 func Test_matchListener(t *testing.T) {
 	testCases := []struct {
 		desc       string

--- a/pkg/provider/kubernetes/gateway/tcproute.go
+++ b/pkg/provider/kubernetes/gateway/tcproute.go
@@ -19,7 +19,7 @@ import (
 	gatev1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
-func (p *Provider) loadTCPRoutes(ctx context.Context, gatewayListeners []gatewayListener, conf *dynamic.Configuration, statusReport *statusReport) {
+func (p *Provider) loadTCPRoutes(ctx context.Context, listenerIndex gatewayListenerIndex, conf *dynamic.Configuration, statusReport *statusReport) {
 	logger := log.Ctx(ctx)
 	routes, err := p.client.ListTCPRoutes()
 	if err != nil {
@@ -27,8 +27,9 @@ func (p *Provider) loadTCPRoutes(ctx context.Context, gatewayListeners []gateway
 		return
 	}
 
+	var routeListeners []gatewayListener
 	for _, route := range routes {
-		routeListeners := matchingGatewayListeners(gatewayListeners, route.Namespace, route.Spec.ParentRefs)
+		routeListeners = listenerIndex.matchingInto(routeListeners[:0], route.Namespace, route.Spec.ParentRefs)
 		if len(routeListeners) == 0 {
 			continue
 		}

--- a/pkg/provider/kubernetes/gateway/tlsroute.go
+++ b/pkg/provider/kubernetes/gateway/tlsroute.go
@@ -20,7 +20,7 @@ import (
 	gatev1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-func (p *Provider) loadTLSRoutes(ctx context.Context, gatewayListeners []gatewayListener, conf *dynamic.Configuration, statusReport *statusReport) {
+func (p *Provider) loadTLSRoutes(ctx context.Context, listenerIndex gatewayListenerIndex, conf *dynamic.Configuration, statusReport *statusReport) {
 	logger := log.Ctx(ctx)
 	routes, err := p.client.ListTLSRoutes()
 	if err != nil {
@@ -28,8 +28,9 @@ func (p *Provider) loadTLSRoutes(ctx context.Context, gatewayListeners []gateway
 		return
 	}
 
+	var routeListeners []gatewayListener
 	for _, route := range routes {
-		routeListeners := matchingGatewayListeners(gatewayListeners, route.Namespace, route.Spec.ParentRefs)
+		routeListeners = listenerIndex.matchingInto(routeListeners[:0], route.Namespace, route.Spec.ParentRefs)
 		if len(routeListeners) == 0 {
 			continue
 		}

--- a/pkg/provider/kubernetes/ingress-nginx/client.go
+++ b/pkg/provider/kubernetes/ingress-nginx/client.go
@@ -20,7 +20,6 @@ import (
 	kerror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	kinformers "k8s.io/client-go/informers"
 	kclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -172,7 +171,11 @@ func (c *clientWrapper) WatchAll(ctx context.Context, namespace, namespaceSelect
 		if err != nil {
 			return nil, err
 		}
-		_, err = factoryKube.Discovery().V1().EndpointSlices().Informer().AddEventHandler(eventHandler)
+		endpointSliceInformer := factoryKube.Discovery().V1().EndpointSlices().Informer()
+		if err = endpointSliceInformer.AddIndexers(k8s.EndpointSliceServiceNameIndexers); err != nil {
+			return nil, err
+		}
+		_, err = endpointSliceInformer.AddEventHandler(eventHandler)
 		if err != nil {
 			return nil, err
 		}
@@ -320,14 +323,7 @@ func (c *clientWrapper) GetEndpointSlicesForService(namespace, serviceName strin
 		return nil, fmt.Errorf("failed to get endpointslices for service %s/%s: namespace is not within watched namespaces", namespace, serviceName)
 	}
 
-	serviceLabelRequirement, err := labels.NewRequirement(discoveryv1.LabelServiceName, selection.Equals, []string{serviceName})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create service label selector requirement: %w", err)
-	}
-	serviceSelector := labels.NewSelector()
-	serviceSelector = serviceSelector.Add(*serviceLabelRequirement)
-
-	return c.factoriesKube[c.lookupNamespace(namespace)].Discovery().V1().EndpointSlices().Lister().EndpointSlices(namespace).List(serviceSelector)
+	return k8s.EndpointSlicesByServiceName(c.factoriesKube[c.lookupNamespace(namespace)].Discovery().V1().EndpointSlices().Informer().GetIndexer(), namespace, serviceName)
 }
 
 // GetConfigMap returns the named configMap from the given namespace.

--- a/pkg/provider/kubernetes/ingress/client.go
+++ b/pkg/provider/kubernetes/ingress/client.go
@@ -20,7 +20,6 @@ import (
 	kerror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	kinformers "k8s.io/client-go/informers"
 	kclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -172,7 +171,11 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 		if err != nil {
 			return nil, err
 		}
-		_, err = factoryKube.Discovery().V1().EndpointSlices().Informer().AddEventHandler(eventHandler)
+		endpointSliceInformer := factoryKube.Discovery().V1().EndpointSlices().Informer()
+		if err = endpointSliceInformer.AddIndexers(k8s.EndpointSliceServiceNameIndexers); err != nil {
+			return nil, err
+		}
+		_, err = endpointSliceInformer.AddEventHandler(eventHandler)
 		if err != nil {
 			return nil, err
 		}
@@ -327,14 +330,7 @@ func (c *clientWrapper) GetEndpointSlicesForService(namespace, serviceName strin
 		return nil, fmt.Errorf("failed to get endpointslices for service %s/%s: namespace is not within watched namespaces", namespace, serviceName)
 	}
 
-	serviceLabelRequirement, err := labels.NewRequirement(discoveryv1.LabelServiceName, selection.Equals, []string{serviceName})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create service label selector requirement: %w", err)
-	}
-	serviceSelector := labels.NewSelector()
-	serviceSelector = serviceSelector.Add(*serviceLabelRequirement)
-
-	return c.factoriesKube[c.lookupNamespace(namespace)].Discovery().V1().EndpointSlices().Lister().EndpointSlices(namespace).List(serviceSelector)
+	return k8s.EndpointSlicesByServiceName(c.factoriesKube[c.lookupNamespace(namespace)].Discovery().V1().EndpointSlices().Informer().GetIndexer(), namespace, serviceName)
 }
 
 // GetSecret returns the named secret from the given namespace.

--- a/pkg/provider/kubernetes/k8s/endpoint_slice.go
+++ b/pkg/provider/kubernetes/k8s/endpoint_slice.go
@@ -1,0 +1,50 @@
+package k8s
+
+import (
+	"fmt"
+
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+const EndpointSliceServiceNameIndex = "endpointSliceServiceName"
+
+var EndpointSliceServiceNameIndexers = cache.Indexers{
+	EndpointSliceServiceNameIndex: endpointSliceServiceNameIndexFunc,
+}
+
+func EndpointSliceServiceNameIndexKey(namespace, serviceName string) string {
+	return fmt.Sprintf("%s/%s", namespace, serviceName)
+}
+
+func EndpointSlicesByServiceName(indexer cache.Indexer, namespace, serviceName string) ([]*discoveryv1.EndpointSlice, error) {
+	objects, err := indexer.ByIndex(EndpointSliceServiceNameIndex, EndpointSliceServiceNameIndexKey(namespace, serviceName))
+	if err != nil {
+		return nil, err
+	}
+
+	endpointSlices := make([]*discoveryv1.EndpointSlice, 0, len(objects))
+	for _, object := range objects {
+		endpointSlice, ok := object.(*discoveryv1.EndpointSlice)
+		if !ok {
+			continue
+		}
+		endpointSlices = append(endpointSlices, endpointSlice)
+	}
+
+	return endpointSlices, nil
+}
+
+func endpointSliceServiceNameIndexFunc(obj any) ([]string, error) {
+	endpointSlice, ok := obj.(*discoveryv1.EndpointSlice)
+	if !ok {
+		return nil, nil
+	}
+
+	serviceName := endpointSlice.Labels[discoveryv1.LabelServiceName]
+	if serviceName == "" {
+		return nil, nil
+	}
+
+	return []string{EndpointSliceServiceNameIndexKey(endpointSlice.Namespace, serviceName)}, nil
+}

--- a/pkg/provider/kubernetes/k8s/endpoint_slice_test.go
+++ b/pkg/provider/kubernetes/k8s/endpoint_slice_test.go
@@ -1,0 +1,55 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestEndpointSlicesByServiceName(t *testing.T) {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, EndpointSliceServiceNameIndexers)
+
+	endpointSlices := []*discoveryv1.EndpointSlice{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo-1",
+				Namespace: "default",
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: "foo",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bar-1",
+				Namespace: "default",
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: "bar",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo-2",
+				Namespace: "other",
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: "foo",
+				},
+			},
+		},
+	}
+
+	for _, endpointSlice := range endpointSlices {
+		require.NoError(t, indexer.Add(endpointSlice))
+	}
+
+	got, err := EndpointSlicesByServiceName(indexer, "default", "foo")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	assert.Equal(t, "foo-1", got[0].Name)
+}

--- a/pkg/provider/kubernetes/k8s/event_handler.go
+++ b/pkg/provider/kubernetes/k8s/event_handler.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -51,6 +52,10 @@ func objChanged(oldObj, newObj any) bool {
 		return endpointSliceChanged(oldObj.(*discoveryv1.EndpointSlice), newObj.(*discoveryv1.EndpointSlice))
 	}
 
+	if _, ok := oldObj.(*corev1.Node); ok {
+		return nodeChanged(oldObj.(*corev1.Node), newObj.(*corev1.Node))
+	}
+
 	return true
 }
 
@@ -59,16 +64,23 @@ func objChanged(oldObj, newObj any) bool {
 // the event can safely be ignored and won't cause unnecessary config reloads.
 // TODO: check if Kubernetes is still using EndpointSlice for leader election, which seems to not be the case anymore.
 func endpointSliceChanged(a, b *discoveryv1.EndpointSlice) bool {
+	if a.Labels[discoveryv1.LabelServiceName] != b.Labels[discoveryv1.LabelServiceName] {
+		return true
+	}
+
 	if len(a.Ports) != len(b.Ports) {
 		return true
 	}
 
 	for i, aport := range a.Ports {
 		bport := b.Ports[i]
-		if aport.Name != bport.Name {
+		if !samePtr(aport.Name, bport.Name) {
 			return true
 		}
-		if aport.Port != bport.Port {
+		if !samePtr(aport.Port, bport.Port) {
+			return true
+		}
+		if !samePtr(aport.Protocol, bport.Protocol) {
 			return true
 		}
 	}
@@ -99,5 +111,55 @@ func endpointChanged(a, b discoveryv1.Endpoint) bool {
 		}
 	}
 
+	if !samePtr(a.Conditions.Ready, b.Conditions.Ready) {
+		return true
+	}
+	if !samePtr(a.Conditions.Serving, b.Conditions.Serving) {
+		return true
+	}
+	if !samePtr(a.Conditions.Terminating, b.Conditions.Terminating) {
+		return true
+	}
+
 	return false
+}
+
+func samePtr[T comparable](a, b *T) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+
+	return *a == *b
+}
+
+func nodeChanged(a, b *corev1.Node) bool {
+	return !sameNodeAddresses(a.Status.Addresses, b.Status.Addresses)
+}
+
+func sameNodeAddresses(a, b []corev1.NodeAddress) bool {
+	aAddresses := nodeAddressSet(a)
+	bAddresses := nodeAddressSet(b)
+	if len(aAddresses) != len(bAddresses) {
+		return false
+	}
+
+	for address := range aAddresses {
+		if _, ok := bAddresses[address]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+func nodeAddressSet(addresses []corev1.NodeAddress) map[corev1.NodeAddress]struct{} {
+	result := map[corev1.NodeAddress]struct{}{}
+	for _, address := range addresses {
+		if address.Type != corev1.NodeInternalIP && address.Type != corev1.NodeExternalIP {
+			continue
+		}
+		result[address] = struct{}{}
+	}
+
+	return result
 }

--- a/pkg/provider/kubernetes/k8s/event_handler_test.go
+++ b/pkg/provider/kubernetes/k8s/event_handler_test.go
@@ -4,14 +4,19 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 func Test_detectChanges(t *testing.T) {
 	portA := int32(80)
+	portACopy := int32(80)
 	portB := int32(8080)
+	portName := "http"
+	portNameCopy := "http"
 	tests := []struct {
 		name   string
 		oldObj any
@@ -129,6 +134,26 @@ func Test_detectChanges(t *testing.T) {
 			},
 		},
 		{
+			name: "With different service name label",
+			oldObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1",
+					Labels: map[string]string{
+						discoveryv1.LabelServiceName: "foo",
+					},
+				},
+			},
+			newObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "2",
+					Labels: map[string]string{
+						discoveryv1.LabelServiceName: "bar",
+					},
+				},
+			},
+			want: true,
+		},
+		{
 			name: "With same endpoints and ports",
 			oldObj: &discoveryv1.EndpointSlice{
 				ObjectMeta: metav1.ObjectMeta{
@@ -143,6 +168,27 @@ func Test_detectChanges(t *testing.T) {
 				},
 				Endpoints: []discoveryv1.Endpoint{},
 				Ports:     []discoveryv1.EndpointPort{},
+			},
+		},
+		{
+			name: "With same ports from different pointers",
+			oldObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1",
+				},
+				Ports: []discoveryv1.EndpointPort{{
+					Name: &portName,
+					Port: &portA,
+				}},
+			},
+			newObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "2",
+				},
+				Ports: []discoveryv1.EndpointPort{{
+					Name: &portNameCopy,
+					Port: &portACopy,
+				}},
 			},
 		},
 		{
@@ -214,6 +260,136 @@ func Test_detectChanges(t *testing.T) {
 				Ports: []discoveryv1.EndpointPort{{
 					Port: &portB,
 				}},
+			},
+			want: true,
+		},
+		{
+			name: "With same endpoint conditions",
+			oldObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses: []string{"10.10.10.10"},
+					Conditions: discoveryv1.EndpointConditions{
+						Ready:       ptr.To(true),
+						Serving:     ptr.To(true),
+						Terminating: ptr.To(false),
+					},
+				}},
+			},
+			newObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "2",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses: []string{"10.10.10.10"},
+					Conditions: discoveryv1.EndpointConditions{
+						Ready:       ptr.To(true),
+						Serving:     ptr.To(true),
+						Terminating: ptr.To(false),
+					},
+				}},
+			},
+		},
+		{
+			name: "With different endpoint conditions",
+			oldObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses: []string{"10.10.10.10"},
+					Conditions: discoveryv1.EndpointConditions{
+						Ready: ptr.To(true),
+					},
+				}},
+			},
+			newObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "2",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses: []string{"10.10.10.10"},
+					Conditions: discoveryv1.EndpointConditions{
+						Ready: ptr.To(false),
+					},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "With nil and false endpoint conditions",
+			oldObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses: []string{"10.10.10.10"},
+				}},
+			},
+			newObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "2",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses: []string{"10.10.10.10"},
+					Conditions: discoveryv1.EndpointConditions{
+						Ready: ptr.To(false),
+					},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "Node with same internal and external addresses",
+			oldObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1",
+				},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{
+						{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+						{Type: corev1.NodeExternalIP, Address: "192.0.2.1"},
+						{Type: corev1.NodeHostName, Address: "node-a"},
+					},
+				},
+			},
+			newObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "2",
+				},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{
+						{Type: corev1.NodeHostName, Address: "node-b"},
+						{Type: corev1.NodeExternalIP, Address: "192.0.2.1"},
+						{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+					},
+					Capacity: corev1.ResourceList{},
+				},
+			},
+		},
+		{
+			name: "Node with different internal address",
+			oldObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1",
+				},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{
+						{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+					},
+				},
+			},
+			newObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "2",
+				},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{
+						{Type: corev1.NodeInternalIP, Address: "10.0.0.2"},
+					},
+				},
 			},
 			want: true,
 		},


### PR DESCRIPTION
### What does this PR do?

This PR reduces Kubernetes provider CPU churn by addressing the main hot paths described in #13011 and an additional Gateway API route-matching hotspot that shows up with large HTTPRoute sets.

- Adds an EndpointSlice informer index keyed by `namespace/serviceName` and uses it in the Kubernetes Ingress, CRD, Gateway, and Ingress-NGINX providers.
- Filters EndpointSlice updates so metadata-only changes do not trigger full configuration rebuilds while still reacting to fields Traefik consumes: service name label, ports, endpoint addresses, and Ready/Serving/Terminating conditions.
- Filters Node updates so kubelet heartbeat/status churn only triggers rebuilds when InternalIP or ExternalIP addresses change.
- Indexes Gateway listeners per Gateway during config builds, so HTTPRoute/GRPCRoute/TLSRoute/TCPRoute parentRef matching does not scan every listener for every route.
- Adds tests for the EndpointSlice index and update filtering behavior, plus a Gateway listener matching benchmark for large route sets.

### Motivation

Related to #13011. The EndpointSlice migration made backend lookup cost proportional to all EndpointSlices in a namespace, and unrelated EndpointSlice/Node updates could trigger repeated full rebuilds. In Gateway API deployments with many HTTPRoutes, listener parentRef matching also adds avoidable CPU work during each rebuild.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Validation run locally:

```console
go test ./pkg/provider/kubernetes/...
go test ./pkg/provider/kubernetes/gateway -run "^$" -bench "^BenchmarkGatewayListenerIndexMatching$" -benchtime=3s -count=3
```

Benchmark result on this machine for 10,000 route parentRef matches against 500 Gateways / 2,000 listeners: about 453-467 µs/op, 0 B/op, 0 allocs/op.
