### PR TITLE
Fix handle empty unknown-length bodies in mirroring

### DIFF
--- a/pkg/server/service/loadbalancer/mirror/mirror.go
+++ b/pkg/server/service/loadbalancer/mirror/mirror.go
@@ -231,7 +231,7 @@ func newReusableRequest(req *http.Request, mirrorBody bool, maxBodySize int64) (
 	// level rather than declared via Content-Length, so a bodyless request arrives
 	// with a non-nil Body and ContentLength == -1. The same shape is possible for a
 	// chunked request that sends no chunks.
-	if errors.Is(err, io.EOF) && n == 0 {
+	if errors.Is(err, io.EOF) {
 		return &reusableRequest{
 			req:  req,
 			body: body[:n],

--- a/pkg/server/service/loadbalancer/mirror/mirror.go
+++ b/pkg/server/service/loadbalancer/mirror/mirror.go
@@ -228,8 +228,9 @@ func newReusableRequest(req *http.Request, mirrorBody bool, maxBodySize int64) (
 	body := make([]byte, maxBodySize+1)
 	n, err := io.ReadFull(req.Body, body)
 	// This happens with HTTP/3, where the end of the body is framed at the stream
-	// level instead of declared with Content-Length. A chunked request with no
-	// chunks has the same shape.
+	// level rather than declared via Content-Length, so a bodyless request arrives
+	// with a non-nil Body and ContentLength == -1. The same shape is possible for a
+	// chunked request that sends no chunks.
 	if errors.Is(err, io.EOF) && n == 0 {
 		return &reusableRequest{
 			req:  req,

--- a/pkg/server/service/loadbalancer/mirror/mirror.go
+++ b/pkg/server/service/loadbalancer/mirror/mirror.go
@@ -227,6 +227,12 @@ func newReusableRequest(req *http.Request, mirrorBody bool, maxBodySize int64) (
 	// the request body is larger than what we allow for the mirrors.
 	body := make([]byte, maxBodySize+1)
 	n, err := io.ReadFull(req.Body, body)
+	if errors.Is(err, io.EOF) && n == 0 {
+		return &reusableRequest{
+			req:  req,
+			body: body[:n],
+		}, nil, nil
+	}
 	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
 		return nil, nil, err
 	}

--- a/pkg/server/service/loadbalancer/mirror/mirror.go
+++ b/pkg/server/service/loadbalancer/mirror/mirror.go
@@ -227,6 +227,9 @@ func newReusableRequest(req *http.Request, mirrorBody bool, maxBodySize int64) (
 	// the request body is larger than what we allow for the mirrors.
 	body := make([]byte, maxBodySize+1)
 	n, err := io.ReadFull(req.Body, body)
+	// This happens with HTTP/3, where the end of the body is framed at the stream
+	// level instead of declared with Content-Length. A chunked request with no
+	// chunks has the same shape.
 	if errors.Is(err, io.EOF) && n == 0 {
 		return &reusableRequest{
 			req:  req,

--- a/pkg/server/service/loadbalancer/mirror/mirror.go
+++ b/pkg/server/service/loadbalancer/mirror/mirror.go
@@ -207,7 +207,7 @@ func newReusableRequest(req *http.Request, mirrorBody bool, maxBodySize int64) (
 	if req == nil {
 		return nil, nil, errors.New("nil input request")
 	}
-	if req.Body == nil || req.ContentLength == 0 || !mirrorBody {
+	if req.Body == nil || !mirrorBody {
 		return &reusableRequest{req: req}, nil, nil
 	}
 

--- a/pkg/server/service/loadbalancer/mirror/mirror_test.go
+++ b/pkg/server/service/loadbalancer/mirror/mirror_test.go
@@ -302,6 +302,43 @@ func TestCloneRequest(t *testing.T) {
 		assert.Empty(t, rr.body)
 	})
 
+	t.Run("valid empty body with unknown content length", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "/", nil)
+		assert.NoError(t, err)
+
+		req.Body = io.NopCloser(bytes.NewReader(nil))
+		req.ContentLength = -1
+
+		rr, expectedBytes, err := newReusableRequest(req, true, 20)
+		assert.NoError(t, err)
+		assert.Nil(t, expectedBytes)
+		assert.Empty(t, rr.body)
+
+		cloned := rr.clone(req.Context())
+		body, err := io.ReadAll(cloned.Body)
+		assert.NoError(t, err)
+		assert.Empty(t, body)
+	})
+
+	t.Run("valid body with unknown content length", func(t *testing.T) {
+		bb := []byte(`unknown length body`)
+
+		req, err := http.NewRequest(http.MethodPost, "/", bytes.NewBuffer(bb))
+		assert.NoError(t, err)
+
+		req.ContentLength = -1
+
+		rr, expectedBytes, err := newReusableRequest(req, true, 20)
+		assert.NoError(t, err)
+		assert.Nil(t, expectedBytes)
+		assert.Equal(t, bb, rr.body)
+
+		cloned := rr.clone(req.Context())
+		body, err := io.ReadAll(cloned.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, bb, body)
+	})
+
 	t.Run("no request given", func(t *testing.T) {
 		_, _, err := newReusableRequest(nil, true, defaultMaxBodySize)
 		assert.Error(t, err)


### PR DESCRIPTION
### What does this PR do?

This handles the empty request-body case when the incoming request has an unknown content length (`ContentLength == -1`). Instead of treating all unknown-length requests as bodyless, it only treats `io.ReadFull` returning `io.EOF` with no bytes read as an empty body.

The regression coverage also checks that unknown-length requests with an actual body are still mirrored.

### Motivation

Fixes #12079.

### More

Tests:
- test success
  - `go test ./pkg/server/service/loadbalancer/mirror`
  - `go test ./pkg/server/service/loadbalancer/failover`
