### PR TITLE
Add regression test coverage ensuring request trailers are not forwarded to the backend

### DIFF
--- a/pkg/proxy/fast/trailer_test.go
+++ b/pkg/proxy/fast/trailer_test.go
@@ -1,0 +1,62 @@
+package fast
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/traefik/traefik/v3/pkg/config/static"
+	"github.com/traefik/traefik/v3/pkg/testhelpers"
+)
+
+// TestRequestTrailersNotForwardedToBackend ensures that request trailers are not
+// forwarded to the backend by the fast reverse proxy.
+//
+// This is a deliberate behavior: trailers arrive after the body, once routing and
+// security decisions have already been made, so forwarding them could raise security
+// concerns in Traefik. This test locks the current behavior to catch any regression.
+func TestRequestTrailersNotForwardedToBackend(t *testing.T) {
+	var backendTrailer http.Header
+
+	backend := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		_, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+
+		backendTrailer = req.Trailer.Clone()
+
+		rw.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(backend.Close)
+
+	builder := NewProxyBuilder(&transportManagerMock{}, static.FastProxyConfig{})
+	proxyHandler, err := builder.Build("", testhelpers.MustParseURL(backend.URL), true, false)
+	require.NoError(t, err)
+
+	proxy := httptest.NewServer(proxyHandler)
+	t.Cleanup(proxy.Close)
+
+	pr, pw := io.Pipe()
+	req, err := http.NewRequest(http.MethodPost, proxy.URL, pr)
+	require.NoError(t, err)
+
+	req.Trailer = http.Header{"X-Test-Trailer": nil}
+
+	go func() {
+		_, _ = pw.Write([]byte("body data"))
+		req.Trailer.Set("X-Test-Trailer", "trailer-value")
+		_ = pw.Close()
+	}()
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	_, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	assert.Empty(t, backendTrailer.Get("X-Test-Trailer"))
+}

--- a/pkg/proxy/httputil/trailer_test.go
+++ b/pkg/proxy/httputil/trailer_test.go
@@ -1,0 +1,62 @@
+package httputil
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRequestTrailersNotForwardedToBackend ensures that request trailers are not
+// forwarded to the backend by the httputil reverse proxy.
+//
+// This is a deliberate behavior: trailers arrive after the body, once routing and
+// security decisions have already been made, so forwarding them could raise security
+// concerns in Traefik. This test locks the current behavior to catch any regression.
+func TestRequestTrailersNotForwardedToBackend(t *testing.T) {
+	var backendTrailer http.Header
+
+	backend := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// Request trailers are only populated after the body has been fully read.
+		_, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+
+		backendTrailer = req.Trailer.Clone()
+
+		rw.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(backend.Close)
+
+	backendURL, err := url.Parse(backend.URL)
+	require.NoError(t, err)
+
+	proxyHandler := buildSingleHostProxy(backendURL, true, false, 0, http.DefaultTransport, newBufferPool())
+	proxy := httptest.NewServer(proxyHandler)
+	t.Cleanup(proxy.Close)
+
+	pr, pw := io.Pipe()
+	req, err := http.NewRequest(http.MethodPost, proxy.URL, pr)
+	require.NoError(t, err)
+
+	req.Trailer = http.Header{"X-Test-Trailer": nil}
+
+	go func() {
+		_, _ = pw.Write([]byte("body data"))
+		req.Trailer.Set("X-Test-Trailer", "trailer-value")
+		_ = pw.Close()
+	}()
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	_, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	assert.Empty(t, backendTrailer.Get("X-Test-Trailer"))
+}


### PR DESCRIPTION
## What does this PR do?
This PR adds regression test coverage ensuring that HTTP request trailer values are not forwarded to the backend across the reverse proxy layer, for both the httputil and fast implementations.

The coverage spins up a backend that captures req.Trailer after fully reading the body, places the real Traefik proxy in front of it, and sends a client request carrying a trailer (X-Test-Trailer: trailer-value, chunked body via io.Pipe). It then asserts the backend never observes the trailer value.

## Motivation
Request trailers arrive after the body, once routing and security decisions have already been made on the headers. Forwarding them could let a late field bypass earlier checks, which raises security concerns in Traefik. The current behavior is to not propagate trailer values to the backend, and we want to keep it that way.

Today this behavior is implicit and untested:

httputil: the stdlib ReverseProxy clones the request (req.Clone) before the trailer values are populated, so the announced trailer key may transit but its value is always empty.
fast: request trailers are dropped entirely.
This coverage locks that behavior in, so any future change that starts propagating trailer values to the backend will fail CI.