### PR TITLE
Fix CORS wildcard when allow-credentials is true

### DIFF
--- a/pkg/middlewares/headers/header.go
+++ b/pkg/middlewares/headers/header.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -78,10 +79,8 @@ func (s *Header) PostRequestModifyResponseHeaders(res *http.Response) error {
 	}
 
 	if res != nil && res.Request != nil {
-		originHeader := res.Request.Header.Get("Origin")
-		allowed, match := s.isOriginAllowed(originHeader)
-
-		if allowed {
+		match, ok := s.matchOrigin(res.Request.Header.Get("Origin"))
+		if ok {
 			res.Header.Set("Access-Control-Allow-Origin", match)
 		}
 	}
@@ -92,7 +91,9 @@ func (s *Header) PostRequestModifyResponseHeaders(res *http.Response) error {
 
 	if len(s.headers.AccessControlExposeHeaders) > 0 {
 		exposeHeaders := strings.Join(s.headers.AccessControlExposeHeaders, ",")
-		res.Header.Set("Access-Control-Expose-Headers", exposeHeaders)
+		if !(slices.Contains(s.headers.AccessControlExposeHeaders, "*") && s.headers.AccessControlAllowCredentials) {
+			res.Header.Set("Access-Control-Expose-Headers", exposeHeaders)
+		}
 	}
 
 	if !s.headers.AddVaryHeader {
@@ -154,41 +155,61 @@ func (s *Header) processCorsHeaders(rw http.ResponseWriter, req *http.Request) b
 		}
 
 		allowHeaders := strings.Join(s.headers.AccessControlAllowHeaders, ",")
-		if allowHeaders != "" {
+		if slices.Contains(s.headers.AccessControlAllowHeaders, "*") && s.headers.AccessControlAllowCredentials {
+			if acrh := req.Header.Get("Access-Control-Request-Headers"); acrh != "" {
+				rw.Header().Set("Access-Control-Allow-Headers", acrh)
+			}
+		} else if allowHeaders != "" {
 			rw.Header().Set("Access-Control-Allow-Headers", allowHeaders)
 		}
 
 		allowMethods := strings.Join(s.headers.AccessControlAllowMethods, ",")
-		if allowMethods != "" {
+		if slices.Contains(s.headers.AccessControlAllowMethods, "*") && s.headers.AccessControlAllowCredentials {
+			rw.Header().Set("Access-Control-Allow-Methods", reqAcMethod)
+		} else if allowMethods != "" {
 			rw.Header().Set("Access-Control-Allow-Methods", allowMethods)
 		}
 
-		allowed, match := s.isOriginAllowed(originHeader)
-		if allowed {
+		match, ok := s.matchOrigin(originHeader)
+		if ok {
 			rw.Header().Set("Access-Control-Allow-Origin", match)
 		}
 
 		if s.headers.AccessControlMaxAge != nil {
 			rw.Header().Set("Access-Control-Max-Age", strconv.FormatInt(*s.headers.AccessControlMaxAge, 10))
 		}
+
+		if len(s.headers.AccessControlExposeHeaders) > 0 {
+			exposeHeaders := strings.Join(s.headers.AccessControlExposeHeaders, ",")
+			if !(slices.Contains(s.headers.AccessControlExposeHeaders, "*") && s.headers.AccessControlAllowCredentials) {
+				rw.Header().Set("Access-Control-Expose-Headers", exposeHeaders)
+			}
+		}
+
 		return true
 	}
 
 	return false
 }
 
-func (s *Header) isOriginAllowed(origin string) (bool, string) {
+func (s *Header) matchOrigin(origin string) (string, bool) {
 	for _, item := range s.headers.AccessControlAllowOriginList {
-		if item == "*" || item == origin {
-			return true, item
+		switch item {
+		case origin:
+			return item, true
+		case "*":
+			if s.headers.AccessControlAllowCredentials {
+				return origin, true // Can't use wildcard with credentials.
+			}
+			return item, true
 		}
 	}
 
 	for _, regex := range s.allowOriginRegexes {
 		if regex.MatchString(origin) {
-			return true, origin
+			return origin, true
 		}
 	}
 
-	return false, ""
+	return "", false
 }

--- a/pkg/middlewares/headers/header_test.go
+++ b/pkg/middlewares/headers/header_test.go
@@ -175,7 +175,7 @@ func TestNewHeader_CORSPreflights(t *testing.T) {
 			},
 			expected: map[string][]string{
 				"Content-Length":                   {"0"},
-				"Access-Control-Allow-Origin":      {"*"},
+				"Access-Control-Allow-Origin":      {"https://foo.bar.org"},
 				"Access-Control-Max-Age":           {"600"},
 				"Access-Control-Allow-Methods":     {"GET,OPTIONS,PUT"},
 				"Access-Control-Allow-Credentials": {"true"},
@@ -371,7 +371,7 @@ func TestNewHeader_CORSResponses(t *testing.T) {
 				"Origin": {"https://foo.bar.org"},
 			},
 			expected: map[string][]string{
-				"Access-Control-Allow-Origin":      {"*"},
+				"Access-Control-Allow-Origin":      {"https://foo.bar.org"},
 				"Access-Control-Allow-Credentials": {"true"},
 			},
 		},


### PR DESCRIPTION
### What does this PR do?

This PR fixes two misalignment with the W3C specs on CORS:

1. [[spec](https://fetch.spec.whatwg.org/#http-responses)] `Access-Control-Expose-Headers` is now also returned in preflight responses. Before that, it was only returned in non-preflight responses, even though it's supposed to be a preflight-only header.
2. [[spec](https://fetch.spec.whatwg.org/#cors-protocol-and-credentials)] when `AC-Allow-Credentials` is configured to `true`, the CORS headers in the backend responses shouldn't include wildcards. So when `AC-Allow-Credentials` is configured as `true`, the middleware now echos the values from the request in the response's CORS headers instead of returning wildcards.

### Motivation

W3C conformance for the upcoming Gateway API CORS filter in the K8s provider.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
