### PR TITLE
Add missing ErrorRequestHeaders field to CRDs

### DIFF
--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -29,6 +29,7 @@ Review in this priority order, and keep the bar high at every level.
 - Do not use `context.Background()` in request paths — propagate the context from the caller.
 - Custom context keys must be unexported struct types (`type myKey struct{}`), never bare strings or integers.
 - Changes must not blur the static/dynamic configuration boundary: static configuration is read at startup only; dynamic configuration is produced by providers at runtime. Code that reads dynamic config at startup, or stores static config in a runtime struct, is a correctness bug.
+- New dynamic configuration options must be replicated everywhere the option's structure is duplicated. In particular, a field added to a `pkg/config/dynamic` type has a mirror in the Kubernetes CRD types under `pkg/provider/kubernetes/crd/traefikio/v1alpha1`; the new field must be added there and wired through the CRD-to-dynamic conversion in `pkg/provider/kubernetes/crd/kubernetes.go`. A dynamic option that is not exposed on the duplicated CRD struct is a bug.
 
 ## Breaking changes
 

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -902,3 +902,20 @@ the dash form, and have the backend read the spoofed value, bypassing the protec
     Set `underscoreHeadersStrategy` to `delete` or `reject` on such entry points.
 
 Please check out the entrypoint [underscoreHeadersStrategy option](../routing/entrypoints.md#underscoreheadersstrategy) documentation for more details.
+
+## v2.11.54
+
+### Kubernetes CRD: Errors middleware `errorRequestHeaders`
+
+The `errorRequestHeaders` option, introduced in `v2.11.44` for the Errors middleware,
+was not exposed on the Kubernetes CRD provider.
+Starting with `v2.11.54`, it can now be configured on the `Middleware` CRD.
+
+To use this new option, the Kubernetes CRDs must be updated in the cluster before upgrading Traefik.
+To do so, please apply the [CRDs](https://raw.githubusercontent.com/traefik/traefik/v2.11/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml) manifest for v2.11:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/traefik/traefik/v2.11/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+```
+
+Please check out the [Error Pages](../middlewares/http/errorpages.md#errorrequestheaders) middleware documentation for more details.

--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
@@ -852,6 +852,14 @@ spec:
                   This middleware returns a custom page in lieu of the default, according to configured ranges of HTTP Status codes.
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/errorpages/
                 properties:
+                  errorRequestHeaders:
+                    description: |-
+                      ErrorRequestHeaders defines the list of request headers forwarded to the error page service.
+                      When nil (not set), all original request headers are forwarded.
+                      Set to an empty list to forward no headers, or list specific headers to forward only those.
+                    items:
+                      type: string
+                    type: array
                   query:
                     description: |-
                       Query defines the URL for the error page (hosted by service).

--- a/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
@@ -237,6 +237,14 @@ spec:
                   This middleware returns a custom page in lieu of the default, according to configured ranges of HTTP Status codes.
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/errorpages/
                 properties:
+                  errorRequestHeaders:
+                    description: |-
+                      ErrorRequestHeaders defines the list of request headers forwarded to the error page service.
+                      When nil (not set), all original request headers are forwarded.
+                      Set to an empty list to forward no headers, or list specific headers to forward only those.
+                    items:
+                      type: string
+                    type: array
                   query:
                     description: |-
                       Query defines the URL for the error page (hosted by service).

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -852,6 +852,14 @@ spec:
                   This middleware returns a custom page in lieu of the default, according to configured ranges of HTTP Status codes.
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/errorpages/
                 properties:
+                  errorRequestHeaders:
+                    description: |-
+                      ErrorRequestHeaders defines the list of request headers forwarded to the error page service.
+                      When nil (not set), all original request headers are forwarded.
+                      Set to an empty list to forward no headers, or list specific headers to forward only those.
+                    items:
+                      type: string
+                    type: array
                   query:
                     description: |-
                       Query defines the URL for the error page (hosted by service).

--- a/pkg/provider/kubernetes/crd/fixtures/with_error_page.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_error_page.yml
@@ -10,6 +10,9 @@ spec:
     - "404"
     - "500"
     query: query
+    errorRequestHeaders:
+    - "X-Foo-Bar"
+    - "X-Bar-Foo"
     service:
       name: whoami
       port: 80

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -453,8 +453,9 @@ func (p *Provider) createErrorPageMiddleware(ctx context.Context, client Client,
 	}
 
 	return balancerName, &dynamic.ErrorPage{
-		Status: errorPage.Status,
-		Query:  errorPage.Query,
+		Status:              errorPage.Status,
+		Query:               errorPage.Query,
+		ErrorRequestHeaders: errorPage.ErrorRequestHeaders,
 	}, balancerServerHTTP, nil
 }
 

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -3571,9 +3571,10 @@ func TestLoadIngressRoutes(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-errorpage": {
 							Errors: &dynamic.ErrorPage{
-								Status:  []string{"404", "500"},
-								Service: "default-errorpage-errorpage-service",
-								Query:   "query",
+								Status:              []string{"404", "500"},
+								Service:             "default-errorpage-errorpage-service",
+								Query:               "query",
+								ErrorRequestHeaders: []string{"X-Foo-Bar", "X-Bar-Foo"},
 							},
 						},
 					},

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/middleware.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/middleware.go
@@ -72,6 +72,10 @@ type ErrorPage struct {
 	// Query defines the URL for the error page (hosted by service).
 	// The {status} variable can be used in order to insert the status code in the URL.
 	Query string `json:"query,omitempty"`
+	// ErrorRequestHeaders defines the list of request headers forwarded to the error page service.
+	// When nil (not set), all original request headers are forwarded.
+	// Set to an empty list to forward no headers, or list specific headers to forward only those.
+	ErrorRequestHeaders []string `json:"errorRequestHeaders,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/zz_generated.deepcopy.go
@@ -184,6 +184,11 @@ func (in *ErrorPage) DeepCopyInto(out *ErrorPage) {
 		copy(*out, *in)
 	}
 	in.Service.DeepCopyInto(&out.Service)
+	if in.ErrorRequestHeaders != nil {
+		in, out := &in.ErrorRequestHeaders, &out.ErrorRequestHeaders
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request adds the missing ErrorRequestHeaders middleware option to the ErrorPage CRD.
It also updates the review skill to make sure that new config options are replicated to the CRDs when necessary. 


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [X] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
