### PR TITLE
chore: replace mailgun/ttlmap with an internal TTL map

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,6 @@ require (
 	github.com/kvtools/redis v1.2.0
 	github.com/kvtools/valkeyrie v1.0.0
 	github.com/kvtools/zookeeper v1.0.2
-	github.com/mailgun/ttlmap v0.0.0-20170619185759-c1c17f74874f // No tag on the repo.
 	github.com/miekg/dns v1.1.72
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/mitchellh/hashstructure v1.0.0
@@ -272,9 +271,7 @@ require (
 	github.com/liquidweb/liquidweb-go v1.6.4 // indirect
 	github.com/lufia/plan9stats v0.0.0-20250317134145-8bc96cf8fc35 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
-	github.com/mailgun/minheap v0.0.0-20170619185613-3dbe6c6bf55f // indirect
 	github.com/mailgun/multibuf v0.2.0 // indirect
-	github.com/mailgun/timetools v0.0.0-20141028012446-7e6055773c51 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
@@ -415,7 +412,6 @@ require (
 replace (
 	github.com/abbot/go-http-auth => github.com/containous/go-http-auth v0.4.1-0.20200324110947-a37a7636d23e
 	github.com/gorilla/mux => github.com/containous/mux v0.0.0-20250523120546-41b6ec3aed59
-	github.com/mailgun/minheap => github.com/containous/minheap v0.0.0-20190809180810-6e71eb837595
 )
 
 // ambiguous import: found package github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http in multiple modules

--- a/go.sum
+++ b/go.sum
@@ -876,8 +876,6 @@ github.com/containous/alice v0.0.0-20181107144136-d83ebdd94cbd h1:0n+lFLh5zU0l6K
 github.com/containous/alice v0.0.0-20181107144136-d83ebdd94cbd/go.mod h1:BbQgeDS5i0tNvypwEoF1oNjOJw8knRAE1DnVvjDstcQ=
 github.com/containous/go-http-auth v0.4.1-0.20200324110947-a37a7636d23e h1:D+uTEzDZc1Fhmd0Pq06c+O9+KkAyExw0eVmu/NOqaHU=
 github.com/containous/go-http-auth v0.4.1-0.20200324110947-a37a7636d23e/go.mod h1:s8kLgBQolDbsJOPVIGCEEv9zGAKUUf/685Gi0Qqg8z8=
-github.com/containous/minheap v0.0.0-20190809180810-6e71eb837595 h1:aPspFRO6b94To3gl4yTDOEtpjFwXI7V2W+z0JcNljQ4=
-github.com/containous/minheap v0.0.0-20190809180810-6e71eb837595/go.mod h1:+lHFbEasIiQVGzhVDVw/cn0ZaOzde2OwNncp1NhXV4c=
 github.com/containous/mux v0.0.0-20250523120546-41b6ec3aed59 h1:lJUOWjGohYjLKEfAz2nyI/dpzfKNPQLi5GLH7aaOZkw=
 github.com/containous/mux v0.0.0-20250523120546-41b6ec3aed59/go.mod h1:z8WW7n06n8/1xF9Jl9WmuDeZuHAhfL+bwarNjsciwwg=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -1512,10 +1510,6 @@ github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8S
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mailgun/multibuf v0.2.0 h1:pGhv93r0GXBVTDu6RMlA9GUQjwwoy4yspIujtaT0AOA=
 github.com/mailgun/multibuf v0.2.0/go.mod h1:E+sUhIy69qgT6EM57kCPdUTlHnjTuxQBO/yf6af9Hes=
-github.com/mailgun/timetools v0.0.0-20141028012446-7e6055773c51 h1:Kg/NPZLLC3aAFr1YToMs98dbCdhootQ1hZIvZU28hAQ=
-github.com/mailgun/timetools v0.0.0-20141028012446-7e6055773c51/go.mod h1:RYmqHbhWwIz3z9eVmQ2rx82rulEMG0t+Q1bzfc9DYN4=
-github.com/mailgun/ttlmap v0.0.0-20170619185759-c1c17f74874f h1:ZZYhg16XocqSKPGNQAe0aeweNtFxuedbwwb4fSlg7h4=
-github.com/mailgun/ttlmap v0.0.0-20170619185759-c1c17f74874f/go.mod h1:8heskWJ5c0v5J9WH89ADhyal1DOZcayll8fSbhB+/9A=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4=

--- a/pkg/middlewares/ratelimiter/in_memory_limiter.go
+++ b/pkg/middlewares/ratelimiter/in_memory_limiter.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/mailgun/ttlmap"
 	"github.com/rs/zerolog"
+	"github.com/traefik/traefik/v3/pkg/middlewares/ratelimiter/ttlmap"
 	"golang.org/x/time/rate"
 )
 
@@ -21,19 +21,19 @@ type inMemoryRateLimiter struct {
 	// each ratelimiter is "garbage collected" when it is considered expired.
 	// It is considered expired after it hasn't been used for ttl seconds.
 	ttl     int
-	buckets *ttlmap.TtlMap // actual buckets, keyed by source.
+	buckets *ttlmap.Map[*rate.Limiter] // actual buckets, keyed by source.
 
 	logger *zerolog.Logger
 }
 
-func newInMemoryRateLimiter(rate rate.Limit, burst int64, maxDelay time.Duration, ttl int, logger *zerolog.Logger) (*inMemoryRateLimiter, error) {
-	buckets, err := ttlmap.NewConcurrent(maxSources)
+func newInMemoryRateLimiter(rl rate.Limit, burst int64, maxDelay time.Duration, ttl int, logger *zerolog.Logger) (*inMemoryRateLimiter, error) {
+	buckets, err := ttlmap.New[*rate.Limiter](maxSources)
 	if err != nil {
 		return nil, fmt.Errorf("creating ttlmap: %w", err)
 	}
 
 	return &inMemoryRateLimiter{
-		rate:     rate,
+		rate:     rl,
 		burst:    burst,
 		maxDelay: maxDelay,
 		ttl:      ttl,
@@ -44,10 +44,8 @@ func newInMemoryRateLimiter(rate rate.Limit, burst int64, maxDelay time.Duration
 
 func (i *inMemoryRateLimiter) Allow(_ context.Context, source string) (*time.Duration, error) {
 	// Get bucket which contains limiter information.
-	var bucket *rate.Limiter
-	if rlSource, exists := i.buckets.Get(source); exists {
-		bucket = rlSource.(*rate.Limiter)
-	} else {
+	bucket, exists := i.buckets.Get(source)
+	if !exists {
 		bucket = rate.NewLimiter(i.rate, int(i.burst))
 	}
 

--- a/pkg/middlewares/ratelimiter/rate_limiter_test.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter_test.go
@@ -12,12 +12,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mailgun/ttlmap"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
+	"github.com/traefik/traefik/v3/pkg/middlewares/ratelimiter/ttlmap"
 	"github.com/traefik/traefik/v3/pkg/testhelpers"
 	"github.com/vulcand/oxy/v2/utils"
 	lua "github.com/yuin/gopher-lua"
@@ -553,11 +553,11 @@ func TestRedisRateLimit(t *testing.T) {
 
 type mockRedisClient struct {
 	ttl  int
-	keys *ttlmap.TtlMap
+	keys *ttlmap.Map[[]string]
 }
 
 func newMockRedisClient(ttl int) Rediser {
-	buckets, _ := ttlmap.NewConcurrent(65536)
+	buckets, _ := ttlmap.New[[]string](65536)
 	return &mockRedisClient{
 		ttl:  ttl,
 		keys: buckets,
@@ -598,16 +598,10 @@ func (m *mockRedisClient) EvalSha(ctx context.Context, _ string, keys []string, 
 				if !ok {
 					state.Push(table)
 				} else {
-					switch v := value.(type) {
-					case []string:
-						if len(v) != 4 {
-							break
+					if len(value) == 4 {
+						for i := range value {
+							table.Append(lua.LString(value[i]))
 						}
-						for i := range v {
-							table.Append(lua.LString(v[i]))
-						}
-					default:
-						fmt.Printf("Unknown type: %T\n", v)
 					}
 					state.Push(table)
 				}

--- a/pkg/middlewares/ratelimiter/ttlmap/ttlmap.go
+++ b/pkg/middlewares/ratelimiter/ttlmap/ttlmap.go
@@ -1,0 +1,149 @@
+package ttlmap
+
+import (
+	"container/heap"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Map is a thread-safe map with a bounded capacity and per-entry expiration.
+type Map[V any] struct {
+	capacity int
+
+	mu       sync.Mutex
+	items    map[string]*item[V]
+	expiries expiryHeap[V]
+
+	clock func() time.Time
+}
+
+// New creates a Map holding at most capacity entries.
+func New[V any](capacity int) (*Map[V], error) {
+	if capacity <= 0 {
+		return nil, errors.New("capacity must be greater than 0")
+	}
+
+	return &Map[V]{
+		capacity: capacity,
+		items:    make(map[string]*item[V]),
+		clock:    time.Now,
+	}, nil
+}
+
+// Get returns the value stored for the key. Expired entries are removed lazily and
+// reported as absent.
+func (m *Map[V]) Get(key string) (V, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var zero V
+	it, ok := m.items[key]
+	if !ok {
+		return zero, false
+	}
+
+	if m.expired(it) {
+		m.remove(it)
+		return zero, false
+	}
+
+	return it.value, true
+}
+
+// Set stores value for a key and resets its expiration to ttlSeconds from now.
+// When the map is full, inserting a new key evicts the entry closest to expiration.
+func (m *Map[V]) Set(key string, value V, ttlSeconds int) error {
+	if ttlSeconds <= 0 {
+		return fmt.Errorf("ttlSeconds must be greater than 0, got %d", ttlSeconds)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	expiry := m.clock().Add(time.Duration(ttlSeconds) * time.Second).Unix()
+
+	if it, ok := m.items[key]; ok {
+		it.value = value
+		it.expiry = expiry
+		heap.Fix(&m.expiries, it.index)
+		return nil
+	}
+
+	if len(m.items) >= m.capacity {
+		m.freeSpace()
+	}
+
+	it := &item[V]{key: key, value: value, expiry: expiry}
+	m.items[key] = it
+	heap.Push(&m.expiries, it)
+
+	return nil
+}
+
+// Len returns the number of entries currently held, including any that have
+// expired but not yet been removed.
+func (m *Map[V]) Len() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return len(m.items)
+}
+
+func (m *Map[V]) expired(it *item[V]) bool {
+	return it.expiry <= m.clock().Unix()
+}
+
+// freeSpace evicts the entry closest to expiration to make room for a new one.
+func (m *Map[V]) freeSpace() {
+	if len(m.expiries) == 0 {
+		return
+	}
+
+	it := heap.Pop(&m.expiries).(*item[V])
+	delete(m.items, it.key)
+}
+
+func (m *Map[V]) remove(it *item[V]) {
+	heap.Remove(&m.expiries, it.index)
+	delete(m.items, it.key)
+}
+
+// item is an entry of the Map.
+type item[V any] struct {
+	key    string
+	value  V
+	expiry int64 // expiration as a Unix timestamp in seconds.
+	index  int   // position in the expiries heap, maintained by the heap.
+}
+
+// expiryHeap is a min-heap of items ordered by expiration, so that the entry
+// closest to expiration sits at the root. It implements heap.Interface.
+type expiryHeap[V any] []*item[V]
+
+func (h expiryHeap[V]) Len() int { return len(h) }
+
+func (h expiryHeap[V]) Less(i, j int) bool { return h[i].expiry < h[j].expiry }
+
+func (h expiryHeap[V]) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].index = i
+	h[j].index = j
+}
+
+func (h *expiryHeap[V]) Push(x any) {
+	it := x.(*item[V])
+	it.index = len(*h)
+	*h = append(*h, it)
+}
+
+func (h *expiryHeap[V]) Pop() any {
+	old := *h
+	n := len(old)
+	it := old[n-1]
+	old[n-1] = nil // avoid memory leak.
+	it.index = -1
+	*h = old[:n-1]
+	return it
+}

--- a/pkg/middlewares/ratelimiter/ttlmap/ttlmap_test.go
+++ b/pkg/middlewares/ratelimiter/ttlmap/ttlmap_test.go
@@ -1,0 +1,124 @@
+package ttlmap
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withClock returns a Map whose clock is controlled by the returned pointer.
+func withClock[V any](t *testing.T, capacity int) (*Map[V], *time.Time) {
+	t.Helper()
+
+	m, err := New[V](capacity)
+	require.NoError(t, err)
+
+	now := time.Unix(1000, 0)
+	m.clock = func() time.Time { return now }
+
+	return m, &now
+}
+
+func TestNew_invalidCapacity(t *testing.T) {
+	_, err := New[string](0)
+	assert.Error(t, err)
+
+	_, err = New[string](-1)
+	assert.Error(t, err)
+}
+
+func TestMap_setAndGet(t *testing.T) {
+	m, _ := withClock[string](t, 10)
+
+	_, ok := m.Get("missing")
+	assert.False(t, ok)
+
+	require.NoError(t, m.Set("key", "value", 10))
+
+	value, ok := m.Get("key")
+	assert.True(t, ok)
+	assert.Equal(t, "value", value)
+}
+
+func TestMap_setInvalidTTL(t *testing.T) {
+	m, _ := withClock[string](t, 10)
+
+	assert.Error(t, m.Set("key", "value", 0))
+	assert.Error(t, m.Set("key", "value", -1))
+}
+
+func TestMap_expiration(t *testing.T) {
+	m, now := withClock[string](t, 10)
+
+	require.NoError(t, m.Set("key", "value", 10))
+
+	// Just before expiry, the entry is still there.
+	*now = now.Add(9 * time.Second)
+	_, ok := m.Get("key")
+	assert.True(t, ok)
+
+	// At/after expiry, it is gone and lazily removed.
+	*now = now.Add(2 * time.Second)
+	_, ok = m.Get("key")
+	assert.False(t, ok)
+	assert.Equal(t, 0, m.Len())
+}
+
+func TestMap_setRefreshesExpiration(t *testing.T) {
+	m, now := withClock[string](t, 10)
+
+	require.NoError(t, m.Set("key", "value", 10))
+
+	*now = now.Add(8 * time.Second)
+	require.NoError(t, m.Set("key", "updated", 10))
+
+	// Original expiry would have passed, but Set pushed it back.
+	*now = now.Add(8 * time.Second)
+	value, ok := m.Get("key")
+	assert.True(t, ok)
+	assert.Equal(t, "updated", value)
+	assert.Equal(t, 1, m.Len())
+}
+
+func TestMap_capacityEvictsClosestToExpiry(t *testing.T) {
+	m, now := withClock[string](t, 2)
+
+	require.NoError(t, m.Set("a", "a", 100)) // expires first.
+	require.NoError(t, m.Set("b", "b", 200))
+
+	// Inserting a third key evicts "a", the entry closest to expiration.
+	require.NoError(t, m.Set("c", "c", 300))
+
+	_, ok := m.Get("a")
+	assert.False(t, ok)
+
+	_, ok = m.Get("b")
+	assert.True(t, ok)
+
+	_, ok = m.Get("c")
+	assert.True(t, ok)
+
+	assert.Equal(t, 2, m.Len())
+
+	// now is unused beyond construction here but kept for symmetry.
+	_ = now
+}
+
+func TestMap_concurrentAccess(t *testing.T) {
+	m, err := New[int](100)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for i := range 50 {
+		wg.Go(func() {
+			key := strconv.Itoa(i)
+			require.NoError(t, m.Set(key, i, 60))
+			m.Get(key)
+		})
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
### What does this PR do?

This PR removes the `github.com/mailgun/ttlmap` dependency from the rate limiter middleware. 
That package was used to store the per-source token buckets. It is now replaced by a small internal generic implementation. The new one is backed by the standard library's `container/heap`. It keeps the same bounded-capacity and per-entry TTL eviction semantics. The call sites are unchanged, and their `interface{}` casts are gone.

### Motivation

`mailgun/ttlmap` is no longer maintained. Its suggested replacement, `github.com/mailgun/holster`, is a large package. It would pull in a lot of new dependencies. Reimplementing only the small subset we rely on is more reasonable. It also lets us drop two transitive dependencies. Those are `github.com/mailgun/timetools` and `github.com/mailgun/minheap`. The latter came with its `containous/minheap` replace directive.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation