### PR TITLE
docs: warn that YAML parse errors drop entire file provider configuration

### DIFF
--- a/docs/content/reference/install-configuration/providers/others/file.md
+++ b/docs/content/reference/install-configuration/providers/others/file.md
@@ -122,4 +122,9 @@ http:
     As it is very difficult to listen to all file system notifications, Traefik uses [fsnotify](https://github.com/fsnotify/fsnotify).
     If using a directory with a mounted directory does not fix your issue, please check your file system compatibility with fsnotify.
 
+    If a configuration file contains a YAML or TOML syntax error, Traefik discards **all** configuration from the file provider.
+    Every router, middleware, and service defined across the entire directory is dropped — not just the broken file.
+    Validate configuration files before deploying (for example, with `traefik healthcheck` or an external YAML validator),
+    and keep backups of known-good configurations.
+
 {% include-markdown "includes/traefik-for-business-applications.md" %}


### PR DESCRIPTION
### What does this PR do?

Adds a warning to the File Provider documentation about a dangerous failure mode: when a single YAML/TOML file has a syntax error, Traefik silently discards **all** configuration from the file provider — not just the broken file. Every router, middleware, and service from the entire directory is dropped.

### Motivation

This happened in production. A single config file had a subtle indentation issue that Python's `yaml.safe_load()` accepted but Traefik's parser rejected. Every middleware reference across all services failed simultaneously. The behavior is undocumented and the recovery path (restore from backup) is not obvious to operators encountering it for the first time.

Related issue: #13464

### More

- [ ] Added/updated tests — N/A (docs-only change)
- [x] Added/updated documentation

### Additional Notes

The change adds 4 lines to the existing "Limitations" admonition in `docs/content/reference/install-configuration/providers/others/file.md`, after the paragraph about filesystem notification issues.
