### PR TITLE
Allow IP anonymization

### DIFF
--- a/docs/content/observe/logs-and-access-logs.md
+++ b/docs/content/observe/logs-and-access-logs.md
@@ -175,5 +175,9 @@ When using the `json` format, you can customize which fields are included in you
 - **Request Headers:** You can also specify which request headers should be included in the logs, and whether their values should be `kept`, `dropped`, or `redacted`.
 - **Request Query Parameters:** You can choose to `keep` or `drop` the query parameters for a request.
 
+## Client IP Anonymization
+
+To comply with privacy requirements, you can truncate client IP addresses in the access logs by configuring `accessLog.anonymization`. Set `ipv4Subnet` and/or `ipv6Subnet` to the prefix length to keep (for example `24` for v4 and `48` for v6); Traefik then logs only the network prefix of the client connection IP, in the `ClientAddr` field and in the `ClientHost` field when it is derived from the connection remote address.
+
 !!! info
     For detailed configuration options, refer to the [reference documentation](../reference/install-configuration/observability/logs-and-accesslogs.md).

--- a/docs/content/reference/install-configuration/configuration-options.md
+++ b/docs/content/reference/install-configuration/configuration-options.md
@@ -9,6 +9,9 @@ THIS FILE MUST NOT BE EDITED BY HAND
 |:-------|:------------|:-------|
 | <a id="opt-accesslog" href="#opt-accesslog" title="#opt-accesslog">accesslog</a> | Access log settings. | false |
 | <a id="opt-accesslog-addinternals" href="#opt-accesslog-addinternals" title="#opt-accesslog-addinternals">accesslog.addinternals</a> | Enables access log for internal services (ping, dashboard, etc...). | false |
+| <a id="opt-accesslog-anonymization" href="#opt-accesslog-anonymization" title="#opt-accesslog-anonymization">accesslog.anonymization</a> | Access log client IP anonymization settings. | false |
+| <a id="opt-accesslog-anonymization-ipv4subnet" href="#opt-accesslog-anonymization-ipv4subnet" title="#opt-accesslog-anonymization-ipv4subnet">accesslog.anonymization.ipv4subnet</a> | Truncate client IPv4 addresses to this prefix length (1-32); 0 disables truncation. | 0 |
+| <a id="opt-accesslog-anonymization-ipv6subnet" href="#opt-accesslog-anonymization-ipv6subnet" title="#opt-accesslog-anonymization-ipv6subnet">accesslog.anonymization.ipv6subnet</a> | Truncate client IPv6 addresses to this prefix length (1-128); 0 disables truncation. | 0 |
 | <a id="opt-accesslog-bufferingsize" href="#opt-accesslog-bufferingsize" title="#opt-accesslog-bufferingsize">accesslog.bufferingsize</a> | Number of access log lines to process in a buffered way. | 0 |
 | <a id="opt-accesslog-dualoutput" href="#opt-accesslog-dualoutput" title="#opt-accesslog-dualoutput">accesslog.dualoutput</a> | Enables access log output alongside OTLP. By default, this output is disabled when OTLP is configured. | false |
 | <a id="opt-accesslog-fields-defaultmode" href="#opt-accesslog-fields-defaultmode" title="#opt-accesslog-fields-defaultmode">accesslog.fields.defaultmode</a> | Default mode for fields: keep | drop | keep |

--- a/docs/content/reference/install-configuration/observability/logs-and-accesslogs.md
+++ b/docs/content/reference/install-configuration/observability/logs-and-accesslogs.md
@@ -174,6 +174,11 @@ accessLog:
     queryParameters:
       # Drop all query parameters
       defaultMode: drop
+  anonymization:
+    # Truncate client IPv4 addresses to their /24 network
+    ipv4Subnet: 24
+    # Truncate client IPv6 addresses to their /48 network
+    ipv6Subnet: 48
 ```
 
 ```toml tab="File (TOML)"
@@ -200,6 +205,10 @@ accessLog:
 
     [accessLog.fields.queryParameters]
       defaultMode = "drop"
+
+  [accessLog.anonymization]
+    ipv4Subnet = 24
+    ipv6Subnet = 48
 ```
 
 ```sh tab="CLI"
@@ -215,6 +224,8 @@ accessLog:
 --accesslog.fields.headers.names.User-Agent=redact
 --accesslog.fields.headers.names.Authorization=drop
 --accesslog.fields.queryparameters.defaultmode=drop
+--accesslog.anonymization.ipv4subnet=24
+--accesslog.anonymization.ipv6subnet=48
 ```
 
 ### Configuration Options
@@ -236,6 +247,8 @@ The section below describes how to configure Traefik access logs using the stati
 | <a id="opt-accesslog-fields-headers-defaultMode" href="#opt-accesslog-fields-headers-defaultMode" title="#opt-accesslog-fields-headers-defaultMode">`accesslog.fields.headers.defaultMode`</a> | Mode to apply by default to the access logs headers (`keep`, `redact` or `drop`).  | drop | No      |
 | <a id="opt-accesslog-fields-headers-names" href="#opt-accesslog-fields-headers-names" title="#opt-accesslog-fields-headers-names">`accesslog.fields.headers.names`</a> | Set the headers list to display in the access logs (format `name:mode`). |   [ ]   | No      |
 | <a id="opt-accesslog-fields-queryParameters-defaultMode" href="#opt-accesslog-fields-queryParameters-defaultMode" title="#opt-accesslog-fields-queryParameters-defaultMode">`accesslog.fields.queryParameters.defaultMode`</a> | Mode to apply by default to the access logs query parameters (`keep` or `drop`) | keep | No      |
+| <a id="opt-accesslog-anonymization-ipv4Subnet" href="#opt-accesslog-anonymization-ipv4Subnet" title="#opt-accesslog-anonymization-ipv4Subnet">`accesslog.anonymization.ipv4Subnet`</a> | Truncate client IPv4 addresses in the access logs to the given prefix length (`1`-`32`).<br />`0` disables IPv4 truncation. Applies to the `ClientAddr` field and to the `ClientHost` field when it is derived from the connection remote address; the `X-Forwarded-For` value is logged in full. | 0 | No      |
+| <a id="opt-accesslog-anonymization-ipv6Subnet" href="#opt-accesslog-anonymization-ipv6Subnet" title="#opt-accesslog-anonymization-ipv6Subnet">`accesslog.anonymization.ipv6Subnet`</a> | Truncate client IPv6 addresses in the access logs to the given prefix length (`1`-`128`).<br />`0` disables IPv6 truncation. Applies to the `ClientAddr` field and to the `ClientHost` field when it is derived from the connection remote address; the `X-Forwarded-For` value is logged in full. | 0 | No      |
 
 ### OpenTelemetry
 

--- a/pkg/ip/strategy.go
+++ b/pkg/ip/strategy.go
@@ -92,6 +92,34 @@ func (s *PoolStrategy) GetIP(req *http.Request) string {
 	return ""
 }
 
+// MaskIP truncates ip to the prefix length configured for its address family.
+// It returns ip unchanged on a parse failure or when the matching subnet is <= 0.
+func MaskIP(ip string, ipv4Subnet, ipv6Subnet int) string {
+	addr, err := netip.ParseAddr(ip)
+	if err != nil {
+		return ip
+	}
+
+	// Normalize 4-in-6 addresses so the family detection below is accurate.
+	addr = addr.Unmap()
+
+	subnet := ipv4Subnet
+	if addr.Is6() {
+		subnet = ipv6Subnet
+	}
+
+	if subnet <= 0 {
+		return ip
+	}
+
+	prefix, err := addr.Prefix(subnet)
+	if err != nil {
+		return ip
+	}
+
+	return prefix.Addr().String()
+}
+
 // getIPv6SubnetIP returns the IPv6 subnet IP.
 // It returns the original IP when it is not an IPv6, or if parsing the IP has failed with an error.
 func getIPv6SubnetIP(ip string, ipv6Subnet int) string {

--- a/pkg/ip/strategy_test.go
+++ b/pkg/ip/strategy_test.go
@@ -15,6 +15,74 @@ const (
 	ipv6BracketsZonePort = "[::abcd:ffff:c0a8:1%1]:80"
 )
 
+func TestMaskIP(t *testing.T) {
+	testCases := []struct {
+		desc       string
+		ip         string
+		ipv4Subnet int
+		ipv6Subnet int
+		expected   string
+	}{
+		{
+			desc:       "IPv4 truncated to /24",
+			ip:         "203.0.113.42",
+			ipv4Subnet: 24,
+			ipv6Subnet: 48,
+			expected:   "203.0.113.0",
+		},
+		{
+			desc:       "IPv6 truncated to /48",
+			ip:         "2001:db8::abcd:ffff:c0a8:1",
+			ipv4Subnet: 24,
+			ipv6Subnet: 48,
+			expected:   "2001:db8::",
+		},
+		{
+			desc:       "IPv4 subnet disabled leaves IPv4 untouched",
+			ip:         "203.0.113.42",
+			ipv4Subnet: 0,
+			ipv6Subnet: 48,
+			expected:   "203.0.113.42",
+		},
+		{
+			desc:       "IPv6 subnet disabled leaves IPv6 untouched",
+			ip:         "2001:db8::1",
+			ipv4Subnet: 24,
+			ipv6Subnet: 0,
+			expected:   "2001:db8::1",
+		},
+		{
+			desc:       "4-in-6 mapped address uses the IPv4 subnet",
+			ip:         "::ffff:203.0.113.42",
+			ipv4Subnet: 24,
+			ipv6Subnet: 48,
+			expected:   "203.0.113.0",
+		},
+		{
+			desc:       "invalid IP is returned unchanged",
+			ip:         "not-an-ip",
+			ipv4Subnet: 24,
+			ipv6Subnet: 48,
+			expected:   "not-an-ip",
+		},
+		{
+			desc:       "out-of-range subnet is returned unchanged",
+			ip:         "203.0.113.42",
+			ipv4Subnet: 40,
+			ipv6Subnet: 48,
+			expected:   "203.0.113.42",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.expected, MaskIP(test.ip, test.ipv4Subnet, test.ipv6Subnet))
+		})
+	}
+}
+
 func TestRemoteAddrStrategy_GetIP(t *testing.T) {
 	testCases := []struct {
 		desc       string

--- a/pkg/middlewares/accesslog/anonymize_test.go
+++ b/pkg/middlewares/accesslog/anonymize_test.go
@@ -1,0 +1,61 @@
+package accesslog
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	otypes "github.com/traefik/traefik/v3/pkg/observability/types"
+)
+
+func TestMaskClientAddr(t *testing.T) {
+	anon := &otypes.AccessLogAnonymization{IPv4Subnet: 24, IPv6Subnet: 80}
+
+	assert.Equal(t, "203.0.113.0:8080", maskClientAddr("203.0.113.42:8080", anon))
+	assert.Equal(t, "[2001:db8:0:0:abcd::]:8080", maskClientAddr("[2001:db8::abcd:ffff:c0a8:1]:8080", anon))
+	assert.Equal(t, "203.0.113.0", maskClientAddr("203.0.113.42", anon))
+}
+
+func TestNewHandlerAnonymizationValidation(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		anon      *otypes.AccessLogAnonymization
+		expectErr bool
+	}{
+		{
+			desc: "valid subnets",
+			anon: &otypes.AccessLogAnonymization{IPv4Subnet: 24, IPv6Subnet: 80},
+		},
+		{
+			desc:      "IPv4 subnet too large",
+			anon:      &otypes.AccessLogAnonymization{IPv4Subnet: 33},
+			expectErr: true,
+		},
+		{
+			desc:      "IPv6 subnet too large",
+			anon:      &otypes.AccessLogAnonymization{IPv6Subnet: 129},
+			expectErr: true,
+		},
+		{
+			desc:      "negative subnet",
+			anon:      &otypes.AccessLogAnonymization{IPv4Subnet: -1},
+			expectErr: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			config := &otypes.AccessLog{Format: CommonFormat, Anonymization: test.anon}
+			handler, err := NewHandler(context.Background(), config)
+			if test.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NoError(t, handler.Close())
+		})
+	}
+}

--- a/pkg/middlewares/accesslog/logger.go
+++ b/pkg/middlewares/accesslog/logger.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/sirupsen/logrus"
 	ptypes "github.com/traefik/paerser/types"
+	"github.com/traefik/traefik/v3/pkg/ip"
 	"github.com/traefik/traefik/v3/pkg/middlewares/capture"
 	"github.com/traefik/traefik/v3/pkg/middlewares/observability"
 	"github.com/traefik/traefik/v3/pkg/observability/logs"
@@ -76,6 +77,15 @@ type Handler struct {
 
 // NewHandler creates a new Handler.
 func NewHandler(ctx context.Context, config *otypes.AccessLog) (*Handler, error) {
+	if a := config.Anonymization; a != nil {
+		if a.IPv4Subnet < 0 || a.IPv4Subnet > 32 {
+			return nil, fmt.Errorf("invalid access log anonymization IPv4 subnet %d: must be between 0 and 32", a.IPv4Subnet)
+		}
+		if a.IPv6Subnet < 0 || a.IPv6Subnet > 128 {
+			return nil, fmt.Errorf("invalid access log anonymization IPv6 subnet %d: must be between 0 and 128", a.IPv6Subnet)
+		}
+	}
+
 	var file io.WriteCloser = noopCloser{os.Stdout}
 	if len(config.FilePath) > 0 {
 		f, err := openAccessLogFile(config.FilePath)
@@ -261,6 +271,11 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request, next http
 
 	core[ClientAddr] = req.RemoteAddr
 	core[ClientHost], core[ClientPort] = silentSplitHostPort(req.RemoteAddr)
+
+	if a := h.config.Anonymization; a != nil {
+		core[ClientHost] = ip.MaskIP(core[ClientHost].(string), a.IPv4Subnet, a.IPv6Subnet)
+		core[ClientAddr] = maskClientAddr(core[ClientAddr].(string), a)
+	}
 
 	if forwardedFor := req.Header.Get("X-Forwarded-For"); forwardedFor != "" {
 		core[ClientHost] = forwardedFor
@@ -456,6 +471,16 @@ func openAccessLogFile(filePath string) (*os.File, error) {
 	}
 
 	return file, nil
+}
+
+// maskClientAddr truncates the host part of a host:port ClientAddr value, keeping the port.
+func maskClientAddr(value string, a *otypes.AccessLogAnonymization) string {
+	host, port := silentSplitHostPort(value)
+	masked := ip.MaskIP(host, a.IPv4Subnet, a.IPv6Subnet)
+	if port == "-" {
+		return masked
+	}
+	return net.JoinHostPort(masked, port)
 }
 
 func silentSplitHostPort(value string) (host, port string) {

--- a/pkg/observability/types/logs.go
+++ b/pkg/observability/types/logs.go
@@ -66,7 +66,15 @@ type AccessLog struct {
 	AddInternals  bool              `description:"Enables access log for internal services (ping, dashboard, etc...)." json:"addInternals,omitempty" toml:"addInternals,omitempty" yaml:"addInternals,omitempty" export:"true"`
 	DualOutput    bool              `description:"Enables access log output alongside OTLP. By default, this output is disabled when OTLP is configured." json:"dualOutput,omitempty" toml:"dualOutput,omitempty" yaml:"dualOutput,omitempty" export:"true"`
 
+	Anonymization *AccessLogAnonymization `description:"Access log client IP anonymization settings." json:"anonymization,omitempty" toml:"anonymization,omitempty" yaml:"anonymization,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
+
 	OTLP *OTelLog `description:"Settings for OpenTelemetry." json:"otlp,omitempty" toml:"otlp,omitempty" yaml:"otlp,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
+}
+
+// AccessLogAnonymization holds the client IP truncation settings for access logs.
+type AccessLogAnonymization struct {
+	IPv4Subnet int `description:"Truncate client IPv4 addresses to this prefix length (1-32); 0 disables truncation." json:"ipv4Subnet,omitempty" toml:"ipv4Subnet,omitempty" yaml:"ipv4Subnet,omitempty" export:"true"`
+	IPv6Subnet int `description:"Truncate client IPv6 addresses to this prefix length (1-128); 0 disables truncation." json:"ipv6Subnet,omitempty" toml:"ipv6Subnet,omitempty" yaml:"ipv6Subnet,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? 

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Under GDPR, an IP is PII, but a subnet is not. As such, operators may want to redact access logs in order to not be required to have short retention times. Add configuration and logic to drop a configurable number of bits from logged IPs. Document legally established /24 and /48 subnets.

### Motivation

<!-- What inspired you to submit this pull request? -->
I am one of those operators

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

I did not follow semantic linebreaks in the documentation updates, because the rest of the file doesn't use them either. If desired, I'll happily update that.

Implements #13517 