### PR TITLE
Add HTTP/2 header memory exhaustion security documentation

### DIFF
--- a/docs/content/security/http2-header-memory.md
+++ b/docs/content/security/http2-header-memory.md
@@ -1,0 +1,71 @@
+---
+title: "HTTP/2 Header Memory"
+description: "Protect Traefik against HTTP/2 header memory exhaustion by bounding the request header size and the number of concurrent streams per connection. Read the technical documentation."
+---
+
+# HTTP/2 Header Memory Exhaustion
+
+Traefik serves HTTP/2 through the Go standard library.
+With HTTP/2, a single connection can multiplex many concurrent requests, each carrying its own header block.
+
+A client can abuse HPACK header compression together with the HTTP/2 flow-control window to expand a small amount of wire data into a large memory allocation on the proxy, and keep that allocation pinned by stalling the streams.
+With enough concurrent streams and connections, this can exhaust the available memory and terminate the Traefik process.
+
+Two entry point options bound this exposure. It is recommended to use them together.
+
+## Limit the Request Header Size
+
+The [`maxHeaderBytes`](../routing/entrypoints.md#maxheaderbytes) option caps the size, in bytes, of the request headers Traefik reads for each request.
+Lowering it from the default (`1048576`, that is 1 MiB) to the smallest value your largest legitimate headers need lets Traefik reject an oversized header block before it can be amplified.
+
+```yaml tab="File (YAML)"
+entryPoints:
+  websecure:
+    address: ':443'
+    http:
+      maxHeaderBytes: 65536
+```
+
+```toml tab="File (TOML)"
+[entryPoints.websecure]
+  address = ":443"
+
+  [entryPoints.websecure.http]
+    maxHeaderBytes = 65536
+```
+
+```bash tab="CLI"
+--entryPoints.websecure.address=:443
+--entryPoints.websecure.http.maxHeaderBytes=65536
+```
+
+## Limit Concurrent Streams per Connection
+
+The [`maxConcurrentStreams`](../routing/entrypoints.md#maxconcurrentstreams) option caps the number of concurrent HTTP/2 streams each client is allowed to initiate on a single connection (default `250`).
+Lowering it reduces the amount of memory a single connection can pin.
+
+```yaml tab="File (YAML)"
+entryPoints:
+  websecure:
+    address: ':443'
+    http2:
+      maxConcurrentStreams: 100
+```
+
+```toml tab="File (TOML)"
+[entryPoints.websecure]
+  address = ":443"
+
+  [entryPoints.websecure.http2]
+    maxConcurrentStreams = 100
+```
+
+```bash tab="CLI"
+--entryPoints.websecure.address=:443
+--entryPoints.websecure.http2.maxConcurrentStreams=100
+```
+
+!!! note "Defense in Depth"
+
+    These two limits bound the memory a single connection can consume.
+    For additional protection, also limit the number of concurrent connections and the request rate per source IP at a fronting load balancer or firewall, and provision the Traefik instance with enough memory to handle the expected legitimate load.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -168,6 +168,7 @@ nav:
   - 'Security':
         - 'Request Path': 'security/request-path.md'
         - 'Content-Length': 'security/content-length.md'
+        - 'HTTP/2 Header Memory': 'security/http2-header-memory.md'
         - 'TLS in Multi-Tenant Kubernetes': 'security/tls-certs-in-multi-tenant-kubernetes.md'
   - 'User Guides':
       - 'Kubernetes and Let''s Encrypt': 'user-guides/crd-acme/index.md'


### PR DESCRIPTION
## What does this PR do?

Adds a Security section page documenting how to harden Traefik against HTTP/2 header memory exhaustion (the "HTTP/2 Bomb" class: HPACK amplification combined with an HTTP/2 flow-control window stall to pin large amounts of memory and OOM-kill the proxy).

The page documents the two entry point levers, used together:

- `http.maxHeaderBytes` (added in #d270272f5): cap the decoded request header block so an oversized block is rejected before it can be amplified.
- `http2.maxConcurrentStreams`: cap the per-connection stream multiplier.

It also points to defense in depth (per-source connection / rate limits at a fronting LB, and adequate memory provisioning).

## Motivation

Follow-up to a security report on the HTTP/2 Bomb attack class. Traefik relies on Go's net/http HTTP/2 implementation, consistent with the Go team's position (golang/go#79936); the exposure is controllable via existing entry point configuration, so this documents the recommended hardening rather than introducing a code change.

## More

- [ ] Added/updated tests
- [x] Added/updated documentation

This page is also needed on v3.x; a separate PR will target the current release branch.