### PR TITLE
Fix cross-provider ref check for TCP ServersTransport in Kubernetes CRD provider

### DIFF
--- a/pkg/provider/kubernetes/crd/fixtures/tcp/with_servers_transport_cross_provider.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/with_servers_transport_cross_provider.yml
@@ -1,0 +1,16 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: test.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+    - match: HostSNI(`foo.com`)
+      services:
+        - name: whoamitcp
+          port: 8000
+          serversTransport: foo@file

--- a/pkg/provider/kubernetes/crd/kubernetes_tcp.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_tcp.go
@@ -307,14 +307,18 @@ func (p *Provider) makeTCPServersTransportKey(parentNamespace string, serversTra
 		return "", nil
 	}
 
-	if !p.AllowCrossNamespace && strings.HasSuffix(serversTransportName, providerNamespaceSeparator+providerName) {
-		// Since we are not able to know if another namespace is in the name (namespace-name@kubernetescrd),
-		// if the provider namespace kubernetescrd is used,
-		// we don't allow this format to avoid cross namespace references.
-		return "", fmt.Errorf("invalid reference to serversTransport %s: namespace-name@kubernetescrd format is not allowed when crossnamespace is disallowed", serversTransportName)
-	}
-
 	if strings.Contains(serversTransportName, providerNamespaceSeparator) {
+		if !p.AllowCrossNamespace && strings.HasSuffix(serversTransportName, providerNamespaceSeparator+providerName) {
+			// Since we are not able to know if another namespace is in the name (namespace-name@kubernetescrd),
+			// if the provider namespace kubernetescrd is used,
+			// we don't allow this format to avoid cross namespace references.
+			return "", fmt.Errorf("invalid reference to serversTransport %s: namespace-name@kubernetescrd format is not allowed when crossnamespace is disallowed", serversTransportName)
+		}
+
+		if !isCrossProviderNamespaceAllowed(p.CrossProviderNamespaces, parentNamespace) {
+			return "", fmt.Errorf("serversTransport %q reference is not allowed: namespace %q is not in crossProviderNamespaces", serversTransportName, parentNamespace)
+		}
+
 		return serversTransportName, nil
 	}
 

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -8356,6 +8356,75 @@ func TestCrossProviderNamespaces_HTTPServersTransport(t *testing.T) {
 	}
 }
 
+// TestCrossProviderNamespaces_TCPServersTransport verifies that the
+// CrossProviderNamespaces option gates @file references in IngressRouteTCP service.serversTransport.
+func TestCrossProviderNamespaces_TCPServersTransport(t *testing.T) {
+	testCases := []struct {
+		desc                    string
+		crossProviderNamespaces []string
+		wantServiceDropped      bool
+	}{
+		{
+			desc:                    "nil: cross-provider ServersTransport ref is accepted (backward compatible)",
+			crossProviderNamespaces: nil,
+		},
+		{
+			desc:                    "empty list: cross-provider ServersTransport ref is rejected, service is dropped",
+			crossProviderNamespaces: []string{},
+			wantServiceDropped:      true,
+		},
+		{
+			desc:                    "namespace allowed: cross-provider ServersTransport ref is accepted",
+			crossProviderNamespaces: []string{"default"},
+		},
+		{
+			desc:                    "namespace not allowed: cross-provider ServersTransport ref is rejected, service is dropped",
+			crossProviderNamespaces: []string{"other"},
+			wantServiceDropped:      true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			k8sObjects, crdObjects := readResources(t, []string{"tcp/services.yml", "tcp/with_servers_transport_cross_provider.yml"})
+
+			kubeClient := kubefake.NewClientset(k8sObjects...)
+			crdClient := traefikcrdfake.NewClientset(crdObjects...)
+
+			client := newClientImpl(kubeClient, crdClient)
+
+			stopCh := make(chan struct{})
+
+			eventCh, err := client.WatchAll(nil, stopCh)
+			require.NoError(t, err)
+
+			if k8sObjects != nil || crdObjects != nil {
+				// just wait for the first event
+				<-eventCh
+			}
+
+			p := Provider{
+				AllowCrossNamespace:     true,
+				CrossProviderNamespaces: test.crossProviderNamespaces,
+			}
+
+			conf := p.loadConfigurationFromCRD(t.Context(), client)
+
+			service, ok := conf.TCP.Services["default-test.route-fdd3e9338e47a45efefc"]
+			if test.wantServiceDropped {
+				assert.False(t, ok)
+				return
+			}
+
+			require.True(t, ok)
+			require.NotNil(t, service.LoadBalancer)
+			assert.Equal(t, "foo@file", service.LoadBalancer.ServersTransport)
+		})
+	}
+}
+
 func TestExternalNameService(t *testing.T) {
 	testCases := []struct {
 		desc                     string


### PR DESCRIPTION

### What does this PR do?

Adds the missing `crossProviderNamespaces` allowlist check to `makeTCPServersTransportKey` in the Kubernetes CRD provider.

### Motivation

Follow up to https://github.com/traefik/traefik/pull/13094.
To align the `crossProviderNamespaces` check behavior; this allowlist is enforced for HTTP `serversTransport`, TLS options, and middlewares on both HTTP and TCP, but the TCP `serversTransport` path never got the same check.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

