### PR TITLE
Fix version in migration guide

### DIFF
--- a/docs/content/migrate/v3.md
+++ b/docs/content/migrate/v3.md
@@ -9,11 +9,11 @@ This guide provides detailed migration steps for upgrading between different Tra
 
 ---
 
-## v3.6.20
+## v3.6.22
 
 ### UnderscoreHeadersStrategy
 
-From version `v3.6.20` onwards, a new `underscoreHeadersStrategy` entry point option defines how request headers with
+From version `v3.6.22` onwards, a new `underscoreHeadersStrategy` entry point option defines how request headers with
 underscores in their names are handled before routing:
 
 - `keep` (default): request headers with underscores are forwarded as is.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request fixes the v3.6 version in the migration guide.

### More

- [ ] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
