### PR TITLE
Fix CORS Max-Age set to 0 by default

### DIFF
--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -324,7 +324,7 @@ type Headers struct {
 	// AccessControlExposeHeaders defines the Access-Control-Expose-Headers values sent in preflight response.
 	AccessControlExposeHeaders []string `json:"accessControlExposeHeaders,omitempty" toml:"accessControlExposeHeaders,omitempty" yaml:"accessControlExposeHeaders,omitempty" export:"true"`
 	// AccessControlMaxAge defines the time that a preflight request may be cached.
-	AccessControlMaxAge int64 `json:"accessControlMaxAge,omitempty" toml:"accessControlMaxAge,omitempty" yaml:"accessControlMaxAge,omitempty" export:"true"`
+	AccessControlMaxAge *int64 `json:"accessControlMaxAge,omitempty" toml:"accessControlMaxAge,omitempty" yaml:"accessControlMaxAge,omitempty" export:"true"`
 	// AddVaryHeader defines whether the Vary header is automatically added/updated when the AccessControlAllowOriginList is set.
 	AddVaryHeader bool `json:"addVaryHeader,omitempty" toml:"addVaryHeader,omitempty" yaml:"addVaryHeader,omitempty" export:"true"`
 	// AllowedHosts defines the fully qualified list of allowed domain names.
@@ -400,7 +400,7 @@ func (h *Headers) HasCorsHeadersDefined() bool {
 		len(h.AccessControlAllowOriginList) != 0 ||
 		len(h.AccessControlAllowOriginListRegex) != 0 ||
 		len(h.AccessControlExposeHeaders) != 0 ||
-		h.AccessControlMaxAge != 0 ||
+		h.AccessControlMaxAge != nil ||
 		h.AddVaryHeader)
 }
 

--- a/pkg/config/dynamic/zz_generated.deepcopy.go
+++ b/pkg/config/dynamic/zz_generated.deepcopy.go
@@ -653,6 +653,11 @@ func (in *Headers) DeepCopyInto(out *Headers) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.AccessControlMaxAge != nil {
+		in, out := &in.AccessControlMaxAge, &out.AccessControlMaxAge
+		*out = new(int64)
+		**out = **in
+	}
 	if in.AllowedHosts != nil {
 		in, out := &in.AllowedHosts, &out.AllowedHosts
 		*out = make([]string, len(*in))

--- a/pkg/config/label/label_test.go
+++ b/pkg/config/label/label_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
 	"github.com/traefik/traefik/v3/pkg/tls"
 	"github.com/traefik/traefik/v3/pkg/types"
+	"k8s.io/utils/ptr"
 )
 
 func pointer[T any](v T) *T { return &v }
@@ -622,7 +623,7 @@ func TestDecodeConfiguration(t *testing.T) {
 							"X-foobar",
 							"X-fiibar",
 						},
-						AccessControlMaxAge: 200,
+						AccessControlMaxAge: ptr.To(int64(200)),
 						AddVaryHeader:       true,
 						AllowedHosts: []string{
 							"foobar",
@@ -1177,7 +1178,7 @@ func TestEncodeConfiguration(t *testing.T) {
 							"X-foobar",
 							"X-fiibar",
 						},
-						AccessControlMaxAge: 200,
+						AccessControlMaxAge: ptr.To(int64(200)),
 						AddVaryHeader:       true,
 						AllowedHosts: []string{
 							"foobar",

--- a/pkg/middlewares/headers/header.go
+++ b/pkg/middlewares/headers/header.go
@@ -168,7 +168,9 @@ func (s *Header) processCorsHeaders(rw http.ResponseWriter, req *http.Request) b
 			rw.Header().Set("Access-Control-Allow-Origin", match)
 		}
 
-		rw.Header().Set("Access-Control-Max-Age", strconv.Itoa(int(s.headers.AccessControlMaxAge)))
+		if s.headers.AccessControlMaxAge != nil {
+			rw.Header().Set("Access-Control-Max-Age", strconv.FormatInt(*s.headers.AccessControlMaxAge, 10))
+		}
 		return true
 	}
 

--- a/pkg/middlewares/headers/header_test.go
+++ b/pkg/middlewares/headers/header_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
+	"k8s.io/utils/ptr"
 )
 
 func TestNewHeader_customRequestHeader(t *testing.T) {
@@ -126,7 +127,7 @@ func TestNewHeader_CORSPreflights(t *testing.T) {
 			cfg: dynamic.Headers{
 				AccessControlAllowMethods:    []string{"GET", "OPTIONS", "PUT"},
 				AccessControlAllowOriginList: []string{"https://foo.bar.org"},
-				AccessControlMaxAge:          600,
+				AccessControlMaxAge:          ptr.To(int64(600)),
 			},
 			requestHeaders: map[string][]string{
 				"Access-Control-Request-Headers": {"origin"},
@@ -145,7 +146,7 @@ func TestNewHeader_CORSPreflights(t *testing.T) {
 			cfg: dynamic.Headers{
 				AccessControlAllowMethods:    []string{"GET", "OPTIONS", "PUT"},
 				AccessControlAllowOriginList: []string{"*"},
-				AccessControlMaxAge:          600,
+				AccessControlMaxAge:          ptr.To(int64(600)),
 			},
 			requestHeaders: map[string][]string{
 				"Access-Control-Request-Headers": {"origin"},
@@ -165,7 +166,7 @@ func TestNewHeader_CORSPreflights(t *testing.T) {
 				AccessControlAllowMethods:     []string{"GET", "OPTIONS", "PUT"},
 				AccessControlAllowOriginList:  []string{"*"},
 				AccessControlAllowCredentials: true,
-				AccessControlMaxAge:           600,
+				AccessControlMaxAge:           ptr.To(int64(600)),
 			},
 			requestHeaders: map[string][]string{
 				"Access-Control-Request-Headers": {"origin"},
@@ -186,7 +187,7 @@ func TestNewHeader_CORSPreflights(t *testing.T) {
 				AccessControlAllowMethods:    []string{"GET", "OPTIONS", "PUT"},
 				AccessControlAllowOriginList: []string{"*"},
 				AccessControlAllowHeaders:    []string{"origin", "X-Forwarded-For"},
-				AccessControlMaxAge:          600,
+				AccessControlMaxAge:          ptr.To(int64(600)),
 			},
 			requestHeaders: map[string][]string{
 				"Access-Control-Request-Headers": {"origin"},
@@ -207,7 +208,7 @@ func TestNewHeader_CORSPreflights(t *testing.T) {
 				AccessControlAllowMethods:    []string{"GET", "OPTIONS", "PUT"},
 				AccessControlAllowOriginList: []string{"*"},
 				AccessControlAllowHeaders:    []string{"origin", "X-Forwarded-For"},
-				AccessControlMaxAge:          600,
+				AccessControlMaxAge:          ptr.To(int64(600)),
 			},
 			requestHeaders: map[string][]string{
 				"Access-Control-Request-Method": {"GET", "OPTIONS"},
@@ -219,6 +220,23 @@ func TestNewHeader_CORSPreflights(t *testing.T) {
 				"Access-Control-Max-Age":       {"600"},
 				"Access-Control-Allow-Methods": {"GET,OPTIONS,PUT"},
 				"Access-Control-Allow-Headers": {"origin,X-Forwarded-For"},
+			},
+		},
+		{
+			desc: "Nil MaxAge Preflight",
+			cfg: dynamic.Headers{
+				AccessControlAllowMethods:    []string{"GET", "OPTIONS", "PUT"},
+				AccessControlAllowOriginList: []string{"*"},
+				AccessControlMaxAge:          nil,
+			},
+			requestHeaders: map[string][]string{
+				"Access-Control-Request-Method": {"GET", "OPTIONS"},
+				"Origin":                        {"https://foo.bar.org"},
+			},
+			expected: map[string][]string{
+				"Content-Length":               {"0"},
+				"Access-Control-Allow-Origin":  {"*"},
+				"Access-Control-Allow-Methods": {"GET,OPTIONS,PUT"},
 			},
 		},
 	}

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
@@ -929,7 +929,7 @@ func applyCORSConfiguration(routerName string, ingressConfig ingressConfig, rt *
 			AccessControlAllowHeaders:     ptr.Deref(ingressConfig.CORSAllowHeaders, []string{"DNT", "Keep-Alive", "User-Agent", "X-Requested-With", "If-Modified-Since", "Cache-Control", "Content-Type", "Range", "Authorization"}),
 			AccessControlAllowMethods:     ptr.Deref(ingressConfig.CORSAllowMethods, []string{"GET", "PUT", "POST", "DELETE", "PATCH", "OPTIONS"}),
 			AccessControlAllowOriginList:  ptr.Deref(ingressConfig.CORSAllowOrigin, []string{"*"}),
-			AccessControlMaxAge:           int64(ptr.Deref(ingressConfig.CORSMaxAge, 1728000)),
+			AccessControlMaxAge:           ptr.To(int64(ptr.Deref(ingressConfig.CORSMaxAge, 1728000))),
 		},
 	}
 

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -535,7 +535,7 @@ func TestLoadIngresses(t *testing.T) {
 								AccessControlAllowMethods:     []string{"PUT", "GET", "POST", "OPTIONS"},
 								AccessControlAllowOriginList:  []string{"*"},
 								AccessControlExposeHeaders:    []string{"X-Forwarded-For", "X-Forwarded-Host"},
-								AccessControlMaxAge:           42,
+								AccessControlMaxAge:           ptr.To(int64(42)),
 							},
 						},
 					},

--- a/pkg/provider/kv/kv_test.go
+++ b/pkg/provider/kv/kv_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
 	"github.com/traefik/traefik/v3/pkg/tls"
 	"github.com/traefik/traefik/v3/pkg/types"
+	"k8s.io/utils/ptr"
 )
 
 func pointer[T any](v T) *T { return &v }
@@ -603,7 +604,7 @@ func Test_buildConfiguration(t *testing.T) {
 							"foobar",
 							"foobar",
 						},
-						AccessControlMaxAge: 42,
+						AccessControlMaxAge: ptr.To(int64(42)),
 						AddVaryHeader:       true,
 						AllowedHosts: []string{
 							"foobar",

--- a/pkg/redactor/redactor_config_test.go
+++ b/pkg/redactor/redactor_config_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/traefik/traefik/v3/pkg/provider/rest"
 	traefiktls "github.com/traefik/traefik/v3/pkg/tls"
 	"github.com/traefik/traefik/v3/pkg/types"
+	"k8s.io/utils/ptr"
 )
 
 var updateExpected = flag.Bool("update_expected", false, "Update expected files in fixtures")
@@ -204,7 +205,7 @@ func init() {
 					AccessControlAllowOriginList:      []string{"foo"},
 					AccessControlAllowOriginListRegex: []string{"foo"},
 					AccessControlExposeHeaders:        []string{"foo"},
-					AccessControlMaxAge:               42,
+					AccessControlMaxAge:               ptr.To(int64(42)),
 					AddVaryHeader:                     true,
 					AllowedHosts:                      []string{"foo"},
 					HostsProxyHeaders:                 []string{"foo"},


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

We don't distinguish a CORS Max-Age that's not configured, from a Max-Age that's explicitly set to `0`.
It causes Traefik to always return a Max-Age of `0` by default, which is treated as `no-cache` by browsers.

This PRs omits the CORS Max-Age header if it hasn't been explicitly configured by the user, letting browsers decide with their own defaults if they should cache or not.


### Motivation

This is a bug that, by default, unintentionally disable CORS caching.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
