### PR TITLE
Fix ExtensionRef filters on backendRefs to resolve against the HTTPRoute namespace

### DIFF
--- a/pkg/provider/kubernetes/gateway/fixtures/httproute/filter_extension_ref.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/httproute/filter_extension_ref.yml
@@ -1,4 +1,20 @@
 ---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-default-to-service
+  namespace: bar
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: default
+  to:
+    - group: ""
+      kind: Service
+      name: whoami-bar
+
+---
 kind: GatewayClass
 apiVersion: gateway.networking.k8s.io/v1
 metadata:
@@ -49,6 +65,19 @@ spec:
           weight: 1
           kind: Service
           group: ""
+        # Cross-namespace backendRef
+        - name: whoami-bar
+          namespace: bar
+          port: 80
+          weight: 1
+          kind: Service
+          group: ""
+          filters:
+            - type: ExtensionRef
+              extensionRef:
+                group: traefik.io
+                kind: Middleware
+                name: my-backend-middleware
       filters:
         - type: ExtensionRef
           extensionRef:

--- a/pkg/provider/kubernetes/gateway/httproute.go
+++ b/pkg/provider/kubernetes/gateway/httproute.go
@@ -281,7 +281,7 @@ func (p *Provider) loadService(ctx context.Context, gatewayName string, listener
 		}
 	}
 
-	middlewares, err := p.loadMiddlewares(conf, namespace, serviceName, backendRef.Filters, pathMatch)
+	middlewares, err := p.loadMiddlewares(conf, route.Namespace, serviceName, backendRef.Filters, pathMatch)
 	if err != nil {
 		return serviceName, &metav1.Condition{
 			Type:               string(gatev1.RouteConditionResolvedRefs),

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -3341,6 +3341,10 @@ func TestLoadHTTPRoutes_filterExtensionRef(t *testing.T) {
 										Name:   "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-af329269dd38031b03e3-svc-default-whoami-0",
 										Weight: ptr.To(1),
 									},
+									{
+										Name:   "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-af329269dd38031b03e3-svc-bar-whoami-bar-1",
+										Weight: ptr.To(1),
+									},
 								},
 							},
 						},
@@ -3360,6 +3364,26 @@ func TestLoadHTTPRoutes_filterExtensionRef(t *testing.T) {
 									FlushInterval: ptypes.Duration(100 * time.Millisecond),
 								},
 							},
+						},
+						// Cross-namespace backendRef: its ExtensionRef filter must resolve to the route's own namespace,
+						// not the backendRef's namespace.
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-af329269dd38031b03e3-svc-bar-whoami-bar-1": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy: dynamic.BalancerStrategyWRR,
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.11:80",
+									},
+									{
+										URL: "http://10.10.0.12:80",
+									},
+								},
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+							Middlewares: []string{"default-my-backend-middleware"},
 						},
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
@@ -3403,8 +3427,9 @@ func TestLoadHTTPRoutes_filterExtensionRef(t *testing.T) {
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{
-						"default-my-first-middleware":  {Headers: &dynamic.Headers{CustomRequestHeaders: map[string]string{"Test-Header": "Test"}}},
-						"default-my-second-middleware": {Headers: &dynamic.Headers{CustomRequestHeaders: map[string]string{"Test-Header": "Test"}}},
+						"default-my-first-middleware":   {Headers: &dynamic.Headers{CustomRequestHeaders: map[string]string{"Test-Header": "Test"}}},
+						"default-my-second-middleware":  {Headers: &dynamic.Headers{CustomRequestHeaders: map[string]string{"Test-Header": "Test"}}},
+						"default-my-backend-middleware": {Headers: &dynamic.Headers{CustomRequestHeaders: map[string]string{"Test-Header": "Test"}}},
 					},
 					Services: map[string]*dynamic.Service{
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-af329269dd38031b03e3-wrr": {
@@ -3412,6 +3437,10 @@ func TestLoadHTTPRoutes_filterExtensionRef(t *testing.T) {
 								Services: []dynamic.WRRService{
 									{
 										Name:   "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-af329269dd38031b03e3-svc-default-whoami-0",
+										Weight: ptr.To(1),
+									},
+									{
+										Name:   "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-af329269dd38031b03e3-svc-bar-whoami-bar-1",
 										Weight: ptr.To(1),
 									},
 								},
@@ -3433,6 +3462,26 @@ func TestLoadHTTPRoutes_filterExtensionRef(t *testing.T) {
 									FlushInterval: ptypes.Duration(100 * time.Millisecond),
 								},
 							},
+						},
+						// Cross-namespace backendRef: its ExtensionRef filter must resolve to the route's own namespace,
+						// not the backendRef's namespace.
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-af329269dd38031b03e3-svc-bar-whoami-bar-1": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy: dynamic.BalancerStrategyWRR,
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.11:80",
+									},
+									{
+										URL: "http://10.10.0.12:80",
+									},
+								},
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+							Middlewares: []string{"default-my-backend-middleware"},
 						},
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},


### PR DESCRIPTION
### What does this PR do?

Fixes the namespace used to resolve ExtensionRef filters declared on a `backendRef` (`HTTPRoute.spec.rules[].backendRefs[].filters[].extensionRef`) to resolve against the HTTPRoute's own namespace, instead of the namespace of the `backendRef` it's attached to.


### Motivation

To fix the Gateway API provider behavior.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation
