### PR TITLE
Remove unrelated error from nonexistent cert resolver log

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -385,7 +385,7 @@ func setupServer(staticConfiguration *static.Configuration) (*server.Server, err
 			}
 
 			if _, ok := resolverNames[rt.TLS.CertResolver]; !ok {
-				log.Error().Err(err).Str(logs.RouterName, rtName).Str("certificateResolver", rt.TLS.CertResolver).
+				log.Error().Str(logs.RouterName, rtName).Str("certificateResolver", rt.TLS.CertResolver).
 					Msg("Router uses a nonexistent certificate resolver")
 			}
 		}


### PR DESCRIPTION
### What does this PR do?
The log entry warning about a router using a nonexistent certificate resolver attached a stale `err` from an outer scope that was unrelated to this condition, producing a misleading error field.

### Additional Notes
I targeted master intentionally, as this is not a high-priority issue. it only misleads the user at runtime when there is an error on the router's cert resolver.