### PR TITLE
Set http.route on root server span and update span name to include route

### DIFF
--- a/pkg/middlewares/observability/entrypoint.go
+++ b/pkg/middlewares/observability/entrypoint.go
@@ -57,7 +57,12 @@ func (e *entryPointTracing) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 	start := time.Now()
 
 	// Follow semantic conventions defined by OTEL: https://opentelemetry.io/docs/specs/semconv/http/http-spans/#name
-	// At the moment this implementation only gets the {method} as there is no guarantee {target} is low cardinality.
+	// The span name initially uses only {method} (e.g. "GET") because the route
+	// is not yet known at the entrypoint level. When a router matches the
+	// request, the router tracing middleware enriches this server span with
+	// the http.route attribute and updates the span name to "{method} {route}"
+	// (e.g. "GET /api/v1/ml-scribe"). If no router matches (404), the span
+	// name remains "{method}".
 	tracingCtx, span := e.tracer.Start(tracingCtx, req.Method, trace.WithSpanKind(trace.SpanKindServer), trace.WithTimestamp(start))
 
 	// Associate the request context with the logger.

--- a/pkg/middlewares/observability/mock_tracing_test.go
+++ b/pkg/middlewares/observability/mock_tracing_test.go
@@ -50,7 +50,7 @@ var _ trace.Span = &mockSpan{}
 func (*mockSpan) SpanContext() trace.SpanContext {
 	return trace.NewSpanContext(trace.SpanContextConfig{TraceID: trace.TraceID{1}, SpanID: trace.SpanID{1}})
 }
-func (*mockSpan) IsRecording() bool                  { return false }
+func (*mockSpan) IsRecording() bool                  { return true }
 func (s *mockSpan) SetStatus(_ codes.Code, _ string) {}
 func (s *mockSpan) SetAttributes(kv ...attribute.KeyValue) {
 	s.attributes = append(s.attributes, kv...)

--- a/pkg/middlewares/observability/router.go
+++ b/pkg/middlewares/observability/router.go
@@ -46,21 +46,24 @@ func newRouter(ctx context.Context, router, routerRule, service string, next htt
 }
 
 func (f *routerTracing) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	if tracer := tracing.TracerFromContext(req.Context()); tracer != nil && DetailedTracingEnabled(req.Context()) {
-		// Capture the root server span before replacing the context with
-		// the router's internal span context. The root server span was
-		// created by the entrypoint middleware and is the parent of all
-		// subsequent spans in this request.
+	// Enrich the root server span with http.route and update its name.
+	// This runs regardless of DetailedTracingEnabled because the root
+	// server span always exists (created by the entrypoint middleware
+	// when TracingEnabled is true). The router span (internal) is only
+	// created when DetailedTracingEnabled is true.
+	if tracer := tracing.TracerFromContext(req.Context()); tracer != nil {
 		serverSpan := trace.SpanFromContext(req.Context())
 
-		tracingCtx, span := tracer.Start(req.Context(), "Router", trace.WithSpanKind(trace.SpanKindInternal))
-		defer span.End()
+		if DetailedTracingEnabled(req.Context()) {
+			tracingCtx, span := tracer.Start(req.Context(), "Router", trace.WithSpanKind(trace.SpanKindInternal))
+			defer span.End()
 
-		req = req.WithContext(tracingCtx)
+			req = req.WithContext(tracingCtx)
 
-		span.SetAttributes(attribute.String("traefik.service.name", f.service))
-		span.SetAttributes(attribute.String("traefik.router.name", f.router))
-		span.SetAttributes(semconv.HTTPRoute(f.routerRule))
+			span.SetAttributes(attribute.String("traefik.service.name", f.service))
+			span.SetAttributes(attribute.String("traefik.router.name", f.router))
+			span.SetAttributes(semconv.HTTPRoute(f.routerRule))
+		}
 
 		// Set http.route on the root server span and update its name to
 		// "{method} {route}" per OTel HTTP semantic conventions:

--- a/pkg/middlewares/observability/router.go
+++ b/pkg/middlewares/observability/router.go
@@ -3,6 +3,7 @@ package observability
 import (
 	"context"
 	"net/http"
+	"regexp"
 
 	"github.com/containous/alice"
 	"github.com/traefik/traefik/v3/pkg/middlewares"
@@ -46,6 +47,12 @@ func newRouter(ctx context.Context, router, routerRule, service string, next htt
 
 func (f *routerTracing) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if tracer := tracing.TracerFromContext(req.Context()); tracer != nil && DetailedTracingEnabled(req.Context()) {
+		// Capture the root server span before replacing the context with
+		// the router's internal span context. The root server span was
+		// created by the entrypoint middleware and is the parent of all
+		// subsequent spans in this request.
+		serverSpan := trace.SpanFromContext(req.Context())
+
 		tracingCtx, span := tracer.Start(req.Context(), "Router", trace.WithSpanKind(trace.SpanKindInternal))
 		defer span.End()
 
@@ -54,7 +61,58 @@ func (f *routerTracing) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		span.SetAttributes(attribute.String("traefik.service.name", f.service))
 		span.SetAttributes(attribute.String("traefik.router.name", f.router))
 		span.SetAttributes(semconv.HTTPRoute(f.routerRule))
+
+		// Set http.route on the root server span and update its name to
+		// "{method} {route}" per OTel HTTP semantic conventions:
+		// https://opentelemetry.io/docs/specs/semconv/http/http-spans/#name
+		//
+		// The root server span is created by the entrypoint middleware with
+		// just the HTTP method as its name (e.g. "GET"). When a router
+		// matches, we enrich that span with the http.route attribute and
+		// update its name to include the route (e.g. "GET /api/v1/ml-scribe").
+		//
+		// The route value is extracted from the router rule. For Path and
+		// PathPrefix matchers, the path argument is used directly. For more
+		// complex rules (PathRegexp, Host, etc.), the raw rule string is
+		// used as a fallback.
+		route := extractRouteFromRule(f.routerRule)
+		if route != "" && serverSpan != nil && serverSpan.IsRecording() {
+			serverSpan.SetAttributes(semconv.HTTPRoute(route))
+			serverSpan.SetName(req.Method + " " + route)
+		}
 	}
 
 	f.next.ServeHTTP(rw, req)
+}
+
+// pathPattern captures the path argument from Path(`/foo`) or PathPrefix(`/foo`).
+var pathPattern = regexp.MustCompile(`(?:Path|PathPrefix)\(\s*\x60([^\x60]+)\x60\s*\)`)
+
+// extractRouteFromRule parses a Traefik router rule and extracts a low-cardinality
+// route string suitable for the http.route OTel semantic convention attribute.
+//
+// For rules using Path or PathPrefix matchers, the path argument is returned
+// directly (e.g. PathPrefix(`/api/v1/ml-scribe`) → /api/v1/ml-scribe).
+//
+// For complex rules that cannot be reduced to a simple path (PathRegexp,
+// Host, Header, etc.), the raw rule string is returned as a fallback so
+// the http.route attribute is always populated when a router matches.
+//
+// When multiple Path/PathPrefix matchers are present (OR'd with ||), the
+// first one is used. This is consistent with how Traefik evaluates rules:
+// the first match wins.
+func extractRouteFromRule(rule string) string {
+	if rule == "" {
+		return ""
+	}
+
+	matches := pathPattern.FindStringSubmatch(rule)
+	if len(matches) >= 2 {
+		return matches[1]
+	}
+
+	// Fallback: use the raw rule string. This covers cases like
+	// Host(`example.com`) && PathRegexp(`/api/.*`) where no simple
+	// path can be extracted.
+	return rule
 }

--- a/pkg/middlewares/observability/router_test.go
+++ b/pkg/middlewares/observability/router_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/traefik/traefik/v3/pkg/observability/tracing"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -24,32 +25,101 @@ func TestNewRouter(t *testing.T) {
 		expected   []expected
 	}{
 		{
-			desc:       "base",
+			desc:       "Path rule",
 			service:    "myService",
 			router:     "myRouter",
 			routerRule: "Path(`/`)",
 			expected: []expected{
 				{
-					name: "GET",
+					// Root server span: name updated from "GET" to "GET /"
+					// and http.route attribute added by the router middleware.
+					name: "GET /",
 					attributes: []attribute.KeyValue{
 						attribute.String("span.kind", "server"),
+						attribute.String("http.route", "/"),
+					},
+				},
+				{
+					// Router internal span: keeps the raw rule as http.route
+					// (the extracted path is only set on the root server span).
+					name: "Router",
+					attributes: []attribute.KeyValue{
+						attribute.String("span.kind", "internal"),
+						attribute.String("traefik.service.name", "myService"),
+						attribute.String("traefik.router.name", "myRouter"),
+						attribute.String("http.route", "Path(`/`)"),
+					},
+				},
+			},
+		},
+		{
+			desc:       "PathPrefix rule",
+			service:    "myService",
+			router:     "myRouter",
+			routerRule: "PathPrefix(`/api/v1/ml-scribe`)",
+			expected: []expected{
+				{
+					name: "GET /api/v1/ml-scribe",
+					attributes: []attribute.KeyValue{
+						attribute.String("span.kind", "server"),
+						attribute.String("http.route", "/api/v1/ml-scribe"),
 					},
 				},
 				{
 					name: "Router",
 					attributes: []attribute.KeyValue{
 						attribute.String("span.kind", "internal"),
-						attribute.String("http.request.method", "GET"),
-						attribute.Int64("http.response.status_code", int64(404)),
-						attribute.String("network.protocol.version", "1.1"),
-						attribute.String("server.address", "www.test.com"),
-						attribute.Int64("server.port", int64(80)),
-						attribute.String("url.full", "http://www.test.com/traces?p=OpenTelemetry"),
-						attribute.String("url.scheme", "http"),
 						attribute.String("traefik.service.name", "myService"),
 						attribute.String("traefik.router.name", "myRouter"),
-						attribute.String("http.route", "Path(`/`)"),
-						attribute.String("user_agent.original", "router-test"),
+						attribute.String("http.route", "PathPrefix(`/api/v1/ml-scribe`)"),
+					},
+				},
+			},
+		},
+		{
+			desc:       "complex rule with Host and PathPrefix",
+			service:    "myService",
+			router:     "myRouter",
+			routerRule: "Host(`example.com`) && PathPrefix(`/grafana`)",
+			expected: []expected{
+				{
+					name: "GET /grafana",
+					attributes: []attribute.KeyValue{
+						attribute.String("span.kind", "server"),
+						attribute.String("http.route", "/grafana"),
+					},
+				},
+				{
+					name: "Router",
+					attributes: []attribute.KeyValue{
+						attribute.String("span.kind", "internal"),
+						attribute.String("traefik.service.name", "myService"),
+						attribute.String("traefik.router.name", "myRouter"),
+						attribute.String("http.route", "Host(`example.com`) && PathPrefix(`/grafana`)"),
+					},
+				},
+			},
+		},
+		{
+			desc:       "Host-only rule (no path extracted, fallback to raw rule)",
+			service:    "myService",
+			router:     "myRouter",
+			routerRule: "Host(`example.com`)",
+			expected: []expected{
+				{
+					name: "GET Host(`example.com`)",
+					attributes: []attribute.KeyValue{
+						attribute.String("span.kind", "server"),
+						attribute.String("http.route", "Host(`example.com`)"),
+					},
+				},
+				{
+					name: "Router",
+					attributes: []attribute.KeyValue{
+						attribute.String("span.kind", "internal"),
+						attribute.String("traefik.service.name", "myService"),
+						attribute.String("traefik.router.name", "myRouter"),
+						attribute.String("http.route", "Host(`example.com`)"),
 					},
 				},
 			},
@@ -62,9 +132,21 @@ func TestNewRouter(t *testing.T) {
 			req.RemoteAddr = "10.0.0.1:1234"
 			req.Header.Set("User-Agent", "router-test")
 
-			tracer := &mockTracer{}
+			mockTracer := &mockTracer{}
+			// Wrap the mock tracer with tracing.NewTracer so that
+			// tracing.TracerFromContext can find it via the span's
+			// TracerProvider (which returns *tracing.Tracer for the
+			// "github.com/traefik/traefik" tracer name).
+			tracer := tracing.NewTracer(mockTracer, nil, nil, nil)
 			tracingCtx, entryPointSpan := tracer.Start(req.Context(), http.MethodGet, trace.WithSpanKind(trace.SpanKindServer))
 			defer entryPointSpan.End()
+
+			// Inject observability state with detailed tracing enabled
+			// so the router middleware actually creates spans.
+			tracingCtx = WithObservability(tracingCtx, Observability{
+				TracingEnabled:          true,
+				DetailedTracingEnabled:  true,
+			})
 
 			req = req.WithContext(tracingCtx)
 
@@ -76,7 +158,7 @@ func TestNewRouter(t *testing.T) {
 			handler := newRouter(t.Context(), test.router, test.routerRule, test.service, next)
 			handler.ServeHTTP(rw, req)
 
-			for i, span := range tracer.spans {
+			for i, span := range mockTracer.spans {
 				assert.Equal(t, test.expected[i].name, span.name)
 				assert.Equal(t, test.expected[i].attributes, span.attributes)
 			}


### PR DESCRIPTION
## What does this PR do?

Fixes #11230

The root server span created by the entrypoint middleware only used the HTTP method as its name (e.g. `"GET"`), making it impossible to distinguish requests by path in tracing backends like Tempo, Jaeger, or Datadog. This is a known limitation discussed in #11230 and acknowledged by the Traefik team.

This PR enriches the root server span when a router matches the request:

- Sets the `http.route` attribute on the root server span with the extracted path from the router rule
- Updates the root server span name to `"{method} {route}"` (e.g. `"GET /api/v1/ml-scribe"`) per the [OTel HTTP semantic conventions](https://opentelemetry.io/docs/specs/semconv/http/http-spans/#name)

### Route extraction

The route value is extracted from the router rule:

| Rule | Extracted `http.route` | Span name |
|------|----------------------|-----------|
| `Path(\`/healthz\`)` | `/healthz` | `GET /healthz` |
| `PathPrefix(\`/api/v1/ml-scribe\`)` | `/api/v1/ml-scribe` | `GET /api/v1/ml-scribe` |
| `Host(\`example.com\`) && PathPrefix(\`/grafana\`)` | `/grafana` | `GET /grafana` |
| `Host(\`example.com\`)` | `Host(\`example.com\`)` (fallback to raw rule) | `GET Host(\`example.com\`)` |

For `Path()` and `PathPrefix()` matchers, the path argument is used directly. For complex rules that cannot be reduced to a simple path (`PathRegexp`, `Host`-only, etc.), the raw rule string is used as a fallback so the `http.route` attribute is always populated when a router matches.

If no router matches (404), the span name remains `"{method}"` and no `http.route` is set — preserving the current behavior for unmatched requests.

### Implementation

The router tracing middleware (`router.go`) captures the root server span from the request context **before** creating its own internal span (which would replace the context's active span). It then sets `http.route` and calls `SetName()` on the root server span.

The router's own internal span keeps the raw rule string as its `http.route` attribute (unchanged behavior).

### Testing

- Updated `router_test.go` with 4 test cases covering Path, PathPrefix, complex (Host + PathPrefix), and Host-only rules
- Fixed `mock_tracing_test.go`: `IsRecording()` now returns `true` so span modifications are testable
- Fixed the test to use `tracing.NewTracer()` wrapper and `WithObservability()` context, which are required for `TracerFromContext` and `DetailedTracingEnabled` to work
- All existing tests in the `observability` package continue to pass

### Notes

- The `http.route` attribute was already being set on the router's internal span (line 56 of `router.go`), but not on the root server span. This PR moves it to the server span where tracing backends expect it for endpoint grouping.
- `Span.SetName()` is used to update the name after span creation. While the OTel Go SDK recommends setting the name at `Start()` time, the route is not known at the entrypoint level (where the server span is created) — it's only known when a router matches. `SetName()` is the correct approach for this use case.
