### PR TITLE
Align Helm chart documented values with chart v41

### DIFF
--- a/docs/content/observe/logs-and-access-logs.md
+++ b/docs/content/observe/logs-and-access-logs.md
@@ -26,11 +26,10 @@ log:
 ```
 
 ```yaml tab="Helm Chart Values"
-logs:
-  general:
-    filePath: "/path/to/log-file.log"
-    format: json
-    level: INFO
+log:
+  filePath: "/path/to/log-file.log"
+  format: json
+  level: INFO
 ```
 
 ## Access Logs
@@ -78,23 +77,22 @@ accessLog:
 
 ```yaml tab="Helm Chart Values"
 # values.yaml
-logs:
-  access:
-    enabled: true
-    format: json
-    filters:
-      statusCodes:
-        - "200"
-        - "400-404"
-        - "500-503"
-    fields:
+accessLog:
+  enabled: true
+  format: json
+  filters:
+    statusCodes:
+      - "200"
+      - "400-404"
+      - "500-503"
+  fields:
+    names:
+      ClientUsername: drop
+    headers:
+      defaultMode: keep
       names:
-        ClientUsername: drop
-      headers:
-        defaultMode: keep
-        names:
-          User-Agent: redact
-          Content-Type: keep
+        User-Agent: redact
+        Content-Type: keep
 ```
 
 ## Per-Router Access Logs

--- a/docs/content/setup/kubernetes.md
+++ b/docs/content/setup/kubernetes.md
@@ -178,12 +178,11 @@ gateway:
           group: ""
 
 # Enable Observability
-logs:
-  general:
-    level: INFO
-  # This enables access logs, outputting them to Traefik's standard output by default. The [Access Logs Documentation](https://doc.traefik.io/traefik/observability/access-logs/) covers formatting, filtering, and output options.
-  access:
-    enabled: true
+log:
+  level: INFO
+# This enables access logs, outputting them to Traefik's standard output by default. The [Access Logs Documentation](https://doc.traefik.io/traefik/observability/access-logs/) covers formatting, filtering, and output options.
+accessLog:
+  enabled: true
 
 # Enables Prometheus for Metrics
 metrics:


### PR DESCRIPTION
## What does this PR do?

[Helm chart v41.0.0](https://github.com/traefik/traefik-helm-chart/releases/tag/v41.0.0)
renamed its logging values to match upstream Traefik syntax: `logs.general` → `log`,
`logs.access` → `accessLog`. 

=> This PR updates the `Helm Chart Values` snippets accordingly.

## Motivation

The documented Helm values no longer match the chart and would fail on v41.0.0.

## More

- [ ] Added/updated tests — n/a (docs only)
- [x] Added/updated documentation