### PR TITLE
Fix handle hostless ingress-nginx default backend fallback

### DIFF
--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-hostless-rule-and-default-backend.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-hostless-rule-and-default-backend.yml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-with-hostless-rule-and-default-backend
+  namespace: default
+spec:
+  ingressClassName: nginx
+  defaultBackend:
+    service:
+      name: whoami
+      port:
+        number: 80
+  rules:
+    - http:
+        paths:
+          - path: /web
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami
+                port:
+                  number: 80

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -298,6 +298,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"http"},
 							Rule:        `Host("whoami.localhost")`,
 							RuleSyntax:  "default",
+							Priority:    math.MinInt32,
 							Service:     "default-ingress-with-service-unavailable-default-backend-default-backend",
 							Middlewares: []string{"default-ingress-with-service-unavailable-default-backend-default-backend-retry"},
 							Observability: &dynamic.RouterObservabilityConfig{
@@ -314,6 +315,7 @@ func TestLoadIngresses(t *testing.T) {
 						"default-ingress-with-service-unavailable-default-backend-default-backend-tls": {
 							EntryPoints: []string{"https"},
 							Rule:        `Host("whoami.localhost")`,
+							Priority:    math.MinInt32,
 							RuleSyntax:  "default",
 							Service:     "default-ingress-with-service-unavailable-default-backend-default-backend",
 							Middlewares: []string{"default-ingress-with-service-unavailable-default-backend-default-backend-tls-retry"},
@@ -5715,6 +5717,172 @@ func TestLoadIngresses(t *testing.T) {
 			},
 		},
 		{
+			desc: "Ingress default backend with hostless rule emits low priority catch-all routers",
+			paths: []string{
+				"services.yml",
+				"ingressclasses.yml",
+				"ingresses/ingress-with-hostless-rule-and-default-backend.yml",
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-ingress-with-hostless-rule-and-default-backend-default-backend": {
+							EntryPoints: []string{"http"},
+							Rule:        `PathPrefix("/")`,
+							RuleSyntax:  "default",
+							Priority:    math.MinInt32,
+							Service:     "default-ingress-with-hostless-rule-and-default-backend-default-backend",
+							Middlewares: []string{"default-ingress-with-hostless-rule-and-default-backend-default-backend-retry"},
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-hostless-rule-and-default-backend",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+						},
+						"default-ingress-with-hostless-rule-and-default-backend-default-backend-tls": {
+							EntryPoints: []string{"https"},
+							Rule:        `PathPrefix("/")`,
+							RuleSyntax:  "default",
+							Priority:    math.MinInt32,
+							Service:     "default-ingress-with-hostless-rule-and-default-backend-default-backend",
+							Middlewares: []string{"default-ingress-with-hostless-rule-and-default-backend-default-backend-tls-retry"},
+							TLS:         &dynamic.RouterTLSConfig{},
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-hostless-rule-and-default-backend",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+						},
+						"default-ingress-with-hostless-rule-and-default-backend-rule-0-path-0": {
+							EntryPoints: []string{"http"},
+							Rule:        `(Path("/web") || PathPrefix("/web/"))`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-hostless-rule-and-default-backend-whoami-80",
+							Middlewares: []string{"default-ingress-with-hostless-rule-and-default-backend-rule-0-path-0-retry"},
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-hostless-rule-and-default-backend",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+						},
+						"default-ingress-with-hostless-rule-and-default-backend-rule-0-path-0-tls": {
+							EntryPoints: []string{"https"},
+							Rule:        `(Path("/web") || PathPrefix("/web/"))`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-hostless-rule-and-default-backend-whoami-80",
+							Middlewares: []string{"default-ingress-with-hostless-rule-and-default-backend-rule-0-path-0-tls-retry"},
+							TLS:         &dynamic.RouterTLSConfig{},
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-hostless-rule-and-default-backend",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-ingress-with-hostless-rule-and-default-backend-default-backend-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
+							},
+						},
+						"default-ingress-with-hostless-rule-and-default-backend-default-backend-tls-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
+							},
+						},
+						"default-ingress-with-hostless-rule-and-default-backend-rule-0-path-0-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
+							},
+						},
+						"default-ingress-with-hostless-rule-and-default-backend-rule-0-path-0-tls-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
+							},
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"unavailable-service": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+						"default-ingress-with-hostless-rule-and-default-backend-default-backend": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{URL: "http://10.10.0.1:80"},
+									{URL: "http://10.10.0.2:80"},
+								},
+								Strategy:         "wrr",
+								PassHostHeader:   ptr.To(true),
+								ServersTransport: "default-ingress-with-hostless-rule-and-default-backend",
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+						"default-ingress-with-hostless-rule-and-default-backend-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{URL: "http://10.10.0.1:80"},
+									{URL: "http://10.10.0.2:80"},
+								},
+								Strategy:         "wrr",
+								PassHostHeader:   ptr.To(true),
+								ServersTransport: "default-ingress-with-hostless-rule-and-default-backend",
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{
+						"default-ingress-with-hostless-rule-and-default-backend": {
+							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
+								DialTimeout:     ptypes.Duration(60 * time.Second),
+								ReadTimeout:     ptypes.Duration(60 * time.Second),
+								WriteTimeout:    ptypes.Duration(60 * time.Second),
+								IdleConnTimeout: ptypes.Duration(60 * time.Second),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
 			desc: "Ingress default backend respects backend-protocol and affinity annotations",
 			paths: []string{
 				"services.yml",
@@ -5768,6 +5936,7 @@ func TestLoadIngresses(t *testing.T) {
 						"default-ingress-with-default-backend-annotations-default-backend": {
 							EntryPoints: []string{"http"},
 							Rule:        `Host("whoami.localhost")`,
+							Priority:    math.MinInt32,
 							RuleSyntax:  "default",
 							Service:     "default-ingress-with-default-backend-annotations-default-backend",
 							Middlewares: []string{"default-ingress-with-default-backend-annotations-default-backend-retry"},
@@ -5786,6 +5955,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"https"},
 							Rule:        `Host("whoami.localhost")`,
 							RuleSyntax:  "default",
+							Priority:    math.MinInt32,
 							Service:     "default-ingress-with-default-backend-annotations-default-backend",
 							Middlewares: []string{"default-ingress-with-default-backend-annotations-default-backend-tls-retry"},
 							TLS:         &dynamic.RouterTLSConfig{},

--- a/pkg/provider/kubernetes/ingress-nginx/translator.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator.go
@@ -185,6 +185,9 @@ func (p *Provider) translate(ctx context.Context, mc *model) *dynamic.Configurat
 			}
 
 			rule := buildRule(srv.Hostname, loc)
+			if loc.IsIngressDefaultBackend && rule == "" {
+				rule = `PathPrefix("/")`
+			}
 
 			var routerKey string
 			if loc.IsIngressDefaultBackend {
@@ -210,6 +213,11 @@ func (p *Provider) translate(ctx context.Context, mc *model) *dynamic.Configurat
 					Options: loc.TLSOptionName,
 				},
 				Observability: obs,
+			}
+
+			if loc.IsIngressDefaultBackend {
+				rt.Priority = math.MinInt32
+				rtTLS.Priority = math.MinInt32
 			}
 
 			// TODO: in case we want to add the unavailable service only when it is used this should be done here.


### PR DESCRIPTION
### What does this PR do?

Fixes the ingress-nginx provider fallback router generated for an Ingress that combines `spec.defaultBackend` with a hostless rule.

When the generated ingress default-backend location has no host and no path, this now emits `PathPrefix("/")` instead of an empty rule. The fallback is scoped to ingress default-backend locations only, and those routers are assigned `math.MinInt32` priority so the catch-all rule does not shadow more specific routes from other ingresses.

### Motivation

Fixes #13151.

This follows up on the closed #13190 and incorporates the review feedback from that discussion: keep the catch-all behavior limited to the ingress default-backend fallback case, and give those fallback routers the same very low priority used by other default-backend catch-all routers.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Added a provider-level regression test for the original manifest shape: `spec.defaultBackend` plus a hostless rule with a `/web` Prefix path.