### PR TITLE
Sanitize rewritten target on ingress-nginx provider

### DIFF
--- a/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target.go
+++ b/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target.go
@@ -152,6 +152,20 @@ func (rt *rewriteTarget) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// Here we are sanitizing the URL when the path is not empty,
+	// as the JoinPath method is adding a leading slash if the path is empty.
+	path := req.URL.Path
+	if path != "" {
+		req.URL = req.URL.JoinPath()
+	}
+
+	// Stop here if the normalization of the path produces a different path.
+	if path != req.URL.Path {
+		logger.Debug().Msgf("Rejecting request, sanitized path: %q is not equivalent to stripped path: %q", path, req.URL.Path)
+		http.Error(rw, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return
+	}
+
 	req.RequestURI = req.URL.RequestURI()
 
 	rt.next.ServeHTTP(rw, req)

--- a/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target_test.go
+++ b/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target_test.go
@@ -43,8 +43,7 @@ func TestRewriteTarget(t *testing.T) {
 			config: dynamic.RewriteTarget{
 				Replacement: "/replacement",
 			},
-			expectedPath:    "/replacement",
-			expectedRawPath: "/replacement",
+			expectedPath: "/replacement",
 		},
 		{
 			desc: "plain replacement with escaped char in replacement",
@@ -63,7 +62,6 @@ func TestRewriteTarget(t *testing.T) {
 				XForwardedPrefix: "/foo",
 			},
 			expectedPath:             "/replacement",
-			expectedRawPath:          "/replacement",
 			expectedXForwardedPrefix: "/foo",
 		},
 		{
@@ -73,8 +71,7 @@ func TestRewriteTarget(t *testing.T) {
 				Regex:       `^/foo/(.*)`,
 				Replacement: "/new/$1",
 			},
-			expectedPath:    "/new/bar",
-			expectedRawPath: "/new/bar",
+			expectedPath: "/new/bar",
 		},
 		{
 			desc: "regex with multiple capture groups",
@@ -83,8 +80,7 @@ func TestRewriteTarget(t *testing.T) {
 				Regex:       `^(?i)/downloads/([^/]+)/([^/]+)$`,
 				Replacement: "/downloads/$1-$2",
 			},
-			expectedPath:    "/downloads/src-source.go",
-			expectedRawPath: "/downloads/src-source.go",
+			expectedPath: "/downloads/src-source.go",
 		},
 		{
 			desc: "regex with escaped char in replacement",
@@ -115,7 +111,6 @@ func TestRewriteTarget(t *testing.T) {
 				XForwardedPrefix: "$1",
 			},
 			expectedPath:             "/bar",
-			expectedRawPath:          "/bar",
 			expectedXForwardedPrefix: "/foo",
 		},
 		{
@@ -127,7 +122,6 @@ func TestRewriteTarget(t *testing.T) {
 				XForwardedPrefix: "/$1/$2",
 			},
 			expectedPath:             "/endpoint",
-			expectedRawPath:          "/endpoint",
 			expectedXForwardedPrefix: "/prefix/sub",
 		},
 		{
@@ -178,9 +172,7 @@ func TestRewriteTarget(t *testing.T) {
 				Regex:       `^/prefix/(.*)`,
 				Replacement: "$1",
 			},
-			expectedPath:       "http://evil.com/malicious",
-			expectedRawPath:    "http://evil.com/malicious",
-			expectedStatusCode: http.StatusOK,
+			expectedStatusCode: http.StatusBadRequest,
 		},
 		{
 			desc: "regex with full URL replacement with no capture groups",
@@ -219,6 +211,24 @@ func TestRewriteTarget(t *testing.T) {
 			},
 			expectedStatusCode:  http.StatusFound,
 			expectedRedirectURL: "https://portal.example.org/site/foo/bar?tenant=acme&id=42",
+		},
+		{
+			desc: "path with ..",
+			path: "/foo../bar",
+			config: dynamic.RewriteTarget{
+				Regex:       `^/foo(.*)`,
+				Replacement: "/$1",
+			},
+			expectedStatusCode: http.StatusBadRequest,
+		},
+		{
+			desc: "capture group without path separator introducing dot-segment traversal",
+			path: "/api../admin",
+			config: dynamic.RewriteTarget{
+				Regex:       `^/api(.*)`,
+				Replacement: "/$1",
+			},
+			expectedStatusCode: http.StatusBadRequest,
 		},
 	}
 

--- a/pkg/middlewares/ingressnginx/snippet/action.go
+++ b/pkg/middlewares/ingressnginx/snippet/action.go
@@ -795,6 +795,18 @@ func createRewriteAction(d config.IDirective) (action, error) {
 			// Otherwise, keep the original query string.
 		}
 
+		// Here we are sanitizing the URL when the path is not empty,
+		// as the JoinPath method is adding a leading slash if the path is empty.
+		rewrittenPath := req.URL.Path
+		if rewrittenPath != "" {
+			req.URL = req.URL.JoinPath()
+		}
+		// Stop here if the normalization of the path produces a different path.
+		if rewrittenPath != req.URL.Path {
+			ctx.statusCode = http.StatusBadRequest
+			return true, nil
+		}
+
 		req.RequestURI = req.URL.RequestURI()
 
 		// In NGINX, last restarts location matching while break stays in the

--- a/pkg/middlewares/ingressnginx/snippet/snippet_test.go
+++ b/pkg/middlewares/ingressnginx/snippet/snippet_test.go
@@ -1141,6 +1141,30 @@ rewrite ^/(.*)$ "${uri}?" break;
 			expectedPath:  "/some/path",
 			expectedQuery: "",
 		},
+		{
+			desc: "rewrite with dot-segment traversal in capture group is rejected",
+			configurationSnippet: `
+rewrite ^/foo(.*)$ /$1 break;
+`,
+			path:               "/foo../bar",
+			expectedStatusCode: http.StatusBadRequest,
+		},
+		{
+			desc: "rewrite with capture group lacking path separator introducing dot-segment traversal is rejected",
+			configurationSnippet: `
+rewrite ^/api(.*)$ /$1 break;
+`,
+			path:               "/api../admin",
+			expectedStatusCode: http.StatusBadRequest,
+		},
+		{
+			desc: "rewrite with percent-encoded character in capture group succeeds",
+			configurationSnippet: `
+rewrite ^/api/(.*)$ /v2/$1 break;
+`,
+			path:         "/api/foo%2Fbar",
+			expectedPath: "/v2/foo/bar",
+		},
 		// --- add_header always tests ---
 		{
 			desc: "add_header with always applies to 200 status",


### PR DESCRIPTION
### What does this PR do?

Sanitize the rewritten path applied for ingress-nginx provider (either via rewrite-target annotation or configuration snippets) to avoid split view.


### Motivation

To fix the behavior.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

