### PR TITLE
Fix redirect with use-regex in IngressNGINX provider

### DIFF
--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-redirect-use-regex.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-redirect-use-regex.yml
@@ -1,0 +1,23 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-with-redirect-use-regex
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/permanent-redirect: "https://redirect.example.com/$1$2"
+
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: redirect-regex.localhost
+      http:
+        paths:
+          - path: /(example)(/.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: whoami
+                port:
+                  number: 80

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -8054,26 +8054,26 @@ func TestLoadIngresses(t *testing.T) {
 							RedirectRegex: &dynamic.RedirectRegex{
 								Regex:       `^https?://[^/]+/(example)(/.*)`,
 								Replacement: "https://redirect.example.com/$1$2",
-								StatusCode:  ptr.To(http.StatusMovedPermanently),
+								StatusCode:  new(http.StatusMovedPermanently),
 							},
 						},
 						"default-ingress-with-redirect-use-regex-rule-0-path-0-tls-redirect": {
 							RedirectRegex: &dynamic.RedirectRegex{
 								Regex:       `^https?://[^/]+/(example)(/.*)`,
 								Replacement: "https://redirect.example.com/$1$2",
-								StatusCode:  ptr.To(http.StatusMovedPermanently),
+								StatusCode:  new(http.StatusMovedPermanently),
 							},
 						},
 						"default-ingress-with-redirect-use-regex-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
 								Attempts:            3,
-								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
+								MaxRequestBodyBytes: new(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-redirect-use-regex-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
 								Attempts:            3,
-								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
+								MaxRequestBodyBytes: new(defaultProxyBodySize),
 							},
 						},
 					},
@@ -8081,7 +8081,7 @@ func TestLoadIngresses(t *testing.T) {
 						"unavailable-service": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Strategy:       "wrr",
-								PassHostHeader: ptr.To(true),
+								PassHostHeader: new(true),
 								ResponseForwarding: &dynamic.ResponseForwarding{
 									FlushInterval: dynamic.DefaultFlushInterval,
 								},
@@ -8098,7 +8098,7 @@ func TestLoadIngresses(t *testing.T) {
 									},
 								},
 								Strategy:         "wrr",
-								PassHostHeader:   ptr.To(true),
+								PassHostHeader:   new(true),
 								ServersTransport: "default-ingress-with-redirect-use-regex",
 								ResponseForwarding: &dynamic.ResponseForwarding{
 									FlushInterval: dynamic.DefaultFlushInterval,

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -8000,6 +8000,127 @@ func TestLoadIngresses(t *testing.T) {
 			},
 		},
 		{
+			desc: "Permanent Redirect with Use Regex",
+			paths: []string{
+				"services.yml",
+				"ingressclasses.yml",
+				"ingresses/ingress-with-redirect-use-regex.yml",
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-ingress-with-redirect-use-regex-rule-0-path-0": {
+							EntryPoints: []string{"http"},
+							Rule:        `Host("redirect-regex.localhost") && PathRegexp("(?i)^/(example)(/.*)")`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-redirect-use-regex-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-redirect-use-regex",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							Middlewares: []string{"default-ingress-with-redirect-use-regex-rule-0-path-0-redirect", "default-ingress-with-redirect-use-regex-rule-0-path-0-retry"},
+						},
+						"default-ingress-with-redirect-use-regex-rule-0-path-0-tls": {
+							EntryPoints: []string{"https"},
+							Rule:        `Host("redirect-regex.localhost") && PathRegexp("(?i)^/(example)(/.*)")`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-redirect-use-regex-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-redirect-use-regex",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							Middlewares: []string{"default-ingress-with-redirect-use-regex-rule-0-path-0-tls-redirect", "default-ingress-with-redirect-use-regex-rule-0-path-0-tls-retry"},
+							TLS:         &dynamic.RouterTLSConfig{},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-ingress-with-redirect-use-regex-rule-0-path-0-redirect": {
+							RedirectRegex: &dynamic.RedirectRegex{
+								Regex:       `^https?://[^/]+/(example)(/.*)`,
+								Replacement: "https://redirect.example.com/$1$2",
+								StatusCode:  ptr.To(http.StatusMovedPermanently),
+							},
+						},
+						"default-ingress-with-redirect-use-regex-rule-0-path-0-tls-redirect": {
+							RedirectRegex: &dynamic.RedirectRegex{
+								Regex:       `^https?://[^/]+/(example)(/.*)`,
+								Replacement: "https://redirect.example.com/$1$2",
+								StatusCode:  ptr.To(http.StatusMovedPermanently),
+							},
+						},
+						"default-ingress-with-redirect-use-regex-rule-0-path-0-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
+							},
+						},
+						"default-ingress-with-redirect-use-regex-rule-0-path-0-tls-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
+							},
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"unavailable-service": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+						"default-ingress-with-redirect-use-regex-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								Strategy:         "wrr",
+								PassHostHeader:   ptr.To(true),
+								ServersTransport: "default-ingress-with-redirect-use-regex",
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{
+						"default-ingress-with-redirect-use-regex": {
+							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
+								DialTimeout:     ptypes.Duration(60 * time.Second),
+								ReadTimeout:     ptypes.Duration(60 * time.Second),
+								WriteTimeout:    ptypes.Duration(60 * time.Second),
+								IdleConnTimeout: ptypes.Duration(60 * time.Second),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
 			desc: "Proxy connect timeout",
 			paths: []string{
 				"services.yml",

--- a/pkg/provider/kubernetes/ingress-nginx/middleware.go
+++ b/pkg/provider/kubernetes/ingress-nginx/middleware.go
@@ -148,8 +148,13 @@ func (p *Provider) buildRedirect(loc *location) {
 		}
 	}
 
+	regex := ".*"
+	if loc.UseRegex {
+		regex = `^https?://[^/]+` + loc.Path
+	}
+
 	loc.Redirect = &dynamic.RedirectRegex{
-		Regex:       ".*",
+		Regex:       regex,
 		Replacement: url,
 		StatusCode:  &code,
 	}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.
Bug:
- for Traefik v3.7: use branch v3.7
-->
### What does this PR do?
Fixes the `buildRedirect` function in the IngressNGINX provider so that `$1`, `$2`, `$3` (regex capture group references) in `permanent-redirect` / `temporal-redirect` annotation values resolve correctly against the path regex when `use-regex: "true"` is set, matching ingress-nginx behavior.
### Motivation
Fixes #13474
When `use-regex: "true"` and the path has regex capture groups (e.g. `/(example)(/|$)(.*)`), the redirect annotation `permanent-redirect: https://hub.example.com/$1$2$3` should capture the path groups and substitute them into the redirect target. Instead, the `RedirectRegex` middleware used a hardcoded `".*"` regex (zero capture groups), so `$n` references resolved to empty strings.
For example, `https://spoke.example.com/example/foo/bar` should redirect to `https://hub.example.com/example/foo/bar`, but was redirecting to `https://hub.example.com/`.
**Where:** `pkg/provider/kubernetes/ingress-nginx/middleware.go` — `buildRedirect` (line 149)
**Fix:** When `loc.UseRegex` is true, the regex is built as `^https?://[^/]+<loc.Path>` instead of `".*"`. The prefix matches the scheme+host portion non-capturing, so the path's own capture groups (`(example)`, `(/|$)`, `(.*)`) are at positions `$1`, `$2`, `$3` as expected. When `use-regex` is false, the regex stays `".*"` — fully backward compatible.
**Why this approach:** `loc.UseRegex` was already computed by the builder from the `use-regex` annotation — no new parsing, no new fields. The fix is a 5-line change that mirrors ingress-nginx's `location ~` semantics exactly.
### More
- [x] Added/updated tests
- [ ] Added/updated documentation
Assisted-by: DeepSeek V4 Pro <agent@atlarix.dev>