### PR TITLE
Webui certificate status improvements

### DIFF
--- a/pkg/api/certificate.go
+++ b/pkg/api/certificate.go
@@ -84,7 +84,7 @@ func buildCertificateRepresentation(cert *x509.Certificate) certificateRepresent
 		SignatureAlgorithm:   cert.SignatureAlgorithm.String(),
 		CertFingerprint:      certFingerprint,
 		PublicKeyFingerprint: pubKeyFingerprint,
-		Status:               getCertificateStatus(cert.NotAfter),
+		Status:               getCertificateStatus(cert.NotBefore, cert.NotAfter),
 	}
 }
 
@@ -159,13 +159,16 @@ func formatVersion(version int) string {
 }
 
 // getCertificateStatus returns the status of a certificate based on its expiry.
-func getCertificateStatus(notAfter time.Time) string {
+func getCertificateStatus(notBefore time.Time, notAfter time.Time) string {
 	remaining := time.Until(notAfter)
 	if remaining < 0 {
 		return certStatusExpired
 	}
-	// Show warning for certificates with validity less than 30 days left.
-	if remaining < 30*24*time.Hour {
+	lifeTime := notAfter.Sub(notBefore)
+	warningRatio := 1 / 3.0
+
+	// Show warning for certificates with validity smaller than allowed ratio.
+	if float64(remaining.Milliseconds()/lifeTime.Milliseconds()) < warningRatio {
 		return certStatusWarning
 	}
 	return certStatusEnabled

--- a/pkg/api/handler_overview.go
+++ b/pkg/api/handler_overview.go
@@ -299,7 +299,7 @@ func getCertificatesSection(tlsManager *tls.Manager) *section {
 	var countErrors int
 
 	for _, cert := range x509Certs {
-		status := getCertificateStatus(cert.NotAfter)
+		status := getCertificateStatus(cert.NotBefore, cert.NotAfter)
 		switch status {
 		case certStatusExpired:
 			countErrors++

--- a/webui/src/components/certificates/CertExpiryBadge.tsx
+++ b/webui/src/components/certificates/CertExpiryBadge.tsx
@@ -5,19 +5,23 @@ type ExpiryStatus = {
   label: string
 }
 
-export const getCertExpiryStatus = (daysLeft: number): ExpiryStatus => {
+// Ratio of the remaining lifetime of a certificate before it is considered expiring
+const expiringRatio = 1 / 3;
+
+export const getCertExpiryStatus = (daysLeft: number, daysLifetime: number): ExpiryStatus => {
   if (daysLeft < 0) return { variant: 'red', label: 'EXPIRED' }
-  if (daysLeft < 30) return { variant: 'orange', label: 'Expiring Soon' }
+  if (daysLeft / daysLifetime < expiringRatio) return { variant: 'orange', label: 'Expiring Soon' }
   return { variant: 'green', label: 'Valid' }
 }
 
 type CertExpiryBadgeProps = {
   daysLeft: number
+  daysLifetime: number
   size?: 'small' | 'large'
 }
 
-const CertExpiryBadge = ({ daysLeft, size = 'large' }: CertExpiryBadgeProps) => {
-  const { variant } = getCertExpiryStatus(daysLeft)
+const CertExpiryBadge = ({ daysLeft, daysLifetime, size = 'large' }: CertExpiryBadgeProps) => {
+  const { variant } = getCertExpiryStatus(daysLeft, daysLifetime)
 
   return (
     <Badge size={size} variant={variant}>

--- a/webui/src/components/certificates/CertificateDetails.tsx
+++ b/webui/src/components/certificates/CertificateDetails.tsx
@@ -15,7 +15,10 @@ const isLinkableHostname = (value?: string) => {
 export const CertificateDetails = ({ certificate }: { certificate: Certificate.Info }) => {
   const validFrom = new Date(certificate.notBefore)
   const validUntil = new Date(certificate.notAfter)
-  const certStatus = useMemo(() => getCertExpiryStatus(certificate.daysLeft), [certificate.daysLeft])
+  const certStatus = useMemo(
+    () => getCertExpiryStatus(certificate.daysLeft, certificate.daysLifetime),
+    [certificate.daysLeft, certificate.daysLifetime],
+  )
 
   const issuedToItems = [
     {
@@ -75,7 +78,7 @@ export const CertificateDetails = ({ certificate }: { certificate: Certificate.I
     { key: 'Valid Until', val: validUntil.toLocaleString() },
     {
       key: 'Expiry',
-      val: <CertExpiryBadge daysLeft={certificate.daysLeft} />,
+      val: <CertExpiryBadge daysLeft={certificate.daysLeft} daysLifetime={certificate.daysLifetime} />,
     },
   ]
 

--- a/webui/src/hooks/use-certificates.ts
+++ b/webui/src/hooks/use-certificates.ts
@@ -1,20 +1,23 @@
 import { useMemo } from 'react'
 import useSWR from 'swr'
 
+const msPerDay = 1000 * 60 * 60 * 24;
+
 export const computeDaysLeft = (notAfter: string): number =>
-  Math.floor((new Date(notAfter).getTime() - Date.now()) / (1000 * 60 * 60 * 24))
+  Math.floor((new Date(notAfter).getTime() - Date.now()) / msPerDay)
+
+const getCertificateInfo = (cert: Certificate.Raw): Certificate.Info => ({
+  ...cert,
+  daysLeft: computeDaysLeft(cert.notAfter),
+})
 
 export const useCertificates = () => {
   const { data, error } = useSWR<Certificate.Raw[]>('/certificates')
 
-  const certificates: Certificate.Info[] = useMemo(() => {
-    if (!data) return []
-
-    return data.map((cert) => ({
-      ...cert,
-      daysLeft: computeDaysLeft(cert.notAfter),
-    }))
-  }, [data])
+  const certificates = useMemo<Certificate.Info[]>(
+    () => data?.map(getCertificateInfo) ?? [],
+    [data],
+  )
 
   return {
     certificates,
@@ -26,14 +29,12 @@ export const useCertificates = () => {
 export const useCertificate = (certId: string) => {
   const { data, error } = useSWR<Certificate.Raw>(certId ? `/certificates/${certId}` : null)
 
-  const certificate: Certificate.Info | null = useMemo(() => {
-    if (!data) return null
-
-    return {
-      ...data,
-      daysLeft: computeDaysLeft(data.notAfter),
-    }
-  }, [data])
+  const certificate = useMemo<Certificate.Info | null>(
+    () => data
+      ? getCertificateInfo(data)
+      : null,
+    [data],
+  )
 
   return {
     certificate,

--- a/webui/src/hooks/use-certificates.ts
+++ b/webui/src/hooks/use-certificates.ts
@@ -6,9 +6,13 @@ const msPerDay = 1000 * 60 * 60 * 24;
 export const computeDaysLeft = (notAfter: string): number =>
   Math.floor((new Date(notAfter).getTime() - Date.now()) / msPerDay)
 
+export const computeDaysLifetime = (notAfter: string, notBefore: string): number =>
+  Math.floor((new Date(notAfter).getTime() - new Date(notBefore).getTime()) / msPerDay)
+
 const getCertificateInfo = (cert: Certificate.Raw): Certificate.Info => ({
   ...cert,
   daysLeft: computeDaysLeft(cert.notAfter),
+  daysLifetime: computeDaysLifetime(cert.notAfter, cert.notBefore),
 })
 
 export const useCertificates = () => {

--- a/webui/src/pages/certificates/Certificates.tsx
+++ b/webui/src/pages/certificates/Certificates.tsx
@@ -11,7 +11,7 @@ import ClickableRow from 'components/tables/ClickableRow'
 import SortableTh from 'components/tables/SortableTh'
 import { searchParamsToState, TableFilter } from 'components/tables/TableFilter'
 import TooltipText from 'components/TooltipText'
-import { computeDaysLeft } from 'hooks/use-certificates'
+import { computeDaysLeft, computeDaysLifetime } from 'hooks/use-certificates'
 import useFetchWithPagination, { pagesResponseInterface, RenderRowType } from 'hooks/use-fetch-with-pagination'
 import { EmptyPlaceholderTd } from 'layout/EmptyPlaceholder'
 import PageTitle from 'layout/PageTitle'
@@ -19,6 +19,7 @@ import PageTitle from 'layout/PageTitle'
 export const CertificateRenderRow: RenderRowType = (row: unknown) => {
   const cert = row as Certificate.Raw
   const daysLeft = computeDaysLeft(cert.notAfter)
+  const daysLifetime = computeDaysLifetime(cert.notAfter, cert.notBefore)
   const validUntil = new Date(cert.notAfter).toLocaleDateString()
 
   return (
@@ -41,7 +42,7 @@ export const CertificateRenderRow: RenderRowType = (row: unknown) => {
         <Text>{validUntil}</Text>
       </AriaTd>
       <AriaTd>
-        <CertExpiryBadge daysLeft={daysLeft} size="small" />
+        <CertExpiryBadge daysLeft={daysLeft} daysLifetime={daysLifetime} size="small" />
       </AriaTd>
     </ClickableRow>
   )

--- a/webui/src/types/resources.d.ts
+++ b/webui/src/types/resources.d.ts
@@ -148,5 +148,6 @@ declare namespace Certificate {
   /** Enriched certificate with computed fields */
   type Info = Raw & {
     daysLeft: number
+    daysLifetime: number
   }
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Recently certificate information was added to the webui (dashboard).
Within the implementation, it was opted to consider certificates with a remaining lifetime less than (static) 30 days as 'expiring soon' / 'warning'. However, depending on your ACME provider and/or settings, this may cause user confusion, as certificates may be intended to be more shortlived.

For example the Let's Encrypt shortlived profile offers 7 day lifetime certificates, where the tlsserver profile has been updated to provide 45 day lifetime certificates, which is the intended future default. See also https://letsencrypt.org/docs/profiles/ and https://letsencrypt.org/2025/12/02/from-90-to-45.

To better accomodate for such usage, this PR aims to switch towards checking for certificates with a remaining lifetime of less than one third of the entire lifetime, rather than comparing to a static value. Although still not perfect, this should be a much more accurate check for a larger group of certificates, while still 'complying' with the previous behavior for 90 day certificates.

Fixes #12946.

### Motivation

<!-- What inspired you to submit this pull request? -->
Noting a lot of my certificates being ("incorrectly") marked as warning/expiring soon,
which was also reported in #12946.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
