### PR TITLE
feat(otel): add traefik.service.name attribute to client spans

### DIFF
--- a/pkg/middlewares/observability/service.go
+++ b/pkg/middlewares/observability/service.go
@@ -15,6 +15,19 @@ const (
 	serviceTypeName = "TracingService"
 )
 
+type serviceNameKey struct{}
+
+// WithServiceName stores the logical service name in the context.
+func WithServiceName(ctx context.Context, service string) context.Context {
+	return context.WithValue(ctx, serviceNameKey{}, service)
+}
+
+// ServiceNameFromContext retrieves the logical service name from the context.
+func ServiceNameFromContext(ctx context.Context) (string, bool) {
+	name, ok := ctx.Value(serviceNameKey{}).(string)
+	return name, ok && name != ""
+}
+
 type serviceTracing struct {
 	service string
 	next    http.Handler
@@ -32,6 +45,9 @@ func NewService(ctx context.Context, service string, next http.Handler) http.Han
 }
 
 func (t *serviceTracing) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	// Store service name in context for use by the RoundTripper client span.
+	req = req.WithContext(WithServiceName(req.Context(), t.service))
+
 	if tracer := tracing.TracerFromContext(req.Context()); tracer != nil && DetailedTracingEnabled(req.Context()) {
 		tracingCtx, span := tracer.Start(req.Context(), "Service", trace.WithSpanKind(trace.SpanKindInternal))
 		defer span.End()

--- a/pkg/proxy/httputil/observability.go
+++ b/pkg/proxy/httputil/observability.go
@@ -43,6 +43,11 @@ func (t *wrapper) RoundTrip(req *http.Request) (*http.Response, error) {
 
 		tracer.CaptureClientRequest(span, req)
 		tracing.InjectContextIntoCarrier(req)
+
+		// Add logical service name to client span if available.
+		if serviceName, ok := observability.ServiceNameFromContext(req.Context()); ok {
+			span.SetAttributes(attribute.String("traefik.service.name", serviceName))
+		}
 	}
 
 	var statusCode int


### PR DESCRIPTION
### What does this PR do?

When Traefik acts as a client (outbound requests to backend Pods), the `ReverseProxy` 
client span only populates `server.address` with the ephemeral Pod IP. This causes APM 
tools and service graph generators to draw hundreds of unique numeric IP nodes instead 
of a unified logical service node.

This PR adds the logical service name as a `traefik.service.name` attribute on the 
client span by:

1. Storing the service name in the request context inside `serviceTracing.ServeHTTP`
2. Reading it in the `RoundTripper` (`pkg/proxy/httputil/observability.go`) and setting 
   it as an attribute on the `ReverseProxy` client span

### Motivation

Fixes #13365

### More
- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

The `traefik.service.name` attribute is already used on the internal `Service` span 
(in `serviceTracing`), so this PR reuses the same attribute name for consistency on 
the client span as well.