### PR TITLE
Ignore other gateways parentRefs and update route parent statuses only for managed gateways

### DIFF
--- a/pkg/provider/kubernetes/gateway/client.go
+++ b/pkg/provider/kubernetes/gateway/client.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
 	gatev1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatev1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatev1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -500,7 +501,40 @@ func (c *clientWrapper) UpdateGatewayStatus(ctx context.Context, gateway ktypes.
 	return nil
 }
 
-func (c *clientWrapper) UpdateHTTPRouteStatus(ctx context.Context, route ktypes.NamespacedName, status gatev1.HTTPRouteStatus) error {
+// mergeRouteParentStatuses returns the desired parentStatuses augmented with the current parentStatuses Traefik does not own.
+func mergeRouteParentStatuses(currentParents, desiredParents []gatev1.RouteParentStatus, gateways []gatewayWithListeners) []gatev1.RouteParentStatus {
+	parentStatuses := make([]gatev1.RouteParentStatus, len(desiredParents))
+	copy(parentStatuses, desiredParents)
+
+	for _, currentParent := range currentParents {
+		// Keep statuses added by other gateway controllers.
+		if currentParent.ControllerName != controllerName {
+			parentStatuses = append(parentStatuses, currentParent)
+			continue
+		}
+
+		// TODO: Implement a mechanism to clean up old parentStatus for gateways that no instance manages.
+		// Also, keep statuses from gateways managed by other Traefik instances.
+		// Ownership of a parentStatus is determined by the presence of a parentRef for a managed gateway.
+		// SectionName or Port is not used to determine ownership.
+		ownByOtherController := true
+		for _, gateway := range gateways {
+			if gateway.Namespace == string(ptr.Deref(currentParent.ParentRef.Namespace, "")) &&
+				gateway.Name == string(currentParent.ParentRef.Name) {
+				ownByOtherController = false
+				break
+			}
+		}
+
+		if ownByOtherController {
+			parentStatuses = append(parentStatuses, currentParent)
+		}
+	}
+
+	return parentStatuses
+}
+
+func (c *clientWrapper) UpdateHTTPRouteStatus(ctx context.Context, route ktypes.NamespacedName, gateways []gatewayWithListeners, status gatev1.HTTPRouteStatus) error {
 	if !c.isWatchedNamespace(route.Namespace) {
 		return fmt.Errorf("updating HTTPRoute status %s/%s: namespace is not within watched namespaces", route.Namespace, route.Name)
 	}
@@ -513,16 +547,7 @@ func (c *clientWrapper) UpdateHTTPRouteStatus(ctx context.Context, route ktypes.
 			return err
 		}
 
-		parentStatuses := make([]gatev1.RouteParentStatus, len(status.Parents))
-		copy(parentStatuses, status.Parents)
-
-		// keep statuses added by other gateway controllers.
-		// TODO: we should also keep statuses for gateways managed by other Traefik instances.
-		for _, parentStatus := range currentRoute.Status.Parents {
-			if parentStatus.ControllerName != controllerName {
-				parentStatuses = append(parentStatuses, parentStatus)
-			}
-		}
+		parentStatuses := mergeRouteParentStatuses(currentRoute.Status.Parents, status.Parents, gateways)
 
 		// do not update status when nothing has changed.
 		if routeParentStatusesEqual(currentRoute.Status.Parents, parentStatuses) {
@@ -551,7 +576,7 @@ func (c *clientWrapper) UpdateHTTPRouteStatus(ctx context.Context, route ktypes.
 	return nil
 }
 
-func (c *clientWrapper) UpdateGRPCRouteStatus(ctx context.Context, route ktypes.NamespacedName, status gatev1.GRPCRouteStatus) error {
+func (c *clientWrapper) UpdateGRPCRouteStatus(ctx context.Context, route ktypes.NamespacedName, gateways []gatewayWithListeners, status gatev1.GRPCRouteStatus) error {
 	if !c.isWatchedNamespace(route.Namespace) {
 		return fmt.Errorf("updating GRPCRoute status %s/%s: namespace is not within watched namespaces", route.Namespace, route.Name)
 	}
@@ -564,16 +589,7 @@ func (c *clientWrapper) UpdateGRPCRouteStatus(ctx context.Context, route ktypes.
 			return err
 		}
 
-		parentStatuses := make([]gatev1.RouteParentStatus, len(status.Parents))
-		copy(parentStatuses, status.Parents)
-
-		// keep statuses added by other gateway controllers.
-		// TODO: we should also keep statuses for gateways managed by other Traefik instances.
-		for _, parentStatus := range currentRoute.Status.Parents {
-			if parentStatus.ControllerName != controllerName {
-				parentStatuses = append(parentStatuses, parentStatus)
-			}
-		}
+		parentStatuses := mergeRouteParentStatuses(currentRoute.Status.Parents, status.Parents, gateways)
 
 		// do not update status when nothing has changed.
 		if routeParentStatusesEqual(currentRoute.Status.Parents, parentStatuses) {
@@ -602,7 +618,7 @@ func (c *clientWrapper) UpdateGRPCRouteStatus(ctx context.Context, route ktypes.
 	return nil
 }
 
-func (c *clientWrapper) UpdateTCPRouteStatus(ctx context.Context, route ktypes.NamespacedName, status gatev1alpha2.TCPRouteStatus) error {
+func (c *clientWrapper) UpdateTCPRouteStatus(ctx context.Context, route ktypes.NamespacedName, gateways []gatewayWithListeners, status gatev1alpha2.TCPRouteStatus) error {
 	if !c.isWatchedNamespace(route.Namespace) {
 		return fmt.Errorf("updating TCPRoute status %s/%s: namespace is not within watched namespaces", route.Namespace, route.Name)
 	}
@@ -615,16 +631,7 @@ func (c *clientWrapper) UpdateTCPRouteStatus(ctx context.Context, route ktypes.N
 			return err
 		}
 
-		parentStatuses := make([]gatev1.RouteParentStatus, len(status.Parents))
-		copy(parentStatuses, status.Parents)
-
-		// keep statuses added by other gateway controllers.
-		// TODO: we should also keep statuses for gateways managed by other Traefik instances.
-		for _, parentStatus := range currentRoute.Status.Parents {
-			if parentStatus.ControllerName != controllerName {
-				parentStatuses = append(parentStatuses, parentStatus)
-			}
-		}
+		parentStatuses := mergeRouteParentStatuses(currentRoute.Status.Parents, status.Parents, gateways)
 
 		// do not update status when nothing has changed.
 		if routeParentStatusesEqual(currentRoute.Status.Parents, parentStatuses) {
@@ -653,7 +660,7 @@ func (c *clientWrapper) UpdateTCPRouteStatus(ctx context.Context, route ktypes.N
 	return nil
 }
 
-func (c *clientWrapper) UpdateTLSRouteStatus(ctx context.Context, route ktypes.NamespacedName, status gatev1alpha2.TLSRouteStatus) error {
+func (c *clientWrapper) UpdateTLSRouteStatus(ctx context.Context, route ktypes.NamespacedName, gateways []gatewayWithListeners, status gatev1alpha2.TLSRouteStatus) error {
 	if !c.isWatchedNamespace(route.Namespace) {
 		return fmt.Errorf("updating TLSRoute status %s/%s: namespace is not within watched namespaces", route.Namespace, route.Name)
 	}
@@ -666,16 +673,7 @@ func (c *clientWrapper) UpdateTLSRouteStatus(ctx context.Context, route ktypes.N
 			return err
 		}
 
-		parentStatuses := make([]gatev1.RouteParentStatus, len(status.Parents))
-		copy(parentStatuses, status.Parents)
-
-		// keep statuses added by other gateway controllers.
-		// TODO: we should also keep statuses for gateways managed by other Traefik instances.
-		for _, parentStatus := range currentRoute.Status.Parents {
-			if parentStatus.ControllerName != controllerName {
-				parentStatuses = append(parentStatuses, parentStatus)
-			}
-		}
+		parentStatuses := mergeRouteParentStatuses(currentRoute.Status.Parents, status.Parents, gateways)
 
 		// do not update status when nothing has changed.
 		if routeParentStatusesEqual(currentRoute.Status.Parents, parentStatuses) {

--- a/pkg/provider/kubernetes/gateway/client.go
+++ b/pkg/provider/kubernetes/gateway/client.go
@@ -501,35 +501,6 @@ func (c *clientWrapper) UpdateGatewayStatus(ctx context.Context, gateway ktypes.
 	return nil
 }
 
-// mergeRouteParentStatuses returns the desired parentStatuses augmented with the current parentStatuses Traefik does not own.
-func mergeRouteParentStatuses(routeNamespace string, currentParents, desiredParents []gatev1.RouteParentStatus, gateways []gatewayWithListeners) []gatev1.RouteParentStatus {
-	parentStatuses := make([]gatev1.RouteParentStatus, len(desiredParents))
-	copy(parentStatuses, desiredParents)
-
-	for _, currentParent := range currentParents {
-		// Keep statuses added by other gateway controllers.
-		if currentParent.ControllerName != controllerName {
-			parentStatuses = append(parentStatuses, currentParent)
-			continue
-		}
-
-		// TODO: Implement a mechanism to clean up old parentStatus for gateways that no instance manages.
-		// Also, keep statuses from gateways managed by other Traefik instances.
-		// We consider a status managed by the current instance when the parentRef targets one of the managed gateways.
-		// SectionName or Port is not used.
-		parentNamespace := string(ptr.Deref(currentParent.ParentRef.Namespace, gatev1.Namespace(routeNamespace)))
-		isManaged := slices.ContainsFunc(gateways, func(gw gatewayWithListeners) bool {
-			return gw.Namespace == parentNamespace && gw.Name == string(currentParent.ParentRef.Name)
-		})
-
-		if !isManaged {
-			parentStatuses = append(parentStatuses, currentParent)
-		}
-	}
-
-	return parentStatuses
-}
-
 func (c *clientWrapper) UpdateHTTPRouteStatus(ctx context.Context, route ktypes.NamespacedName, gateways []gatewayWithListeners, status gatev1.HTTPRouteStatus) error {
 	if !c.isWatchedNamespace(route.Namespace) {
 		return fmt.Errorf("updating HTTPRoute status %s/%s: namespace is not within watched namespaces", route.Namespace, route.Name)
@@ -780,6 +751,35 @@ func (c *clientWrapper) isWatchedNamespace(namespace string) bool {
 	}
 
 	return slices.Contains(c.watchedNamespaces, namespace)
+}
+
+// mergeRouteParentStatuses returns the desired parentStatuses augmented with the current parentStatuses Traefik does not own.
+func mergeRouteParentStatuses(routeNamespace string, currentParents, desiredParents []gatev1.RouteParentStatus, gateways []gatewayWithListeners) []gatev1.RouteParentStatus {
+	parentStatuses := make([]gatev1.RouteParentStatus, len(desiredParents))
+	copy(parentStatuses, desiredParents)
+
+	for _, currentParent := range currentParents {
+		// Keep statuses added by other gateway controllers.
+		if currentParent.ControllerName != controllerName {
+			parentStatuses = append(parentStatuses, currentParent)
+			continue
+		}
+
+		// TODO: Implement a mechanism to clean up old parentStatus for gateways that no instance manages.
+		// Also, keep statuses from gateways managed by other Traefik instances.
+		// We consider a status managed by the current instance when the parentRef targets one of the managed gateways.
+		// SectionName or Port is not used.
+		parentNamespace := string(ptr.Deref(currentParent.ParentRef.Namespace, gatev1.Namespace(routeNamespace)))
+		isManaged := slices.ContainsFunc(gateways, func(gw gatewayWithListeners) bool {
+			return gw.Namespace == parentNamespace && gw.Name == string(currentParent.ParentRef.Name)
+		})
+
+		if !isManaged {
+			parentStatuses = append(parentStatuses, currentParent)
+		}
+	}
+
+	return parentStatuses
 }
 
 func gatewayStatusEqual(statusA, statusB gatev1.GatewayStatus) bool {

--- a/pkg/provider/kubernetes/gateway/client.go
+++ b/pkg/provider/kubernetes/gateway/client.go
@@ -502,7 +502,7 @@ func (c *clientWrapper) UpdateGatewayStatus(ctx context.Context, gateway ktypes.
 }
 
 // mergeRouteParentStatuses returns the desired parentStatuses augmented with the current parentStatuses Traefik does not own.
-func mergeRouteParentStatuses(currentParents, desiredParents []gatev1.RouteParentStatus, gateways []gatewayWithListeners) []gatev1.RouteParentStatus {
+func mergeRouteParentStatuses(routeNamespace string, currentParents, desiredParents []gatev1.RouteParentStatus, gateways []gatewayWithListeners) []gatev1.RouteParentStatus {
 	parentStatuses := make([]gatev1.RouteParentStatus, len(desiredParents))
 	copy(parentStatuses, desiredParents)
 
@@ -517,9 +517,10 @@ func mergeRouteParentStatuses(currentParents, desiredParents []gatev1.RouteParen
 		// Also, keep statuses from gateways managed by other Traefik instances.
 		// Ownership of a parentStatus is determined by the presence of a parentRef for a managed gateway.
 		// SectionName or Port is not used to determine ownership.
+		parentNamespace := string(ptr.Deref(currentParent.ParentRef.Namespace, gatev1.Namespace(routeNamespace)))
 		ownByOtherController := true
 		for _, gateway := range gateways {
-			if gateway.Namespace == string(ptr.Deref(currentParent.ParentRef.Namespace, "")) &&
+			if gateway.Namespace == parentNamespace &&
 				gateway.Name == string(currentParent.ParentRef.Name) {
 				ownByOtherController = false
 				break
@@ -547,7 +548,7 @@ func (c *clientWrapper) UpdateHTTPRouteStatus(ctx context.Context, route ktypes.
 			return err
 		}
 
-		parentStatuses := mergeRouteParentStatuses(currentRoute.Status.Parents, status.Parents, gateways)
+		parentStatuses := mergeRouteParentStatuses(route.Namespace, currentRoute.Status.Parents, status.Parents, gateways)
 
 		// do not update status when nothing has changed.
 		if routeParentStatusesEqual(currentRoute.Status.Parents, parentStatuses) {
@@ -589,7 +590,7 @@ func (c *clientWrapper) UpdateGRPCRouteStatus(ctx context.Context, route ktypes.
 			return err
 		}
 
-		parentStatuses := mergeRouteParentStatuses(currentRoute.Status.Parents, status.Parents, gateways)
+		parentStatuses := mergeRouteParentStatuses(route.Namespace, currentRoute.Status.Parents, status.Parents, gateways)
 
 		// do not update status when nothing has changed.
 		if routeParentStatusesEqual(currentRoute.Status.Parents, parentStatuses) {
@@ -631,7 +632,7 @@ func (c *clientWrapper) UpdateTCPRouteStatus(ctx context.Context, route ktypes.N
 			return err
 		}
 
-		parentStatuses := mergeRouteParentStatuses(currentRoute.Status.Parents, status.Parents, gateways)
+		parentStatuses := mergeRouteParentStatuses(route.Namespace, currentRoute.Status.Parents, status.Parents, gateways)
 
 		// do not update status when nothing has changed.
 		if routeParentStatusesEqual(currentRoute.Status.Parents, parentStatuses) {
@@ -673,7 +674,7 @@ func (c *clientWrapper) UpdateTLSRouteStatus(ctx context.Context, route ktypes.N
 			return err
 		}
 
-		parentStatuses := mergeRouteParentStatuses(currentRoute.Status.Parents, status.Parents, gateways)
+		parentStatuses := mergeRouteParentStatuses(route.Namespace, currentRoute.Status.Parents, status.Parents, gateways)
 
 		// do not update status when nothing has changed.
 		if routeParentStatusesEqual(currentRoute.Status.Parents, parentStatuses) {

--- a/pkg/provider/kubernetes/gateway/client.go
+++ b/pkg/provider/kubernetes/gateway/client.go
@@ -515,19 +515,14 @@ func mergeRouteParentStatuses(routeNamespace string, currentParents, desiredPare
 
 		// TODO: Implement a mechanism to clean up old parentStatus for gateways that no instance manages.
 		// Also, keep statuses from gateways managed by other Traefik instances.
-		// Ownership of a parentStatus is determined by the presence of a parentRef for a managed gateway.
-		// SectionName or Port is not used to determine ownership.
+		// We consider a status managed by the current instance when the parentRef targets one of the managed gateways.
+		// SectionName or Port is not used.
 		parentNamespace := string(ptr.Deref(currentParent.ParentRef.Namespace, gatev1.Namespace(routeNamespace)))
-		ownByOtherController := true
-		for _, gateway := range gateways {
-			if gateway.Namespace == parentNamespace &&
-				gateway.Name == string(currentParent.ParentRef.Name) {
-				ownByOtherController = false
-				break
-			}
-		}
+		isManaged := slices.ContainsFunc(gateways, func(gw gatewayWithListeners) bool {
+			return gw.Namespace == parentNamespace && gw.Name == string(currentParent.ParentRef.Name)
+		})
 
-		if ownByOtherController {
+		if !isManaged {
 			parentStatuses = append(parentStatuses, currentParent)
 		}
 	}

--- a/pkg/provider/kubernetes/gateway/fixtures/grpcroute/with_multiple_gateways_parent_refs.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/grpcroute/with_multiple_gateways_parent_refs.yml
@@ -1,0 +1,99 @@
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-gateway-class
+spec:
+  controllerName: traefik.io/gateway-controller
+
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: other-gateway-class
+spec:
+  controllerName: example.com/other-controller
+
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        kinds:
+          - kind: GRPCRoute
+            group: gateway.networking.k8s.io
+        namespaces:
+          from: Same
+
+---
+# Gateway owned by another controller. Traefik must ignore it, and must not write
+# any status for parentRefs pointing to it.
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: other-gateway
+  namespace: default
+spec:
+  gatewayClassName: other-gateway-class
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        kinds:
+          - kind: GRPCRoute
+            group: gateway.networking.k8s.io
+        namespaces:
+          from: Same
+
+---
+# References both our Gateway and the foreign one: only our parent must be managed,
+# and the listener must count this route only once.
+kind: GRPCRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: grpc-app-1
+  namespace: default
+spec:
+  parentRefs:
+    - name: my-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+    - name: other-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  hostnames:
+    - "foo.com"
+  rules:
+    - backendRefs:
+        - name: whoami
+          port: 80
+          weight: 1
+
+---
+# References only the foreign Gateway: Traefik must not write any status for it.
+kind: GRPCRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: grpc-app-2
+  namespace: default
+spec:
+  parentRefs:
+    - name: other-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  hostnames:
+    - "bar.com"
+  rules:
+    - backendRefs:
+        - name: whoami
+          port: 80
+          weight: 1

--- a/pkg/provider/kubernetes/gateway/fixtures/httproute/with_multiple_gateways_parent_refs.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/httproute/with_multiple_gateways_parent_refs.yml
@@ -1,0 +1,111 @@
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-gateway-class
+spec:
+  controllerName: traefik.io/gateway-controller
+
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: other-gateway-class
+spec:
+  controllerName: example.com/other-controller
+
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        kinds:
+          - kind: HTTPRoute
+            group: gateway.networking.k8s.io
+        namespaces:
+          from: Same
+
+---
+# Gateway owned by another controller. Traefik must ignore it, and must not write
+# any status for parentRefs pointing to it.
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: other-gateway
+  namespace: default
+spec:
+  gatewayClassName: other-gateway-class
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        kinds:
+          - kind: HTTPRoute
+            group: gateway.networking.k8s.io
+        namespaces:
+          from: Same
+
+---
+# References both our Gateway and the foreign one: only our parent must be managed,
+# and the listener must count this route only once.
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-app-1
+  namespace: default
+spec:
+  parentRefs:
+    - name: my-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+    - name: other-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  hostnames:
+    - "foo.com"
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /bar
+      backendRefs:
+        - name: whoami
+          port: 80
+          weight: 1
+          kind: Service
+          group: ""
+
+---
+# References only the foreign Gateway: Traefik must not write any status for it.
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-app-2
+  namespace: default
+spec:
+  parentRefs:
+    - name: other-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  hostnames:
+    - "bar.com"
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /bar
+      backendRefs:
+        - name: whoami
+          port: 80
+          weight: 1
+          kind: Service
+          group: ""

--- a/pkg/provider/kubernetes/gateway/fixtures/tcproute/with_multiple_gateways_parent_refs.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/tcproute/with_multiple_gateways_parent_refs.yml
@@ -1,0 +1,99 @@
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-gateway-class
+spec:
+  controllerName: traefik.io/gateway-controller
+
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: other-gateway-class
+spec:
+  controllerName: example.com/other-controller
+
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-tcp-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners:
+    - name: tcp
+      protocol: TCP
+      port: 9000
+      allowedRoutes:
+        kinds:
+          - kind: TCPRoute
+            group: gateway.networking.k8s.io
+        namespaces:
+          from: Same
+
+---
+# Gateway owned by another controller. Traefik must ignore it, and must not write
+# any status for parentRefs pointing to it.
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: other-tcp-gateway
+  namespace: default
+spec:
+  gatewayClassName: other-gateway-class
+  listeners:
+    - name: tcp
+      protocol: TCP
+      port: 9000
+      allowedRoutes:
+        kinds:
+          - kind: TCPRoute
+            group: gateway.networking.k8s.io
+        namespaces:
+          from: Same
+
+---
+# References both our Gateway and the foreign one: only our parent must be managed,
+# and the listener must count this route only once.
+kind: TCPRoute
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: tcp-app-1
+  namespace: default
+spec:
+  parentRefs:
+    - name: my-tcp-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+    - name: other-tcp-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  rules:
+    - backendRefs:
+        - name: whoamitcp
+          port: 9000
+          weight: 1
+          kind: Service
+          group: ""
+
+---
+# References only the foreign Gateway: Traefik must not write any status for it.
+kind: TCPRoute
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: tcp-app-2
+  namespace: default
+spec:
+  parentRefs:
+    - name: other-tcp-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  rules:
+    - backendRefs:
+        - name: whoamitcp
+          port: 9000
+          weight: 1
+          kind: Service
+          group: ""

--- a/pkg/provider/kubernetes/gateway/fixtures/tlsroute/with_multiple_gateways_parent_refs.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/tlsroute/with_multiple_gateways_parent_refs.yml
@@ -1,0 +1,109 @@
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-gateway-class
+spec:
+  controllerName: traefik.io/gateway-controller
+
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: other-gateway-class
+spec:
+  controllerName: example.com/other-controller
+
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-tls-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners:
+    - name: tls
+      protocol: TLS
+      hostname: foo.example.com
+      port: 9000
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        kinds:
+          - kind: TLSRoute
+            group: gateway.networking.k8s.io
+        namespaces:
+          from: Same
+
+---
+# Gateway owned by another controller. Traefik must ignore it, and must not write
+# any status for parentRefs pointing to it.
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: other-tls-gateway
+  namespace: default
+spec:
+  gatewayClassName: other-gateway-class
+  listeners:
+    - name: tls
+      protocol: TLS
+      hostname: foo.example.com
+      port: 9000
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        kinds:
+          - kind: TLSRoute
+            group: gateway.networking.k8s.io
+        namespaces:
+          from: Same
+
+---
+# References both our Gateway and the foreign one: only our parent must be managed,
+# and the listener must count this route only once.
+kind: TLSRoute
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: tls-app-1
+  namespace: default
+spec:
+  parentRefs:
+    - name: my-tls-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+    - name: other-tls-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  hostnames:
+    - foo.example.com
+  rules:
+    - backendRefs:
+        - name: whoamitcp
+          port: 9000
+          weight: 1
+          kind: Service
+          group: ""
+
+---
+# References only the foreign Gateway: Traefik must not write any status for it.
+kind: TLSRoute
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: tls-app-2
+  namespace: default
+spec:
+  parentRefs:
+    - name: other-tls-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  hostnames:
+    - foo.example.com
+  rules:
+    - backendRefs:
+        - name: whoamitcp
+          port: 9000
+          weight: 1
+          kind: Service
+          group: ""

--- a/pkg/provider/kubernetes/gateway/grpcroute.go
+++ b/pkg/provider/kubernetes/gateway/grpcroute.go
@@ -78,7 +78,7 @@ func (p *Provider) loadGRPCRoutes(ctx context.Context, gateways []gatewayWithLis
 				// even when the route does not attach to the listener.
 				routeConf, condition := p.loadGRPCRoute(logger.WithContext(ctx), match.gatewayName, match.gatewayNamespace, listener, route, hostnames)
 				if resolvedRefCondition == nil || resolvedRefCondition.Status == metav1.ConditionTrue {
-					resolvedRefCondition = &condition
+					resolvedRefCondition = ptr.To(condition)
 				}
 
 				if accepted && listener.Attached {

--- a/pkg/provider/kubernetes/gateway/grpcroute.go
+++ b/pkg/provider/kubernetes/gateway/grpcroute.go
@@ -51,35 +51,42 @@ func (p *Provider) loadGRPCRoutes(ctx context.Context, gateways []gatewayWithLis
 
 			var resolvedRefCondition *metav1.Condition
 			for _, listener := range match.listeners {
-				if !allowRoute(listener, route.Namespace, kindGRPCRoute) {
+				// A parentRef can target specific listeners through its SectionName or Port.
+				accepted := matchListener(listener, match.parentRef)
+
+				if accepted && !allowRoute(listener, route.Namespace, kindGRPCRoute) {
 					if acceptedCondition.Status == metav1.ConditionFalse {
 						acceptedCondition.Reason = string(gatev1.RouteReasonNotAllowedByListeners)
 					}
-					continue
+					accepted = false
 				}
 
 				hostnames, ok := findMatchingHostnames(listener.Hostname, route.Spec.Hostnames)
-				if !ok {
+				if accepted && !ok {
 					if acceptedCondition.Status == metav1.ConditionFalse {
 						acceptedCondition.Reason = string(gatev1.RouteReasonNoMatchingListenerHostname)
 					}
-					continue
+					accepted = false
 				}
 
-				// Gateway listener should have AttachedRoutes set even when Gateway has unresolved refs.
-				listener.Status.AttachedRoutes++
+				if accepted {
+					// Gateway listener should have AttachedRoutes set even when Gateway has unresolved refs.
+					listener.Status.AttachedRoutes++
+				}
 
+				// The ResolvedRefs condition must be reported for every parentRef,
+				// even when the route does not attach to the listener.
 				routeConf, condition := p.loadGRPCRoute(logger.WithContext(ctx), match.gatewayName, match.gatewayNamespace, listener, route, hostnames)
-				if listener.Attached {
+				if resolvedRefCondition == nil || resolvedRefCondition.Status == metav1.ConditionTrue {
+					resolvedRefCondition = &condition
+				}
+
+				if accepted && listener.Attached {
 					mergeHTTPConfiguration(routeConf, conf)
 
 					// Only consider the route attached if the listener is in an "attached" state.
 					acceptedCondition.Reason = string(gatev1.RouteReasonAccepted)
 					acceptedCondition.Status = metav1.ConditionTrue
-				}
-
-				if resolvedRefCondition == nil || resolvedRefCondition.Status == metav1.ConditionTrue {
-					resolvedRefCondition = &condition
 				}
 			}
 

--- a/pkg/provider/kubernetes/gateway/grpcroute.go
+++ b/pkg/provider/kubernetes/gateway/grpcroute.go
@@ -21,7 +21,7 @@ import (
 )
 
 // TODO: as described in the specification https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.GRPCRoute, we should check for hostname conflicts between HTTP and GRPC routes.
-func (p *Provider) loadGRPCRoutes(ctx context.Context, gatewayListeners []gatewayListener, conf *dynamic.Configuration) {
+func (p *Provider) loadGRPCRoutes(ctx context.Context, gateways []gatewayWithListeners, conf *dynamic.Configuration) {
 	routes, err := p.client.ListGRPCRoutes()
 	if err != nil {
 		log.Ctx(ctx).Error().Err(err).Msg("Unable to list GRPCRoutes")
@@ -34,58 +34,65 @@ func (p *Provider) loadGRPCRoutes(ctx context.Context, gatewayListeners []gatewa
 			Str("namespace", route.Namespace).
 			Logger()
 
-		routeListeners := matchingGatewayListeners(gatewayListeners, route.Namespace, route.Spec.ParentRefs)
-		if len(routeListeners) == 0 {
+		routeParentRefs := matchingGatewayListenersForParentRef(gateways, route.Namespace, route.Spec.ParentRefs)
+		if len(routeParentRefs) == 0 {
 			continue
 		}
 
 		var parentStatuses []gatev1.RouteParentStatus
-		for _, parentRef := range route.Spec.ParentRefs {
-			parentStatus := &gatev1.RouteParentStatus{
-				ParentRef:      parentRef,
-				ControllerName: controllerName,
-				Conditions: []metav1.Condition{
-					{
-						Type:               string(gatev1.RouteConditionAccepted),
-						Status:             metav1.ConditionFalse,
-						ObservedGeneration: route.Generation,
-						LastTransitionTime: metav1.Now(),
-						Reason:             string(gatev1.RouteReasonNoMatchingParent),
-					},
-				},
+		for _, match := range routeParentRefs {
+			acceptedCondition := metav1.Condition{
+				Type:               string(gatev1.RouteConditionAccepted),
+				Status:             metav1.ConditionFalse,
+				ObservedGeneration: route.Generation,
+				LastTransitionTime: metav1.Now(),
+				Reason:             string(gatev1.RouteReasonNoMatchingParent),
 			}
 
-			for _, listener := range routeListeners {
-				accepted := matchListener(listener, parentRef)
-
-				if accepted && !allowRoute(listener, route.Namespace, kindGRPCRoute) {
-					parentStatus.Conditions = updateRouteConditionAccepted(parentStatus.Conditions, string(gatev1.RouteReasonNotAllowedByListeners))
-					accepted = false
-				}
-				hostnames, ok := findMatchingHostnames(listener.Hostname, route.Spec.Hostnames)
-				if accepted && !ok {
-					parentStatus.Conditions = updateRouteConditionAccepted(parentStatus.Conditions, string(gatev1.RouteReasonNoMatchingListenerHostname))
-					accepted = false
-				}
-
-				if accepted {
-					// Gateway listener should have AttachedRoutes set even when Gateway has unresolved refs.
-					listener.Status.AttachedRoutes++
-					// Only consider the route attached if the listener is in an "attached" state.
-					if listener.Attached {
-						parentStatus.Conditions = updateRouteConditionAccepted(parentStatus.Conditions, string(gatev1.RouteReasonAccepted))
+			var resolvedRefCondition *metav1.Condition
+			for _, listener := range match.listeners {
+				if !allowRoute(listener, route.Namespace, kindGRPCRoute) {
+					if acceptedCondition.Status == metav1.ConditionFalse {
+						acceptedCondition.Reason = string(gatev1.RouteReasonNotAllowedByListeners)
 					}
+					continue
 				}
 
-				routeConf, resolveRefCondition := p.loadGRPCRoute(logger.WithContext(ctx), listener, route, hostnames)
-				if accepted && listener.Attached {
+				hostnames, ok := findMatchingHostnames(listener.Hostname, route.Spec.Hostnames)
+				if !ok {
+					if acceptedCondition.Status == metav1.ConditionFalse {
+						acceptedCondition.Reason = string(gatev1.RouteReasonNoMatchingListenerHostname)
+					}
+					continue
+				}
+
+				// Gateway listener should have AttachedRoutes set even when Gateway has unresolved refs.
+				listener.Status.AttachedRoutes++
+
+				routeConf, condition := p.loadGRPCRoute(logger.WithContext(ctx), match.gatewayName, match.gatewayNamespace, listener, route, hostnames)
+				if listener.Attached {
 					mergeHTTPConfiguration(routeConf, conf)
+
+					// Only consider the route attached if the listener is in an "attached" state.
+					acceptedCondition.Reason = string(gatev1.RouteReasonAccepted)
+					acceptedCondition.Status = metav1.ConditionTrue
 				}
 
-				parentStatus.Conditions = upsertRouteConditionResolvedRefs(parentStatus.Conditions, resolveRefCondition)
+				if resolvedRefCondition == nil || resolvedRefCondition.Status == metav1.ConditionTrue {
+					resolvedRefCondition = &condition
+				}
 			}
 
-			parentStatuses = append(parentStatuses, *parentStatus)
+			parentStatusConditions := []metav1.Condition{acceptedCondition}
+			if resolvedRefCondition != nil {
+				parentStatusConditions = append(parentStatusConditions, *resolvedRefCondition)
+			}
+
+			parentStatuses = append(parentStatuses, gatev1.RouteParentStatus{
+				ParentRef:      match.parentRef,
+				ControllerName: controllerName,
+				Conditions:     parentStatusConditions,
+			})
 		}
 
 		status := gatev1.GRPCRouteStatus{
@@ -93,7 +100,7 @@ func (p *Provider) loadGRPCRoutes(ctx context.Context, gatewayListeners []gatewa
 				Parents: parentStatuses,
 			},
 		}
-		if err := p.client.UpdateGRPCRouteStatus(ctx, ktypes.NamespacedName{Namespace: route.Namespace, Name: route.Name}, status); err != nil {
+		if err := p.client.UpdateGRPCRouteStatus(ctx, ktypes.NamespacedName{Namespace: route.Namespace, Name: route.Name}, gateways, status); err != nil {
 			logger.Warn().
 				Err(err).
 				Msg("Unable to update GRPCRoute status")
@@ -101,7 +108,7 @@ func (p *Provider) loadGRPCRoutes(ctx context.Context, gatewayListeners []gatewa
 	}
 }
 
-func (p *Provider) loadGRPCRoute(ctx context.Context, listener gatewayListener, route *gatev1.GRPCRoute, hostnames []gatev1.Hostname) (*dynamic.Configuration, metav1.Condition) {
+func (p *Provider) loadGRPCRoute(ctx context.Context, gatewayName, gatewayNamespace string, listener gatewayListener, route *gatev1.GRPCRoute, hostnames []gatev1.Hostname) (*dynamic.Configuration, metav1.Condition) {
 	conf := &dynamic.Configuration{
 		HTTP: &dynamic.HTTPConfiguration{
 			Routers:           make(map[string]*dynamic.Router),
@@ -121,7 +128,7 @@ func (p *Provider) loadGRPCRoute(ctx context.Context, listener gatewayListener, 
 
 	for ri, routeRule := range route.Spec.Rules {
 		// Adding the gateway desc and the entryPoint desc prevents overlapping of routers build from the same routes.
-		routeKey := provider.Normalize(fmt.Sprintf("%s-%s-%s-gw-%s-%s-ep-%s-%d", strings.ToLower(kindGRPCRoute), route.Namespace, route.Name, listener.GWNamespace, listener.GWName, listener.EPName, ri))
+		routeKey := provider.Normalize(fmt.Sprintf("%s-%s-%s-gw-%s-%s-ep-%s-%d", strings.ToLower(kindGRPCRoute), route.Namespace, route.Name, gatewayNamespace, gatewayName, listener.EPName, ri))
 
 		matches := routeRule.Matches
 		if len(matches) == 0 {

--- a/pkg/provider/kubernetes/gateway/httproute.go
+++ b/pkg/provider/kubernetes/gateway/httproute.go
@@ -80,7 +80,7 @@ func (p *Provider) loadHTTPRoutes(ctx context.Context, gateways []gatewayWithLis
 				// even when the route does not attach to the listener.
 				routeConf, condition := p.loadHTTPRoute(logger.WithContext(ctx), match.gatewayName, match.gatewayNamespace, listener, route, hostnames)
 				if resolvedRefCondition == nil || resolvedRefCondition.Status == metav1.ConditionTrue {
-					resolvedRefCondition = &condition
+					resolvedRefCondition = ptr.To(condition)
 				}
 
 				if accepted && listener.Attached {

--- a/pkg/provider/kubernetes/gateway/httproute.go
+++ b/pkg/provider/kubernetes/gateway/httproute.go
@@ -23,7 +23,7 @@ import (
 	gatev1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-func (p *Provider) loadHTTPRoutes(ctx context.Context, gatewayListeners []gatewayListener, conf *dynamic.Configuration) {
+func (p *Provider) loadHTTPRoutes(ctx context.Context, gateways []gatewayWithListeners, conf *dynamic.Configuration) {
 	routes, err := p.client.ListHTTPRoutes()
 	if err != nil {
 		log.Ctx(ctx).Error().Err(err).Msg("Unable to list HTTPRoutes")
@@ -36,58 +36,65 @@ func (p *Provider) loadHTTPRoutes(ctx context.Context, gatewayListeners []gatewa
 			Str("namespace", route.Namespace).
 			Logger()
 
-		routeListeners := matchingGatewayListeners(gatewayListeners, route.Namespace, route.Spec.ParentRefs)
-		if len(routeListeners) == 0 {
+		routeParentRefs := matchingGatewayListenersForParentRef(gateways, route.Namespace, route.Spec.ParentRefs)
+		if len(routeParentRefs) == 0 {
 			continue
 		}
 
 		var parentStatuses []gatev1.RouteParentStatus
-		for _, parentRef := range route.Spec.ParentRefs {
-			parentStatus := &gatev1.RouteParentStatus{
-				ParentRef:      parentRef,
-				ControllerName: controllerName,
-				Conditions: []metav1.Condition{
-					{
-						Type:               string(gatev1.RouteConditionAccepted),
-						Status:             metav1.ConditionFalse,
-						ObservedGeneration: route.Generation,
-						LastTransitionTime: metav1.Now(),
-						Reason:             string(gatev1.RouteReasonNoMatchingParent),
-					},
-				},
+		for _, match := range routeParentRefs {
+			acceptedCondition := metav1.Condition{
+				Type:               string(gatev1.RouteConditionAccepted),
+				Status:             metav1.ConditionFalse,
+				ObservedGeneration: route.Generation,
+				LastTransitionTime: metav1.Now(),
+				Reason:             string(gatev1.RouteReasonNoMatchingParent),
 			}
 
-			for _, listener := range routeListeners {
-				accepted := matchListener(listener, parentRef)
-
-				if accepted && !allowRoute(listener, route.Namespace, kindHTTPRoute) {
-					parentStatus.Conditions = updateRouteConditionAccepted(parentStatus.Conditions, string(gatev1.RouteReasonNotAllowedByListeners))
-					accepted = false
-				}
-				hostnames, ok := findMatchingHostnames(listener.Hostname, route.Spec.Hostnames)
-				if accepted && !ok {
-					parentStatus.Conditions = updateRouteConditionAccepted(parentStatus.Conditions, string(gatev1.RouteReasonNoMatchingListenerHostname))
-					accepted = false
-				}
-
-				if accepted {
-					// Gateway listener should have AttachedRoutes set even when Gateway has unresolved refs.
-					listener.Status.AttachedRoutes++
-					// Only consider the route attached if the listener is in an "attached" state.
-					if listener.Attached {
-						parentStatus.Conditions = updateRouteConditionAccepted(parentStatus.Conditions, string(gatev1.RouteReasonAccepted))
+			var resolvedRefCondition *metav1.Condition
+			for _, listener := range match.listeners {
+				if !allowRoute(listener, route.Namespace, kindHTTPRoute) {
+					if acceptedCondition.Status == metav1.ConditionFalse {
+						acceptedCondition.Reason = string(gatev1.RouteReasonNotAllowedByListeners)
 					}
+					continue
 				}
 
-				routeConf, resolveRefCondition := p.loadHTTPRoute(logger.WithContext(ctx), listener, route, hostnames)
-				if accepted && listener.Attached {
+				hostnames, ok := findMatchingHostnames(listener.Hostname, route.Spec.Hostnames)
+				if !ok {
+					if acceptedCondition.Status == metav1.ConditionFalse {
+						acceptedCondition.Reason = string(gatev1.RouteReasonNoMatchingListenerHostname)
+					}
+					continue
+				}
+
+				// Gateway listener should have AttachedRoutes set even when Gateway has unresolved refs.
+				listener.Status.AttachedRoutes++
+
+				routeConf, condition := p.loadHTTPRoute(logger.WithContext(ctx), match.gatewayName, match.gatewayNamespace, listener, route, hostnames)
+				if listener.Attached {
 					mergeHTTPConfiguration(routeConf, conf)
+
+					// Only consider the route attached if the listener is in an "attached" state.
+					acceptedCondition.Reason = string(gatev1.RouteReasonAccepted)
+					acceptedCondition.Status = metav1.ConditionTrue
 				}
 
-				parentStatus.Conditions = upsertRouteConditionResolvedRefs(parentStatus.Conditions, resolveRefCondition)
+				if resolvedRefCondition == nil || resolvedRefCondition.Status == metav1.ConditionTrue {
+					resolvedRefCondition = &condition
+				}
 			}
 
-			parentStatuses = append(parentStatuses, *parentStatus)
+			parentStatusConditions := []metav1.Condition{acceptedCondition}
+			if resolvedRefCondition != nil {
+				parentStatusConditions = append(parentStatusConditions, *resolvedRefCondition)
+			}
+
+			parentStatuses = append(parentStatuses, gatev1.RouteParentStatus{
+				ParentRef:      match.parentRef,
+				ControllerName: controllerName,
+				Conditions:     parentStatusConditions,
+			})
 		}
 
 		status := gatev1.HTTPRouteStatus{
@@ -95,7 +102,7 @@ func (p *Provider) loadHTTPRoutes(ctx context.Context, gatewayListeners []gatewa
 				Parents: parentStatuses,
 			},
 		}
-		if err := p.client.UpdateHTTPRouteStatus(ctx, ktypes.NamespacedName{Namespace: route.Namespace, Name: route.Name}, status); err != nil {
+		if err := p.client.UpdateHTTPRouteStatus(ctx, ktypes.NamespacedName{Namespace: route.Namespace, Name: route.Name}, gateways, status); err != nil {
 			logger.Warn().
 				Err(err).
 				Msg("Unable to update HTTPRoute status")
@@ -103,7 +110,7 @@ func (p *Provider) loadHTTPRoutes(ctx context.Context, gatewayListeners []gatewa
 	}
 }
 
-func (p *Provider) loadHTTPRoute(ctx context.Context, listener gatewayListener, route *gatev1.HTTPRoute, hostnames []gatev1.Hostname) (*dynamic.Configuration, metav1.Condition) {
+func (p *Provider) loadHTTPRoute(ctx context.Context, gatewayName, gatewayNamespace string, listener gatewayListener, route *gatev1.HTTPRoute, hostnames []gatev1.Hostname) (*dynamic.Configuration, metav1.Condition) {
 	conf := &dynamic.Configuration{
 		HTTP: &dynamic.HTTPConfiguration{
 			Routers:           make(map[string]*dynamic.Router),
@@ -123,7 +130,7 @@ func (p *Provider) loadHTTPRoute(ctx context.Context, listener gatewayListener, 
 
 	for ri, routeRule := range route.Spec.Rules {
 		// Adding the gateway desc and the entryPoint desc prevents overlapping of routers build from the same routes.
-		routeKey := provider.Normalize(fmt.Sprintf("%s-%s-%s-gw-%s-%s-ep-%s-%d", strings.ToLower(kindHTTPRoute), route.Namespace, route.Name, listener.GWNamespace, listener.GWName, listener.EPName, ri))
+		routeKey := provider.Normalize(fmt.Sprintf("%s-%s-%s-gw-%s-%s-ep-%s-%d", strings.ToLower(kindHTTPRoute), route.Namespace, route.Name, gatewayNamespace, gatewayName, listener.EPName, ri))
 
 		for _, match := range routeRule.Matches {
 			rule, priority := buildMatchRule(hostnames, match)
@@ -175,7 +182,7 @@ func (p *Provider) loadHTTPRoute(ctx context.Context, listener gatewayListener, 
 
 			default:
 				var serviceCondition *metav1.Condition
-				router.Service, serviceCondition = p.loadWRRService(ctx, listener, conf, routerName, routeRule, route)
+				router.Service, serviceCondition = p.loadWRRService(ctx, gatewayName, listener, conf, routerName, routeRule, route)
 				if serviceCondition != nil {
 					condition = *serviceCondition
 				}
@@ -190,7 +197,7 @@ func (p *Provider) loadHTTPRoute(ctx context.Context, listener gatewayListener, 
 	return conf, condition
 }
 
-func (p *Provider) loadWRRService(ctx context.Context, listener gatewayListener, conf *dynamic.Configuration, routeKey string, routeRule gatev1.HTTPRouteRule, route *gatev1.HTTPRoute) (string, *metav1.Condition) {
+func (p *Provider) loadWRRService(ctx context.Context, gatewayName string, listener gatewayListener, conf *dynamic.Configuration, routeKey string, routeRule gatev1.HTTPRouteRule, route *gatev1.HTTPRoute) (string, *metav1.Condition) {
 	name := routeKey + "-wrr"
 	if _, ok := conf.HTTP.Services[name]; ok {
 		return name, nil
@@ -199,7 +206,7 @@ func (p *Provider) loadWRRService(ctx context.Context, listener gatewayListener,
 	var wrr dynamic.WeightedRoundRobin
 	var condition *metav1.Condition
 	for _, backendRef := range routeRule.BackendRefs {
-		svcName, errCondition := p.loadService(ctx, listener, conf, route, backendRef)
+		svcName, errCondition := p.loadService(ctx, gatewayName, listener, conf, route, backendRef)
 		weight := ptr.To(int(ptr.Deref(backendRef.Weight, 1)))
 		if errCondition != nil {
 			log.Ctx(ctx).Error().
@@ -226,7 +233,7 @@ func (p *Provider) loadWRRService(ctx context.Context, listener gatewayListener,
 
 // loadService returns a dynamic.Service config corresponding to the given gatev1.HTTPBackendRef.
 // Note that the returned dynamic.Service config can be nil (for cross-provider, internal services, and backendFunc).
-func (p *Provider) loadService(ctx context.Context, listener gatewayListener, conf *dynamic.Configuration, route *gatev1.HTTPRoute, backendRef gatev1.HTTPBackendRef) (string, *metav1.Condition) {
+func (p *Provider) loadService(ctx context.Context, gatewayName string, listener gatewayListener, conf *dynamic.Configuration, route *gatev1.HTTPRoute, backendRef gatev1.HTTPBackendRef) (string, *metav1.Condition) {
 	kind := ptr.Deref(backendRef.Kind, kindService)
 
 	group := groupCore
@@ -298,7 +305,7 @@ func (p *Provider) loadService(ctx context.Context, listener gatewayListener, co
 	portStr := strconv.FormatInt(int64(port), 10)
 	serviceName = provider.Normalize(serviceName + "-" + portStr)
 
-	lb, st, errCondition := p.loadHTTPServers(ctx, namespace, route, backendRef, listener)
+	lb, st, errCondition := p.loadHTTPServers(ctx, gatewayName, namespace, route, backendRef, listener)
 	if errCondition != nil {
 		return serviceName, errCondition
 	}
@@ -425,7 +432,7 @@ func (p *Provider) loadHTTPRouteFilterExtensionRef(namespace string, extensionRe
 	return filterFunc(string(extensionRef.Name), namespace)
 }
 
-func (p *Provider) loadHTTPServers(ctx context.Context, namespace string, route *gatev1.HTTPRoute, backendRef gatev1.HTTPBackendRef, listener gatewayListener) (*dynamic.ServersLoadBalancer, *dynamic.ServersTransport, *metav1.Condition) {
+func (p *Provider) loadHTTPServers(ctx context.Context, gatewayName, namespace string, route *gatev1.HTTPRoute, backendRef gatev1.HTTPBackendRef, listener gatewayListener) (*dynamic.ServersLoadBalancer, *dynamic.ServersTransport, *metav1.Condition) {
 	backendAddresses, svcPort, err := p.getBackendAddresses(namespace, backendRef.BackendRef)
 	if err != nil {
 		return nil, nil, &metav1.Condition{
@@ -477,7 +484,7 @@ func (p *Provider) loadHTTPServers(ctx context.Context, namespace string, route 
 					Group:       ptr.To(gatev1.Group(groupGateway)),
 					Kind:        ptr.To(gatev1.Kind(kindGateway)),
 					Namespace:   ptr.To(gatev1.Namespace(namespace)),
-					Name:        gatev1.ObjectName(listener.GWName),
+					Name:        gatev1.ObjectName(gatewayName),
 					SectionName: ptr.To(gatev1.SectionName(listener.Name)),
 				},
 				ControllerName: controllerName,

--- a/pkg/provider/kubernetes/gateway/httproute.go
+++ b/pkg/provider/kubernetes/gateway/httproute.go
@@ -53,35 +53,42 @@ func (p *Provider) loadHTTPRoutes(ctx context.Context, gateways []gatewayWithLis
 
 			var resolvedRefCondition *metav1.Condition
 			for _, listener := range match.listeners {
-				if !allowRoute(listener, route.Namespace, kindHTTPRoute) {
+				// A parentRef can target specific listeners through its SectionName or Port.
+				accepted := matchListener(listener, match.parentRef)
+
+				if accepted && !allowRoute(listener, route.Namespace, kindHTTPRoute) {
 					if acceptedCondition.Status == metav1.ConditionFalse {
 						acceptedCondition.Reason = string(gatev1.RouteReasonNotAllowedByListeners)
 					}
-					continue
+					accepted = false
 				}
 
 				hostnames, ok := findMatchingHostnames(listener.Hostname, route.Spec.Hostnames)
-				if !ok {
+				if accepted && !ok {
 					if acceptedCondition.Status == metav1.ConditionFalse {
 						acceptedCondition.Reason = string(gatev1.RouteReasonNoMatchingListenerHostname)
 					}
-					continue
+					accepted = false
 				}
 
-				// Gateway listener should have AttachedRoutes set even when Gateway has unresolved refs.
-				listener.Status.AttachedRoutes++
+				if accepted {
+					// Gateway listener should have AttachedRoutes set even when Gateway has unresolved refs.
+					listener.Status.AttachedRoutes++
+				}
 
+				// The ResolvedRefs condition must be reported for every parentRef,
+				// even when the route does not attach to the listener.
 				routeConf, condition := p.loadHTTPRoute(logger.WithContext(ctx), match.gatewayName, match.gatewayNamespace, listener, route, hostnames)
-				if listener.Attached {
+				if resolvedRefCondition == nil || resolvedRefCondition.Status == metav1.ConditionTrue {
+					resolvedRefCondition = &condition
+				}
+
+				if accepted && listener.Attached {
 					mergeHTTPConfiguration(routeConf, conf)
 
 					// Only consider the route attached if the listener is in an "attached" state.
 					acceptedCondition.Reason = string(gatev1.RouteReasonAccepted)
 					acceptedCondition.Status = metav1.ConditionTrue
-				}
-
-				if resolvedRefCondition == nil || resolvedRefCondition.Status == metav1.ConditionTrue {
-					resolvedRefCondition = &condition
 				}
 			}
 

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -1158,7 +1158,7 @@ func matchingGatewayListenersForParentRef(gateways []gatewayWithListeners, route
 
 		var matchingGateway *gatewayWithListeners
 		for _, gateway := range gateways {
-			if gateway.Namespace != parentRefNamespace {
+			if parentRefNamespace != gateway.Namespace {
 				continue
 			}
 

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -135,10 +135,14 @@ type gatewayListener struct {
 
 	Attached bool
 
-	GWName       string
-	GWNamespace  string
-	GWGeneration int64
-	EPName       string
+	EPName string
+}
+
+type gatewayWithListeners struct {
+	Name      string
+	Namespace string
+
+	listeners []gatewayListener
 }
 
 // RegisterFilterFuncs registers an allowed Group, Kind, and builder for the Filter ExtensionRef objects.
@@ -379,23 +383,27 @@ func (p *Provider) loadConfigurationFromGateways(ctx context.Context) *dynamic.C
 		gateways = append(gateways, gateway)
 	}
 
-	var gatewayListeners []gatewayListener
+	var selectedGateways []gatewayWithListeners
 	for _, gateway := range gateways {
 		logger := log.Ctx(ctx).With().
 			Str("gateway", gateway.Name).
 			Str("namespace", gateway.Namespace).
 			Logger()
 
-		gatewayListeners = append(gatewayListeners, p.loadGatewayListeners(logger.WithContext(ctx), gateway, conf)...)
+		selectedGateways = append(selectedGateways, gatewayWithListeners{
+			Name:      gateway.Name,
+			Namespace: gateway.Namespace,
+			listeners: p.loadGatewayListeners(logger.WithContext(ctx), gateway, conf),
+		})
 	}
 
-	p.loadHTTPRoutes(ctx, gatewayListeners, conf)
+	p.loadHTTPRoutes(ctx, selectedGateways, conf)
 
-	p.loadGRPCRoutes(ctx, gatewayListeners, conf)
+	p.loadGRPCRoutes(ctx, selectedGateways, conf)
 
 	if p.ExperimentalChannel {
-		p.loadTCPRoutes(ctx, gatewayListeners, conf)
-		p.loadTLSRoutes(ctx, gatewayListeners, conf)
+		p.loadTCPRoutes(ctx, selectedGateways, conf)
+		p.loadTLSRoutes(ctx, selectedGateways, conf)
 	}
 
 	for _, gateway := range gateways {
@@ -405,9 +413,9 @@ func (p *Provider) loadConfigurationFromGateways(ctx context.Context) *dynamic.C
 			Logger()
 
 		var listeners []gatewayListener
-		for _, listener := range gatewayListeners {
-			if listener.GWName == gateway.Name && listener.GWNamespace == gateway.Namespace {
-				listeners = append(listeners, listener)
+		for _, selectedGateway := range selectedGateways {
+			if selectedGateway.Name == gateway.Name && selectedGateway.Namespace == gateway.Namespace {
+				listeners = append(listeners, selectedGateway.listeners...)
 			}
 		}
 
@@ -443,14 +451,11 @@ func (p *Provider) loadGatewayListeners(ctx context.Context, gateway *gatev1.Gat
 
 	for i, listener := range gateway.Spec.Listeners {
 		gatewayListeners[i] = gatewayListener{
-			Name:         string(listener.Name),
-			GWName:       gateway.Name,
-			GWNamespace:  gateway.Namespace,
-			GWGeneration: gateway.Generation,
-			Port:         listener.Port,
-			Protocol:     listener.Protocol,
-			TLS:          listener.TLS,
-			Hostname:     listener.Hostname,
+			Name:     string(listener.Name),
+			Port:     listener.Port,
+			Protocol: listener.Protocol,
+			TLS:      listener.TLS,
+			Hostname: listener.Hostname,
 			Status: &gatev1.ListenerStatus{
 				Name:           listener.Name,
 				SupportedKinds: []gatev1.RouteGroupKind{},
@@ -1123,33 +1128,64 @@ func allowRoute(listener gatewayListener, routeNamespace, routeKind string) bool
 	})
 }
 
-func matchingGatewayListeners(gatewayListeners []gatewayListener, routeNamespace string, parentRefs []gatev1.ParentReference) []gatewayListener {
-	var listeners []gatewayListener
+// gatewayListenersForParentRef associates a route parentRef with the listeners of
+// the Gateway it refers to, among the Gateways managed by this controller.
+type gatewayListenersForParentRef struct {
+	parentRef gatev1.ParentReference
 
-	for _, listener := range gatewayListeners {
-		for _, parentRef := range parentRefs {
-			if ptr.Deref(parentRef.Group, gatev1.GroupName) != gatev1.GroupName {
+	gatewayName      string
+	gatewayNamespace string
+
+	listeners []gatewayListener
+}
+
+// matchingGatewayListenersForParentRef returns the listeners of that Gateway,
+// for each parentRef referring to a Gateway managed by this controller.
+// parentRefs that do not refer to one of our Gateways are omitted.
+func matchingGatewayListenersForParentRef(gateways []gatewayWithListeners, routeNamespace string, parentRefs []gatev1.ParentReference) []gatewayListenersForParentRef {
+	var matches []gatewayListenersForParentRef
+
+	for _, parentRef := range parentRefs {
+		if ptr.Deref(parentRef.Group, gatev1.GroupName) != gatev1.GroupName {
+			continue
+		}
+
+		if ptr.Deref(parentRef.Kind, kindGateway) != kindGateway {
+			continue
+		}
+
+		parentRefNamespace := string(ptr.Deref(parentRef.Namespace, gatev1.Namespace(routeNamespace)))
+
+		var matchingGateway *gatewayWithListeners
+		var listeners []gatewayListener
+		for _, gateway := range gateways {
+			if gateway.Namespace != parentRefNamespace {
 				continue
 			}
 
-			if ptr.Deref(parentRef.Kind, kindGateway) != kindGateway {
+			if string(parentRef.Name) != gateway.Name {
 				continue
 			}
 
-			parentRefNamespace := string(ptr.Deref(parentRef.Namespace, gatev1.Namespace(routeNamespace)))
-			if listener.GWNamespace != parentRefNamespace {
-				continue
+			matchingGateway = &gateway
+			for _, listener := range gateway.listeners {
+				if matchListener(listener, parentRef) {
+					listeners = append(listeners, listener)
+				}
 			}
+		}
 
-			if string(parentRef.Name) != listener.GWName {
-				continue
-			}
-
-			listeners = append(listeners, listener)
+		if matchingGateway != nil {
+			matches = append(matches, gatewayListenersForParentRef{
+				parentRef:        parentRef,
+				gatewayName:      matchingGateway.Name,
+				gatewayNamespace: matchingGateway.Namespace,
+				listeners:        listeners,
+			})
 		}
 	}
 
-	return listeners
+	return matches
 }
 
 func matchListener(listener gatewayListener, parentRef gatev1.ParentReference) bool {
@@ -1347,42 +1383,6 @@ func kindToString(p *gatev1.Kind) string {
 		return "<nil>"
 	}
 	return string(*p)
-}
-
-func updateRouteConditionAccepted(conditions []metav1.Condition, reason string) []metav1.Condition {
-	var conds []metav1.Condition
-	for _, c := range conditions {
-		if c.Type == string(gatev1.RouteConditionAccepted) && c.Status != metav1.ConditionTrue {
-			c.Reason = reason
-			c.LastTransitionTime = metav1.Now()
-
-			if reason == string(gatev1.RouteReasonAccepted) {
-				c.Status = metav1.ConditionTrue
-			}
-		}
-
-		conds = append(conds, c)
-	}
-
-	return conds
-}
-
-func upsertRouteConditionResolvedRefs(conditions []metav1.Condition, condition metav1.Condition) []metav1.Condition {
-	var (
-		curr  *metav1.Condition
-		conds []metav1.Condition
-	)
-	for _, c := range conditions {
-		if c.Type == string(gatev1.RouteConditionResolvedRefs) {
-			curr = &c
-			continue
-		}
-		conds = append(conds, c)
-	}
-	if curr != nil && curr.Status == metav1.ConditionFalse && condition.Status == metav1.ConditionTrue {
-		return append(conds, *curr)
-	}
-	return append(conds, condition)
 }
 
 func upsertGatewayClassConditionAccepted(conditions []metav1.Condition, condition metav1.Condition) []metav1.Condition {

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -1139,8 +1139,8 @@ type gatewayListenersForParentRef struct {
 	listeners []gatewayListener
 }
 
-// matchingGatewayListenersForParentRef returns the listeners of that Gateway,
-// for each parentRef referring to a Gateway managed by this controller.
+// matchingGatewayListenersForParentRef returns, for each parentRef referring to a
+// Gateway managed by this controller, all the listeners of that Gateway.
 // parentRefs that do not refer to one of our Gateways are omitted.
 func matchingGatewayListenersForParentRef(gateways []gatewayWithListeners, routeNamespace string, parentRefs []gatev1.ParentReference) []gatewayListenersForParentRef {
 	var matches []gatewayListenersForParentRef
@@ -1157,7 +1157,6 @@ func matchingGatewayListenersForParentRef(gateways []gatewayWithListeners, route
 		parentRefNamespace := string(ptr.Deref(parentRef.Namespace, gatev1.Namespace(routeNamespace)))
 
 		var matchingGateway *gatewayWithListeners
-		var listeners []gatewayListener
 		for _, gateway := range gateways {
 			if gateway.Namespace != parentRefNamespace {
 				continue
@@ -1168,19 +1167,19 @@ func matchingGatewayListenersForParentRef(gateways []gatewayWithListeners, route
 			}
 
 			matchingGateway = &gateway
-			for _, listener := range gateway.listeners {
-				if matchListener(listener, parentRef) {
-					listeners = append(listeners, listener)
-				}
-			}
+			break
 		}
 
 		if matchingGateway != nil {
+			// All the Gateway listeners are kept: the parentRef is associated to its
+			// Gateway here, and whether each listener is actually targeted (SectionName,
+			// Port) is decided when loading the route, so that ResolvedRefs is reported
+			// even for parentRefs that match no listener.
 			matches = append(matches, gatewayListenersForParentRef{
 				parentRef:        parentRef,
 				gatewayName:      matchingGateway.Name,
 				gatewayNamespace: matchingGateway.Namespace,
-				listeners:        listeners,
+				listeners:        matchingGateway.listeners,
 			})
 		}
 	}

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -7254,69 +7254,66 @@ func TestLoadRoutesWithReferenceGrants(t *testing.T) {
 func Test_matchingGatewayListener(t *testing.T) {
 	testCases := []struct {
 		desc           string
-		gwListeners    []gatewayListener
+		gateways       []gatewayWithListeners
 		parentRefs     []gatev1.ParentReference
 		routeNamespace string
-		wantLen        int
+		want           []gatewayListenersForParentRef
 	}{
 		{
 			desc: "Unsupported group",
-			gwListeners: []gatewayListener{{
-				Name:        "foo",
-				GWName:      "gateway",
-				GWNamespace: "default",
+			gateways: []gatewayWithListeners{{
+				Name:      "gateway",
+				Namespace: "default",
+				listeners: []gatewayListener{{Name: "foo"}},
 			}},
 			parentRefs: []gatev1.ParentReference{{
 				Group: ptr.To(gatev1.Group("foo")),
 			}},
-			wantLen: 0,
 		},
 		{
 			desc: "Unsupported kind",
-			gwListeners: []gatewayListener{{
-				Name:        "foo",
-				GWName:      "gateway",
-				GWNamespace: "default",
+			gateways: []gatewayWithListeners{{
+				Name:      "gateway",
+				Namespace: "default",
+				listeners: []gatewayListener{{Name: "foo"}},
 			}},
 			parentRefs: []gatev1.ParentReference{{
 				Group: ptr.To(gatev1.Group(gatev1.GroupName)),
 				Kind:  ptr.To(gatev1.Kind("foo")),
 			}},
-			wantLen: 0,
 		},
 		{
 			desc: "Namespace does not match the listener",
-			gwListeners: []gatewayListener{{
-				Name:        "foo",
-				GWName:      "gateway",
-				GWNamespace: "default",
+			gateways: []gatewayWithListeners{{
+				Name:      "gateway",
+				Namespace: "default",
+				listeners: []gatewayListener{{Name: "foo"}},
 			}},
 			parentRefs: []gatev1.ParentReference{{
 				Namespace: ptr.To(gatev1.Namespace("foo")),
 				Group:     ptr.To(gatev1.Group(gatev1.GroupName)),
 				Kind:      ptr.To(gatev1.Kind("Gateway")),
 			}},
-			wantLen: 0,
 		},
 		{
 			desc: "Route namespace defaulting does not match the listener",
-			gwListeners: []gatewayListener{{
-				Name:        "foo",
-				GWName:      "gateway",
-				GWNamespace: "default",
+			gateways: []gatewayWithListeners{{
+				Name:      "gateway",
+				Namespace: "default",
+				listeners: []gatewayListener{{Name: "foo"}},
 			}},
 			routeNamespace: "foo",
 			parentRefs: []gatev1.ParentReference{{
 				Group: ptr.To(gatev1.Group(gatev1.GroupName)),
 				Kind:  ptr.To(gatev1.Kind("Gateway")),
 			}},
-			wantLen: 0,
 		},
 		{
 			desc: "Name does not match the listener",
-			gwListeners: []gatewayListener{{
-				GWName:      "gateway",
-				GWNamespace: "default",
+			gateways: []gatewayWithListeners{{
+				Name:      "gateway",
+				Namespace: "default",
+				listeners: []gatewayListener{{}},
 			}},
 			parentRefs: []gatev1.ParentReference{{
 				Namespace: ptr.To(gatev1.Namespace("default")),
@@ -7324,13 +7321,13 @@ func Test_matchingGatewayListener(t *testing.T) {
 				Group:     ptr.To(gatev1.Group(gatev1.GroupName)),
 				Kind:      ptr.To(gatev1.Kind("Gateway")),
 			}},
-			wantLen: 0,
 		},
 		{
 			desc: "Match",
-			gwListeners: []gatewayListener{{
-				GWName:      "gateway",
-				GWNamespace: "default",
+			gateways: []gatewayWithListeners{{
+				Name:      "gateway",
+				Namespace: "default",
+				listeners: []gatewayListener{{}},
 			}},
 			parentRefs: []gatev1.ParentReference{{
 				Name:      "gateway",
@@ -7338,13 +7335,24 @@ func Test_matchingGatewayListener(t *testing.T) {
 				Group:     ptr.To(gatev1.Group(gatev1.GroupName)),
 				Kind:      ptr.To(gatev1.Kind("Gateway")),
 			}},
-			wantLen: 1,
+			want: []gatewayListenersForParentRef{{
+				parentRef: gatev1.ParentReference{
+					Name:      "gateway",
+					Namespace: ptr.To(gatev1.Namespace("default")),
+					Group:     ptr.To(gatev1.Group(gatev1.GroupName)),
+					Kind:      ptr.To(gatev1.Kind("Gateway")),
+				},
+				gatewayName:      "gateway",
+				gatewayNamespace: "default",
+				listeners:        []gatewayListener{{}},
+			}},
 		},
 		{
 			desc: "Match with route namespace defaulting",
-			gwListeners: []gatewayListener{{
-				GWName:      "gateway",
-				GWNamespace: "default",
+			gateways: []gatewayWithListeners{{
+				Name:      "gateway",
+				Namespace: "default",
+				listeners: []gatewayListener{{}},
 			}},
 			routeNamespace: "default",
 			parentRefs: []gatev1.ParentReference{{
@@ -7352,7 +7360,117 @@ func Test_matchingGatewayListener(t *testing.T) {
 				Group: ptr.To(gatev1.Group(gatev1.GroupName)),
 				Kind:  ptr.To(gatev1.Kind("Gateway")),
 			}},
-			wantLen: 1,
+			want: []gatewayListenersForParentRef{{
+				parentRef: gatev1.ParentReference{
+					Name:  "gateway",
+					Group: ptr.To(gatev1.Group(gatev1.GroupName)),
+					Kind:  ptr.To(gatev1.Kind("Gateway")),
+				},
+				gatewayName:      "gateway",
+				gatewayNamespace: "default",
+				listeners:        []gatewayListener{{}},
+			}},
+		},
+		{
+			// A Route may reference Gateways owned by other controllers; those
+			// parentRefs must not be associated to (and thus get status written by)
+			// this controller.
+			desc: "Only parentRefs targeting our Gateways are returned",
+			gateways: []gatewayWithListeners{{
+				Name:      "gateway",
+				Namespace: "default",
+				listeners: []gatewayListener{{}},
+			}},
+			parentRefs: []gatev1.ParentReference{
+				{
+					Name:      "gateway",
+					Namespace: ptr.To(gatev1.Namespace("default")),
+					Group:     ptr.To(gatev1.Group(gatev1.GroupName)),
+					Kind:      ptr.To(gatev1.Kind("Gateway")),
+				},
+				{
+					Name:      "other-gateway",
+					Namespace: ptr.To(gatev1.Namespace("default")),
+					Group:     ptr.To(gatev1.Group(gatev1.GroupName)),
+					Kind:      ptr.To(gatev1.Kind("Gateway")),
+				},
+			},
+			want: []gatewayListenersForParentRef{{
+				parentRef: gatev1.ParentReference{
+					Name:      "gateway",
+					Namespace: ptr.To(gatev1.Namespace("default")),
+					Group:     ptr.To(gatev1.Group(gatev1.GroupName)),
+					Kind:      ptr.To(gatev1.Kind("Gateway")),
+				},
+				gatewayName:      "gateway",
+				gatewayNamespace: "default",
+				listeners:        []gatewayListener{{}},
+			}},
+		},
+		{
+			desc: "ParentRef is associated to all the listeners of its Gateway",
+			gateways: []gatewayWithListeners{{
+				Name:      "gateway",
+				Namespace: "default",
+				listeners: []gatewayListener{
+					{Name: "web"},
+					{Name: "websecure"},
+				},
+			}},
+			parentRefs: []gatev1.ParentReference{{
+				Name:      "gateway",
+				Namespace: ptr.To(gatev1.Namespace("default")),
+				Group:     ptr.To(gatev1.Group(gatev1.GroupName)),
+				Kind:      ptr.To(gatev1.Kind("Gateway")),
+			}},
+			want: []gatewayListenersForParentRef{{
+				parentRef: gatev1.ParentReference{
+					Name:      "gateway",
+					Namespace: ptr.To(gatev1.Namespace("default")),
+					Group:     ptr.To(gatev1.Group(gatev1.GroupName)),
+					Kind:      ptr.To(gatev1.Kind("Gateway")),
+				},
+				gatewayName:      "gateway",
+				gatewayNamespace: "default",
+				listeners: []gatewayListener{
+					{Name: "web"},
+					{Name: "websecure"},
+				},
+			}},
+		},
+		{
+			// A parentRef must only be associated to the listeners of the Gateway it
+			// targets, even when several of our Gateways are known.
+			desc: "ParentRef is only associated to the referenced Gateway",
+			gateways: []gatewayWithListeners{
+				{
+					Name:      "gateway-a",
+					Namespace: "default",
+					listeners: []gatewayListener{{Name: "web"}},
+				},
+				{
+					Name:      "gateway-b",
+					Namespace: "default",
+					listeners: []gatewayListener{{Name: "web"}},
+				},
+			},
+			parentRefs: []gatev1.ParentReference{{
+				Name:      "gateway-a",
+				Namespace: ptr.To(gatev1.Namespace("default")),
+				Group:     ptr.To(gatev1.Group(gatev1.GroupName)),
+				Kind:      ptr.To(gatev1.Kind("Gateway")),
+			}},
+			want: []gatewayListenersForParentRef{{
+				parentRef: gatev1.ParentReference{
+					Name:      "gateway-a",
+					Namespace: ptr.To(gatev1.Namespace("default")),
+					Group:     ptr.To(gatev1.Group(gatev1.GroupName)),
+					Kind:      ptr.To(gatev1.Kind("Gateway")),
+				},
+				gatewayName:      "gateway-a",
+				gatewayNamespace: "default",
+				listeners:        []gatewayListener{{Name: "web"}},
+			}},
 		},
 	}
 
@@ -7360,10 +7478,209 @@ func Test_matchingGatewayListener(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			listeners := matchingGatewayListeners(test.gwListeners, test.routeNamespace, test.parentRefs)
-			assert.Len(t, listeners, test.wantLen)
+			matches := matchingGatewayListenersForParentRef(test.gateways, test.routeNamespace, test.parentRefs)
+			assert.Equal(t, test.want, matches)
 		})
 	}
+}
+
+// Test_loadRoutes_multipleGatewaysParentRefs ensures that, when a Route
+// references several Gateways (including one owned by another controller), Traefik
+// only manages the parents it is responsible for: it writes a single RouteParentStatus
+// for its own parentRef, writes nothing for a Route that targets only a foreign
+// Gateway, and counts each attached Route only once in the listener AttachedRoutes.
+func Test_loadRoutes_multipleGatewaysParentRefs(t *testing.T) {
+	testCases := []struct {
+		desc                string
+		path                string
+		entryPoints         map[string]Entrypoint
+		experimentalChannel bool
+		gatewayName         string
+		route1, route2      string
+		getParents          func(t *testing.T, gwClient *gatefake.Clientset, name string) []gatev1.RouteParentStatus
+	}{
+		{
+			desc:        "HTTPRoute",
+			path:        "httproute/with_multiple_gateways_parent_refs.yml",
+			entryPoints: map[string]Entrypoint{"web": {Address: ":80"}},
+			gatewayName: "my-gateway",
+			route1:      "http-app-1",
+			route2:      "http-app-2",
+			getParents: func(t *testing.T, gwClient *gatefake.Clientset, name string) []gatev1.RouteParentStatus {
+				t.Helper()
+				route, err := gwClient.GatewayV1().HTTPRoutes("default").Get(t.Context(), name, metav1.GetOptions{})
+				require.NoError(t, err)
+				return route.Status.Parents
+			},
+		},
+		{
+			desc:        "GRPCRoute",
+			path:        "grpcroute/with_multiple_gateways_parent_refs.yml",
+			entryPoints: map[string]Entrypoint{"web": {Address: ":80"}},
+			gatewayName: "my-gateway",
+			route1:      "grpc-app-1",
+			route2:      "grpc-app-2",
+			getParents: func(t *testing.T, gwClient *gatefake.Clientset, name string) []gatev1.RouteParentStatus {
+				t.Helper()
+				route, err := gwClient.GatewayV1().GRPCRoutes("default").Get(t.Context(), name, metav1.GetOptions{})
+				require.NoError(t, err)
+				return route.Status.Parents
+			},
+		},
+		{
+			desc:                "TCPRoute",
+			path:                "tcproute/with_multiple_gateways_parent_refs.yml",
+			entryPoints:         map[string]Entrypoint{"tcp": {Address: ":9000"}},
+			experimentalChannel: true,
+			gatewayName:         "my-tcp-gateway",
+			route1:              "tcp-app-1",
+			route2:              "tcp-app-2",
+			getParents: func(t *testing.T, gwClient *gatefake.Clientset, name string) []gatev1.RouteParentStatus {
+				t.Helper()
+				route, err := gwClient.GatewayV1alpha2().TCPRoutes("default").Get(t.Context(), name, metav1.GetOptions{})
+				require.NoError(t, err)
+				return route.Status.Parents
+			},
+		},
+		{
+			desc:                "TLSRoute",
+			path:                "tlsroute/with_multiple_gateways_parent_refs.yml",
+			entryPoints:         map[string]Entrypoint{"tls": {Address: ":9000"}},
+			experimentalChannel: true,
+			gatewayName:         "my-tls-gateway",
+			route1:              "tls-app-1",
+			route2:              "tls-app-2",
+			getParents: func(t *testing.T, gwClient *gatefake.Clientset, name string) []gatev1.RouteParentStatus {
+				t.Helper()
+				route, err := gwClient.GatewayV1alpha2().TLSRoutes("default").Get(t.Context(), name, metav1.GetOptions{})
+				require.NoError(t, err)
+				return route.Status.Parents
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			k8sObjects, gwObjects := readResources(t, []string{"services.yml", test.path})
+
+			gwClient := newGatewaySimpleClientSet(t, gwObjects...)
+			client := newClientImpl(kubefake.NewClientset(k8sObjects...), gwClient)
+			client.experimentalChannel = test.experimentalChannel
+
+			eventCh, err := client.WatchAll(nil, make(chan struct{}))
+			require.NoError(t, err)
+			<-eventCh
+
+			p := Provider{
+				EntryPoints:         test.entryPoints,
+				ExperimentalChannel: test.experimentalChannel,
+				client:              client,
+			}
+
+			_ = p.loadConfigurationFromGateways(t.Context())
+
+			// route1 references our Gateway and a foreign one: only our parentRef must
+			// get a status entry, written under our controllerName and accepted.
+			parents1 := test.getParents(t, gwClient, test.route1)
+			require.Len(t, parents1, 1)
+			assert.Equal(t, gatev1.GatewayController(controllerName), parents1[0].ControllerName)
+			assert.Equal(t, gatev1.ObjectName(test.gatewayName), parents1[0].ParentRef.Name)
+
+			acceptedCondition := findCondition(parents1[0].Conditions, gatev1.RouteConditionAccepted)
+			require.NotNil(t, acceptedCondition)
+			assert.Equal(t, metav1.ConditionTrue, acceptedCondition.Status)
+			assert.Equal(t, string(gatev1.RouteReasonAccepted), acceptedCondition.Reason)
+
+			// route2 references only the foreign Gateway: Traefik must not write any status.
+			assert.Empty(t, test.getParents(t, gwClient, test.route2))
+
+			// The listener must count route1 once, ignoring the foreign parentRef and
+			// the foreign-only Route.
+			gateway, err := gwClient.GatewayV1().Gateways("default").Get(t.Context(), test.gatewayName, metav1.GetOptions{})
+			require.NoError(t, err)
+			require.Len(t, gateway.Status.Listeners, 1)
+			assert.Equal(t, int32(1), gateway.Status.Listeners[0].AttachedRoutes)
+		})
+	}
+}
+
+// Test_mergeRouteParentStatuses ensures the merge keeps the parentStatuses Traefik
+// does not own: those written by another controller, and those written by another
+// Traefik instance (our controllerName but a parentRef not targeting a managed
+// Gateway), while replacing our stale statuses with the freshly computed ones.
+func Test_mergeRouteParentStatuses(t *testing.T) {
+	gateways := []gatewayWithListeners{{Name: "my-gateway", Namespace: "default"}}
+
+	otherController := gatev1.RouteParentStatus{
+		ControllerName: "example.com/other-controller",
+		ParentRef:      gatev1.ParentReference{Namespace: ptr.To(gatev1.Namespace("default")), Name: "other-gateway"},
+	}
+	otherTraefik := gatev1.RouteParentStatus{
+		ControllerName: controllerName,
+		ParentRef:      gatev1.ParentReference{Namespace: ptr.To(gatev1.Namespace("default")), Name: "other-traefik-gateway"},
+	}
+	staleManaged := gatev1.RouteParentStatus{
+		ControllerName: controllerName,
+		ParentRef:      gatev1.ParentReference{Namespace: ptr.To(gatev1.Namespace("default")), Name: "my-gateway"},
+	}
+	desired := gatev1.RouteParentStatus{
+		ControllerName: controllerName,
+		ParentRef:      gatev1.ParentReference{Namespace: ptr.To(gatev1.Namespace("default")), Name: "my-gateway"},
+		Conditions: []metav1.Condition{{
+			Type:   string(gatev1.RouteConditionAccepted),
+			Status: metav1.ConditionTrue,
+			Reason: string(gatev1.RouteReasonAccepted),
+		}},
+	}
+
+	testCases := []struct {
+		desc    string
+		current []gatev1.RouteParentStatus
+		want    []gatev1.RouteParentStatus
+	}{
+		{
+			desc: "no current status",
+			want: []gatev1.RouteParentStatus{desired},
+		},
+		{
+			desc:    "keeps status owned by another controller",
+			current: []gatev1.RouteParentStatus{otherController},
+			want:    []gatev1.RouteParentStatus{desired, otherController},
+		},
+		{
+			desc:    "keeps our status targeting a Gateway managed by another Traefik instance",
+			current: []gatev1.RouteParentStatus{otherTraefik},
+			want:    []gatev1.RouteParentStatus{desired, otherTraefik},
+		},
+		{
+			desc:    "drops our stale status targeting a managed Gateway",
+			current: []gatev1.RouteParentStatus{staleManaged},
+			want:    []gatev1.RouteParentStatus{desired},
+		},
+		{
+			desc:    "mixed: keeps unmanaged, drops managed",
+			current: []gatev1.RouteParentStatus{otherController, otherTraefik, staleManaged},
+			want:    []gatev1.RouteParentStatus{desired, otherController, otherTraefik},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			got := mergeRouteParentStatuses(test.current, []gatev1.RouteParentStatus{desired}, gateways)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func findCondition(conditions []metav1.Condition, conditionType gatev1.RouteConditionType) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == string(conditionType) {
+			return &conditions[i]
+		}
+	}
+	return nil
 }
 
 func Test_matchListener(t *testing.T) {
@@ -7442,9 +7759,7 @@ func Test_allowRoute(t *testing.T) {
 		{
 			desc: "Not allowed Kind",
 			gwListener: gatewayListener{
-				Name:        "foo",
-				GWName:      "gateway",
-				GWNamespace: "default",
+				Name: "foo",
 				AllowedRouteKinds: []string{
 					"foo",
 					"bar",
@@ -7456,9 +7771,7 @@ func Test_allowRoute(t *testing.T) {
 		{
 			desc: "Allowed Kind",
 			gwListener: gatewayListener{
-				Name:        "foo",
-				GWName:      "gateway",
-				GWNamespace: "default",
+				Name: "foo",
 				AllowedRouteKinds: []string{
 					"foo",
 					"bar",
@@ -7473,9 +7786,7 @@ func Test_allowRoute(t *testing.T) {
 		{
 			desc: "Not allowed namespace",
 			gwListener: gatewayListener{
-				Name:        "foo",
-				GWName:      "gateway",
-				GWNamespace: "default",
+				Name: "foo",
 				AllowedRouteKinds: []string{
 					"foo",
 				},
@@ -7491,9 +7802,7 @@ func Test_allowRoute(t *testing.T) {
 		{
 			desc: "Allowed namespace",
 			gwListener: gatewayListener{
-				Name:        "foo",
-				GWName:      "gateway",
-				GWNamespace: "default",
+				Name: "foo",
 				AllowedRouteKinds: []string{
 					"foo",
 				},
@@ -7509,9 +7818,7 @@ func Test_allowRoute(t *testing.T) {
 		{
 			desc: "Allowed namespace",
 			gwListener: gatewayListener{
-				Name:        "foo",
-				GWName:      "gateway",
-				GWNamespace: "default",
+				Name: "foo",
 				AllowedRouteKinds: []string{
 					"foo",
 				},
@@ -8159,136 +8466,6 @@ func Test_gatewayAddresses(t *testing.T) {
 			test.wantErr(t, err)
 
 			assert.Equal(t, test.want, got)
-		})
-	}
-}
-
-func Test_upsertRouteConditionResolvedRefs(t *testing.T) {
-	testCases := []struct {
-		desc           string
-		conditions     []metav1.Condition
-		condition      metav1.Condition
-		wantConditions []metav1.Condition
-	}{
-		{
-			desc: "True to False",
-			conditions: []metav1.Condition{
-				{
-					Type:    "foo",
-					Status:  "bar",
-					Reason:  "baz",
-					Message: "foobarbaz",
-				},
-				{
-					Type:    string(gatev1.RouteConditionResolvedRefs),
-					Status:  metav1.ConditionTrue,
-					Reason:  "foo",
-					Message: "foo",
-				},
-			},
-			condition: metav1.Condition{
-				Type:    string(gatev1.RouteConditionResolvedRefs),
-				Status:  metav1.ConditionFalse,
-				Reason:  "bar",
-				Message: "bar",
-			},
-			wantConditions: []metav1.Condition{
-				{
-					Type:    "foo",
-					Status:  "bar",
-					Reason:  "baz",
-					Message: "foobarbaz",
-				},
-				{
-					Type:    string(gatev1.RouteConditionResolvedRefs),
-					Status:  metav1.ConditionFalse,
-					Reason:  "bar",
-					Message: "bar",
-				},
-			},
-		},
-		{
-			desc: "False to False",
-			conditions: []metav1.Condition{
-				{
-					Type:    "foo",
-					Status:  "bar",
-					Reason:  "baz",
-					Message: "foobarbaz",
-				},
-				{
-					Type:    string(gatev1.RouteConditionResolvedRefs),
-					Status:  metav1.ConditionFalse,
-					Reason:  "foo",
-					Message: "foo",
-				},
-			},
-			condition: metav1.Condition{
-				Type:    string(gatev1.RouteConditionResolvedRefs),
-				Status:  metav1.ConditionFalse,
-				Reason:  "bar",
-				Message: "bar",
-			},
-			wantConditions: []metav1.Condition{
-				{
-					Type:    "foo",
-					Status:  "bar",
-					Reason:  "baz",
-					Message: "foobarbaz",
-				},
-				{
-					Type:    string(gatev1.RouteConditionResolvedRefs),
-					Status:  metav1.ConditionFalse,
-					Reason:  "bar",
-					Message: "bar",
-				},
-			},
-		},
-		{
-			desc: "False to True: no upsert",
-			conditions: []metav1.Condition{
-				{
-					Type:    "foo",
-					Status:  "bar",
-					Reason:  "baz",
-					Message: "foobarbaz",
-				},
-				{
-					Type:    string(gatev1.RouteConditionResolvedRefs),
-					Status:  metav1.ConditionFalse,
-					Reason:  "foo",
-					Message: "foo",
-				},
-			},
-			condition: metav1.Condition{
-				Type:    string(gatev1.RouteConditionResolvedRefs),
-				Status:  metav1.ConditionTrue,
-				Reason:  "bar",
-				Message: "bar",
-			},
-			wantConditions: []metav1.Condition{
-				{
-					Type:    "foo",
-					Status:  "bar",
-					Reason:  "baz",
-					Message: "foobarbaz",
-				},
-				{
-					Type:    string(gatev1.RouteConditionResolvedRefs),
-					Status:  metav1.ConditionFalse,
-					Reason:  "foo",
-					Message: "foo",
-				},
-			},
-		},
-	}
-
-	for _, test := range testCases {
-		t.Run(test.desc, func(t *testing.T) {
-			t.Parallel()
-
-			got := upsertRouteConditionResolvedRefs(test.conditions, test.condition)
-			assert.Equal(t, test.wantConditions, got)
 		})
 	}
 }

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -7472,6 +7472,36 @@ func Test_matchingGatewayListener(t *testing.T) {
 				listeners:        []gatewayListener{{Name: "web"}},
 			}},
 		},
+		{
+			// A parentRef with a non-matching SectionName or Port still targets the
+			// Gateway: all its listeners are returned so the route loader can report
+			// ResolvedRefs even though the route attaches to none of them.
+			desc: "ParentRef with a non-matching port still returns the Gateway listeners",
+			gateways: []gatewayWithListeners{{
+				Name:      "gateway",
+				Namespace: "default",
+				listeners: []gatewayListener{{Name: "web", Port: 80}},
+			}},
+			parentRefs: []gatev1.ParentReference{{
+				Name:      "gateway",
+				Namespace: ptr.To(gatev1.Namespace("default")),
+				Group:     ptr.To(gatev1.Group(gatev1.GroupName)),
+				Kind:      ptr.To(gatev1.Kind("Gateway")),
+				Port:      ptr.To(gatev1.PortNumber(8080)),
+			}},
+			want: []gatewayListenersForParentRef{{
+				parentRef: gatev1.ParentReference{
+					Name:      "gateway",
+					Namespace: ptr.To(gatev1.Namespace("default")),
+					Group:     ptr.To(gatev1.Group(gatev1.GroupName)),
+					Kind:      ptr.To(gatev1.Kind("Gateway")),
+					Port:      ptr.To(gatev1.PortNumber(8080)),
+				},
+				gatewayName:      "gateway",
+				gatewayNamespace: "default",
+				listeners:        []gatewayListener{{Name: "web", Port: 80}},
+			}},
+		},
 	}
 
 	for _, test := range testCases {
@@ -7623,6 +7653,12 @@ func Test_mergeRouteParentStatuses(t *testing.T) {
 		ControllerName: controllerName,
 		ParentRef:      gatev1.ParentReference{Namespace: ptr.To(gatev1.Namespace("default")), Name: "my-gateway"},
 	}
+	// A parentRef without an explicit namespace defaults to the Route namespace,
+	// and must still be recognized as targeting a managed Gateway.
+	staleManagedDefaulted := gatev1.RouteParentStatus{
+		ControllerName: controllerName,
+		ParentRef:      gatev1.ParentReference{Name: "my-gateway"},
+	}
 	desired := gatev1.RouteParentStatus{
 		ControllerName: controllerName,
 		ParentRef:      gatev1.ParentReference{Namespace: ptr.To(gatev1.Namespace("default")), Name: "my-gateway"},
@@ -7658,6 +7694,11 @@ func Test_mergeRouteParentStatuses(t *testing.T) {
 			want:    []gatev1.RouteParentStatus{desired},
 		},
 		{
+			desc:    "drops our stale status targeting a managed Gateway via namespace defaulting",
+			current: []gatev1.RouteParentStatus{staleManagedDefaulted},
+			want:    []gatev1.RouteParentStatus{desired},
+		},
+		{
 			desc:    "mixed: keeps unmanaged, drops managed",
 			current: []gatev1.RouteParentStatus{otherController, otherTraefik, staleManaged},
 			want:    []gatev1.RouteParentStatus{desired, otherController, otherTraefik},
@@ -7668,7 +7709,7 @@ func Test_mergeRouteParentStatuses(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			got := mergeRouteParentStatuses(test.current, []gatev1.RouteParentStatus{desired}, gateways)
+			got := mergeRouteParentStatuses("default", test.current, []gatev1.RouteParentStatus{desired}, gateways)
 			assert.Equal(t, test.want, got)
 		})
 	}

--- a/pkg/provider/kubernetes/gateway/tcproute.go
+++ b/pkg/provider/kubernetes/gateway/tcproute.go
@@ -50,26 +50,33 @@ func (p *Provider) loadTCPRoutes(ctx context.Context, gateways []gatewayWithList
 
 			var resolvedRefCondition *metav1.Condition
 			for _, listener := range match.listeners {
-				if !allowRoute(listener, route.Namespace, kindTCPRoute) {
+				// A parentRef can target specific listeners through its SectionName or Port.
+				accepted := matchListener(listener, match.parentRef)
+
+				if accepted && !allowRoute(listener, route.Namespace, kindTCPRoute) {
 					if acceptedCondition.Status == metav1.ConditionFalse {
 						acceptedCondition.Reason = string(gatev1.RouteReasonNotAllowedByListeners)
 					}
-					continue
+					accepted = false
 				}
 
-				listener.Status.AttachedRoutes++
+				if accepted {
+					listener.Status.AttachedRoutes++
+				}
 
+				// The ResolvedRefs condition must be reported for every parentRef,
+				// even when the route does not attach to the listener.
 				routeConf, condition := p.loadTCPRoute(match.gatewayName, match.gatewayNamespace, listener, route)
-				if listener.Attached {
+				if resolvedRefCondition == nil || resolvedRefCondition.Status == metav1.ConditionTrue {
+					resolvedRefCondition = &condition
+				}
+
+				if accepted && listener.Attached {
 					mergeTCPConfiguration(routeConf, conf)
 
 					// Only consider the route attached if the listener is in an "attached" state.
 					acceptedCondition.Reason = string(gatev1.RouteReasonAccepted)
 					acceptedCondition.Status = metav1.ConditionTrue
-				}
-
-				if resolvedRefCondition == nil || resolvedRefCondition.Status == metav1.ConditionTrue {
-					resolvedRefCondition = &condition
 				}
 			}
 

--- a/pkg/provider/kubernetes/gateway/tcproute.go
+++ b/pkg/provider/kubernetes/gateway/tcproute.go
@@ -68,7 +68,7 @@ func (p *Provider) loadTCPRoutes(ctx context.Context, gateways []gatewayWithList
 				// even when the route does not attach to the listener.
 				routeConf, condition := p.loadTCPRoute(match.gatewayName, match.gatewayNamespace, listener, route)
 				if resolvedRefCondition == nil || resolvedRefCondition.Status == metav1.ConditionTrue {
-					resolvedRefCondition = &condition
+					resolvedRefCondition = ptr.To(condition)
 				}
 
 				if accepted && listener.Attached {

--- a/pkg/provider/kubernetes/gateway/tcproute.go
+++ b/pkg/provider/kubernetes/gateway/tcproute.go
@@ -19,7 +19,7 @@ import (
 	gatev1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
-func (p *Provider) loadTCPRoutes(ctx context.Context, gatewayListeners []gatewayListener, conf *dynamic.Configuration) {
+func (p *Provider) loadTCPRoutes(ctx context.Context, gateways []gatewayWithListeners, conf *dynamic.Configuration) {
 	logger := log.Ctx(ctx)
 	routes, err := p.client.ListTCPRoutes()
 	if err != nil {
@@ -33,51 +33,56 @@ func (p *Provider) loadTCPRoutes(ctx context.Context, gatewayListeners []gateway
 			Str("namespace", route.Namespace).
 			Logger()
 
-		routeListeners := matchingGatewayListeners(gatewayListeners, route.Namespace, route.Spec.ParentRefs)
-		if len(routeListeners) == 0 {
+		routeParentRefs := matchingGatewayListenersForParentRef(gateways, route.Namespace, route.Spec.ParentRefs)
+		if len(routeParentRefs) == 0 {
 			continue
 		}
 
 		var parentStatuses []gatev1alpha2.RouteParentStatus
-		for _, parentRef := range route.Spec.ParentRefs {
-			parentStatus := &gatev1alpha2.RouteParentStatus{
-				ParentRef:      parentRef,
-				ControllerName: controllerName,
-				Conditions: []metav1.Condition{
-					{
-						Type:               string(gatev1.RouteConditionAccepted),
-						Status:             metav1.ConditionFalse,
-						ObservedGeneration: route.Generation,
-						LastTransitionTime: metav1.Now(),
-						Reason:             string(gatev1.RouteReasonNoMatchingParent),
-					},
-				},
+		for _, match := range routeParentRefs {
+			acceptedCondition := metav1.Condition{
+				Type:               string(gatev1.RouteConditionAccepted),
+				Status:             metav1.ConditionFalse,
+				ObservedGeneration: route.Generation,
+				LastTransitionTime: metav1.Now(),
+				Reason:             string(gatev1.RouteReasonNoMatchingParent),
 			}
 
-			for _, listener := range routeListeners {
-				accepted := matchListener(listener, parentRef)
-
-				if accepted && !allowRoute(listener, route.Namespace, kindTCPRoute) {
-					parentStatus.Conditions = updateRouteConditionAccepted(parentStatus.Conditions, string(gatev1.RouteReasonNotAllowedByListeners))
-					accepted = false
-				}
-
-				if accepted {
-					listener.Status.AttachedRoutes++
-					// only consider the route attached if the listener is in an "attached" state.
-					if listener.Attached {
-						parentStatus.Conditions = updateRouteConditionAccepted(parentStatus.Conditions, string(gatev1.RouteReasonAccepted))
+			var resolvedRefCondition *metav1.Condition
+			for _, listener := range match.listeners {
+				if !allowRoute(listener, route.Namespace, kindTCPRoute) {
+					if acceptedCondition.Status == metav1.ConditionFalse {
+						acceptedCondition.Reason = string(gatev1.RouteReasonNotAllowedByListeners)
 					}
+					continue
 				}
 
-				routeConf, resolveRefCondition := p.loadTCPRoute(listener, route)
-				if accepted && listener.Attached {
+				listener.Status.AttachedRoutes++
+
+				routeConf, condition := p.loadTCPRoute(match.gatewayName, match.gatewayNamespace, listener, route)
+				if listener.Attached {
 					mergeTCPConfiguration(routeConf, conf)
+
+					// Only consider the route attached if the listener is in an "attached" state.
+					acceptedCondition.Reason = string(gatev1.RouteReasonAccepted)
+					acceptedCondition.Status = metav1.ConditionTrue
 				}
-				parentStatus.Conditions = upsertRouteConditionResolvedRefs(parentStatus.Conditions, resolveRefCondition)
+
+				if resolvedRefCondition == nil || resolvedRefCondition.Status == metav1.ConditionTrue {
+					resolvedRefCondition = &condition
+				}
 			}
 
-			parentStatuses = append(parentStatuses, *parentStatus)
+			parentStatusConditions := []metav1.Condition{acceptedCondition}
+			if resolvedRefCondition != nil {
+				parentStatusConditions = append(parentStatusConditions, *resolvedRefCondition)
+			}
+
+			parentStatuses = append(parentStatuses, gatev1alpha2.RouteParentStatus{
+				ParentRef:      match.parentRef,
+				ControllerName: controllerName,
+				Conditions:     parentStatusConditions,
+			})
 		}
 
 		routeStatus := gatev1alpha2.TCPRouteStatus{
@@ -85,7 +90,7 @@ func (p *Provider) loadTCPRoutes(ctx context.Context, gatewayListeners []gateway
 				Parents: parentStatuses,
 			},
 		}
-		if err := p.client.UpdateTCPRouteStatus(ctx, ktypes.NamespacedName{Namespace: route.Namespace, Name: route.Name}, routeStatus); err != nil {
+		if err := p.client.UpdateTCPRouteStatus(ctx, ktypes.NamespacedName{Namespace: route.Namespace, Name: route.Name}, gateways, routeStatus); err != nil {
 			logger.Warn().
 				Err(err).
 				Msg("Unable to update TCPRoute status")
@@ -93,7 +98,7 @@ func (p *Provider) loadTCPRoutes(ctx context.Context, gatewayListeners []gateway
 	}
 }
 
-func (p *Provider) loadTCPRoute(listener gatewayListener, route *gatev1alpha2.TCPRoute) (*dynamic.Configuration, metav1.Condition) {
+func (p *Provider) loadTCPRoute(gatewayName, gatewayNamespace string, listener gatewayListener, route *gatev1alpha2.TCPRoute) (*dynamic.Configuration, metav1.Condition) {
 	conf := &dynamic.Configuration{
 		TCP: &dynamic.TCPConfiguration{
 			Routers:           make(map[string]*dynamic.TCPRouter),
@@ -131,7 +136,7 @@ func (p *Provider) loadTCPRoute(listener gatewayListener, route *gatev1alpha2.TC
 		}
 
 		// Adding the gateway desc and the entryPoint desc prevents overlapping of routers build from the same routes.
-		routeKey := provider.Normalize(fmt.Sprintf("%s-%s-%s-gw-%s-%s-ep-%s-%d", strings.ToLower(kindTCPRoute), route.Namespace, route.Name, listener.GWNamespace, listener.GWName, listener.EPName, ri))
+		routeKey := provider.Normalize(fmt.Sprintf("%s-%s-%s-gw-%s-%s-ep-%s-%d", strings.ToLower(kindTCPRoute), route.Namespace, route.Name, gatewayNamespace, gatewayName, listener.EPName, ri))
 		// Routing criteria should be introduced at some point.
 		routerName := makeRouterName("", routeKey)
 

--- a/pkg/provider/kubernetes/gateway/tlsroute.go
+++ b/pkg/provider/kubernetes/gateway/tlsroute.go
@@ -19,7 +19,7 @@ import (
 	gatev1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
-func (p *Provider) loadTLSRoutes(ctx context.Context, gatewayListeners []gatewayListener, conf *dynamic.Configuration) {
+func (p *Provider) loadTLSRoutes(ctx context.Context, gateways []gatewayWithListeners, conf *dynamic.Configuration) {
 	logger := log.Ctx(ctx)
 	routes, err := p.client.ListTLSRoutes()
 	if err != nil {
@@ -32,56 +32,64 @@ func (p *Provider) loadTLSRoutes(ctx context.Context, gatewayListeners []gateway
 			Str("tls_route", route.Name).
 			Str("namespace", route.Namespace).Logger()
 
-		routeListeners := matchingGatewayListeners(gatewayListeners, route.Namespace, route.Spec.ParentRefs)
-		if len(routeListeners) == 0 {
+		routeParentRefs := matchingGatewayListenersForParentRef(gateways, route.Namespace, route.Spec.ParentRefs)
+		if len(routeParentRefs) == 0 {
 			continue
 		}
 
 		var parentStatuses []gatev1alpha2.RouteParentStatus
-		for _, parentRef := range route.Spec.ParentRefs {
-			parentStatus := &gatev1alpha2.RouteParentStatus{
-				ParentRef:      parentRef,
-				ControllerName: controllerName,
-				Conditions: []metav1.Condition{
-					{
-						Type:               string(gatev1.RouteConditionAccepted),
-						Status:             metav1.ConditionFalse,
-						ObservedGeneration: route.Generation,
-						LastTransitionTime: metav1.Now(),
-						Reason:             string(gatev1.RouteReasonNoMatchingParent),
-					},
-				},
+		for _, match := range routeParentRefs {
+			acceptedCondition := metav1.Condition{
+				Type:               string(gatev1.RouteConditionAccepted),
+				Status:             metav1.ConditionFalse,
+				ObservedGeneration: route.Generation,
+				LastTransitionTime: metav1.Now(),
+				Reason:             string(gatev1.RouteReasonNoMatchingParent),
 			}
 
-			for _, listener := range routeListeners {
-				accepted := matchListener(listener, parentRef)
-
-				if accepted && !allowRoute(listener, route.Namespace, kindTLSRoute) {
-					parentStatus.Conditions = updateRouteConditionAccepted(parentStatus.Conditions, string(gatev1.RouteReasonNotAllowedByListeners))
-					accepted = false
-				}
-				hostnames, ok := findMatchingHostnames(listener.Hostname, route.Spec.Hostnames)
-				if accepted && !ok {
-					parentStatus.Conditions = updateRouteConditionAccepted(parentStatus.Conditions, string(gatev1.RouteReasonNoMatchingListenerHostname))
-					accepted = false
-				}
-
-				if accepted {
-					listener.Status.AttachedRoutes++
-					// only consider the route attached if the listener is in an "attached" state.
-					if listener.Attached {
-						parentStatus.Conditions = updateRouteConditionAccepted(parentStatus.Conditions, string(gatev1.RouteReasonAccepted))
+			var resolvedRefCondition *metav1.Condition
+			for _, listener := range match.listeners {
+				if !allowRoute(listener, route.Namespace, kindTLSRoute) {
+					if acceptedCondition.Status == metav1.ConditionFalse {
+						acceptedCondition.Reason = string(gatev1.RouteReasonNotAllowedByListeners)
 					}
+					continue
 				}
 
-				routeConf, resolveRefCondition := p.loadTLSRoute(listener, route, hostnames)
-				if accepted && listener.Attached {
-					mergeTCPConfiguration(routeConf, conf)
+				hostnames, ok := findMatchingHostnames(listener.Hostname, route.Spec.Hostnames)
+				if !ok {
+					if acceptedCondition.Status == metav1.ConditionFalse {
+						acceptedCondition.Reason = string(gatev1.RouteReasonNoMatchingListenerHostname)
+					}
+					continue
 				}
-				parentStatus.Conditions = upsertRouteConditionResolvedRefs(parentStatus.Conditions, resolveRefCondition)
+
+				listener.Status.AttachedRoutes++
+
+				routeConf, condition := p.loadTLSRoute(match.gatewayName, match.gatewayNamespace, listener, route, hostnames)
+				if listener.Attached {
+					mergeTCPConfiguration(routeConf, conf)
+
+					// Only consider the route attached if the listener is in an "attached" state.
+					acceptedCondition.Reason = string(gatev1.RouteReasonAccepted)
+					acceptedCondition.Status = metav1.ConditionTrue
+				}
+
+				if resolvedRefCondition == nil || resolvedRefCondition.Status == metav1.ConditionTrue {
+					resolvedRefCondition = &condition
+				}
 			}
 
-			parentStatuses = append(parentStatuses, *parentStatus)
+			parentStatusConditions := []metav1.Condition{acceptedCondition}
+			if resolvedRefCondition != nil {
+				parentStatusConditions = append(parentStatusConditions, *resolvedRefCondition)
+			}
+
+			parentStatuses = append(parentStatuses, gatev1alpha2.RouteParentStatus{
+				ParentRef:      match.parentRef,
+				ControllerName: controllerName,
+				Conditions:     parentStatusConditions,
+			})
 		}
 
 		routeStatus := gatev1alpha2.TLSRouteStatus{
@@ -89,7 +97,7 @@ func (p *Provider) loadTLSRoutes(ctx context.Context, gatewayListeners []gateway
 				Parents: parentStatuses,
 			},
 		}
-		if err := p.client.UpdateTLSRouteStatus(ctx, ktypes.NamespacedName{Namespace: route.Namespace, Name: route.Name}, routeStatus); err != nil {
+		if err := p.client.UpdateTLSRouteStatus(ctx, ktypes.NamespacedName{Namespace: route.Namespace, Name: route.Name}, gateways, routeStatus); err != nil {
 			logger.Warn().
 				Err(err).
 				Msg("Unable to update TLSRoute status")
@@ -97,7 +105,7 @@ func (p *Provider) loadTLSRoutes(ctx context.Context, gatewayListeners []gateway
 	}
 }
 
-func (p *Provider) loadTLSRoute(listener gatewayListener, route *gatev1alpha2.TLSRoute, hostnames []gatev1.Hostname) (*dynamic.Configuration, metav1.Condition) {
+func (p *Provider) loadTLSRoute(gatewayName, gatewayNamespace string, listener gatewayListener, route *gatev1alpha2.TLSRoute, hostnames []gatev1.Hostname) (*dynamic.Configuration, metav1.Condition) {
 	conf := &dynamic.Configuration{
 		TCP: &dynamic.TCPConfiguration{
 			Routers:           make(map[string]*dynamic.TCPRouter),
@@ -134,7 +142,7 @@ func (p *Provider) loadTLSRoute(listener gatewayListener, route *gatev1alpha2.TL
 		}
 
 		// Adding the gateway desc and the entryPoint desc prevents overlapping of routers build from the same routes.
-		routeKey := provider.Normalize(fmt.Sprintf("%s-%s-%s-gw-%s-%s-ep-%s-%d", strings.ToLower(kindTLSRoute), route.Namespace, route.Name, listener.GWNamespace, listener.GWName, listener.EPName, ri))
+		routeKey := provider.Normalize(fmt.Sprintf("%s-%s-%s-gw-%s-%s-ep-%s-%d", strings.ToLower(kindTLSRoute), route.Namespace, route.Name, gatewayNamespace, gatewayName, listener.EPName, ri))
 		// Routing criteria should be introduced at some point.
 		routerName := makeRouterName("", routeKey)
 

--- a/pkg/provider/kubernetes/gateway/tlsroute.go
+++ b/pkg/provider/kubernetes/gateway/tlsroute.go
@@ -49,34 +49,41 @@ func (p *Provider) loadTLSRoutes(ctx context.Context, gateways []gatewayWithList
 
 			var resolvedRefCondition *metav1.Condition
 			for _, listener := range match.listeners {
-				if !allowRoute(listener, route.Namespace, kindTLSRoute) {
+				// A parentRef can target specific listeners through its SectionName or Port.
+				accepted := matchListener(listener, match.parentRef)
+
+				if accepted && !allowRoute(listener, route.Namespace, kindTLSRoute) {
 					if acceptedCondition.Status == metav1.ConditionFalse {
 						acceptedCondition.Reason = string(gatev1.RouteReasonNotAllowedByListeners)
 					}
-					continue
+					accepted = false
 				}
 
 				hostnames, ok := findMatchingHostnames(listener.Hostname, route.Spec.Hostnames)
-				if !ok {
+				if accepted && !ok {
 					if acceptedCondition.Status == metav1.ConditionFalse {
 						acceptedCondition.Reason = string(gatev1.RouteReasonNoMatchingListenerHostname)
 					}
-					continue
+					accepted = false
 				}
 
-				listener.Status.AttachedRoutes++
+				if accepted {
+					listener.Status.AttachedRoutes++
+				}
 
+				// The ResolvedRefs condition must be reported for every parentRef,
+				// even when the route does not attach to the listener.
 				routeConf, condition := p.loadTLSRoute(match.gatewayName, match.gatewayNamespace, listener, route, hostnames)
-				if listener.Attached {
+				if resolvedRefCondition == nil || resolvedRefCondition.Status == metav1.ConditionTrue {
+					resolvedRefCondition = &condition
+				}
+
+				if accepted && listener.Attached {
 					mergeTCPConfiguration(routeConf, conf)
 
 					// Only consider the route attached if the listener is in an "attached" state.
 					acceptedCondition.Reason = string(gatev1.RouteReasonAccepted)
 					acceptedCondition.Status = metav1.ConditionTrue
-				}
-
-				if resolvedRefCondition == nil || resolvedRefCondition.Status == metav1.ConditionTrue {
-					resolvedRefCondition = &condition
 				}
 			}
 

--- a/pkg/provider/kubernetes/gateway/tlsroute.go
+++ b/pkg/provider/kubernetes/gateway/tlsroute.go
@@ -75,7 +75,7 @@ func (p *Provider) loadTLSRoutes(ctx context.Context, gateways []gatewayWithList
 				// even when the route does not attach to the listener.
 				routeConf, condition := p.loadTLSRoute(match.gatewayName, match.gatewayNamespace, listener, route, hostnames)
 				if resolvedRefCondition == nil || resolvedRefCondition.Status == metav1.ConditionTrue {
-					resolvedRefCondition = &condition
+					resolvedRefCondition = ptr.To(condition)
 				}
 
 				if accepted && listener.Attached {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes two behaviors:
- ignore other gateways parentRefs when building route configuration and statuses
- update route parent statuses only for managed gateways
<!-- A brief description of the change being made with this pull request. -->

### Motivation

To fix the Gateway API provider behavior.
<!-- What inspired you to submit this pull request? -->

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Assisted-by: Claude Opus 4.8 (1M context)

<!-- Anything else we should know when reviewing? -->
