### PR TITLE
Add code-review skill

### DIFF
--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: review
+description: Repository-specific guidance for the AI code review agent reviewing this repo
+user-invocable: true
+disable-model-invocation: true
+---
+
+# Code review guidance
+
+This is Traefik (Go), a cloud-native reverse proxy and load balancer. The reviewer already fixes the
+role, the tools, the severity definitions, the finding mechanics and the output format; this guidance
+is **additive** and must not restate them. Record findings only with the severities the reviewer
+accepts: `CRITICAL`, `IMPORTANT`, `MINOR`, `QUESTION`.
+
+Review in this priority order, and keep the bar high at every level.
+
+## Security
+
+- Validate authentication, authorization and trust boundaries at every boundary crossing.
+- Trace untrusted input through to dangerous sinks (exec, SQL, file I/O, template rendering).
+- No hardcoded passwords, tokens or API keys; no secrets or sensitive data in logs.
+
+## Correctness
+
+- Nil dereferences, race conditions, off-by-one errors, inverted conditions, unhandled edge cases.
+- Errors are wrapped with `fmt.Errorf` in gerund form, e.g. `fmt.Errorf("unmarshalling data: %w", err)`, and never silently dropped with `_`.
+- Resource leaks: unclosed connections, leaked goroutines, contexts not propagated or cancelled.
+- `context.Context` must be the first argument of every function that accepts one, named `ctx`.
+- Do not use `context.Background()` in request paths — propagate the context from the caller.
+- Custom context keys must be unexported struct types (`type myKey struct{}`), never bare strings or integers.
+- Changes must not blur the static/dynamic configuration boundary: static configuration is read at startup only; dynamic configuration is produced by providers at runtime. Code that reads dynamic config at startup, or stores static config in a runtime struct, is a correctness bug.
+
+## Breaking changes
+
+- Flag breaking changes to exported Go APIs and to CRD schemas under `traefik.io/v1alpha1`.
+- Flag configuration changes that affect existing deployments.
+
+## Performance
+
+- Superlinear algorithms where linear suffices, and avoidable allocations or I/O, but only in hot paths where it measurably matters.
+
+## Maintainability
+
+- Use `github.com/rs/zerolog` exclusively — do not import `log`, `slog`, or `logrus`.
+- Interfaces: prefer single-method, `-er` suffix, declared at the usage site.
+- Idiomatic Go: early returns and guard clauses, the standard library (`slices`, `maps`, `cmp`) over premature abstraction or third-party helpers, grouped import ordering, exported items with a doc comment starting with the item name.
+- Comments must explain *why*, not *what*; the code already says what. Every comment must end with a period.
+- Tests: new behaviour needs tests using `testify/assert` and `testify/require`; use `require` for preconditions that must stop the test, `assert` for independent checks. Tests must be table-driven with `t.Parallel()`. Blackbox testing (`package x_test`) is preferred. Do not add verbose message arguments to `assert`/`require` calls — the test name provides the context.
+
+## Do not flag
+
+- Generated code: files matching `zz_generated*.go`, everything under `pkg/provider/kubernetes/crd/generated/`, and `webui/static/`.
+- Test mocks: files matching `mock_*.go` or `*_mock.go`.
+- `//nolint:` directives — they are intentional.
+- Integration test fixtures under `integration/fixtures/` — Docker-dependent behaviour cannot be verified statically.
+- Patterns already used consistently across the codebase.
+
+Before claiming a change is unsafe, check how the changed functions are used elsewhere in the repository: the call sites decide.

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -7,7 +7,7 @@ disable-model-invocation: true
 
 # Code review guidance
 
-This is Traefik (Go), a cloud-native reverse proxy and load balancer. The reviewer already fixes the
+This is Traefik Proxy (Go), a cloud-native reverse proxy and load balancer. The reviewer already fixes the
 role, the tools, the severity definitions, the finding mechanics and the output format; this guidance
 is **additive** and must not restate them. Record findings only with the severities the reviewer
 accepts: `CRITICAL`, `IMPORTANT`, `MINOR`, `QUESTION`.

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -41,7 +41,6 @@ Review in this priority order, and keep the bar high at every level.
 
 ## Maintainability
 
-- Use `github.com/rs/zerolog` exclusively — do not import `log`, `slog`, or `logrus`.
 - Interfaces: prefer single-method, `-er` suffix, declared at the usage site.
 - Idiomatic Go: early returns and guard clauses, the standard library (`slices`, `maps`, `cmp`) over premature abstraction or third-party helpers, grouped import ordering, exported items with a doc comment starting with the item name.
 - Comments must explain *why*, not *what*; the code already says what. Every comment must end with a period.

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ plugins-storage/
 plugins-local/
 traefik_changelog.md
 integration/tailscale.secret
+.claude/settings.local.json

--- a/docs/content/contributing/submitting-pull-requests.md
+++ b/docs/content/contributing/submitting-pull-requests.md
@@ -77,6 +77,8 @@ in short, it looks like this:
     * During code review, we ask that you be reasonably responsive,
       if a PR languishes in code review it is at risk of rejection,
       or we may take ownership of the PR and the contributor will become a co-author.
+    * Maintainers may add the `ai/review` label to trigger an automated AI review of the pull request.
+      The review is based on repository-specific guidelines and posted as inline comments.
 * Merge.
     * Success!
 
@@ -222,6 +224,26 @@ In this situation, you can ask the primary reviewer (assignee) whether they want
 to clear out all the comments.
 You do not have to fix every issue raised by every person who feels like commenting,
 but you should answer reasonable comments with an explanation.
+
+## AI-Assisted Code Review
+
+Maintainers may add the `ai/review` label to a pull request to trigger an automated AI code review.
+
+When the label is applied, an AI agent reads the diff and the full content of every changed file,
+then posts inline comments directly on the pull request.
+The review follows repository-specific guidelines covering security, correctness, breaking changes,
+performance, and Go conventions (error wrapping, context propagation, logging, test style, and more).
+
+**What to expect:**
+
+* Comments are categorized by severity: `CRITICAL`, `IMPORTANT`, `MINOR`, or `QUESTION`.
+* The agent checks call sites before flagging a change as unsafe — a finding that does not survive that check will not be posted.
+* Generated files, `//nolint:` directives, and patterns already used consistently across the codebase are not flagged.
+
+**How to respond:**
+
+Treat AI review comments the same way you would a human reviewer's comments.
+If a finding is incorrect or does not apply to your change, explain why in a reply — maintainers read every thread before approving.
 
 ## Common Sense and Courtesy
 


### PR DESCRIPTION
### What does this PR do?

Adds repository-specific guidance for the AI code review skill and documents the `ai/review` label workflow for contributors.

- `.claude/skills/review/SKILL.md`: Traefik-specific review guidance (security, correctness, Go conventions, what to skip) consumed by the AI code review agent.
- `docs/content/contributing/submitting-pull-requests.md`: Documents the `ai/review` label — what it triggers, how comments are categorized, and how contributors should respond.
- `.gitignore`: Ignores `.claude/settings.local.json`.

### Motivation

Maintainers need a way to trigger AI-assisted review on specific pull requests without enabling it globally. The review guidance ensures the agent applies Traefik's conventions rather than generic defaults.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes
