### PR TITLE
Defer the CONNECT payload until the backend accepts the tunnel

### DIFF
--- a/pkg/middlewares/auth/forward.go
+++ b/pkg/middlewares/auth/forward.go
@@ -172,6 +172,10 @@ func (fa *forwardAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	if forwardReqMethod == http.MethodConnect {
+		forwardReq.Close = true
+	}
+
 	if fa.forwardBody {
 		bodyBytes, err := fa.readBodyBytes(req)
 		if errors.Is(err, errBodyTooLarge) {
@@ -192,7 +196,10 @@ func (fa *forwardAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		// bodyBytes is nil when the request has no body.
 		if bodyBytes != nil {
 			req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
-			forwardReq.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
+			if forwardReqMethod != http.MethodConnect {
+				forwardReq.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+			}
 		}
 	}
 

--- a/pkg/middlewares/auth/forward_test.go
+++ b/pkg/middlewares/auth/forward_test.go
@@ -264,6 +264,101 @@ func TestForwardAuthNotForwardBody(t *testing.T) {
 	assert.Equal(t, 1, nextCallCount)
 }
 
+func TestForwardAuthConnectBodyNotForwarded(t *testing.T) {
+	// smuggled is a complete HTTP/1 request an attacker hides in the CONNECT body, hoping the auth server reads it as a
+	// pipelined request once the unframed body desynchronizes the shared keep-alive pool.
+	smuggled := []byte("GET /whoami?tag=SMUGGLED HTTP/1.1\r\nHost: victim\r\n\r\n")
+
+	testCases := []struct {
+		desc                string
+		method              string
+		expectBodyForwarded bool
+	}{
+		{
+			desc:                "CONNECT body is dropped and never reaches the auth server",
+			method:              http.MethodConnect,
+			expectBodyForwarded: false,
+		},
+		{
+			desc:                "POST body is still forwarded to the auth server",
+			method:              http.MethodPost,
+			expectBodyForwarded: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			// A raw listener captures the exact bytes Traefik writes to the auth server, so the assertion can tell
+			// whether an unframed CONNECT body reaches the wire at all.
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = listener.Close() })
+
+			rawCh := make(chan []byte, 1)
+			go func() {
+				conn, err := listener.Accept()
+				if err != nil {
+					rawCh <- nil
+					return
+				}
+				defer conn.Close()
+
+				// The client sends the whole request before reading the response, so a short read deadline captures any
+				// trailing unframed body while keeping the test deterministic.
+				_ = conn.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
+				raw, _ := io.ReadAll(conn)
+
+				_, _ = conn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"))
+				rawCh <- raw
+			}()
+
+			var nextCalled bool
+			var nextBody []byte
+			next := http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+				nextCalled = true
+				nextBody, _ = io.ReadAll(req.Body)
+			})
+
+			maxBodySize := int64(len(smuggled))
+			auth := dynamic.ForwardAuth{
+				Address:               "http://" + listener.Addr().String(),
+				ForwardBody:           true,
+				PreserveRequestMethod: true,
+				MaxBodySize:           &maxBodySize,
+			}
+
+			middleware, err := NewForward(t.Context(), next, auth, "authTest")
+			require.NoError(t, err)
+
+			req, err := http.NewRequestWithContext(t.Context(), test.method, "http://example.com/whoami", bytes.NewReader(smuggled))
+			require.NoError(t, err)
+			req.RemoteAddr = "10.0.0.1:1234"
+
+			middleware.ServeHTTP(httptest.NewRecorder(), req)
+
+			raw := <-rawCh
+			require.NotNil(t, raw)
+
+			got := string(raw)
+			assert.True(t, bytes.HasPrefix(raw, []byte(test.method+" ")))
+
+			if test.expectBodyForwarded {
+				assert.Contains(t, got, "SMUGGLED")
+			} else {
+				assert.NotContains(t, got, "SMUGGLED")
+				// Defense-in-depth: the CONNECT auth connection is closed instead of returned to the pool.
+				assert.Contains(t, got, "Connection: close")
+			}
+
+			// The buffered body is preserved on the request for the downstream handler regardless of the method.
+			assert.True(t, nextCalled)
+			assert.Equal(t, smuggled, nextBody)
+		})
+	}
+}
+
 func TestForwardAuthRedirect(t *testing.T) {
 	authTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "http://example.com/redirect-test", http.StatusFound)

--- a/pkg/proxy/httputil/connect.go
+++ b/pkg/proxy/httputil/connect.go
@@ -1,0 +1,64 @@
+package httputil
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httputil"
+)
+
+// connectTunnelKey is the context key carrying the deferred payload of an in-flight CONNECT request.
+type connectTunnelKey struct{}
+
+// connectTunnel holds the payload of a CONNECT request until the backend has accepted the tunnel.
+type connectTunnel struct {
+	in      *io.PipeWriter
+	payload io.Reader
+}
+
+// deferConnectPayload detaches the body of an outgoing CONNECT request so it only reaches the backend
+// once the tunnel is established.
+// net/http writes a CONNECT body unframed onto the backend connection, so forwarding it before the tunnel is
+// accepted would let a client smuggle a pipelined request into the backend's HTTP/1 parser.
+func deferConnectPayload(pr *httputil.ProxyRequest) {
+	if pr.Out.Body == nil {
+		return
+	}
+
+	pipeReader, pipeWriter := io.Pipe()
+	tunnel := &connectTunnel{in: pipeWriter, payload: pr.Out.Body}
+
+	// The Transport blocks on the empty pipe, so only the header section reaches the backend until
+	// openConnectTunnel releases the payload.
+	pr.Out.Body = pipeReader
+	pr.Out.ContentLength = -1
+	pr.Out = pr.Out.WithContext(context.WithValue(pr.Out.Context(), connectTunnelKey{}, tunnel))
+}
+
+// openConnectTunnel releases the deferred payload of a CONNECT request once the backend has accepted the tunnel.
+// RFC 9110 §9.3.6 states that any 2xx response makes the sender switch to tunnel mode immediately after the response
+// header section, which is the point where the payload legitimately becomes tunnel data.
+func openConnectTunnel(res *http.Response) error {
+	tunnel, ok := res.Request.Context().Value(connectTunnelKey{}).(*connectTunnel)
+	if !ok {
+		return nil
+	}
+
+	if res.StatusCode/100 != 2 {
+		// The tunnel was refused, so the payload never becomes tunnel data and must not reach the backend.
+		if err := tunnel.in.Close(); err != nil {
+			return fmt.Errorf("closing refused CONNECT tunnel: %w", err)
+		}
+
+		return nil
+	}
+
+	go func() {
+		_, err := io.Copy(tunnel.in, tunnel.payload)
+		// CloseWithError propagates the failure to the Transport reading the outgoing body.
+		_ = tunnel.in.CloseWithError(err)
+	}()
+
+	return nil
+}

--- a/pkg/proxy/httputil/connect_test.go
+++ b/pkg/proxy/httputil/connect_test.go
@@ -1,0 +1,191 @@
+package httputil
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// smuggled is a complete pipelined HTTP/1 request an attacker hides in a CONNECT body,
+// hoping a refusing backend parses it as a second request.
+const smuggled = "GET /smuggled HTTP/1.1\r\nHost: victim\r\n\r\n"
+
+// http2Transport returns a Transport speaking prior-knowledge HTTP/2 over plain TCP.
+func http2Transport() *http.Transport {
+	protocols := new(http.Protocols)
+	protocols.SetUnencryptedHTTP2(true)
+
+	return &http.Transport{Protocols: protocols}
+}
+
+// connectBackend is an HTTP/1 backend that either accepts CONNECT tunnels and echoes them back,
+// or refuses them. It records every payload byte received after the CONNECT header section.
+type connectBackend struct {
+	url     *url.URL
+	payload *atomic.Pointer[string]
+}
+
+func newConnectBackend(t *testing.T, accept bool) *connectBackend {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	backend := &connectBackend{payload: &atomic.Pointer[string]{}}
+	empty := ""
+	backend.payload.Store(&empty)
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+
+			go func() {
+				defer conn.Close()
+
+				br := bufio.NewReader(conn)
+				// Consume the CONNECT header section.
+				for {
+					line, err := br.ReadString('\n')
+					if err != nil {
+						return
+					}
+					if strings.TrimSpace(line) == "" {
+						break
+					}
+				}
+
+				if !accept {
+					_, _ = io.WriteString(conn, "HTTP/1.1 405 Method Not Allowed\r\nContent-Length: 0\r\n\r\n")
+					// Record anything the proxy pushed despite the refusal.
+					var payload strings.Builder
+					buf := make([]byte, 1)
+					for {
+						_ = conn.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
+						n, err := br.Read(buf)
+						if n > 0 {
+							payload.Write(buf[:n])
+						}
+						if err != nil {
+							break
+						}
+					}
+					got := payload.String()
+					backend.payload.Store(&got)
+
+					return
+				}
+
+				_, _ = io.WriteString(conn, "HTTP/1.1 200 Connection Established\r\n\r\n")
+
+				// Blind relay: echo every line back uppercased.
+				var payload strings.Builder
+				for {
+					_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+					line, err := br.ReadString('\n')
+					if len(line) > 0 {
+						payload.WriteString(line)
+						got := payload.String()
+						backend.payload.Store(&got)
+						_, _ = io.WriteString(conn, strings.ToUpper(line))
+					}
+					if err != nil {
+						return
+					}
+				}
+			}()
+		}
+	}()
+
+	backend.url, err = url.Parse("http://" + listener.Addr().String())
+	require.NoError(t, err)
+
+	return backend
+}
+
+func (b *connectBackend) received() string {
+	return *b.payload.Load()
+}
+
+// serveProxy exposes the Traefik proxy handler over a plain TCP listener, with h2c enabled so that
+// both HTTP/1 and prior-knowledge HTTP/2 clients can reach it.
+func serveProxy(t *testing.T, target *url.URL) string {
+	t.Helper()
+
+	handler := buildSingleHostProxy(target, true, false, 0, http.DefaultTransport, nil)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	protocols := new(http.Protocols)
+	protocols.SetHTTP1(true)
+	protocols.SetUnencryptedHTTP2(true)
+
+	srv := &http.Server{Handler: handler, Protocols: protocols}
+	go func() { _ = srv.Serve(listener) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	return listener.Addr().String()
+}
+
+func TestConnect_HTTP2_TunnelEstablished(t *testing.T) {
+	backend := newConnectBackend(t, true)
+	addr := serveProxy(t, backend.url)
+
+	transport := http2Transport()
+
+	pipeReader, pipeWriter := io.Pipe()
+	t.Cleanup(func() { _ = pipeWriter.Close() })
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodConnect, "http://"+addr, pipeReader)
+	require.NoError(t, err)
+	req.Host = "tunnel.example.com:443"
+
+	res, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = res.Body.Close() })
+
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	// Payload sent after the tunnel is established must reach the backend and echo back.
+	_, err = io.WriteString(pipeWriter, "ping\n")
+	require.NoError(t, err)
+
+	echo, err := bufio.NewReader(res.Body).ReadString('\n')
+	require.NoError(t, err)
+	assert.Equal(t, "PING", strings.TrimSpace(echo))
+}
+
+func TestConnect_HTTP2_RefusedTunnelDropsPayload(t *testing.T) {
+	backend := newConnectBackend(t, false)
+	addr := serveProxy(t, backend.url)
+
+	transport := http2Transport()
+
+	// The attacker pushes the smuggled request immediately, without waiting for the tunnel.
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodConnect, "http://"+addr, strings.NewReader(smuggled))
+	require.NoError(t, err)
+	req.Host = "tunnel.example.com:443"
+
+	res, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = res.Body.Close() })
+
+	assert.Equal(t, http.StatusMethodNotAllowed, res.StatusCode)
+
+	time.Sleep(500 * time.Millisecond)
+	assert.Empty(t, backend.received())
+}

--- a/pkg/proxy/httputil/proxy.go
+++ b/pkg/proxy/httputil/proxy.go
@@ -53,12 +53,13 @@ func ShouldNotAppendXFF(ctx context.Context) bool {
 
 func buildSingleHostProxy(target *url.URL, passHostHeader bool, preservePath bool, flushInterval time.Duration, roundTripper http.RoundTripper, bufferPool httputil.BufferPool) http.Handler {
 	return &httputil.ReverseProxy{
-		Rewrite:       rewriteRequestBuilder(target, passHostHeader, preservePath),
-		Transport:     roundTripper,
-		FlushInterval: flushInterval,
-		BufferPool:    bufferPool,
-		ErrorLog:      stdlog.New(logs.NoLevel(log.Logger, zerolog.DebugLevel), "", 0),
-		ErrorHandler:  ErrorHandler,
+		Rewrite:        rewriteRequestBuilder(target, passHostHeader, preservePath),
+		Transport:      roundTripper,
+		FlushInterval:  flushInterval,
+		BufferPool:     bufferPool,
+		ErrorLog:       stdlog.New(logs.NoLevel(log.Logger, zerolog.DebugLevel), "", 0),
+		ErrorHandler:   ErrorHandler,
+		ModifyResponse: openConnectTunnel,
 	}
 }
 
@@ -114,6 +115,10 @@ func rewriteRequestBuilder(target *url.URL, passHostHeader bool, preservePath bo
 
 		if isWebSocketUpgrade(pr.Out) {
 			cleanWebSocketHeaders(pr.Out)
+		}
+
+		if pr.Out.Method == http.MethodConnect {
+			deferConnectPayload(pr)
 		}
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR defers a proxied `CONNECT` request payload so it only reaches the backend once the tunnel is established (RFC 9110 §9.3.6). A refused CONNECT never forwards a single payload byte.

It also makes the ForwardAuth middleware never forward a `CONNECT` body to the auth server, and close the auth connection instead of returning it to the shared pool.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation