### PR TITLE
Test trailers behavior for httputil and fasthttp proxies

### DIFF
--- a/pkg/config/static/static_config_test.go
+++ b/pkg/config/static/static_config_test.go
@@ -70,8 +70,9 @@ func TestConfiguration_SetEffectiveConfiguration(t *testing.T) {
 					ProxyProtocol:    nil,
 					ForwardedHeaders: &ForwardedHeaders{},
 					HTTP: HTTPConfig{
-						SanitizePath:   pointer(true),
-						MaxHeaderBytes: 1048576,
+						SanitizePath:              pointer(true),
+						MaxHeaderBytes:            1048576,
+						UnderscoreHeadersStrategy: UnderscoreHeadersStrategyKeep,
 					},
 					HTTP2: &HTTP2Config{
 						MaxConcurrentStreams:      250,
@@ -118,8 +119,9 @@ func TestConfiguration_SetEffectiveConfiguration(t *testing.T) {
 					ProxyProtocol:    nil,
 					ForwardedHeaders: &ForwardedHeaders{},
 					HTTP: HTTPConfig{
-						SanitizePath:   pointer(true),
-						MaxHeaderBytes: 1048576,
+						SanitizePath:              pointer(true),
+						MaxHeaderBytes:            1048576,
+						UnderscoreHeadersStrategy: UnderscoreHeadersStrategyKeep,
 					},
 					HTTP2: &HTTP2Config{
 						MaxConcurrentStreams:      250,
@@ -177,8 +179,9 @@ func TestConfiguration_SetEffectiveConfiguration(t *testing.T) {
 					ProxyProtocol:    nil,
 					ForwardedHeaders: &ForwardedHeaders{},
 					HTTP: HTTPConfig{
-						SanitizePath:   pointer(true),
-						MaxHeaderBytes: 1048576,
+						SanitizePath:              pointer(true),
+						MaxHeaderBytes:            1048576,
+						UnderscoreHeadersStrategy: UnderscoreHeadersStrategyKeep,
 					},
 					HTTP2: &HTTP2Config{
 						MaxConcurrentStreams:      250,
@@ -240,8 +243,9 @@ func TestConfiguration_SetEffectiveConfiguration(t *testing.T) {
 					ProxyProtocol:    nil,
 					ForwardedHeaders: &ForwardedHeaders{},
 					HTTP: HTTPConfig{
-						SanitizePath:   pointer(true),
-						MaxHeaderBytes: 1048576,
+						SanitizePath:              pointer(true),
+						MaxHeaderBytes:            1048576,
+						UnderscoreHeadersStrategy: UnderscoreHeadersStrategyKeep,
 					},
 					HTTP2: &HTTP2Config{
 						MaxConcurrentStreams:      250,

--- a/pkg/proxy/fast/trailer_test.go
+++ b/pkg/proxy/fast/trailer_test.go
@@ -1,0 +1,74 @@
+package fast
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/traefik/traefik/v3/pkg/config/static"
+	"github.com/vulcand/oxy/v2/roundrobin"
+)
+
+// TestRequestTrailersNotForwardedToBackend ensures that request trailers are not
+// forwarded to the backend by the fast reverse proxy.
+//
+// This is a deliberate behavior: trailers arrive after the body, once routing and
+// security decisions have already been made, so forwarding them could raise security
+// concerns in Traefik. This test locks the current behavior to catch any regression.
+func TestRequestTrailersNotForwardedToBackend(t *testing.T) {
+	var backendTrailer http.Header
+
+	backend := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// Request trailers are only populated after the body has been fully read.
+		_, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+
+		backendTrailer = req.Trailer.Clone()
+
+		rw.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(backend.Close)
+
+	backendURL, err := url.Parse(backend.URL)
+	require.NoError(t, err)
+
+	transportManager := &transportManagerMock{}
+
+	p, err := NewProxyBuilder(transportManager, static.FastProxyConfig{}).Build("default", backendURL, true, false)
+	require.NoError(t, err)
+
+	lb, err := roundrobin.New(p)
+	require.NoError(t, err)
+
+	err = lb.UpsertServer(backendURL)
+	require.NoError(t, err)
+
+	proxy := httptest.NewServer(lb)
+	t.Cleanup(proxy.Close)
+
+	pr, pw := io.Pipe()
+	req, err := http.NewRequest(http.MethodPost, proxy.URL, pr)
+	require.NoError(t, err)
+
+	req.Trailer = http.Header{"X-Test-Trailer": nil}
+
+	go func() {
+		_, _ = pw.Write([]byte("body data"))
+		req.Trailer.Set("X-Test-Trailer", "trailer-value")
+		_ = pw.Close()
+	}()
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	_, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	assert.Empty(t, backendTrailer.Get("X-Test-Trailer"))
+}

--- a/pkg/proxy/httputil/trailer_test.go
+++ b/pkg/proxy/httputil/trailer_test.go
@@ -1,4 +1,4 @@
-package service
+package httputil
 
 import (
 	"io"
@@ -32,13 +32,17 @@ func TestRequestTrailersNotForwardedToBackend(t *testing.T) {
 	}))
 	t.Cleanup(backend.Close)
 
-	proxyHandler, err := buildProxy(pointer(true), nil, http.DefaultTransport, nil)
-	require.NoError(t, err)
-
-	lb, err := roundrobin.New(proxyHandler)
-	require.NoError(t, err)
+	transportManager := &transportManagerMock{
+		roundTrippers: map[string]http.RoundTripper{"default": &http.Transport{}},
+	}
 
 	backendURL, err := url.Parse(backend.URL)
+	require.NoError(t, err)
+
+	p, err := NewProxyBuilder(transportManager, nil).Build("default", backendURL, true, false, 0)
+	require.NoError(t, err)
+
+	lb, err := roundrobin.New(p)
 	require.NoError(t, err)
 
 	err = lb.UpsertServer(backendURL)

--- a/pkg/server/server_entrypoint_tcp_test.go
+++ b/pkg/server/server_entrypoint_tcp_test.go
@@ -509,7 +509,7 @@ func TestUnderscoreHeadersStrategy(t *testing.T) {
 			epConfig := &static.EntryPointsTransport{}
 			epConfig.SetDefaults()
 
-			entryPoint, err := NewTCPEntryPoint(t.Context(), &static.EntryPoint{
+			entryPoint, err := NewTCPEntryPoint(t.Context(), "", &static.EntryPoint{
 				Address:          ":0",
 				Transport:        epConfig,
 				ForwardedHeaders: &static.ForwardedHeaders{},
@@ -517,7 +517,7 @@ func TestUnderscoreHeadersStrategy(t *testing.T) {
 				HTTP: static.HTTPConfig{
 					UnderscoreHeadersStrategy: test.strategy,
 				},
-			}, nil)
+			}, nil, nil)
 			require.NoError(t, err)
 
 			router, err := tcprouter.NewRouter()


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request adds a test to pinpoint the trailer's behavior for  httputil and fasthttp reverse proxies.


### Motivation

To fix failing tests.

### More

- [X] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
