### PR TITLE
Remove go-retryablehttp dependency from plugin downloader

### DIFF
--- a/cmd/traefik/plugins.go
+++ b/cmd/traefik/plugins.go
@@ -6,10 +6,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/hashicorp/go-retryablehttp"
-	"github.com/rs/zerolog/log"
 	"github.com/traefik/traefik/v3/pkg/config/static"
-	"github.com/traefik/traefik/v3/pkg/observability/logs"
 	"github.com/traefik/traefik/v3/pkg/plugins"
 )
 
@@ -34,15 +31,10 @@ func initPlugins(staticCfg *static.Configuration) (*plugins.Manager, map[string]
 	plgs := map[string]plugins.Descriptor{}
 
 	if hasPlugins(staticCfg) {
-		httpClient := retryablehttp.NewClient()
-		httpClient.Logger = logs.NewRetryableHTTPLogger(log.Logger)
-		httpClient.HTTPClient = &http.Client{Timeout: 10 * time.Second}
-		httpClient.RetryMax = 3
-
 		// Create separate downloader for HTTP operations
 		archivesPath := filepath.Join(outputDir, "archives")
 		downloader, err := plugins.NewRegistryDownloader(plugins.RegistryDownloaderOptions{
-			HTTPClient:   httpClient.HTTPClient,
+			HTTPClient:   &http.Client{Timeout: 10 * time.Second},
 			ArchivesPath: archivesPath,
 		})
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/hashicorp/consul/api v1.26.1
 	github.com/hashicorp/go-hclog v1.6.3
-	github.com/hashicorp/go-retryablehttp v0.7.8
+	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hashicorp/go-version v1.9.0
 	github.com/hashicorp/nomad/api v0.0.0-20231213195942-64e3dca9274b // No tag on the repo.
 	github.com/http-wasm/http-wasm-host-go v0.7.0


### PR DESCRIPTION
### What does this PR do?

Replace the `go-retryablehttp` HTTP client with a standard `http.Client` in the plugin downloader initialization, and remove the direct dependency on `github.com/hashicorp/go-retryablehttp`.

### Motivation

The `initPlugins` function previously used a `retryablehttp.Client` with custom logger and retry settings for downloading plugin archives. This added an unnecessary direct dependency for a straightforward HTTP GET operation. A standard `http.Client` with a reasonable timeout is sufficient and keeps the dependency graph leaner.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

The `go-retryablehttp` dependency remains in `go.mod` as an indirect dependency (still required by other packages in the dependency tree), so no `go mod tidy` changes are needed.
