### PR TITLE
Fix panic in retry middleware with Websockets

### DIFF
--- a/pkg/middlewares/retry/retry.go
+++ b/pkg/middlewares/retry/retry.go
@@ -371,6 +371,9 @@ func (r *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if !ok {
 		return nil, nil, fmt.Errorf("%T is not a http.Hijacker", r.responseWriter)
 	}
+
+	// When the connection is Hijack we can not retry.
+	r.written = true
 	return hijacker.Hijack()
 }
 

--- a/pkg/middlewares/retry/retry.go
+++ b/pkg/middlewares/retry/retry.go
@@ -230,8 +230,9 @@ func (r *retry) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 		r.next.ServeHTTP(retryResponseWriter, retryReq)
 
-		// End the operation as soon as the client received something.
-		if retryResponseWriter.written {
+		// End the operation as soon as the client received something
+		// or when the request is hijacked.
+		if retryResponseWriter.written || retryResponseWriter.hijacked {
 			return nil
 		}
 
@@ -298,6 +299,7 @@ type responseWriter struct {
 
 	proxyReached   atomic.Bool
 	wroteRequest   atomic.Bool
+	hijacked       bool
 	written        bool
 	shouldNotWrite bool
 }
@@ -372,8 +374,10 @@ func (r *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 		return nil, nil, fmt.Errorf("%T is not a http.Hijacker", r.responseWriter)
 	}
 
-	// When the connection is Hijack we can not retry.
-	r.written = true
+	// When the connection is Hijacked when using Websockets, we don't want to retry anymore,
+	// so we set the hijacked flag to true.
+	r.hijacked = true
+
 	return hijacker.Hijack()
 }
 

--- a/pkg/middlewares/retry/retry_test.go
+++ b/pkg/middlewares/retry/retry_test.go
@@ -882,20 +882,18 @@ func TestRetryDoesNotBufferBodyForNonIdempotentMethod(t *testing.T) {
 // it, so WriteHeader is never called on the retry responseWriter and written stays false.
 // When the client goes away, the retry middleware therefore replays the request, this time getting a regular
 // Content-Length response, which makes copyResponse arm the maxLatencyWriter flush timer.
-// The delayed flush then flushes an http.response whose buffered writer has been released by Hijack.
+// The delayed flush then flushes an http.Response whose buffered writer has been released by Hijack.
 //
 // Until the retry middleware stops replaying hijacked requests, this does not report a test failure:
 // it panics in a timer goroutine, which takes the whole test binary down with a SIGSEGV.
 func TestRetryWebsocketDelayedFlush(t *testing.T) {
-	var backendCalls atomic.Int32
-
+	var backendCallCount atomic.Int32
 	backend := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		if backendCalls.Add(1) == 1 {
+		if backendCallCount.Add(1) == 1 {
 			upgrader := websocket.Upgrader{}
 			conn, err := upgrader.Upgrade(rw, req, nil)
-			if !assert.NoError(t, err) {
-				return
-			}
+			require.NoError(t, err)
+
 			defer conn.Close()
 
 			// Hold the stream until the client goes away.
@@ -911,7 +909,7 @@ func TestRetryWebsocketDelayedFlush(t *testing.T) {
 		rw.(http.Flusher).Flush()
 
 		// Give the flush timer time to fire before the body completes the copy.
-		time.Sleep(300 * time.Millisecond)
+		time.Sleep(time.Second)
 
 		_, _ = rw.Write([]byte("0123456789"))
 	}))
@@ -921,17 +919,17 @@ func TestRetryWebsocketDelayedFlush(t *testing.T) {
 	require.NoError(t, err)
 
 	proxy := &httputil.ReverseProxy{
-		Rewrite: func(pr *httputil.ProxyRequest) {
-			pr.Out.URL.Scheme = backendURL.Scheme
-			pr.Out.URL.Host = backendURL.Host
-		},
 		FlushInterval: 100 * time.Millisecond,
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.Out.URL.Host = backendURL.Host
+			pr.Out.URL.Scheme = backendURL.Scheme
+		},
 	}
 
-	retryH, err := New(t.Context(), WrapHandler(proxy), dynamic.Retry{Attempts: 3}, &countingRetryListener{}, "traefikTest")
+	handler, err := New(t.Context(), WrapHandler(proxy), dynamic.Retry{Attempts: 3}, &countingRetryListener{}, "traefikTest")
 	require.NoError(t, err)
 
-	retryServer := httptest.NewServer(retryH)
+	retryServer := httptest.NewServer(handler)
 	t.Cleanup(retryServer.Close)
 
 	conn, response, err := websocket.DefaultDialer.Dial(strings.Replace(retryServer.URL, "http", "ws", 1), nil)
@@ -944,5 +942,5 @@ func TestRetryWebsocketDelayedFlush(t *testing.T) {
 	// Leave the replayed attempt time to arm and fire the delayed flush.
 	time.Sleep(time.Second)
 
-	assert.Equal(t, int32(1), backendCalls.Load(), "an upgraded request must not be replayed")
+	assert.Equal(t, int32(1), backendCallCount.Load(), "an upgraded request must not be replayed")
 }

--- a/pkg/middlewares/retry/retry_test.go
+++ b/pkg/middlewares/retry/retry_test.go
@@ -7,8 +7,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/http/httptrace"
+	"net/http/httputil"
 	"net/textproto"
+	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -311,6 +314,20 @@ func TestRetryWebsocket(t *testing.T) {
 			maxRequestAttempts:     3,
 			expectedRetryAttempts:  2,
 			amountFaultyEndpoints:  2,
+			expectedResponseStatus: http.StatusSwitchingProtocols,
+		},
+		{
+			desc:                   "Switching ok on the first attempt is not retried",
+			maxRequestAttempts:     3,
+			expectedRetryAttempts:  0,
+			amountFaultyEndpoints:  0,
+			expectedResponseStatus: http.StatusSwitchingProtocols,
+		},
+		{
+			desc:                   "Switching ok on an intermediate attempt is not retried",
+			maxRequestAttempts:     3,
+			expectedRetryAttempts:  1,
+			amountFaultyEndpoints:  1,
 			expectedResponseStatus: http.StatusSwitchingProtocols,
 		},
 		{
@@ -857,4 +874,75 @@ func TestRetryDoesNotBufferBodyForNonIdempotentMethod(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, recorder.Code)
 	assert.Equal(t, 0, retryListener.timesCalled)
+}
+
+// TestRetryWebsocketDelayedFlush reproduces https://github.com/traefik/traefik/issues/13513.
+//
+// httputil.ReverseProxy serves a protocol upgrade by hijacking the connection and writing the 101 response directly to
+// it, so WriteHeader is never called on the retry responseWriter and written stays false.
+// When the client goes away, the retry middleware therefore replays the request, this time getting a regular
+// Content-Length response, which makes copyResponse arm the maxLatencyWriter flush timer.
+// The delayed flush then flushes an http.response whose buffered writer has been released by Hijack.
+//
+// Until the retry middleware stops replaying hijacked requests, this does not report a test failure:
+// it panics in a timer goroutine, which takes the whole test binary down with a SIGSEGV.
+func TestRetryWebsocketDelayedFlush(t *testing.T) {
+	var backendCalls atomic.Int32
+
+	backend := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if backendCalls.Add(1) == 1 {
+			upgrader := websocket.Upgrader{}
+			conn, err := upgrader.Upgrade(rw, req, nil)
+			if !assert.NoError(t, err) {
+				return
+			}
+			defer conn.Close()
+
+			// Hold the stream until the client goes away.
+			_, _, _ = conn.ReadMessage()
+
+			return
+		}
+
+		// The replayed request no longer matches a live stream, and the backend answers with a regular response.
+		// A known Content-Length is what makes ReverseProxy arm the flush timer instead of flushing inline.
+		rw.Header().Set("Content-Length", "10")
+		rw.WriteHeader(http.StatusOK)
+		rw.(http.Flusher).Flush()
+
+		// Give the flush timer time to fire before the body completes the copy.
+		time.Sleep(300 * time.Millisecond)
+
+		_, _ = rw.Write([]byte("0123456789"))
+	}))
+	t.Cleanup(backend.Close)
+
+	backendURL, err := url.Parse(backend.URL)
+	require.NoError(t, err)
+
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.Out.URL.Scheme = backendURL.Scheme
+			pr.Out.URL.Host = backendURL.Host
+		},
+		FlushInterval: 100 * time.Millisecond,
+	}
+
+	retryH, err := New(t.Context(), WrapHandler(proxy), dynamic.Retry{Attempts: 3}, &countingRetryListener{}, "traefikTest")
+	require.NoError(t, err)
+
+	retryServer := httptest.NewServer(retryH)
+	t.Cleanup(retryServer.Close)
+
+	conn, response, err := websocket.DefaultDialer.Dial(strings.Replace(retryServer.URL, "http", "ws", 1), nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusSwitchingProtocols, response.StatusCode)
+
+	// The client goes away: handleUpgradeResponse returns, and the retry middleware replays the request.
+	require.NoError(t, conn.Close())
+
+	// Leave the replayed attempt time to arm and fire the delayed flush.
+	time.Sleep(time.Second)
+
+	assert.Equal(t, int32(1), backendCalls.Load(), "an upgraded request must not be replayed")
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes the retry middleware to not retry when connection is Hijack ( websocket connection for example )

### Motivation

Fixes #13513 

### More

- [x] Added/updated tests
- [ ] Added/updated documentation
