### PR TITLE
Fix broken CRD reference links in IngressRoute page

### DIFF
--- a/docs/content/reference/routing-configuration/kubernetes/crd/http/ingressroute.md
+++ b/docs/content/reference/routing-configuration/kubernetes/crd/http/ingressroute.md
@@ -5,7 +5,7 @@ description: "An IngressRoute is a Traefik CRD is in charge of connecting incomi
 
 `IngressRoute` is the CRD implementation of a [Traefik HTTP router](../../../http/routing/rules-and-priority.md).
 
-Before creating `IngressRoute` objects, you need to apply the Traefik Kubernetes CRDs such as [Definitions](/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml) and [RBAC](/docs/content/reference/dynamic-configuration/kubernetes-crd-rbac.yml) to your Kubernetes cluster.
+Before creating `IngressRoute` objects, you need to apply the Traefik Kubernetes CRDs such as [Definitions](../../../../dynamic-configuration/kubernetes-crd-definition-v1.yml) and [RBAC](../../../../dynamic-configuration/kubernetes-crd-rbac.yml) to your Kubernetes cluster.
 
 This registers the `IngressRoute` kind and other Traefik-specific resources.
 


### PR DESCRIPTION
The IngressRoute page linked the CRD Definitions/RBAC YAMLs with absolute `/docs/content/...` paths, which 404 on the rendered site. Changed them to relative paths, matching every other doc that references these files.
