### PR TITLE
Fix consistency between HostSNI(*) and Host(*)

### DIFF
--- a/docs/content/migrate/v3.md
+++ b/docs/content/migrate/v3.md
@@ -9,6 +9,17 @@ This guide provides detailed migration steps for upgrading between different Tra
 
 ---
 
+## v3.7.7
+
+### Wildcard Host matcher
+
+From version `v3.7.7` onwards, the `Host` matcher treats a bare `*` as a catch-all, consistent with the TCP `HostSNI(`*`)` matcher.
+``Host(`*`)`` now matches every request regardless of its host, including requests with no host at all.
+
+Previously, the `*` was treated as a single wildcard label, so ``Host(`*`)`` only matched hosts made of a single segment (e.g. `localhost`) and not multi-segment hosts (e.g. `example.com`).
+
+Please check out the [HTTP routing rules](../reference/routing-configuration/http/routing/rules-and-priority.md#host-and-hostregexp) documentation for more details.
+
 ## v3.7.6
 
 ### UnderscoreHeadersStrategy

--- a/docs/content/reference/routing-configuration/http/routing/rules-and-priority.md
+++ b/docs/content/reference/routing-configuration/http/routing/rules-and-priority.md
@@ -63,9 +63,16 @@ These matchers will match the request's host in lowercase.
 
     This is only available with the **v3 rule syntax** (the default).
 
+!!! info "Exception: a bare wildcard matches every request"
+
+    As an exception to the rules above, a bare `*` is not treated as a subdomain wildcard but as a catch-all:
+    ``Host(`*`)`` matches every request regardless of its host, including requests with no host at all.
+    This mirrors the behaviour of the TCP [``HostSNI(`*`)``](../../tcp/routing/rules-and-priority.md#hostsni-and-hostsniregexp) matcher, so both stay consistent.
+
 | Behavior                                                        | Rule                                                                    |
 |-----------------------------------------------------------------|:------------------------------------------------------------------------|
 | <a id="opt-Match-requests-with-Host-set-to-example-com" href="#opt-Match-requests-with-Host-set-to-example-com" title="#opt-Match-requests-with-Host-set-to-example-com">Match requests with `Host` set to `example.com`.</a> | ```Host(`example.com`)``` |
+| <a id="opt-Match-every-request-regardless-of-its-host-see-the-exception-above" href="#opt-Match-every-request-regardless-of-its-host-see-the-exception-above" title="#opt-Match-every-request-regardless-of-its-host-see-the-exception-above">Match every request regardless of its host (see the exception above).</a> | ```Host(`*`)``` |
 | <a id="opt-Match-requests-sent-to-any-subdomain-of-example-com" href="#opt-Match-requests-sent-to-any-subdomain-of-example-com" title="#opt-Match-requests-sent-to-any-subdomain-of-example-com">Match requests sent to any subdomain of `example.com`.</a> | ```HostRegexp(`^.+\.example\.com$`)``` |
 | <a id="opt-Match-requests-with-Host-set-to-either-example-com-or-example-org" href="#opt-Match-requests-with-Host-set-to-either-example-com-or-example-org" title="#opt-Match-requests-with-Host-set-to-either-example-com-or-example-org">Match requests with `Host` set to either `example.com` or `example.org`.</a> | ```HostRegexp(`^example\.(com|org)$`)``` |
 | <a id="opt-Match-Host-case-insensitively" href="#opt-Match-Host-case-insensitively" title="#opt-Match-Host-case-insensitively">Match `Host` [case-insensitively](https://en.wikipedia.org/wiki/Case_sensitivity).</a> | ```HostRegexp(`(?i)^example\.(com|org)$`)``` |

--- a/pkg/muxer/http/matcher.go
+++ b/pkg/muxer/http/matcher.go
@@ -71,6 +71,13 @@ func method(tree *matchersTree, methods ...string) error {
 func host(tree *matchersTree, hosts ...string) error {
 	hostExpr := hosts[0]
 
+	if hostExpr == "*" {
+		// On the TCP side, * matches every serverName (empty or not),
+		// so we keep the same behavior in Host for consistency.
+		tree.matcher = func(req *http.Request) bool { return true }
+		return nil
+	}
+
 	if !muxer.IsASCII(hostExpr) {
 		return fmt.Errorf("invalid value %q for Host matcher, non-ASCII characters are not allowed", hostExpr)
 	}

--- a/pkg/muxer/http/matcher_test.go
+++ b/pkg/muxer/http/matcher_test.go
@@ -266,6 +266,18 @@ func TestHostMatcher(t *testing.T) {
 				"https://test.otherexample.com": http.StatusNotFound,
 			},
 		},
+
+		{
+			desc: "* match everything",
+			rule: "Host(`*`)",
+			expected: map[string]int{
+				"https://test.example.com":      http.StatusOK,
+				"https://other.example.com":     http.StatusOK,
+				"https://example.com":           http.StatusOK,
+				"https://test.otherexample.com": http.StatusOK,
+				"https://localhost":             http.StatusOK,
+			},
+		},
 	}
 
 	for _, test := range testCases {

--- a/pkg/muxer/tcp/matcher.go
+++ b/pkg/muxer/tcp/matcher.go
@@ -70,7 +70,7 @@ func hostSNI(tree *matchersTree, hosts ...string) error {
 
 	if hostExpr == "*" {
 		// Since a HostSNI(`*`) rule has been provided as catchAll for non-TLS TCP,
-		// it allows matching with an empty serverName.
+		// it allows matching with an empty serverName or every serverName.
 		tree.matcher = func(meta ConnData) bool { return true }
 		return nil
 	}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes the consistency between HostSNI(\*) and Host(\*)

### Motivation

To be sure the TLSOption choice is the same as the host header choice.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

