### PR TITLE
Clarify entryPoint middleware reference format

### DIFF
--- a/docs/content/reference/install-configuration/entrypoints.md
+++ b/docs/content/reference/install-configuration/entrypoints.md
@@ -246,7 +246,7 @@ Behavior examples:
 | <a id="opt-false-2" href="#opt-false-2" title="#opt-false-2">false</a> | foo=bar&baz=bar;foo | foo=bar&baz=bar&foo     |
 | <a id="opt-true-2" href="#opt-true-2" title="#opt-true-2">true</a> | foo=bar&baz=bar;foo | foo=bar&baz=bar%3Bfoo   |
 
-### SanitizePath
+### sanitizePath
 
 The `sanitizePath` option defines whether to enable the request path sanitization.
 When disabled, the incoming request path is passed to the backend as is.
@@ -469,7 +469,7 @@ to do
 canary deployments against Traefik itself. Like upgrading Traefik version
 or reloading the static configuration without any service downtime.
 
-#### Trace Verbosity
+### traceVerbosity
 
 `observability.traceVerbosity` defines the tracing verbosity level for routers attached to this EntryPoint.
 Routers can override this value in their own observability configuration.

--- a/docs/content/reference/install-configuration/entrypoints.md
+++ b/docs/content/reference/install-configuration/entrypoints.md
@@ -28,8 +28,8 @@ entryPoints:
     http:
       tls: {}
       middlewares:
-        - auth@kubernetescrd
-        - strip@kubernetescrd
+        - default-auth@kubernetescrd
+        - default-strip@kubernetescrd
 ```
 
 ```toml tab="File (TOML)"
@@ -49,7 +49,7 @@ entryPoints:
   [entryPoints.websecure]
     address = ":443"
     [entryPoints.websecure.http]
-      middlewares = ["auth@kubernetescrd", "strip@kubernetescrd"]
+      middlewares = ["default-auth@kubernetescrd", "default-strip@kubernetescrd"]
       [entryPoints.websecure.http.tls]
 ```
 
@@ -63,8 +63,8 @@ ports:
     tls:
       enabled: true
     middlewares:
-      - auth@kubernetescrd
-      - strip@kubernetescrd
+      - default-auth@kubernetescrd
+      - default-strip@kubernetescrd
 additionalArguments:
   - --entryPoints.web.http.redirections.entryPoint.to=websecure
   - --entryPoints.web.http.redirections.entryPoint.scheme=https
@@ -204,8 +204,16 @@ the request to the service.
 (the Middlewares declared on the [IngressRoute](../../reference/routing-configuration/kubernetes/crd/http/ingressroute.md#middleware)
 or the [Ingress](../../reference/routing-configuration/kubernetes/ingress.md#on-ingress)
 are applied after the ones declared on the Entrypoint)
-- The option allows attaching a list of middleware using the format 
-`middlewarename@providername` as described in the example below:
+- Middlewares must be referenced by their **fully qualified name**, including the
+[provider namespace](../../reference/install-configuration/providers/overview.md#provider-namespace)
+suffix (`<middleware-name>@<provider-name>`). The exact value depends on the
+provider that declares the middleware:
+
+    | Provider           | Format                                              | Example                       |
+    |--------------------|-----------------------------------------------------|-------------------------------|
+    | <a id="opt-File" href="#opt-File" title="#opt-File">File</a> | `<middleware-name>@file`                             | `strip@file`                  |
+    | <a id="opt-Docker" href="#opt-Docker" title="#opt-Docker">Docker</a> | `<middleware-name>@docker`                           | `strip@docker`                |
+    | <a id="opt-Kubernetes-CRD" href="#opt-Kubernetes-CRD" title="#opt-Kubernetes-CRD">Kubernetes CRD</a> | `<middleware-namespace>-<middleware-name>@kubernetescrd` | `default-auth@kubernetescrd`  |
 
 ```yaml tab="File (YAML)"
 entryPoints:
@@ -213,7 +221,7 @@ entryPoints:
     address: :80
     http:
       middlewares:
-        - auth@kubernetescrd
+        - default-auth@kubernetescrd
         - strip@file
 ```
 
@@ -223,7 +231,7 @@ ports:
     port: :80
     http:
       middlewares:
-        - auth@kubernetescrd
+        - default-auth@kubernetescrd
         - strip@file
 ```
 


### PR DESCRIPTION
### What does this PR do?

Fixes the EntryPoint `http.middlewares` examples and documents the per-provider name format (table).

EntryPoint middleware names are used as-is, so kubernetescrd references need the Namespace prefix (`default-auth@kubernetescrd`, not `auth@kubernetescrd`); the old form never matched and silently failed.

### Motivation

The documented format is currently inaccurate. Confirmed against the v3.6 code (`pkg/provider/kubernetes/crd/kubernetes.go:252`): kubernetescrd middlewares are keyed `<namespace>-<name>@kubernetescrd`, and EntryPoint names are qualified without auto-prefixing. Matches the form already used for Ingress, ServersTransport and TLSOption references.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

* Documentation-only change, targeting `v3.6` per the PR template.