### PR TITLE
Remove experimental note for Gateway API/TLSRoute documentation

### DIFF
--- a/docs/content/reference/routing-configuration/kubernetes/gateway-api.md
+++ b/docs/content/reference/routing-configuration/kubernetes/gateway-api.md
@@ -770,11 +770,6 @@ Once everything is deployed, sending the WHO command should return the following
 
 ### TLS
 
-!!! info "Experimental Channel"
-
-    The `TLSRoute` resource described below is currently available only in the Experimental channel of the Gateway API. 
-    Therefore, to use this resource, the [experimentalChannel](../../install-configuration/providers/kubernetes/kubernetes-gateway.md) option must be enabled.
-
 The `TLSRoute` is a resource in the Gateway API specification designed to define how TLS (Transport Layer Security) traffic should be routed within a Kubernetes cluster. 
 It specifies routing rules for TLS connections, directing them to appropriate backend services based on the SNI (Server Name Indication) of the incoming connection.
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Remove the `Experimental Channel` note for the `TLSRoute` resource of the Gateway API.

### Motivation

<!-- What inspired you to submit this pull request? -->
This has graduated to stable as of v1.5.0 (see also https://gateway-api.sigs.k8s.io/docs/concepts/api-overview/#tlsroute). Given that Traefik v3.7 requires v1.5.1 of the Gateway API, this note is no longer relevant on current version.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
