### PR TITLE
skip health_status: healthy events to prevent config churn

### DIFF
--- a/pkg/provider/docker/pdocker.go
+++ b/pkg/provider/docker/pdocker.go
@@ -119,9 +119,7 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 				for {
 					select {
 					case event := <-res.Messages:
-						if event.Action == "start" ||
-							event.Action == "die" ||
-							strings.HasPrefix(string(event.Action), "health_status") {
+						if shouldHandleEvent(event.Action) {
 							startStopHandle(event)
 						}
 					case err := <-res.Err:
@@ -148,6 +146,11 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 	})
 
 	return nil
+}
+
+func shouldHandleEvent(action eventtypes.Action) bool {
+	// Skip health_status: healthy events to avoid unnecessary reloads.
+	return action == eventtypes.ActionStart || action == eventtypes.ActionDie || (strings.HasPrefix(string(action), "health_status") && action != eventtypes.ActionHealthStatusHealthy)
 }
 
 func (p *Provider) createClient(ctx context.Context) (*client.Client, error) {

--- a/pkg/provider/docker/pdocker_test.go
+++ b/pkg/provider/docker/pdocker_test.go
@@ -1,0 +1,54 @@
+package docker
+
+import (
+	"testing"
+
+	eventtypes "github.com/moby/moby/api/types/events"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldHandleEvent(t *testing.T) {
+	tests := []struct {
+		desc   string
+		action eventtypes.Action
+		want   bool
+	}{
+		{
+			desc:   "start event triggers reload",
+			action: eventtypes.ActionStart,
+			want:   true,
+		},
+		{
+			desc:   "die event triggers reload",
+			action: eventtypes.ActionDie,
+			want:   true,
+		},
+		{
+			desc:   "health_status: healthy does NOT trigger reload",
+			action: eventtypes.ActionHealthStatusHealthy,
+			want:   false,
+		},
+		{
+			desc:   "health_status: unhealthy triggers reload",
+			action: eventtypes.ActionHealthStatusUnhealthy,
+			want:   true,
+		},
+		{
+			desc:   "health_status: running triggers reload",
+			action: eventtypes.ActionHealthStatusRunning,
+			want:   true,
+		},
+		{
+			desc:   "other action triggers reload",
+			action: eventtypes.ActionStop,
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got := shouldHandleEvent(tt.action)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

This PR prevents unnecessary configuration regeneration when Traefik receives a Docker event with `health_status: healthy`. When such an event is received, and it does not represent an actual state change relevant to routing or configuration, Traefik now skips rebuilding the dynamic configuration.

### Motivation

As described in #13321, Docker emits `health_status: healthy` events even when a container is already in a stable healthy state.

Currently, these events trigger the Docker provider to recompute configuration, even though no meaningful change has occurred. This leads to redundant configuration updates and unnecessary processing overhead.

This change ensures that only relevant health transitions trigger configuration regeneration, improving efficiency and reducing noise from Docker health event churn.

### More

* [x] Added/updated tests
* [ ] Added/updated documentation

### Additional Notes

This change is scoped specifically to Docker `health_status: healthy` events and does not affect other Docker event types or health state transitions.
