### PR TITLE
Log which responding timeout closed the connection

### DIFF
--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -284,7 +284,13 @@ func (e *TCPEntryPoint) Start(ctx context.Context) {
 				}
 			}
 
-			e.switcher.ServeTCP(newTrackedConnection(writeCloser, e.tracker))
+			e.switcher.ServeTCP(newTrackedConnection(
+				writeCloser,
+				e.tracker,
+				logger,
+				time.Duration(e.transportConfiguration.RespondingTimeouts.ReadTimeout),
+				time.Duration(e.transportConfiguration.RespondingTimeouts.WriteTimeout),
+			))
 		})
 	}
 }
@@ -761,18 +767,40 @@ func getConnKey(conn net.Conn) string {
 	return fmt.Sprintf("%s => %s", conn.RemoteAddr(), conn.LocalAddr())
 }
 
-func newTrackedConnection(conn tcp.WriteCloser, tracker *connectionTracker) *trackedConnection {
+func newTrackedConnection(conn tcp.WriteCloser, tracker *connectionTracker, logger *zerolog.Logger, readTimeout, writeTimeout time.Duration) *trackedConnection {
 	tracker.AddConnection(conn)
 	return &trackedConnection{
-		WriteCloser: conn,
-		tracker:     tracker,
+		WriteCloser:  conn,
+		tracker:      tracker,
+		logger:       logger,
+		readTimeout:  readTimeout,
+		writeTimeout: writeTimeout,
 	}
 }
 
 type trackedConnection struct {
 	tcp.WriteCloser
 
-	tracker *connectionTracker
+	tracker      *connectionTracker
+	logger       *zerolog.Logger
+	readTimeout  time.Duration
+	writeTimeout time.Duration
+}
+
+func (t *trackedConnection) Read(b []byte) (int, error) {
+	n, err := t.WriteCloser.Read(b)
+	if err != nil && t.readTimeout > 0 && errors.Is(err, os.ErrDeadlineExceeded) {
+		t.logger.Debug().Dur("readTimeout", t.readTimeout).Msg("Closing connection: read timeout exceeded")
+	}
+	return n, err
+}
+
+func (t *trackedConnection) Write(b []byte) (int, error) {
+	n, err := t.WriteCloser.Write(b)
+	if err != nil && t.writeTimeout > 0 && errors.Is(err, os.ErrDeadlineExceeded) {
+		t.logger.Debug().Dur("writeTimeout", t.writeTimeout).Msg("Closing connection: write timeout exceeded")
+	}
+	return n, err
 }
 
 func (t *trackedConnection) Close() error {

--- a/pkg/server/server_entrypoint_tcp_test.go
+++ b/pkg/server/server_entrypoint_tcp_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -9,10 +10,12 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	ptypes "github.com/traefik/paerser/types"
@@ -933,6 +936,82 @@ func Test_rejectHeadersWithUnderscores(t *testing.T) {
 			}
 
 			assert.True(t, reachedBackend)
+		})
+	}
+}
+
+type fakeTimeoutConn struct {
+	net.Conn
+
+	readErr  error
+	writeErr error
+}
+
+func (c *fakeTimeoutConn) Read(_ []byte) (int, error)  { return 0, c.readErr }
+func (c *fakeTimeoutConn) Write(b []byte) (int, error) { return len(b), c.writeErr }
+func (c *fakeTimeoutConn) CloseWrite() error           { return nil }
+
+func TestTrackedConnectionTimeoutLogging(t *testing.T) {
+	tests := []struct {
+		desc         string
+		readTimeout  time.Duration
+		writeTimeout time.Duration
+		readErr      error
+		writeErr     error
+		write        bool
+		wantLog      string
+	}{
+		{
+			desc:        "read deadline exceeded logs readTimeout",
+			readTimeout: 30 * time.Second,
+			readErr:     os.ErrDeadlineExceeded,
+			wantLog:     "readTimeout",
+		},
+		{
+			desc:         "write deadline exceeded logs writeTimeout",
+			writeTimeout: 15 * time.Second,
+			writeErr:     os.ErrDeadlineExceeded,
+			write:        true,
+			wantLog:      "writeTimeout",
+		},
+		{
+			desc:        "non-timeout error is not logged",
+			readTimeout: 30 * time.Second,
+			readErr:     io.EOF,
+		},
+		{
+			desc:    "deadline exceeded with the timeout unset is not logged",
+			readErr: os.ErrDeadlineExceeded,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			logger := zerolog.New(&buf).Level(zerolog.DebugLevel)
+
+			conn := &trackedConnection{
+				WriteCloser:  &fakeTimeoutConn{readErr: test.readErr, writeErr: test.writeErr},
+				logger:       &logger,
+				readTimeout:  test.readTimeout,
+				writeTimeout: test.writeTimeout,
+			}
+
+			var err error
+			if test.write {
+				_, err = conn.Write([]byte("ping"))
+			} else {
+				_, err = conn.Read(make([]byte, 4))
+			}
+			require.Error(t, err)
+
+			if test.wantLog == "" {
+				assert.Empty(t, buf.String())
+				return
+			}
+			assert.Contains(t, buf.String(), test.wantLog)
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

adds a debug log saying which respondingTimeout (read or write) closed a connection, so a timeout is diagnosable instead of only showing up as a bare gateway error. the read/write deadlines are already set on the wrapped conn in server_entrypoint_tcp.go - this just reports which one fired, tagged with the entrypoint. no defaults or behaviour change, only an extra log line.

### Motivation

follows up on #13503. right now when a readTimeout/writeTimeout fires nothing in the logs says so - you only get a generic 502/504 and have to correlate logs across hosts to find the cause. the issue describes a large-upload case where the default 60s readTimeout was the culprit and took a while to track down.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

kept it conservative (read/write only). a couple of things i'd like your call on before finalising, hence draft:

- log level: i put it at Debug to not be noisy on busy proxies (matches the already-swallowed http.Server ErrorLog level). downside is Debug is off by default, so someone hitting this still wouldn't see it without turning the level up. if it should be visible by default, Info/Warn might fit better.
- idleTimeout is left out on purpose. net/http enforces IdleTimeout with a read deadline on keep-alive conns, so at the conn wrapper an idle close looks identical to a readTimeout. writeTimeout is unambiguous. didn't want to mislabel idle closes as readTimeout - happy to add it if you have a preferred way to tell them apart.
- timeout detection uses errors.Is(err, os.ErrDeadlineExceeded) (the deadlines we set produce exactly that) instead of the net.Error.Timeout() idiom used elsewhere, to stay specific to the responding deadlines. can switch if you'd rather be consistent.
