### PR TITLE
Restore gateway TCPRoute-on-TLS test coverage after TLSRoute GA

### DIFF
--- a/pkg/provider/kubernetes/gateway/fixtures/referencegrant/for_secret.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/referencegrant/for_secret.yml
@@ -53,16 +53,16 @@ spec:
             group: ""
       allowedRoutes:
         kinds:
-          - kind: TCPRoute
+          - kind: TLSRoute
             group: gateway.networking.k8s.io
         namespaces:
           from: Same
 
 ---
-kind: TCPRoute
-apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+apiVersion: gateway.networking.k8s.io/v1
 metadata:
-  name: tcp-app-1
+  name: tls-app-1
   namespace: default
 spec:
   parentRefs:

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -4672,7 +4672,7 @@ func TestLoadTCPRoutes(t *testing.T) {
 			},
 		},
 		{
-			desc:  "Simple TCPRoute, with TLS",
+			desc:  "Empty caused by TCPRoute attached to a TLS listener",
 			paths: []string{"services.yml", "tcproute/with_protocol_tls.yml"},
 			entryPoints: map[string]Entrypoint{
 				"tls": {Address: ":9000"},
@@ -5427,7 +5427,7 @@ func TestLoadTLSRoutes(t *testing.T) {
 			},
 		},
 		{
-			desc:  "Simple TLS listener to TCPRoute in Terminate mode",
+			desc:  "Empty caused by TCPRoute attached to a TLS listener in Terminate mode",
 			paths: []string{"services.yml", "tlsroute/simple_TLS_to_TCPRoute.yml"},
 			entryPoints: map[string]Entrypoint{
 				"tcp": {Address: ":9000"},
@@ -5453,7 +5453,7 @@ func TestLoadTLSRoutes(t *testing.T) {
 			},
 		},
 		{
-			desc:  "Simple TLS listener to TCPRoute in Passthrough mode",
+			desc:  "Empty caused by TCPRoute attached to a TLS listener in Passthrough mode",
 			paths: []string{"services.yml", "tlsroute/simple_TLS_to_TCPRoute_passthrough.yml"},
 			entryPoints: map[string]Entrypoint{
 				"tcp": {Address: ":9000"},
@@ -7859,16 +7859,54 @@ func TestLoadRoutesWithReferenceGrants(t *testing.T) {
 			entryPoints: map[string]Entrypoint{
 				"tls": {Address: ":9000"},
 			},
-			experimentalChannel: true,
 			expected: &dynamic.Configuration{
 				UDP: &dynamic.UDPConfiguration{
 					Routers:  map[string]*dynamic.UDPRouter{},
 					Services: map[string]*dynamic.UDPService{},
 				},
 				TCP: &dynamic.TCPConfiguration{
-					Routers:           map[string]*dynamic.TCPRouter{},
-					Middlewares:       map[string]*dynamic.TCPMiddleware{},
-					Services:          map[string]*dynamic.TCPService{},
+					Routers: map[string]*dynamic.TCPRouter{
+						"deny-unknown-host": {
+							Rule:     "HostSNI(`*`) && !ALPN(`h2`) && !ALPN(`http/1.1`)",
+							Priority: 1,
+							Service:  "deny-unknown-host",
+							TLS:      &dynamic.RouterTCPTLSConfig{},
+						},
+						"tlsroute-default-tls-app-1-gw-default-my-gateway-ep-tls-0-e3b0c44298fc1c149afb": {
+							EntryPoints: []string{"tls"},
+							Service:     "tlsroute-default-tls-app-1-gw-default-my-gateway-ep-tls-0-e3b0c44298fc1c149afb-wrr",
+							Rule:        `HostSNI("foo.example.com")`,
+							RuleSyntax:  "default",
+							Priority:    15,
+							TLS:         &dynamic.RouterTCPTLSConfig{},
+						},
+					},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services: map[string]*dynamic.TCPService{
+						"deny-unknown-host": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{},
+						},
+						"tlsroute-default-tls-app-1-gw-default-my-gateway-ep-tls-0-e3b0c44298fc1c149afb-wrr": {
+							Weighted: &dynamic.TCPWeightedRoundRobin{
+								Services: []dynamic.TCPWRRService{{
+									Name:   "tlsroute-default-tls-app-1-gw-default-my-gateway-ep-tls-0-e3b0c44298fc1c149afb-svc-default-whoamitcp-0",
+									Weight: new(1),
+								}},
+							},
+						},
+						"tlsroute-default-tls-app-1-gw-default-my-gateway-ep-tls-0-e3b0c44298fc1c149afb-svc-default-whoamitcp-0": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{
+										Address: "10.10.0.9:9000",
+									},
+									{
+										Address: "10.10.0.10:9000",
+									},
+								},
+							},
+						},
+					},
 					ServersTransports: map[string]*dynamic.TCPServersTransport{},
 				},
 				HTTP: &dynamic.HTTPConfiguration{
@@ -7877,7 +7915,16 @@ func TestLoadRoutesWithReferenceGrants(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Certificates: []*tls.CertAndStores{
+						{
+							Certificate: tls.Certificate{
+								CertFile: types.FileOrContent(listenerCert),
+								KeyFile:  types.FileOrContent(listenerKey),
+							},
+						},
+					},
+				},
 			},
 		},
 		{


### PR DESCRIPTION
### What does this PR do?

Restores meaningful gateway test coverage that was lost when the Gateway API was bumped to v1.5.1.

That bump promoted TLSRoute to GA and dropped `TCPRoute` from the supported route kinds of a `TLS` protocol listener. As a result, every fixture attaching a TCPRoute to a TLS listener stopped producing any configuration. The affected `expected` outputs were blanked to make the tests pass, which left several cases asserting an empty configuration while their input fixtures still described a TCPRoute on a TLS listener — tests that no longer exercise anything.

This PR makes the intent explicit instead of asserting silent emptiness:

- Renames the three now-invalid TCPRoute-on-TLS cases (`TestLoadTCPRoutes` / `TestLoadTLSRoutes`) to document that the combination is no longer allowed and legitimately yields no configuration.
- Converts the ReferenceGrant "For Secret" fixture from a TCPRoute to a TLSRoute so the cross-namespace Secret grant is exercised again with real routing configuration. The grant is `Gateway → Secret` (TLS-termination certificate), so it is orthogonal to the route kind. This also adds the previously missing TLSRoute Terminate coverage.

### Motivation

Blanking expected outputs hid the behavior change behind tests that assert nothing. The inputs should describe valid scenarios that produce configuration, and the genuinely-invalid combinations should be explicit negative tests.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Targets `v3.7` because the Gateway API v1.5.1 change lives only on `v3.7`.