### PR TITLE
fix(ingress-nginx): preserve query string in app-root variable interpolation

### DIFF
--- a/pkg/middlewares/ingressnginx/interpolation.go
+++ b/pkg/middlewares/ingressnginx/interpolation.go
@@ -120,7 +120,15 @@ func variableValue(rawVariable, variable string, req *http.Request, responseHead
 		return "http", nil
 
 	case args, queryString:
-		return req.URL.RawQuery, nil
+		if req.URL.RawQuery != "" {
+			return req.URL.RawQuery, nil
+		}
+		// Fallback: req.RequestURI is immutable from the wire and retains the query string
+		// even when req.URL is rebuilt by middleware without copying RawQuery.
+		if _, q, found := strings.Cut(req.RequestURI, "?"); found {
+			return q, nil
+		}
+		return "", nil
 
 	case remoteAddress:
 		return stripPort(req.RemoteAddr), nil
@@ -161,6 +169,10 @@ func variableValue(rawVariable, variable string, req *http.Request, responseHead
 
 	case isArgs:
 		if req.URL.RawQuery != "" {
+			return "?", nil
+		}
+		// Fallback: check RequestURI for cases where req.URL.RawQuery is lost by middleware.
+		if strings.Contains(req.RequestURI, "?") {
 			return "?", nil
 		}
 		return "", nil

--- a/pkg/middlewares/ingressnginx/interpolation_test.go
+++ b/pkg/middlewares/ingressnginx/interpolation_test.go
@@ -269,6 +269,30 @@ func Test_ReplaceVariables(t *testing.T) {
 			expected: "val=8080",
 		},
 		{
+			desc:     "$args via RequestURI fallback when URL.RawQuery is empty",
+			src:      "val=$args",
+			req:      mustNewRequestWithEmptyRawQuery(t, http.MethodGet, "http://baz.com/foo?q=test&other=1"),
+			expected: "val=q=test&other=1",
+		},
+		{
+			desc:     "$query_string via RequestURI fallback when URL.RawQuery is empty",
+			src:      "val=$query_string",
+			req:      mustNewRequestWithEmptyRawQuery(t, http.MethodGet, "http://baz.com/foo?q=test&other=1"),
+			expected: "val=q=test&other=1",
+		},
+		{
+			desc:     "$is_args via RequestURI fallback when URL.RawQuery is empty",
+			src:      "val=$is_args",
+			req:      mustNewRequestWithEmptyRawQuery(t, http.MethodGet, "http://baz.com/foo?q=test"),
+			expected: "val=?",
+		},
+		{
+			desc:     "$is_args$args via RequestURI fallback preserves query params",
+			src:      "/login$is_args$args",
+			req:      mustNewRequestWithEmptyRawQuery(t, http.MethodGet, "http://baz.com/?foo=bar"),
+			expected: "/login?foo=bar",
+		},
+		{
 			desc:     "$proxy_add_x_forwarded_for without existing header",
 			src:      "val=$proxy_add_x_forwarded_for",
 			req:      mustNewRequestWithRemoteAddr(t, http.MethodGet, "http://baz.com/foo", "192.168.1.1:12345"),
@@ -338,6 +362,16 @@ func mustNewRequestWithCookie(t *testing.T, method, target, cookieName, cookieVa
 	req := httptest.NewRequest(method, target, http.NoBody)
 	req.AddCookie(&http.Cookie{Name: cookieName, Value: cookieValue})
 
+	return req
+}
+
+// mustNewRequestWithEmptyRawQuery creates a request where req.URL.RawQuery is cleared
+// but req.RequestURI still retains the query string. This simulates a middleware that
+// rebuilds req.URL (e.g. copies only the path) without preserving RawQuery.
+func mustNewRequestWithEmptyRawQuery(t *testing.T, method, target string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(method, target, http.NoBody)
+	req.URL.RawQuery = ""
 	return req
 }
 


### PR DESCRIPTION
### What does this PR do?

Fixes `$args`, `$query_string` and `$is_args` variable resolution dropping the query string in `app-root` redirects. When a middleware earlier in the pipeline rebuilds `req.URL`, `RawQuery` is left empty. The resolver now falls back to parsing the query from `req.RequestURI`, which is set directly from the wire and is never modified by the pipeline.

### Motivation

Annotations such as `nginx.ingress.kubernetes.io/app-root: /login$is_args$args` are expected to carry the original query string into the redirect target. Because `req.URL.RawQuery` can be cleared by upstream middleware, `/?foo=bar` was silently redirected to `/login` instead of `/login?foo=bar`.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Four new test cases cover the fallback by deliberately clearing `req.URL.RawQuery` while keeping `req.RequestURI` intact, reproducing the middleware-rebuild scenario.