### PR TITLE
Fix(ingress-nginx): respect explicit ingress classes

### DIFF
--- a/pkg/provider/kubernetes/ingress-nginx/build.go
+++ b/pkg/provider/kubernetes/ingress-nginx/build.go
@@ -955,7 +955,7 @@ func (p *Provider) resolveHTTPErrorBackend(namespace string, cfg IngressConfig) 
 func (p *Provider) shouldProcess(ing *netv1.Ingress, ingressClasses []*netv1.IngressClass) bool {
 	if len(ingressClasses) > 0 && ing.Spec.IngressClassName != nil {
 		return slices.ContainsFunc(ingressClasses, func(ic *netv1.IngressClass) bool {
-			return *ing.Spec.IngressClassName == ic.ObjectMeta.Name
+			return *ing.Spec.IngressClassName == ic.Name
 		})
 	}
 
@@ -963,7 +963,7 @@ func (p *Provider) shouldProcess(ing *netv1.Ingress, ingressClasses []*netv1.Ing
 		return class == p.IngressClass
 	}
 
-	return p.WatchIngressWithoutClass
+	return p.WatchIngressWithoutClass && ing.Spec.IngressClassName == nil
 }
 
 func (p *Provider) validateIngress(ing *netv1.Ingress, cfg IngressConfig) error {


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug in the `kubernetesIngressNGINX` provider where it incorrectly processes Ingress resources belonging to other controllers (such as `traefik`) when `WatchIngressWithoutClass` is set to `true`.

### Motivation

When `WatchIngressWithoutClass: true` is configured, the Ingress-NGINX provider is intended to process Ingresses that do not explicitly define an `ingressClassName` or `kubernetes.io/ingress.class` annotation. However, due to a logic flaw in the `shouldProcess` method, the provider was ignoring the explicitly defined class on the Ingress and incorrectly adopting resources explicitly targeted at other controllers.

This caused routing conflicts and overlapping configurations when running multiple Ingress controllers in the same cluster. 

This fix ensures that if an Ingress resource explicitly defines a class, and that class does not match the provider's configured NGINX ingress class, the resource will be correctly ignored regardless of the `WatchIngressWithoutClass` setting.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>