### PR TITLE
feat(accesslog): report upstream failure cause in access logs

### DIFF
--- a/docs/content/reference/install-configuration/observability/logs-and-accesslogs.md
+++ b/docs/content/reference/install-configuration/observability/logs-and-accesslogs.md
@@ -382,6 +382,7 @@ Below the fields displayed with the generic CLF format:
 | <a id="opt-OriginContentSize" href="#opt-OriginContentSize" title="#opt-OriginContentSize">`OriginContentSize`</a> | The content length specified by the origin server, or 0 if unspecified.    |
 | <a id="opt-OriginStatus" href="#opt-OriginStatus" title="#opt-OriginStatus">`OriginStatus`</a> | The HTTP status code returned by the origin server. If the request was handled by this Traefik instance (e.g. with a redirect), then this value will be absent (0). |
 | <a id="opt-OriginStatusLine" href="#opt-OriginStatusLine" title="#opt-OriginStatusLine">`OriginStatusLine`</a> | `OriginStatus` + Status code explanation   |
+| <a id="opt-OriginError" href="#opt-OriginError" title="#opt-OriginError">`OriginError`</a> | The error message returned when forwarding to the origin server fails. Empty when the request succeeds or when the client closes the request. |
 | <a id="opt-DownstreamStatus" href="#opt-DownstreamStatus" title="#opt-DownstreamStatus">`DownstreamStatus`</a> | The HTTP status code returned to the client.    |
 | <a id="opt-DownstreamStatusLine" href="#opt-DownstreamStatusLine" title="#opt-DownstreamStatusLine">`DownstreamStatusLine`</a> | The `DownstreamStatus` and status code explanation.     |
 | <a id="opt-DownstreamContentSize" href="#opt-DownstreamContentSize" title="#opt-DownstreamContentSize">`DownstreamContentSize`</a> | The number of bytes in the response entity returned to the client. This is in addition to the "Content-Length" header, which may be present in the origin response. |

--- a/pkg/middlewares/accesslog/logdata.go
+++ b/pkg/middlewares/accesslog/logdata.go
@@ -57,6 +57,9 @@ const (
 	// OriginStatus is the map key used for the HTTP status code returned by the origin server.
 	// If the request was handled by this Traefik instance (e.g. with a redirect), then this value will be absent.
 	OriginStatus = "OriginStatus"
+	// OriginError is the map key used for the error message when forwarding to the origin server fails.
+	// Empty when the request succeeds or when the client closes the request.
+	OriginError = "OriginError"
 	// DownstreamStatus is the map key used for the HTTP status code returned to the client.
 	DownstreamStatus = "DownstreamStatus"
 	// DownstreamContentSize is the map key used for the number of bytes in the response entity returned to the client.
@@ -130,6 +133,7 @@ var defaultCoreKeys = [...]string{
 	OriginDuration,
 	OriginContentSize,
 	OriginStatus,
+	OriginError,
 	DownstreamStatus,
 	DownstreamContentSize,
 	RequestCount,

--- a/pkg/middlewares/accesslog/logger.go
+++ b/pkg/middlewares/accesslog/logger.go
@@ -437,7 +437,12 @@ func (h *Handler) keepAccessLog(statusCode, retryAttempts int, duration time.Dur
 // GetLogData gets the request context object that contains logging data.
 // This creates data as the request passes through the middleware chain.
 func GetLogData(req *http.Request) *LogData {
-	if ld, ok := req.Context().Value(DataTableKey).(*LogData); ok {
+	return GetLogDataTable(req.Context())
+}
+
+// GetLogDataTable gets the logging data from the given context.
+func GetLogDataTable(ctx context.Context) *LogData {
+	if ld, ok := ctx.Value(DataTableKey).(*LogData); ok {
 		return ld
 	}
 	return nil

--- a/pkg/middlewares/accesslog/logger_test.go
+++ b/pkg/middlewares/accesslog/logger_test.go
@@ -1631,3 +1631,108 @@ func (s *mockSpan) SetName(_ string) {}
 func (s *mockSpan) TracerProvider() trace.TracerProvider {
 	return nil
 }
+
+func TestLoggerJSON_OriginError(t *testing.T) {
+	testCases := []struct {
+		desc            string
+		originError     string
+		setOriginError  bool
+		wantOriginError any
+	}{
+		{
+			desc:            "OriginError populated",
+			originError:     "connection refused",
+			setOriginError:  true,
+			wantOriginError: "connection refused",
+		},
+		{
+			desc:            "OriginError empty string",
+			originError:     "",
+			setOriginError:  true,
+			wantOriginError: "",
+		},
+		{
+			desc:            "OriginError absent",
+			setOriginError:  false,
+			wantOriginError: nil,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			logFilePath := filepath.Join(t.TempDir(), logFileNameSuffix)
+			config := &otypes.AccessLog{FilePath: logFilePath, Format: JSONFormat}
+
+			logger, err := NewHandler(t.Context(), config)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				err := logger.Close()
+				require.NoError(t, err)
+			})
+
+			req := &http.Request{
+				Header: map[string][]string{
+					"User-Agent": {testUserAgent},
+					"Referer":    {testReferer},
+				},
+				Proto:      testProto,
+				Host:       testHostname,
+				Method:     testMethod,
+				RemoteAddr: fmt.Sprintf("%s:%d", testHostname, testPort),
+				URL: &url.URL{
+					User: url.UserPassword(testUsername, ""),
+					Path: testPath,
+				},
+				Body: io.NopCloser(bytes.NewReader([]byte("bar"))),
+			}
+
+			chain := alice.New()
+			chain = chain.Append(capture.Wrap)
+			chain = chain.Append(func(next http.Handler) (http.Handler, error) {
+				return observability.WithObservabilityHandler(next, observability.Observability{
+					AccessLogsEnabled: true,
+				}), nil
+			})
+			chain = chain.Append(logger.AliceConstructor())
+
+			handler, err := chain.Then(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+				logData := GetLogData(r)
+				require.NotNil(t, logData)
+
+				logData.Core[RouterName] = testRouterName
+				logData.Core[ServiceURL] = testServiceName
+				logData.Core[OriginStatus] = testStatus
+				logData.Core[OriginContentSize] = testContentSize
+				logData.Core[RetryAttempts] = testRetryAttempts
+				logData.Core[StartUTC] = testStart.UTC()
+				logData.Core[StartLocal] = testStart.Local()
+
+				if test.setOriginError {
+					logData.Core[OriginError] = test.originError
+				}
+
+				rw.WriteHeader(testStatus)
+				_, _ = rw.Write([]byte(testContent))
+			}))
+			require.NoError(t, err)
+
+			handler.ServeHTTP(httptest.NewRecorder(), req)
+
+			logData, err := os.ReadFile(logFilePath)
+			require.NoError(t, err)
+
+			jsonData := make(map[string]any)
+			err = json.Unmarshal(logData, &jsonData)
+			require.NoError(t, err)
+
+			if test.wantOriginError != nil {
+				assert.Equal(t, test.wantOriginError, jsonData[OriginError])
+			} else {
+				_, exists := jsonData[OriginError]
+				assert.False(t, exists)
+			}
+		})
+	}
+}

--- a/pkg/proxy/httputil/proxy.go
+++ b/pkg/proxy/httputil/proxy.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"github.com/traefik/traefik/v3/pkg/middlewares/accesslog"
 	"github.com/traefik/traefik/v3/pkg/observability/logs"
 	"golang.org/x/net/http/httpguts"
 )
@@ -180,6 +181,13 @@ func ErrorHandlerWithContext(ctx context.Context, w http.ResponseWriter, err err
 		logger.Error().Err(err).Msgf("%d %s", statusCode, statusText(statusCode))
 	} else {
 		logger.Debug().Err(err).Msgf("%d %s", statusCode, statusText(statusCode))
+	}
+
+	// Populate the access log OriginError field, unless the client closed the request.
+	if statusCode != StatusClientClosedRequest {
+		if table := accesslog.GetLogDataTable(ctx); table != nil {
+			table.Core[accesslog.OriginError] = err.Error()
+		}
 	}
 
 	w.WriteHeader(statusCode)

--- a/pkg/proxy/httputil/proxy_test.go
+++ b/pkg/proxy/httputil/proxy_test.go
@@ -1,8 +1,10 @@
 package httputil
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -11,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/traefik/traefik/v3/pkg/middlewares/accesslog"
 	"github.com/traefik/traefik/v3/pkg/testhelpers"
 )
 
@@ -179,4 +182,95 @@ func Test_isTLSConfigError(t *testing.T) {
 			require.Equal(t, test.expected, actual)
 		})
 	}
+}
+
+// timeoutError is a net.Error that reports a timeout.
+type timeoutError struct{ msg string }
+
+func (e *timeoutError) Error() string   { return e.msg }
+func (e *timeoutError) Timeout() bool   { return true }
+func (e *timeoutError) Temporary() bool { return false }
+
+// netError is a net.Error that does not report a timeout.
+type netError struct{ msg string }
+
+func (e *netError) Error() string   { return e.msg }
+func (e *netError) Timeout() bool   { return false }
+func (e *netError) Temporary() bool { return false }
+
+func TestErrorHandlerWithContext_OriginError(t *testing.T) {
+	testCases := []struct {
+		desc               string
+		err                error
+		wantStatus         int
+		wantOriginError    bool
+		wantOriginErrorMsg string
+	}{
+		{
+			desc:               "io.EOF",
+			err:                io.EOF,
+			wantStatus:         http.StatusBadGateway,
+			wantOriginError:    true,
+			wantOriginErrorMsg: io.EOF.Error(),
+		},
+		{
+			desc:               "network timeout",
+			err:                &timeoutError{msg: "i/o timeout"},
+			wantStatus:         http.StatusGatewayTimeout,
+			wantOriginError:    true,
+			wantOriginErrorMsg: "i/o timeout",
+		},
+		{
+			desc:               "network non-timeout",
+			err:                &netError{msg: "connection refused"},
+			wantStatus:         http.StatusBadGateway,
+			wantOriginError:    true,
+			wantOriginErrorMsg: "connection refused",
+		},
+		{
+			desc:            "context canceled",
+			err:             context.Canceled,
+			wantStatus:      StatusClientClosedRequest,
+			wantOriginError: false,
+		},
+		{
+			desc:               "TLS config error",
+			err:                &tls.RecordHeaderError{RecordHeader: [5]byte{}, Conn: nil, Msg: "bad TLS record"},
+			wantStatus:         http.StatusInternalServerError,
+			wantOriginError:    true,
+			wantOriginErrorMsg: (&tls.RecordHeaderError{RecordHeader: [5]byte{}, Msg: "bad TLS record"}).Error(),
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			logData := &accesslog.LogData{Core: accesslog.CoreLogData{}}
+			ctx := context.WithValue(t.Context(), accesslog.DataTableKey, logData)
+
+			rw := httptest.NewRecorder()
+			ErrorHandlerWithContext(ctx, rw, test.err)
+
+			assert.Equal(t, test.wantStatus, rw.Code)
+
+			if test.wantOriginError {
+				val, ok := logData.Core[accesslog.OriginError]
+				assert.True(t, ok)
+				assert.Equal(t, test.wantOriginErrorMsg, val)
+			} else {
+				_, ok := logData.Core[accesslog.OriginError]
+				assert.False(t, ok)
+			}
+		})
+	}
+}
+
+func TestErrorHandlerWithContext_OriginError_NoLogData(t *testing.T) {
+	// No LogData in context: the handler must not panic.
+	rw := httptest.NewRecorder()
+	assert.NotPanics(t, func() {
+		ErrorHandlerWithContext(t.Context(), rw, io.EOF)
+	})
+	assert.Equal(t, http.StatusBadGateway, rw.Code)
 }


### PR DESCRIPTION
### What does this PR do?

Closes #12011 (more detailed context there)
This feature  surfaces the upstream failure cause directly in access logs via a new `OriginError` field.

A small change at the single error choke point (`ErrorHandlerWithContext` in `pkg/proxy/httputil`) shared by both HTTP proxies. The existing `LogData.Core` context mechanism (same as `RetryAttempts`) is reused.

### Motivation

Before this, diagnosing a 502/504 meant enabling `DEBUG` logging and correlating two separate log streams. Now the error message (`connection refused`, `i/o timeout`, TLS errors, etc.) is a first-class access log field, present only when forwarding actually fails (absent on success and on 499 client-closed requests).

### More

- [X] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

Fully tested locally with: 
- **Unit tests:** 5 error types (network timeout, connection refused, `io.EOF`, `context.Canceled`, TLS errors) across HTTP 499/500/502/504, plus nil-guard and JSON serialization.
- **Manual testing:** docker-compose setup with three routes: a healthy backend, a connection-refused backend (502), and a hanging backend (504). Verified `OriginError` presence/absence in JSON access logs.
