### PR TITLE
Disable Zstd support in the gzhttp wrapper

### DIFF
--- a/pkg/middlewares/compress/compress.go
+++ b/pkg/middlewares/compress/compress.go
@@ -190,11 +190,13 @@ func (c *compress) newGzipHandler() (http.Handler, error) {
 
 	if len(c.includes) > 0 {
 		wrapper, err = gzhttp.NewWrapper(
+			gzhttp.EnableZstd(false),
 			gzhttp.ContentTypes(c.includes),
 			gzhttp.MinSize(c.minSize),
 		)
 	} else {
 		wrapper, err = gzhttp.NewWrapper(
+			gzhttp.EnableZstd(false),
 			gzhttp.ExceptContentTypes(c.excludes),
 			gzhttp.MinSize(c.minSize),
 		)

--- a/pkg/middlewares/compress/compress_test.go
+++ b/pkg/middlewares/compress/compress_test.go
@@ -93,14 +93,9 @@ func TestNegotiation(t *testing.T) {
 			expEncoding:     gzipName,
 		},
 		{
-			// github.com/klauspost/compress v1.18.4 and up use zstd
-			// as preferred compression if all accept headers have
-			// an equal "q" (implicit "q=1.0").
-			//
-			// see https://github.com/klauspost/compress/pull/1121
 			desc:            "multi accept header list, prefer best",
 			acceptEncHeader: "gzip, br, zstd",
-			expEncoding:     zstdName,
+			expEncoding:     "gzip",
 		},
 	}
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request disables the zstd support added in https://github.com/klauspost/compress/pull/1121 by default in the gzhttp wrapper because we want to support only Gzip compression in this handler. This is a regression introduced by https://github.com/traefik/traefik/pull/12937

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [X] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
