### PR TITLE
Fix grammar in TLS, TCP service, and routing reference docs

### DIFF
--- a/docs/content/reference/routing-configuration/http/routing/rules-and-priority.md
+++ b/docs/content/reference/routing-configuration/http/routing/rules-and-priority.md
@@ -117,7 +117,7 @@ It only matches the request client IP and does not use the `X-Forwarded-For` hea
     RuleSyntax option is deprecated and will be removed in the next major version.
     Please do not use this field and rewrite the router rules to use the v3 syntax.
 
-In Traefik v3 a new rule syntax has been introduced ([migration guide](../../../../migrate/v3.md)). the `ruleSyntax` option allows to configure the rule syntax to be used for parsing the rule on a per-router basis. This allows to have heterogeneous router configurations and ease migration.
+In Traefik v3 a new rule syntax has been introduced ([migration guide](../../../../migrate/v3.md)). The `ruleSyntax` option allows configuring the rule syntax to be used for parsing the rule on a per-router basis. This allows having heterogeneous router configurations and eases migration.
 
 The default value of the `ruleSyntax` option is inherited from the `core.defaultRuleSyntax` option in the install configuration (formerly known as static configuration). By default, the `core.defaultRuleSyntax` static option is v3, meaning that the default rule syntax is also v3
 

--- a/docs/content/reference/routing-configuration/http/tls/tls-options.md
+++ b/docs/content/reference/routing-configuration/http/tls/tls-options.md
@@ -106,7 +106,7 @@ tls:
 
 ### Curve Preferences
 
-This option allows to set the preferred elliptic curves.
+This option allows setting the preferred elliptic curves.
 
 The names of the curves defined by [`crypto`](https://godoc.org/crypto/tls#CurveID) (e.g. `CurveP521`) and the [RFC defined names](https://tools.ietf.org/html/rfc8446#section-4.2.7) (e. g. `secp521r1`) can be used.
 
@@ -158,7 +158,7 @@ tls:
 
 _Optional, Default="h2, http/1.1, acme-tls/1"_
 
-This option allows to specify the list of supported application level protocols for the TLS handshake,
+This option allows specifying the list of supported application level protocols for the TLS handshake,
 in order of preference.
 If the client supports ALPN, the selected protocol will be one from this list, 
 and the connection will fail if there is no mutually supported protocol.

--- a/docs/content/reference/routing-configuration/tcp/service.md
+++ b/docs/content/reference/routing-configuration/tcp/service.md
@@ -76,7 +76,7 @@ labels:
 | <a id="opt-servers" href="#opt-servers" title="#opt-servers">`servers`</a> |  Servers declare a single instance of your program.  | "" |
 | <a id="opt-servers-address" href="#opt-servers-address" title="#opt-servers-address">`servers.address`</a> |   The address option (IP:Port) point to a specific instance. | "" |
 | <a id="opt-servers-tls" href="#opt-servers-tls" title="#opt-servers-tls">`servers.tls`</a> | The `tls` option determines whether to use TLS when dialing with the backend. | false |
-| <a id="opt-serversTransport" href="#opt-serversTransport" title="#opt-serversTransport">`serversTransport`</a> | `serversTransport` allows to reference a TCP [ServersTransport](./serverstransport.md) configuration for the communication between Traefik and your servers. If no serversTransport is specified, the default@internal will be used. |  "" |
+| <a id="opt-serversTransport" href="#opt-serversTransport" title="#opt-serversTransport">`serversTransport`</a> | `serversTransport` allows referencing a TCP [ServersTransport](./serverstransport.md) configuration for the communication between Traefik and your servers. If no serversTransport is specified, the default@internal will be used. |  "" |
 | <a id="opt-healthCheck" href="#opt-healthCheck" title="#opt-healthCheck">`healthCheck`</a> | Configures health check to remove unhealthy servers from the load balancing rotation. See [HealthCheck](#health-check) for details. | | No |
 
 ### Health Check


### PR DESCRIPTION
Fixes grammar across Traefik reference documentation:

- TLS options: `allows to set/specify` → `allows setting/specifying`
- TCP service: `allows to reference` → `allows referencing`
- Routing rules: capitalization fix and `allows to configure` → `allows configuring`

Signed-off-by: almightymoon <almightymoon@users.noreply.github.com>


---

This pull request was prepared with assistance from an AI tool. The commit author is solely responsible for the changes; no co-authorship metadata is included on the commit.