### PR TITLE
Align certificateRef and indicate ports

### DIFF
--- a/docs/content/expose/kubernetes/basic.md
+++ b/docs/content/expose/kubernetes/basic.md
@@ -322,6 +322,11 @@ kubectl create secret tls whoami-tls --cert=tls.crt --key=tls.key
 
     Example configuration in `values.yaml`:
     ```yaml
+    ports:
+      web:
+        port: 80
+      websecure:
+        port: 443
     gateway:
       listeners:
         web:
@@ -337,7 +342,7 @@ kubectl create secret tls whoami-tls --cert=tls.crt --key=tls.key
           mode: Terminate
           certificateRefs:
             - kind: Secret
-              name: local-selfsigned-tls
+              name: whoami-tls
               group: ""
     ```
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Updated TLS configuration in Traefik example to use 'whoami-tls' certificate instead of 'local-selfsigned-tls' and add ports to the snippet.

### Motivation

<!-- What inspired you to submit this pull request? -->
I'm following the docs for https://doc.traefik.io/traefik/v3.7/expose/kubernetes/basic/#create-a-self-signed-certificate and the snippet was taken from another docs which uses a different secret tls name. As a result, I faced some error. Also, the port was not declared in the snippet for the helm chart value.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
