### PR TITLE
Defer the CONNECT payload until the backend accepts the tunnel

### DIFF
--- a/pkg/server/service/connect.go
+++ b/pkg/server/service/connect.go
@@ -40,7 +40,7 @@ func (h *connectHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	pipeReader, pipeWriter := io.Pipe()
-	tunnel := &connectTunnel{in: pipeWriter, payload: req.Body}
+	tunnel := &connectTunnel{in: pipeWriter, data: req.Body}
 
 	// The Transport blocks on the empty pipe, so only the header section reaches the backend until
 	// connectResponseWriter releases the payload once the backend accepts the tunnel.
@@ -49,27 +49,27 @@ func (h *connectHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	h.next.ServeHTTP(&connectResponseWriter{ResponseWriter: rw, req: req, tunnel: tunnel}, req)
 }
 
-// connectTunnel holds the payload of a CONNECT request until the backend has accepted the tunnel.
+// connectTunnel holds the data of a CONNECT request until the backend has accepted the tunnel.
 type connectTunnel struct {
-	in      *io.PipeWriter
-	payload io.Reader
+	in   *io.PipeWriter
+	data io.Reader
 }
 
-// release forwards the deferred payload to the backend once it has accepted the tunnel, or drops it otherwise.
+// release forwards the deferred request body to the backend once it has accepted the tunnel, or drops it otherwise.
 // RFC 9110 §9.3.6 states that any 2xx response makes the sender switch to tunnel mode immediately after the response
-// header section, which is the point where the payload legitimately becomes tunnel data.
+// header section, which is the point where the request body legitimately becomes tunnel data.
 func (t *connectTunnel) release(req *http.Request, statusCode int) {
-	// The tunnel was refused, so the payload never becomes tunnel data and must not reach the backend.
+	// The tunnel was refused, so the request body never becomes tunnel data and must not reach the backend.
 	if statusCode/100 != 2 {
 		_ = t.in.Close()
 		return
 	}
 
-	// Forward the payload to the backend in the background: for an established tunnel this copy runs
+	// Forward the tunnel data to the backend in the background: for an established tunnel this copy runs
 	// for the lifetime of the tunnel, so release must return to let the response direction be pumped.
 	copyDoneCh := make(chan struct{})
 	go func() {
-		_, err := io.Copy(t.in, t.payload)
+		_, err := io.Copy(t.in, t.data)
 		_ = t.in.CloseWithError(err)
 		close(copyDoneCh)
 	}()

--- a/pkg/server/service/connect.go
+++ b/pkg/server/service/connect.go
@@ -54,13 +54,14 @@ type connectTunnel struct {
 	data        io.Reader
 }
 
+// Close closes tunnel.
 func (t *connectTunnel) Close() {
 	_ = t.in.Close()
 }
 
 // Release forwards the deferred request body to the backend and copy the subsequent bytes to the tunnel.
-// RFC 9110 §9.3.6 states that any 2xx response makes the sender switch to tunnel mode immediately after the response
-// header section, which is the point where the request body legitimately becomes tunnel data.
+// As described in https://datatracker.ietf.org/doc/html/rfc9931#name-requirements-for-http-conne we must wait for a 2xx (Successful)
+// response before forwarding any tunnel data.
 func (t *connectTunnel) Release(req *http.Request) {
 	t.releaseOnce.Do(func() {
 		// Forward the tunnel data to the backend in the background: for an established tunnel this copy runs

--- a/pkg/server/service/connect.go
+++ b/pkg/server/service/connect.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"sync"
 )
 
 // connectHandler defers the payload of a CONNECT request until the backend has accepted the tunnel.
@@ -48,37 +49,38 @@ func (h *connectHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 // connectTunnel holds the data of a CONNECT request until the backend has accepted the tunnel.
 type connectTunnel struct {
-	in   *io.PipeWriter
-	data io.Reader
+	in          *io.PipeWriter
+	releaseOnce sync.Once
+	data        io.Reader
 }
 
-// release forwards the deferred request body to the backend once it has accepted the tunnel, or drops it otherwise.
+func (t *connectTunnel) Close() {
+	_ = t.in.Close()
+}
+
+// Release forwards the deferred request body to the backend and copy the subsequent bytes to the tunnel.
 // RFC 9110 §9.3.6 states that any 2xx response makes the sender switch to tunnel mode immediately after the response
 // header section, which is the point where the request body legitimately becomes tunnel data.
-func (t *connectTunnel) release(req *http.Request, statusCode int) {
-	// The tunnel was refused, so the request body never becomes tunnel data and must not reach the backend.
-	if statusCode/100 != 2 {
-		_ = t.in.Close()
-		return
-	}
+func (t *connectTunnel) Release(req *http.Request) {
+	t.releaseOnce.Do(func() {
+		// Forward the tunnel data to the backend in the background: for an established tunnel this copy runs
+		// for the lifetime of the tunnel, so release must return to let the response direction be pumped.
+		copyDoneCh := make(chan struct{})
+		go func() {
+			_, err := io.Copy(t.in, t.data)
+			_ = t.in.CloseWithError(err)
+			close(copyDoneCh)
+		}()
 
-	// Forward the tunnel data to the backend in the background: for an established tunnel this copy runs
-	// for the lifetime of the tunnel, so release must return to let the response direction be pumped.
-	copyDoneCh := make(chan struct{})
-	go func() {
-		_, err := io.Copy(t.in, t.data)
-		_ = t.in.CloseWithError(err)
-		close(copyDoneCh)
-	}()
-
-	// If the request is canceled, the payload must not reach the backend, so close the pipe to unblock the Transport.
-	go func() {
-		select {
-		case <-req.Context().Done():
-			_ = t.in.Close()
-		case <-copyDoneCh:
-		}
-	}()
+		// If the request is canceled, the payload must not reach the backend, so close the pipe to unblock the Transport.
+		go func() {
+			select {
+			case <-req.Context().Done():
+				_ = t.in.Close()
+			case <-copyDoneCh:
+			}
+		}()
+	})
 }
 
 // connectResponseWriter releases the deferred CONNECT payload as soon as the backend's response status is known,
@@ -86,16 +88,16 @@ func (t *connectTunnel) release(req *http.Request, statusCode int) {
 type connectResponseWriter struct {
 	http.ResponseWriter
 
-	req      *http.Request
-	tunnel   *connectTunnel
-	released bool
+	req    *http.Request
+	tunnel *connectTunnel
 }
 
 func (w *connectResponseWriter) WriteHeader(statusCode int) {
-	// Informational responses (1xx) are not the final response, so the tunnel decision must wait.
-	if statusCode >= 200 && !w.released {
-		w.released = true
-		w.tunnel.release(w.req, statusCode)
+	// The tunnel was refused, so the request body never becomes tunnel data and must not reach the backend.
+	if statusCode/100 != 2 {
+		w.tunnel.Close()
+	} else {
+		w.tunnel.Release(w.req)
 	}
 
 	w.ResponseWriter.WriteHeader(statusCode)

--- a/pkg/server/service/connect.go
+++ b/pkg/server/service/connect.go
@@ -24,10 +24,9 @@ func (h *connectHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// The CONNECT method is not supported in HTTP/1.1 so we are rejecting it.
-	// This avoids putting a half-open tunnel to the backend to the pool.
-	if req.Proto == "HTTP/1.1" {
-		rw.WriteHeader(http.StatusMethodNotAllowed)
+	// Tunneling is only supported for clients speaking HTTP/2 and above.
+	if req.ProtoMajor == 1 {
+		rw.WriteHeader(http.StatusNotImplemented)
 		return
 	}
 
@@ -114,4 +113,8 @@ func (w *connectResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	}
 
 	return nil, nil, fmt.Errorf("not a hijacker: %T", w.ResponseWriter)
+}
+
+func (w *connectResponseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
 }

--- a/pkg/server/service/connect.go
+++ b/pkg/server/service/connect.go
@@ -102,14 +102,12 @@ func (w *connectResponseWriter) WriteHeader(statusCode int) {
 	w.ResponseWriter.WriteHeader(statusCode)
 }
 
-// Flush forwards flushes so the reverse proxy can stream the tunnel in both directions.
 func (w *connectResponseWriter) Flush() {
 	if f, ok := w.ResponseWriter.(http.Flusher); ok {
 		f.Flush()
 	}
 }
 
-// Hijack forwards hijacking for the HTTP/1 tunnels the wrapped ResponseWriter supports.
 func (w *connectResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if hijacker, ok := w.ResponseWriter.(http.Hijacker); ok {
 		return hijacker.Hijack()

--- a/pkg/server/service/connect.go
+++ b/pkg/server/service/connect.go
@@ -1,14 +1,53 @@
 package service
 
 import (
-	"context"
+	"bufio"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 )
 
-// connectTunnelKey is the context key carrying the deferred payload of an in-flight CONNECT request.
-type connectTunnelKey struct{}
+// connectHandler defers the payload of a CONNECT request until the backend has accepted the tunnel.
+// net/http writes a CONNECT body unframed onto the backend connection, so forwarding it before the tunnel is
+// accepted would let a client smuggle a pipelined request into the backend's HTTP/1 parser.
+type connectHandler struct {
+	next http.Handler
+}
+
+// newConnectHandler wraps next with the CONNECT payload deferral behavior.
+func newConnectHandler(next http.Handler) http.Handler {
+	return &connectHandler{next: next}
+}
+
+func (h *connectHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodConnect {
+		h.next.ServeHTTP(rw, req)
+		return
+	}
+
+	// The CONNECT method is not supported in HTTP/1.1 so we are rejecting it.
+	// This avoids putting a half-open tunnel to the backend to the pool.
+	if req.Proto == "HTTP/1.1" {
+		rw.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Nothing to defer for a CONNECT without body.
+	if req.Body == nil {
+		h.next.ServeHTTP(rw, req)
+		return
+	}
+
+	pipeReader, pipeWriter := io.Pipe()
+	tunnel := &connectTunnel{in: pipeWriter, payload: req.Body}
+
+	// The Transport blocks on the empty pipe, so only the header section reaches the backend until
+	// connectResponseWriter releases the payload once the backend accepts the tunnel.
+	req.Body = pipeReader
+
+	h.next.ServeHTTP(&connectResponseWriter{ResponseWriter: rw, req: req, tunnel: tunnel}, req)
+}
 
 // connectTunnel holds the payload of a CONNECT request until the backend has accepted the tunnel.
 type connectTunnel struct {
@@ -16,48 +55,80 @@ type connectTunnel struct {
 	payload io.Reader
 }
 
-// deferConnectPayload detaches the body of an outgoing CONNECT request so it only reaches the backend
-// once the tunnel is established.
-// net/http writes a CONNECT body unframed onto the backend connection, so forwarding it before the tunnel is
-// accepted would let a client smuggle a pipelined request into the backend's HTTP/1 parser.
-func deferConnectPayload(outReq *http.Request) {
-	if outReq.Body == nil {
+// release forwards the deferred payload to the backend once it has accepted the tunnel, or drops it otherwise.
+// RFC 9110 §9.3.6 states that any 2xx response makes the sender switch to tunnel mode immediately after the response
+// header section, which is the point where the payload legitimately becomes tunnel data.
+func (t *connectTunnel) release(req *http.Request, statusCode int) {
+	// The tunnel was refused, so the payload never becomes tunnel data and must not reach the backend.
+	if statusCode/100 != 2 {
+		_ = t.in.Close()
 		return
 	}
 
-	pipeReader, pipeWriter := io.Pipe()
-	tunnel := &connectTunnel{in: pipeWriter, payload: outReq.Body}
-
-	// The Transport blocks on the empty pipe, so only the header section reaches the backend until
-	// openConnectTunnel releases the payload.
-	*outReq = *outReq.WithContext(context.WithValue(outReq.Context(), connectTunnelKey{}, tunnel))
-	outReq.Body = pipeReader
-	outReq.ContentLength = -1
-}
-
-// openConnectTunnel releases the deferred payload of a CONNECT request once the backend has accepted the tunnel.
-// RFC 9110 §9.3.6 states that any 2xx response makes the sender switch to tunnel mode immediately after the response
-// header section, which is the point where the payload legitimately becomes tunnel data.
-func openConnectTunnel(res *http.Response) error {
-	tunnel, ok := res.Request.Context().Value(connectTunnelKey{}).(*connectTunnel)
-	if !ok {
-		return nil
-	}
-
-	if res.StatusCode/100 != 2 {
-		// The tunnel was refused, so the payload never becomes tunnel data and must not reach the backend.
-		if err := tunnel.in.Close(); err != nil {
-			return fmt.Errorf("closing refused CONNECT tunnel: %w", err)
-		}
-
-		return nil
-	}
-
+	// Forward the payload to the backend in the background: for an established tunnel this copy runs
+	// for the lifetime of the tunnel, so release must return to let the response direction be pumped.
+	copyDoneCh := make(chan struct{})
 	go func() {
-		_, err := io.Copy(tunnel.in, tunnel.payload)
-		// CloseWithError propagates the failure to the Transport reading the outgoing body.
-		_ = tunnel.in.CloseWithError(err)
+		_, err := io.Copy(t.in, t.payload)
+		_ = t.in.CloseWithError(err)
+		close(copyDoneCh)
 	}()
 
-	return nil
+	// If the request is canceled, the payload must not reach the backend, so close the pipe to unblock the Transport.
+	go func() {
+		select {
+		case <-req.Context().Done():
+			_ = t.in.Close()
+		case <-copyDoneCh:
+		}
+	}()
+}
+
+// connectResponseWriter releases the deferred CONNECT payload as soon as the backend's response status is known,
+// then behaves as the wrapped ResponseWriter.
+type connectResponseWriter struct {
+	http.ResponseWriter
+
+	req         *http.Request
+	tunnel      *connectTunnel
+	headersSent bool
+	released    bool
+}
+
+func (w *connectResponseWriter) WriteHeader(statusCode int) {
+	// Informational responses (1xx) are not the final response, so the tunnel decision must wait.
+	if statusCode >= 200 && !w.released {
+		w.released = true
+		w.tunnel.release(w.req, statusCode)
+	}
+
+	w.headersSent = true
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+// As a CONNECT response should never send a body per the specification, this method should never be called.
+func (w *connectResponseWriter) Write(b []byte) (int, error) {
+	// This case happen when Write is called without calling WriteHeader first, so the default status code 200 is used.
+	if !w.headersSent && !w.released {
+		w.released = true
+		w.tunnel.release(w.req, http.StatusOK)
+	}
+
+	return w.ResponseWriter.Write(b)
+}
+
+// Flush forwards flushes so the reverse proxy can stream the tunnel in both directions.
+func (w *connectResponseWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Hijack forwards hijacking for the HTTP/1 tunnels the wrapped ResponseWriter supports.
+func (w *connectResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hijacker, ok := w.ResponseWriter.(http.Hijacker); ok {
+		return hijacker.Hijack()
+	}
+
+	return nil, nil, fmt.Errorf("not a hijacker: %T", w.ResponseWriter)
 }

--- a/pkg/server/service/connect.go
+++ b/pkg/server/service/connect.go
@@ -32,7 +32,7 @@ func (h *connectHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	// Nothing to defer for a CONNECT without body or with a fixed Content-Length.
-	if req.ContentLength > 0 || req.Body == nil {
+	if req.ContentLength >= 0 || req.Body == nil || req.Body == http.NoBody {
 		h.next.ServeHTTP(rw, req)
 		return
 	}

--- a/pkg/server/service/connect.go
+++ b/pkg/server/service/connect.go
@@ -30,8 +30,8 @@ func (h *connectHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// Nothing to defer for a CONNECT without body.
-	if req.Body == nil {
+	// Nothing to defer for a CONNECT without body or with a fixed Content-Length.
+	if req.ContentLength > 0 || req.Body == nil {
 		h.next.ServeHTTP(rw, req)
 		return
 	}

--- a/pkg/server/service/connect.go
+++ b/pkg/server/service/connect.go
@@ -89,10 +89,9 @@ func (t *connectTunnel) release(req *http.Request, statusCode int) {
 type connectResponseWriter struct {
 	http.ResponseWriter
 
-	req         *http.Request
-	tunnel      *connectTunnel
-	headersSent bool
-	released    bool
+	req      *http.Request
+	tunnel   *connectTunnel
+	released bool
 }
 
 func (w *connectResponseWriter) WriteHeader(statusCode int) {
@@ -102,19 +101,7 @@ func (w *connectResponseWriter) WriteHeader(statusCode int) {
 		w.tunnel.release(w.req, statusCode)
 	}
 
-	w.headersSent = true
 	w.ResponseWriter.WriteHeader(statusCode)
-}
-
-// As a CONNECT response should never send a body per the specification, this method should never be called.
-func (w *connectResponseWriter) Write(b []byte) (int, error) {
-	// This case happen when Write is called without calling WriteHeader first, so the default status code 200 is used.
-	if !w.headersSent && !w.released {
-		w.released = true
-		w.tunnel.release(w.req, http.StatusOK)
-	}
-
-	return w.ResponseWriter.Write(b)
 }
 
 // Flush forwards flushes so the reverse proxy can stream the tunnel in both directions.

--- a/pkg/server/service/connect.go
+++ b/pkg/server/service/connect.go
@@ -1,0 +1,63 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// connectTunnelKey is the context key carrying the deferred payload of an in-flight CONNECT request.
+type connectTunnelKey struct{}
+
+// connectTunnel holds the payload of a CONNECT request until the backend has accepted the tunnel.
+type connectTunnel struct {
+	in      *io.PipeWriter
+	payload io.Reader
+}
+
+// deferConnectPayload detaches the body of an outgoing CONNECT request so it only reaches the backend
+// once the tunnel is established.
+// net/http writes a CONNECT body unframed onto the backend connection, so forwarding it before the tunnel is
+// accepted would let a client smuggle a pipelined request into the backend's HTTP/1 parser.
+func deferConnectPayload(outReq *http.Request) {
+	if outReq.Body == nil {
+		return
+	}
+
+	pipeReader, pipeWriter := io.Pipe()
+	tunnel := &connectTunnel{in: pipeWriter, payload: outReq.Body}
+
+	// The Transport blocks on the empty pipe, so only the header section reaches the backend until
+	// openConnectTunnel releases the payload.
+	*outReq = *outReq.WithContext(context.WithValue(outReq.Context(), connectTunnelKey{}, tunnel))
+	outReq.Body = pipeReader
+	outReq.ContentLength = -1
+}
+
+// openConnectTunnel releases the deferred payload of a CONNECT request once the backend has accepted the tunnel.
+// RFC 9110 §9.3.6 states that any 2xx response makes the sender switch to tunnel mode immediately after the response
+// header section, which is the point where the payload legitimately becomes tunnel data.
+func openConnectTunnel(res *http.Response) error {
+	tunnel, ok := res.Request.Context().Value(connectTunnelKey{}).(*connectTunnel)
+	if !ok {
+		return nil
+	}
+
+	if res.StatusCode/100 != 2 {
+		// The tunnel was refused, so the payload never becomes tunnel data and must not reach the backend.
+		if err := tunnel.in.Close(); err != nil {
+			return fmt.Errorf("closing refused CONNECT tunnel: %w", err)
+		}
+
+		return nil
+	}
+
+	go func() {
+		_, err := io.Copy(tunnel.in, tunnel.payload)
+		// CloseWithError propagates the failure to the Transport reading the outgoing body.
+		_ = tunnel.in.CloseWithError(err)
+	}()
+
+	return nil
+}

--- a/pkg/server/service/connect.go
+++ b/pkg/server/service/connect.go
@@ -9,8 +9,6 @@ import (
 )
 
 // connectHandler defers the payload of a CONNECT request until the backend has accepted the tunnel.
-// net/http writes a CONNECT body unframed onto the backend connection, so forwarding it before the tunnel is
-// accepted would let a client smuggle a pipelined request into the backend's HTTP/1 parser.
 type connectHandler struct {
 	next http.Handler
 }

--- a/pkg/server/service/connect_test.go
+++ b/pkg/server/service/connect_test.go
@@ -3,7 +3,6 @@ package service
 import (
 	"bufio"
 	"io"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -28,7 +27,7 @@ func TestConnect_HTTP1_Rejected(t *testing.T) {
 
 	addr := serveProxy(t, backendURL)
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodConnect, "http://"+addr, nil)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodConnect, addr, nil)
 	require.NoError(t, err)
 
 	res, err := http.DefaultClient.Do(req)
@@ -46,7 +45,7 @@ func TestConnect_HTTP2_TunnelEstablished(t *testing.T) {
 	pipeReader, pipeWriter := io.Pipe()
 	t.Cleanup(func() { _ = pipeWriter.Close() })
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodConnect, "http://"+addr, pipeReader)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodConnect, addr, pipeReader)
 	require.NoError(t, err)
 
 	protocols := new(http.Protocols)
@@ -73,7 +72,7 @@ func TestConnect_HTTP2_RefusedTunnelWithContentLength(t *testing.T) {
 	backend := newConnectBackend(t, false)
 	addr := serveProxy(t, backend.url)
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodConnect, "http://"+addr, strings.NewReader("foo"))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodConnect, addr, strings.NewReader("foo"))
 	require.NoError(t, err)
 
 	protocols := new(http.Protocols)
@@ -93,7 +92,7 @@ func TestConnect_HTTP2_RefusedTunnelDropsPayloadWithoutContentLength(t *testing.
 	addr := serveProxy(t, backend.url)
 
 	// Wrapping the reader hides its length, so the request is sent without a Content-Length header.
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodConnect, "http://"+addr, io.NopCloser(strings.NewReader("foo")))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodConnect, addr, io.NopCloser(strings.NewReader("foo")))
 	require.NoError(t, err)
 
 	protocols := new(http.Protocols)
@@ -137,9 +136,7 @@ func newConnectBackend(t *testing.T, accept bool) *connectBackend {
 
 			// No declared body: hijack to make sure the proxy did not push anything on the raw connection.
 			conn, brw, err := rw.(http.Hijacker).Hijack()
-			if err != nil {
-				return
-			}
+			require.NoError(t, err)
 			defer conn.Close()
 
 			var payload strings.Builder
@@ -165,9 +162,7 @@ func newConnectBackend(t *testing.T, accept bool) *connectBackend {
 		// The tunnel is a raw byte stream, so hijack the connection to bypass the HTTP response machinery.
 		// The returned reader already holds any payload buffered alongside the CONNECT header section.
 		conn, brw, err := rw.(http.Hijacker).Hijack()
-		if err != nil {
-			return
-		}
+		require.NoError(t, err)
 		defer conn.Close()
 
 		_, _ = io.WriteString(conn, "HTTP/1.1 200 Connection Established\r\n\r\n")
@@ -197,8 +192,8 @@ func newConnectBackend(t *testing.T, accept bool) *connectBackend {
 	return backend
 }
 
-// serveProxy exposes the Traefik proxy handler over a plain TCP listener, with h2c enabled so that
-// both HTTP/1 and prior-knowledge HTTP/2 clients can reach it.
+// serveProxy exposes the Traefik proxy handler over a httptest server,
+// with h2c enabled so that both HTTP/1 and prior-knowledge HTTP/2 clients can reach it.
 func serveProxy(t *testing.T, target *url.URL) string {
 	t.Helper()
 
@@ -212,17 +207,14 @@ func serveProxy(t *testing.T, target *url.URL) string {
 		proxy.ServeHTTP(rw, req)
 	})
 
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = listener.Close() })
-
 	protocols := new(http.Protocols)
 	protocols.SetHTTP1(true)
 	protocols.SetUnencryptedHTTP2(true)
 
-	srv := &http.Server{Handler: handler, Protocols: protocols}
-	go func() { _ = srv.Serve(listener) }()
-	t.Cleanup(func() { _ = srv.Close() })
+	srv := httptest.NewUnstartedServer(handler)
+	srv.Config.Protocols = protocols
+	srv.Start()
+	t.Cleanup(srv.Close)
 
-	return listener.Addr().String()
+	return srv.URL
 }

--- a/pkg/server/service/connect_test.go
+++ b/pkg/server/service/connect_test.go
@@ -73,8 +73,7 @@ func TestConnect_HTTP2_RefusedTunnelDropsPayload(t *testing.T) {
 	backend := newConnectBackend(t, false)
 	addr := serveProxy(t, backend.url)
 
-	payload := strings.NewReader("GET /foo HTTP/1.1\r\nHost: foo\r\n\r\n")
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodConnect, "http://"+addr, payload)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodConnect, "http://"+addr, strings.NewReader("foo"))
 	require.NoError(t, err)
 
 	protocols := new(http.Protocols)

--- a/pkg/server/service/connect_test.go
+++ b/pkg/server/service/connect_test.go
@@ -1,0 +1,199 @@
+package service
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// smuggled is a complete pipelined HTTP/1 request an attacker hides in a CONNECT body,
+// hoping a refusing backend parses it as a second request.
+const smuggled = "GET /smuggled HTTP/1.1\r\nHost: victim\r\n\r\n"
+
+// http2Transport returns a Transport speaking prior-knowledge HTTP/2 over plain TCP.
+func http2Transport() *http.Transport {
+	protocols := new(http.Protocols)
+	protocols.SetUnencryptedHTTP2(true)
+
+	return &http.Transport{Protocols: protocols}
+}
+
+// connectBackend is an HTTP/1 backend that either accepts CONNECT tunnels and echoes them back,
+// or refuses them. It records every payload byte received after the CONNECT header section.
+type connectBackend struct {
+	url     *url.URL
+	payload *atomic.Pointer[string]
+}
+
+func newConnectBackend(t *testing.T, accept bool) *connectBackend {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	backend := &connectBackend{payload: &atomic.Pointer[string]{}}
+	empty := ""
+	backend.payload.Store(&empty)
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+
+			go func() {
+				defer conn.Close()
+
+				br := bufio.NewReader(conn)
+				// Consume the CONNECT header section.
+				for {
+					line, err := br.ReadString('\n')
+					if err != nil {
+						return
+					}
+					if strings.TrimSpace(line) == "" {
+						break
+					}
+				}
+
+				if !accept {
+					_, _ = io.WriteString(conn, "HTTP/1.1 405 Method Not Allowed\r\nContent-Length: 0\r\n\r\n")
+					// Record anything the proxy pushed despite the refusal.
+					var payload strings.Builder
+					buf := make([]byte, 1)
+					for {
+						_ = conn.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
+						n, err := br.Read(buf)
+						if n > 0 {
+							payload.Write(buf[:n])
+						}
+						if err != nil {
+							break
+						}
+					}
+					got := payload.String()
+					backend.payload.Store(&got)
+
+					return
+				}
+
+				_, _ = io.WriteString(conn, "HTTP/1.1 200 Connection Established\r\n\r\n")
+
+				// Blind relay: echo every line back uppercased.
+				var payload strings.Builder
+				for {
+					_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+					line, err := br.ReadString('\n')
+					if len(line) > 0 {
+						payload.WriteString(line)
+						got := payload.String()
+						backend.payload.Store(&got)
+						_, _ = io.WriteString(conn, strings.ToUpper(line))
+					}
+					if err != nil {
+						return
+					}
+				}
+			}()
+		}
+	}()
+
+	backend.url, err = url.Parse("http://" + listener.Addr().String())
+	require.NoError(t, err)
+
+	return backend
+}
+
+func (b *connectBackend) received() string {
+	return *b.payload.Load()
+}
+
+// serveProxy exposes the Traefik proxy handler over a plain TCP listener, with h2c enabled so that
+// both HTTP/1 and prior-knowledge HTTP/2 clients can reach it.
+func serveProxy(t *testing.T, target *url.URL) string {
+	t.Helper()
+
+	proxy, err := buildProxy(new(true), nil, http.DefaultTransport, newBufferPool())
+	require.NoError(t, err)
+
+	// The load balancer sets the backend server on the request URL before the proxy runs.
+	handler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		req.URL.Scheme = target.Scheme
+		req.URL.Host = target.Host
+		proxy.ServeHTTP(rw, req)
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	protocols := new(http.Protocols)
+	protocols.SetHTTP1(true)
+	protocols.SetUnencryptedHTTP2(true)
+
+	srv := &http.Server{Handler: handler, Protocols: protocols}
+	go func() { _ = srv.Serve(listener) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	return listener.Addr().String()
+}
+
+func TestConnect_HTTP2_TunnelEstablished(t *testing.T) {
+	backend := newConnectBackend(t, true)
+	addr := serveProxy(t, backend.url)
+
+	transport := http2Transport()
+
+	pipeReader, pipeWriter := io.Pipe()
+	t.Cleanup(func() { _ = pipeWriter.Close() })
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodConnect, "http://"+addr, pipeReader)
+	require.NoError(t, err)
+	req.Host = "tunnel.example.com:443"
+
+	res, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = res.Body.Close() })
+
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	// Payload sent after the tunnel is established must reach the backend and echo back.
+	_, err = io.WriteString(pipeWriter, "ping\n")
+	require.NoError(t, err)
+
+	echo, err := bufio.NewReader(res.Body).ReadString('\n')
+	require.NoError(t, err)
+	assert.Equal(t, "PING", strings.TrimSpace(echo))
+}
+
+func TestConnect_HTTP2_RefusedTunnelDropsPayload(t *testing.T) {
+	backend := newConnectBackend(t, false)
+	addr := serveProxy(t, backend.url)
+
+	transport := http2Transport()
+
+	// The attacker pushes the smuggled request immediately, without waiting for the tunnel.
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodConnect, "http://"+addr, strings.NewReader(smuggled))
+	require.NoError(t, err)
+	req.Host = "tunnel.example.com:443"
+
+	res, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = res.Body.Close() })
+
+	assert.Equal(t, http.StatusMethodNotAllowed, res.StatusCode)
+
+	time.Sleep(500 * time.Millisecond)
+	assert.Empty(t, backend.received())
+}

--- a/pkg/server/service/connect_test.go
+++ b/pkg/server/service/connect_test.go
@@ -35,7 +35,7 @@ func TestConnect_HTTP1_Rejected(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = res.Body.Close() })
 
-	assert.Equal(t, http.StatusMethodNotAllowed, res.StatusCode)
+	assert.Equal(t, http.StatusNotImplemented, res.StatusCode)
 	assert.False(t, backendCalled)
 }
 

--- a/pkg/server/service/connect_test.go
+++ b/pkg/server/service/connect_test.go
@@ -170,7 +170,6 @@ func newConnectBackend(t *testing.T, accept bool) *connectBackend {
 		// Blind relay: echo every line back uppercased.
 		var payload strings.Builder
 		for {
-			_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
 			line, err := brw.ReadString('\n')
 			if len(line) > 0 {
 				payload.WriteString(line)

--- a/pkg/server/service/connect_test.go
+++ b/pkg/server/service/connect_test.go
@@ -15,22 +15,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// smuggled is a complete pipelined HTTP/1 request an attacker hides in a CONNECT body,
-// hoping a refusing backend parses it as a second request.
-const smuggled = "GET /smuggled HTTP/1.1\r\nHost: victim\r\n\r\n"
-
 func TestConnect_HTTP2_TunnelEstablished(t *testing.T) {
 	backend := newConnectBackend(t, true)
 	addr := serveProxy(t, backend.url)
-
-	transport := http2Transport()
 
 	pipeReader, pipeWriter := io.Pipe()
 	t.Cleanup(func() { _ = pipeWriter.Close() })
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodConnect, "http://"+addr, pipeReader)
 	require.NoError(t, err)
-	req.Host = "tunnel.example.com:443"
+
+	protocols := new(http.Protocols)
+	protocols.SetUnencryptedHTTP2(true)
+	transport := http.Transport{Protocols: protocols}
 
 	res, err := transport.RoundTrip(req)
 	require.NoError(t, err)
@@ -44,6 +41,7 @@ func TestConnect_HTTP2_TunnelEstablished(t *testing.T) {
 
 	echo, err := bufio.NewReader(res.Body).ReadString('\n')
 	require.NoError(t, err)
+
 	assert.Equal(t, "PING", strings.TrimSpace(echo))
 }
 
@@ -51,12 +49,13 @@ func TestConnect_HTTP2_RefusedTunnelDropsPayload(t *testing.T) {
 	backend := newConnectBackend(t, false)
 	addr := serveProxy(t, backend.url)
 
-	transport := http2Transport()
-
-	// The attacker pushes the smuggled request immediately, without waiting for the tunnel.
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodConnect, "http://"+addr, strings.NewReader(smuggled))
+	payload := strings.NewReader("GET /foo HTTP/1.1\r\nHost: foo\r\n\r\n")
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodConnect, "http://"+addr, payload)
 	require.NoError(t, err)
-	req.Host = "tunnel.example.com:443"
+
+	protocols := new(http.Protocols)
+	protocols.SetUnencryptedHTTP2(true)
+	transport := http.Transport{Protocols: protocols}
 
 	res, err := transport.RoundTrip(req)
 	require.NoError(t, err)
@@ -65,15 +64,7 @@ func TestConnect_HTTP2_RefusedTunnelDropsPayload(t *testing.T) {
 	assert.Equal(t, http.StatusMethodNotAllowed, res.StatusCode)
 
 	time.Sleep(500 * time.Millisecond)
-	assert.Empty(t, backend.received())
-}
-
-// http2Transport returns a Transport speaking prior-knowledge HTTP/2 over plain TCP.
-func http2Transport() *http.Transport {
-	protocols := new(http.Protocols)
-	protocols.SetUnencryptedHTTP2(true)
-
-	return &http.Transport{Protocols: protocols}
+	assert.Empty(t, *backend.payload.Load())
 }
 
 // connectBackend is an HTTP/1 backend that either accepts CONNECT tunnels and echoes them back,
@@ -162,10 +153,6 @@ func newConnectBackend(t *testing.T, accept bool) *connectBackend {
 	require.NoError(t, err)
 
 	return backend
-}
-
-func (b *connectBackend) received() string {
-	return *b.payload.Load()
 }
 
 // serveProxy exposes the Traefik proxy handler over a plain TCP listener, with h2c enabled so that

--- a/pkg/server/service/connect_test.go
+++ b/pkg/server/service/connect_test.go
@@ -69,7 +69,7 @@ func TestConnect_HTTP2_TunnelEstablished(t *testing.T) {
 	assert.Equal(t, "PING", strings.TrimSpace(echo))
 }
 
-func TestConnect_HTTP2_RefusedTunnelDropsPayload(t *testing.T) {
+func TestConnect_HTTP2_RefusedTunnelWithContentLength(t *testing.T) {
 	backend := newConnectBackend(t, false)
 	addr := serveProxy(t, backend.url)
 
@@ -85,8 +85,26 @@ func TestConnect_HTTP2_RefusedTunnelDropsPayload(t *testing.T) {
 	t.Cleanup(func() { _ = res.Body.Close() })
 
 	assert.Equal(t, http.StatusMethodNotAllowed, res.StatusCode)
+	assert.Equal(t, "foo", *backend.payload.Load())
+}
 
-	time.Sleep(500 * time.Millisecond)
+func TestConnect_HTTP2_RefusedTunnelDropsPayloadWithoutContentLength(t *testing.T) {
+	backend := newConnectBackend(t, false)
+	addr := serveProxy(t, backend.url)
+
+	// Wrapping the reader hides its length, so the request is sent without a Content-Length header.
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodConnect, "http://"+addr, io.NopCloser(strings.NewReader("foo")))
+	require.NoError(t, err)
+
+	protocols := new(http.Protocols)
+	protocols.SetUnencryptedHTTP2(true)
+	transport := http.Transport{Protocols: protocols}
+
+	res, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = res.Body.Close() })
+
+	assert.Equal(t, http.StatusMethodNotAllowed, res.StatusCode)
 	assert.Empty(t, *backend.payload.Load())
 }
 
@@ -100,80 +118,81 @@ type connectBackend struct {
 func newConnectBackend(t *testing.T, accept bool) *connectBackend {
 	t.Helper()
 
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = listener.Close() })
-
 	backend := &connectBackend{payload: &atomic.Pointer[string]{}}
 	empty := ""
 	backend.payload.Store(&empty)
 
-	go func() {
-		for {
-			conn, err := listener.Accept()
-			if err != nil {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if !accept {
+			if req.ContentLength > 0 {
+				// A declared body means the proxy forwarded payload; read it to capture what leaked.
+				body, _ := io.ReadAll(req.Body)
+				got := string(body)
+				backend.payload.Store(&got)
+
+				rw.WriteHeader(http.StatusMethodNotAllowed)
+
 				return
 			}
 
-			go func() {
-				defer conn.Close()
+			// No declared body: hijack to make sure the proxy did not push anything on the raw connection.
+			conn, brw, err := rw.(http.Hijacker).Hijack()
+			if err != nil {
+				return
+			}
+			defer conn.Close()
 
-				br := bufio.NewReader(conn)
-				// Consume the CONNECT header section.
-				for {
-					line, err := br.ReadString('\n')
-					if err != nil {
-						return
-					}
-					if strings.TrimSpace(line) == "" {
-						break
-					}
+			var payload strings.Builder
+			buf := make([]byte, 1)
+			for {
+				_ = conn.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
+				n, err := brw.Read(buf)
+				if n > 0 {
+					payload.Write(buf[:n])
 				}
-
-				if !accept {
-					_, _ = io.WriteString(conn, "HTTP/1.1 405 Method Not Allowed\r\nContent-Length: 0\r\n\r\n")
-					// Record anything the proxy pushed despite the refusal.
-					var payload strings.Builder
-					buf := make([]byte, 1)
-					for {
-						_ = conn.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
-						n, err := br.Read(buf)
-						if n > 0 {
-							payload.Write(buf[:n])
-						}
-						if err != nil {
-							break
-						}
-					}
-					got := payload.String()
-					backend.payload.Store(&got)
-
-					return
+				if err != nil {
+					break
 				}
+			}
+			got := payload.String()
+			backend.payload.Store(&got)
 
-				_, _ = io.WriteString(conn, "HTTP/1.1 200 Connection Established\r\n\r\n")
+			_, _ = io.WriteString(conn, "HTTP/1.1 405 Method Not Allowed\r\nContent-Length: 0\r\n\r\n")
 
-				// Blind relay: echo every line back uppercased.
-				var payload strings.Builder
-				for {
-					_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
-					line, err := br.ReadString('\n')
-					if len(line) > 0 {
-						payload.WriteString(line)
-						got := payload.String()
-						backend.payload.Store(&got)
-						_, _ = io.WriteString(conn, strings.ToUpper(line))
-					}
-					if err != nil {
-						return
-					}
-				}
-			}()
+			return
 		}
-	}()
 
-	backend.url, err = url.Parse("http://" + listener.Addr().String())
+		// The tunnel is a raw byte stream, so hijack the connection to bypass the HTTP response machinery.
+		// The returned reader already holds any payload buffered alongside the CONNECT header section.
+		conn, brw, err := rw.(http.Hijacker).Hijack()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		_, _ = io.WriteString(conn, "HTTP/1.1 200 Connection Established\r\n\r\n")
+
+		// Blind relay: echo every line back uppercased.
+		var payload strings.Builder
+		for {
+			_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+			line, err := brw.ReadString('\n')
+			if len(line) > 0 {
+				payload.WriteString(line)
+				got := payload.String()
+				backend.payload.Store(&got)
+				_, _ = io.WriteString(conn, strings.ToUpper(line))
+			}
+			if err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	backendURL, err := url.Parse(server.URL)
 	require.NoError(t, err)
+	backend.url = backendURL
 
 	return backend
 }

--- a/pkg/server/service/connect_test.go
+++ b/pkg/server/service/connect_test.go
@@ -19,6 +19,55 @@ import (
 // hoping a refusing backend parses it as a second request.
 const smuggled = "GET /smuggled HTTP/1.1\r\nHost: victim\r\n\r\n"
 
+func TestConnect_HTTP2_TunnelEstablished(t *testing.T) {
+	backend := newConnectBackend(t, true)
+	addr := serveProxy(t, backend.url)
+
+	transport := http2Transport()
+
+	pipeReader, pipeWriter := io.Pipe()
+	t.Cleanup(func() { _ = pipeWriter.Close() })
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodConnect, "http://"+addr, pipeReader)
+	require.NoError(t, err)
+	req.Host = "tunnel.example.com:443"
+
+	res, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = res.Body.Close() })
+
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	// Payload sent after the tunnel is established must reach the backend and echo back.
+	_, err = io.WriteString(pipeWriter, "ping\n")
+	require.NoError(t, err)
+
+	echo, err := bufio.NewReader(res.Body).ReadString('\n')
+	require.NoError(t, err)
+	assert.Equal(t, "PING", strings.TrimSpace(echo))
+}
+
+func TestConnect_HTTP2_RefusedTunnelDropsPayload(t *testing.T) {
+	backend := newConnectBackend(t, false)
+	addr := serveProxy(t, backend.url)
+
+	transport := http2Transport()
+
+	// The attacker pushes the smuggled request immediately, without waiting for the tunnel.
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodConnect, "http://"+addr, strings.NewReader(smuggled))
+	require.NoError(t, err)
+	req.Host = "tunnel.example.com:443"
+
+	res, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = res.Body.Close() })
+
+	assert.Equal(t, http.StatusMethodNotAllowed, res.StatusCode)
+
+	time.Sleep(500 * time.Millisecond)
+	assert.Empty(t, backend.received())
+}
+
 // http2Transport returns a Transport speaking prior-knowledge HTTP/2 over plain TCP.
 func http2Transport() *http.Transport {
 	protocols := new(http.Protocols)
@@ -147,53 +196,4 @@ func serveProxy(t *testing.T, target *url.URL) string {
 	t.Cleanup(func() { _ = srv.Close() })
 
 	return listener.Addr().String()
-}
-
-func TestConnect_HTTP2_TunnelEstablished(t *testing.T) {
-	backend := newConnectBackend(t, true)
-	addr := serveProxy(t, backend.url)
-
-	transport := http2Transport()
-
-	pipeReader, pipeWriter := io.Pipe()
-	t.Cleanup(func() { _ = pipeWriter.Close() })
-
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodConnect, "http://"+addr, pipeReader)
-	require.NoError(t, err)
-	req.Host = "tunnel.example.com:443"
-
-	res, err := transport.RoundTrip(req)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = res.Body.Close() })
-
-	require.Equal(t, http.StatusOK, res.StatusCode)
-
-	// Payload sent after the tunnel is established must reach the backend and echo back.
-	_, err = io.WriteString(pipeWriter, "ping\n")
-	require.NoError(t, err)
-
-	echo, err := bufio.NewReader(res.Body).ReadString('\n')
-	require.NoError(t, err)
-	assert.Equal(t, "PING", strings.TrimSpace(echo))
-}
-
-func TestConnect_HTTP2_RefusedTunnelDropsPayload(t *testing.T) {
-	backend := newConnectBackend(t, false)
-	addr := serveProxy(t, backend.url)
-
-	transport := http2Transport()
-
-	// The attacker pushes the smuggled request immediately, without waiting for the tunnel.
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodConnect, "http://"+addr, strings.NewReader(smuggled))
-	require.NoError(t, err)
-	req.Host = "tunnel.example.com:443"
-
-	res, err := transport.RoundTrip(req)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = res.Body.Close() })
-
-	assert.Equal(t, http.StatusMethodNotAllowed, res.StatusCode)
-
-	time.Sleep(500 * time.Millisecond)
-	assert.Empty(t, backend.received())
 }

--- a/pkg/server/service/connect_test.go
+++ b/pkg/server/service/connect_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"sync/atomic"
@@ -14,6 +15,29 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestConnect_HTTP1_Rejected(t *testing.T) {
+	var backendCalled bool
+	backend := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		backendCalled = true
+	}))
+	t.Cleanup(backend.Close)
+
+	backendURL, err := url.Parse(backend.URL)
+	require.NoError(t, err)
+
+	addr := serveProxy(t, backendURL)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodConnect, "http://"+addr, nil)
+	require.NoError(t, err)
+
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = res.Body.Close() })
+
+	assert.Equal(t, http.StatusMethodNotAllowed, res.StatusCode)
+	assert.False(t, backendCalled)
+}
 
 func TestConnect_HTTP2_TunnelEstablished(t *testing.T) {
 	backend := newConnectBackend(t, true)

--- a/pkg/server/service/proxy.go
+++ b/pkg/server/service/proxy.go
@@ -86,10 +86,6 @@ func buildProxy(passHostHeader *bool, responseForwarding *dynamic.ResponseForwar
 				delete(outReq.Header, "Sec-Websocket-Protocol")
 				delete(outReq.Header, "Sec-Websocket-Version")
 			}
-
-			if outReq.Method == http.MethodConnect {
-				deferConnectPayload(outReq)
-			}
 		},
 		Transport:     roundTripper,
 		FlushInterval: time.Duration(flushInterval),
@@ -128,10 +124,9 @@ func buildProxy(passHostHeader *bool, responseForwarding *dynamic.ResponseForwar
 				log.WithoutContext().Debugf("Error while writing status code", werr)
 			}
 		},
-		ModifyResponse: openConnectTunnel,
 	}
 
-	return proxy, nil
+	return newConnectHandler(proxy), nil
 }
 
 // isTLSError returns true if the error is a TLS error which is related to configuration.

--- a/pkg/server/service/proxy.go
+++ b/pkg/server/service/proxy.go
@@ -86,6 +86,10 @@ func buildProxy(passHostHeader *bool, responseForwarding *dynamic.ResponseForwar
 				delete(outReq.Header, "Sec-Websocket-Protocol")
 				delete(outReq.Header, "Sec-Websocket-Version")
 			}
+
+			if outReq.Method == http.MethodConnect {
+				deferConnectPayload(outReq)
+			}
 		},
 		Transport:     roundTripper,
 		FlushInterval: time.Duration(flushInterval),
@@ -124,6 +128,7 @@ func buildProxy(passHostHeader *bool, responseForwarding *dynamic.ResponseForwar
 				log.WithoutContext().Debugf("Error while writing status code", werr)
 			}
 		},
+		ModifyResponse: openConnectTunnel,
 	}
 
 	return proxy, nil


### PR DESCRIPTION
### What does this PR do?

This PR defers a proxied `CONNECT` request payload so it only reaches the backend once the tunnel is established (RFC 9110 §9.3.6). A refused CONNECT never forwards a single payload byte.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation