### PR TITLE
Optimize loadService calls for multiple paths sharing the same service host:port

### DIFF
--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -403,26 +403,29 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 					continue
 				}
 
-				service, err := p.loadService(client, ingress.Namespace, pa.Backend)
-				if err != nil {
-					logger.Error().
-						Str("serviceName", pa.Backend.Service.Name).
-						Str("servicePort", pa.Backend.Service.Port.String()).
-						Err(err).
-						Msg("Cannot create service")
-					continue
-				}
-
-				if len(service.LoadBalancer.Servers) == 0 && !p.AllowEmptyServices {
-					logger.Error().
-						Str("serviceName", pa.Backend.Service.Name).
-						Str("servicePort", pa.Backend.Service.Port.String()).
-						Msg("Skipping service: no endpoints found")
-					continue
-				}
-
 				serviceName := provider.Normalize(ingress.Namespace + "-" + pa.Backend.Service.Name + "-" + portString(pa.Backend.Service.Port))
-				conf.HTTP.Services[serviceName] = service
+
+				if _, exists := conf.HTTP.Services[serviceName]; !exists {
+					service, err := p.loadService(client, ingress.Namespace, pa.Backend)
+					if err != nil {
+						logger.Error().
+							Str("serviceName", pa.Backend.Service.Name).
+							Str("servicePort", pa.Backend.Service.Port.String()).
+							Err(err).
+							Msg("Cannot create service")
+						continue
+					}
+
+					if len(service.LoadBalancer.Servers) == 0 && !p.AllowEmptyServices {
+						logger.Error().
+							Str("serviceName", pa.Backend.Service.Name).
+							Str("servicePort", pa.Backend.Service.Port.String()).
+							Msg("Skipping service: no endpoints found")
+						continue
+					}
+
+					conf.HTTP.Services[serviceName] = service
+				}
 
 				rt, err := p.loadRouter(ingress, rule, pa, rtConfig, serviceName)
 				if err != nil {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

When multiple Ingress path rules reference the same backend service and port, loadService was called for each occurrence — fetching the Service, resolving EndpointSlices, and building the server list from scratch every time, only to overwrite the same map entry with an identical result.

This change checks whether conf.HTTP.Services[serviceName] already exists before calling loadService. If the service was already resolved by an earlier path rule, the redundant work is skipped entirely.

In clusters where many Ingress rules route to a shared backend (e.g. multiple hosts fronting the same API service), this eliminates O(N-1) unnecessary GetService + GetEndpointSlicesForService calls per shared service per configuration rebuild.

### Motivation

<!-- What inspired you to submit this pull request? -->

Minor and simple optimization when multiple paths are sharing the same service host:port.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
