### PR TITLE
Detect EndpointSlice condition changes

### DIFF
--- a/pkg/provider/kubernetes/k8s/event_handler.go
+++ b/pkg/provider/kubernetes/k8s/event_handler.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 // ResourceEventHandler handles Add, Update or Delete Events for resources.
@@ -97,6 +98,15 @@ func endpointChanged(a, b discoveryv1.Endpoint) bool {
 		if aaddr != baddr {
 			return true
 		}
+	}
+
+	// A nil condition has a defined meaning that consumers resolve with the same defaults
+	// (Ready and Serving default to true, Terminating to false), so comparison must use those
+	// defaults to avoid reporting a nil-to-default transition as a change.
+	if ptr.Deref(a.Conditions.Ready, true) != ptr.Deref(b.Conditions.Ready, true) ||
+		ptr.Deref(a.Conditions.Serving, true) != ptr.Deref(b.Conditions.Serving, true) ||
+		ptr.Deref(a.Conditions.Terminating, false) != ptr.Deref(b.Conditions.Terminating, false) {
+		return true
 	}
 
 	return false

--- a/pkg/provider/kubernetes/k8s/event_handler_test.go
+++ b/pkg/provider/kubernetes/k8s/event_handler_test.go
@@ -7,13 +7,10 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 func Test_detectChanges(t *testing.T) {
-	portA := int32(80)
-	portB := int32(8080)
-	trueValue := true
-	falseValue := false
 	tests := []struct {
 		name   string
 		oldObj any
@@ -191,7 +188,7 @@ func Test_detectChanges(t *testing.T) {
 				},
 				Endpoints: []discoveryv1.Endpoint{{
 					Addresses:  []string{"10.10.10.10"},
-					Conditions: discoveryv1.EndpointConditions{Ready: &trueValue},
+					Conditions: discoveryv1.EndpointConditions{Ready: ptr.To(true)},
 				}},
 			},
 			newObj: &discoveryv1.EndpointSlice{
@@ -200,7 +197,7 @@ func Test_detectChanges(t *testing.T) {
 				},
 				Endpoints: []discoveryv1.Endpoint{{
 					Addresses:  []string{"10.10.10.10"},
-					Conditions: discoveryv1.EndpointConditions{Ready: &falseValue},
+					Conditions: discoveryv1.EndpointConditions{Ready: ptr.To(false)},
 				}},
 			},
 			want: true,
@@ -213,7 +210,7 @@ func Test_detectChanges(t *testing.T) {
 				},
 				Endpoints: []discoveryv1.Endpoint{{
 					Addresses:  []string{"10.10.10.10"},
-					Conditions: discoveryv1.EndpointConditions{Serving: &trueValue},
+					Conditions: discoveryv1.EndpointConditions{Serving: ptr.To(true)},
 				}},
 			},
 			newObj: &discoveryv1.EndpointSlice{
@@ -222,7 +219,7 @@ func Test_detectChanges(t *testing.T) {
 				},
 				Endpoints: []discoveryv1.Endpoint{{
 					Addresses:  []string{"10.10.10.10"},
-					Conditions: discoveryv1.EndpointConditions{Serving: &falseValue},
+					Conditions: discoveryv1.EndpointConditions{Serving: ptr.To(false)},
 				}},
 			},
 			want: true,
@@ -235,7 +232,7 @@ func Test_detectChanges(t *testing.T) {
 				},
 				Endpoints: []discoveryv1.Endpoint{{
 					Addresses:  []string{"10.10.10.10"},
-					Conditions: discoveryv1.EndpointConditions{Terminating: &falseValue},
+					Conditions: discoveryv1.EndpointConditions{Terminating: ptr.To(false)},
 				}},
 			},
 			newObj: &discoveryv1.EndpointSlice{
@@ -244,7 +241,7 @@ func Test_detectChanges(t *testing.T) {
 				},
 				Endpoints: []discoveryv1.Endpoint{{
 					Addresses:  []string{"10.10.10.10"},
-					Conditions: discoveryv1.EndpointConditions{Terminating: &trueValue},
+					Conditions: discoveryv1.EndpointConditions{Terminating: ptr.To(true)},
 				}},
 			},
 			want: true,
@@ -265,7 +262,7 @@ func Test_detectChanges(t *testing.T) {
 				},
 				Endpoints: []discoveryv1.Endpoint{{
 					Addresses:  []string{"10.10.10.10"},
-					Conditions: discoveryv1.EndpointConditions{Serving: &trueValue},
+					Conditions: discoveryv1.EndpointConditions{Serving: ptr.To(true)},
 				}},
 			},
 		},
@@ -285,7 +282,7 @@ func Test_detectChanges(t *testing.T) {
 				},
 				Endpoints: []discoveryv1.Endpoint{{
 					Addresses:  []string{"10.10.10.10"},
-					Conditions: discoveryv1.EndpointConditions{Serving: &falseValue},
+					Conditions: discoveryv1.EndpointConditions{Serving: ptr.To(false)},
 				}},
 			},
 			want: true,
@@ -306,7 +303,7 @@ func Test_detectChanges(t *testing.T) {
 				},
 				Endpoints: []discoveryv1.Endpoint{{
 					Addresses:  []string{"10.10.10.10"},
-					Conditions: discoveryv1.EndpointConditions{Terminating: &falseValue},
+					Conditions: discoveryv1.EndpointConditions{Terminating: ptr.To(false)},
 				}},
 			},
 		},
@@ -326,7 +323,7 @@ func Test_detectChanges(t *testing.T) {
 				},
 				Endpoints: []discoveryv1.Endpoint{{
 					Addresses:  []string{"10.10.10.10"},
-					Conditions: discoveryv1.EndpointConditions{Terminating: &trueValue},
+					Conditions: discoveryv1.EndpointConditions{Terminating: ptr.To(true)},
 				}},
 			},
 			want: true,
@@ -354,7 +351,7 @@ func Test_detectChanges(t *testing.T) {
 					ResourceVersion: "1",
 				},
 				Ports: []discoveryv1.EndpointPort{{
-					Port: &portA,
+					Port: ptr.To[int32](80),
 				}},
 			},
 			newObj: &discoveryv1.EndpointSlice{
@@ -362,7 +359,7 @@ func Test_detectChanges(t *testing.T) {
 					ResourceVersion: "2",
 				},
 				Ports: []discoveryv1.EndpointPort{{
-					Port: &portB,
+					Port: ptr.To[int32](8080),
 				}},
 			},
 			want: true,

--- a/pkg/provider/kubernetes/k8s/event_handler_test.go
+++ b/pkg/provider/kubernetes/k8s/event_handler_test.go
@@ -12,6 +12,8 @@ import (
 func Test_detectChanges(t *testing.T) {
 	portA := int32(80)
 	portB := int32(8080)
+	trueValue := true
+	falseValue := false
 	tests := []struct {
 		name   string
 		oldObj any
@@ -177,6 +179,154 @@ func Test_detectChanges(t *testing.T) {
 				},
 				Endpoints: []discoveryv1.Endpoint{{
 					Addresses: []string{"10.10.10.11"},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "With different endpoint ready condition",
+			oldObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses:  []string{"10.10.10.10"},
+					Conditions: discoveryv1.EndpointConditions{Ready: &trueValue},
+				}},
+			},
+			newObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "2",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses:  []string{"10.10.10.10"},
+					Conditions: discoveryv1.EndpointConditions{Ready: &falseValue},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "With different endpoint serving condition",
+			oldObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses:  []string{"10.10.10.10"},
+					Conditions: discoveryv1.EndpointConditions{Serving: &trueValue},
+				}},
+			},
+			newObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "2",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses:  []string{"10.10.10.10"},
+					Conditions: discoveryv1.EndpointConditions{Serving: &falseValue},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "With different endpoint terminating condition",
+			oldObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses:  []string{"10.10.10.10"},
+					Conditions: discoveryv1.EndpointConditions{Terminating: &falseValue},
+				}},
+			},
+			newObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "2",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses:  []string{"10.10.10.10"},
+					Conditions: discoveryv1.EndpointConditions{Terminating: &trueValue},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "With endpoint serving condition nil then explicitly true",
+			oldObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses: []string{"10.10.10.10"},
+				}},
+			},
+			newObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "2",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses:  []string{"10.10.10.10"},
+					Conditions: discoveryv1.EndpointConditions{Serving: &trueValue},
+				}},
+			},
+		},
+		{
+			name: "With endpoint serving condition nil then explicitly false",
+			oldObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses: []string{"10.10.10.10"},
+				}},
+			},
+			newObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "2",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses:  []string{"10.10.10.10"},
+					Conditions: discoveryv1.EndpointConditions{Serving: &falseValue},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "With endpoint terminating condition nil then explicitly false",
+			oldObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses: []string{"10.10.10.10"},
+				}},
+			},
+			newObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "2",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses:  []string{"10.10.10.10"},
+					Conditions: discoveryv1.EndpointConditions{Terminating: &falseValue},
+				}},
+			},
+		},
+		{
+			name: "With endpoint terminating condition nil then explicitly true",
+			oldObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses: []string{"10.10.10.10"},
+				}},
+			},
+			newObj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "2",
+				},
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses:  []string{"10.10.10.10"},
+					Conditions: discoveryv1.EndpointConditions{Terminating: &trueValue},
 				}},
 			},
 			want: true,


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Adds content-aware change detection for EndpointSlice update events, so a rebuild only fires when fields Traefik consumes change (ports, endpoint addresses, and the Ready/Serving/Terminating tri-state) — ignoring updates that only bump metadata/resourceVersion.

### Motivation

Supercedes #13270

### More

- [X] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Piotr Maksymiuk <piotr.maksymiuk@docplanner.com>
