### PR TITLE
Do not add back CONNECT requests to the pool

### DIFF
--- a/pkg/server/service/connect.go
+++ b/pkg/server/service/connect.go
@@ -67,9 +67,14 @@ func newBodyDeferrer(doneCh <-chan struct{}, body io.ReadCloser) *bodyDeferrer {
 
 func (bd *bodyDeferrer) Read(p []byte) (n int, err error) {
 	select {
-	case <-bd.doneCh:
-		return 0, context.Canceled
 	case <-bd.releaseCh:
+		// already released
+	default:
+		select {
+		case <-bd.doneCh:
+			return 0, context.Canceled
+		case <-bd.releaseCh:
+		}
 	}
 	return bd.body.Read(p)
 }

--- a/pkg/server/service/connect.go
+++ b/pkg/server/service/connect.go
@@ -38,7 +38,7 @@ func (h *connectHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	bodyDeferrer := newBodyDeferrer(req.Body)
+	bodyDeferrer := newBodyDeferrer(req.Context().Done(), req.Body)
 	req.Body = bodyDeferrer
 
 	h.next.ServeHTTP(&connectResponseWriter{ResponseWriter: rw, req: req, bodyDeferrer: bodyDeferrer}, req)
@@ -46,62 +46,45 @@ func (h *connectHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 // bodyDeferrer holds the body of a CONNECT request until the backend has accepted the tunnel.
 type bodyDeferrer struct {
-	*io.PipeReader
-
-	writer      *io.PipeWriter
-	body        io.ReadCloser
-	releaseOnce sync.Once
+	doneCh           <-chan struct{}
+	body             io.ReadCloser
+	releaseCh        chan struct{}
+	closeReleaseOnce func()
 }
 
-func newBodyDeferrer(body io.ReadCloser) *bodyDeferrer {
-	pipeReader, pipeWriter := io.Pipe()
+func newBodyDeferrer(doneCh <-chan struct{}, body io.ReadCloser) *bodyDeferrer {
+	releaseCh := make(chan struct{})
 
 	return &bodyDeferrer{
-		PipeReader: pipeReader,
-		writer:     pipeWriter,
-		body:       body,
+		doneCh:    doneCh,
+		body:      body,
+		releaseCh: releaseCh,
+		closeReleaseOnce: sync.OnceFunc(func() {
+			close(releaseCh)
+		}),
 	}
 }
 
-// Close the deferrer.
-func (bd *bodyDeferrer) Close() error {
-	var errs []error
-	if err := bd.writer.Close(); err != nil {
-		errs = append(errs, fmt.Errorf("closing bodyDeferrer pipe writer: %w", err))
+func (bd *bodyDeferrer) Read(p []byte) (n int, err error) {
+	select {
+	case <-bd.doneCh:
+		return 0, errors.New("request context canceled")
+	case <-bd.releaseCh:
 	}
-	if err := bd.PipeReader.Close(); err != nil {
-		errs = append(errs, fmt.Errorf("closing bodyDeferrer pipe reader: %w", err))
-	}
-	if err := bd.body.Close(); err != nil {
-		errs = append(errs, fmt.Errorf("closing bodyDeferrer request body: %w", err))
-	}
+	return bd.body.Read(p)
+}
 
-	return errors.Join(errs...)
+// Close releases the deferred request body and closes the underlying request body.
+func (bd *bodyDeferrer) Close() error {
+	defer bd.closeReleaseOnce()
+	return bd.body.Close()
 }
 
 // Release forwards the deferred request body to the backend and copy the subsequent bytes to the tunnel.
 // As described in https://datatracker.ietf.org/doc/html/rfc9931#name-requirements-for-http-conne we must wait for a 2xx (Successful)
 // response before forwarding any tunnel data.
-func (bd *bodyDeferrer) Release(req *http.Request) {
-	bd.releaseOnce.Do(func() {
-		// Forward the tunnel data to the backend in the background: for an established tunnel this copy runs
-		// for the lifetime of the tunnel, so release must return to let the response direction be pumped.
-		copyDoneCh := make(chan struct{})
-		go func() {
-			_, err := io.Copy(bd.writer, bd.body)
-			_ = bd.writer.CloseWithError(err)
-			close(copyDoneCh)
-		}()
-
-		// If the request is canceled, the payload must not reach the backend, so close the pipe to unblock the Transport.
-		go func() {
-			select {
-			case <-req.Context().Done():
-				bd.Close()
-			case <-copyDoneCh:
-			}
-		}()
-	})
+func (bd *bodyDeferrer) Release() {
+	bd.closeReleaseOnce()
 }
 
 // connectResponseWriter releases the deferred CONNECT payload as soon as the backend's response status is known,
@@ -118,7 +101,7 @@ func (w *connectResponseWriter) WriteHeader(statusCode int) {
 	if statusCode/100 != 2 {
 		_ = w.bodyDeferrer.Close()
 	} else {
-		w.bodyDeferrer.Release(w.req)
+		w.bodyDeferrer.Release()
 	}
 
 	w.ResponseWriter.WriteHeader(statusCode)

--- a/pkg/server/service/connect.go
+++ b/pkg/server/service/connect.go
@@ -74,7 +74,7 @@ func (bd *bodyDeferrer) Read(p []byte) (n int, err error) {
 	return bd.body.Read(p)
 }
 
-// Close releases the deferred request body and closes the underlying request body.
+// Close closes the underlying request body before releasing the deferred request body read operation.
 func (bd *bodyDeferrer) Close() error {
 	defer bd.closeReleaseOnce()
 	return bd.body.Close()

--- a/pkg/server/service/connect.go
+++ b/pkg/server/service/connect.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -37,39 +38,58 @@ func (h *connectHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	pipeReader, pipeWriter := io.Pipe()
-	tunnel := &connectTunnel{in: pipeWriter, data: req.Body}
+	bodyDeferrer := newBodyDeferrer(req.Body)
+	req.Body = bodyDeferrer
 
-	// The Transport blocks on the empty pipe, so only the header section reaches the backend until
-	// connectResponseWriter releases the payload once the backend accepts the tunnel.
-	req.Body = pipeReader
-
-	h.next.ServeHTTP(&connectResponseWriter{ResponseWriter: rw, req: req, tunnel: tunnel}, req)
+	h.next.ServeHTTP(&connectResponseWriter{ResponseWriter: rw, req: req, bodyDeferrer: bodyDeferrer}, req)
 }
 
-// connectTunnel holds the data of a CONNECT request until the backend has accepted the tunnel.
-type connectTunnel struct {
-	in          *io.PipeWriter
+// bodyDeferrer holds the body of a CONNECT request until the backend has accepted the tunnel.
+type bodyDeferrer struct {
+	*io.PipeReader
+
+	writer      *io.PipeWriter
+	body        io.ReadCloser
 	releaseOnce sync.Once
-	data        io.Reader
 }
 
-// Close closes tunnel.
-func (t *connectTunnel) Close() {
-	_ = t.in.Close()
+func newBodyDeferrer(body io.ReadCloser) *bodyDeferrer {
+	pipeReader, pipeWriter := io.Pipe()
+
+	return &bodyDeferrer{
+		PipeReader: pipeReader,
+		writer:     pipeWriter,
+		body:       body,
+	}
+}
+
+// Close the deferrer.
+func (bd *bodyDeferrer) Close() error {
+	var errs []error
+	if err := bd.writer.Close(); err != nil {
+		errs = append(errs, fmt.Errorf("closing bodyDeferrer pipe writer: %w", err))
+	}
+	if err := bd.PipeReader.Close(); err != nil {
+		errs = append(errs, fmt.Errorf("closing bodyDeferrer pipe reader: %w", err))
+	}
+	if err := bd.body.Close(); err != nil {
+		errs = append(errs, fmt.Errorf("closing bodyDeferrer request body: %w", err))
+	}
+
+	return errors.Join(errs...)
 }
 
 // Release forwards the deferred request body to the backend and copy the subsequent bytes to the tunnel.
 // As described in https://datatracker.ietf.org/doc/html/rfc9931#name-requirements-for-http-conne we must wait for a 2xx (Successful)
 // response before forwarding any tunnel data.
-func (t *connectTunnel) Release(req *http.Request) {
-	t.releaseOnce.Do(func() {
+func (bd *bodyDeferrer) Release(req *http.Request) {
+	bd.releaseOnce.Do(func() {
 		// Forward the tunnel data to the backend in the background: for an established tunnel this copy runs
 		// for the lifetime of the tunnel, so release must return to let the response direction be pumped.
 		copyDoneCh := make(chan struct{})
 		go func() {
-			_, err := io.Copy(t.in, t.data)
-			_ = t.in.CloseWithError(err)
+			_, err := io.Copy(bd.writer, bd.body)
+			_ = bd.writer.CloseWithError(err)
 			close(copyDoneCh)
 		}()
 
@@ -77,7 +97,7 @@ func (t *connectTunnel) Release(req *http.Request) {
 		go func() {
 			select {
 			case <-req.Context().Done():
-				_ = t.in.Close()
+				bd.Close()
 			case <-copyDoneCh:
 			}
 		}()
@@ -89,16 +109,16 @@ func (t *connectTunnel) Release(req *http.Request) {
 type connectResponseWriter struct {
 	http.ResponseWriter
 
-	req    *http.Request
-	tunnel *connectTunnel
+	req          *http.Request
+	bodyDeferrer *bodyDeferrer
 }
 
 func (w *connectResponseWriter) WriteHeader(statusCode int) {
 	// The tunnel was refused, so the request body never becomes tunnel data and must not reach the backend.
 	if statusCode/100 != 2 {
-		w.tunnel.Close()
+		_ = w.bodyDeferrer.Close()
 	} else {
-		w.tunnel.Release(w.req)
+		w.bodyDeferrer.Release(w.req)
 	}
 
 	w.ResponseWriter.WriteHeader(statusCode)

--- a/pkg/server/service/connect.go
+++ b/pkg/server/service/connect.go
@@ -2,7 +2,7 @@ package service
 
 import (
 	"bufio"
-	"errors"
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -68,7 +68,7 @@ func newBodyDeferrer(doneCh <-chan struct{}, body io.ReadCloser) *bodyDeferrer {
 func (bd *bodyDeferrer) Read(p []byte) (n int, err error) {
 	select {
 	case <-bd.doneCh:
-		return 0, errors.New("request context canceled")
+		return 0, context.Canceled
 	case <-bd.releaseCh:
 	}
 	return bd.body.Read(p)

--- a/pkg/server/service/connect.go
+++ b/pkg/server/service/connect.go
@@ -46,8 +46,8 @@ func (h *connectHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 // bodyDeferrer holds the body of a CONNECT request until the backend has accepted the tunnel.
 type bodyDeferrer struct {
-	doneCh           <-chan struct{}
 	body             io.ReadCloser
+	doneCh           <-chan struct{}
 	releaseCh        chan struct{}
 	closeReleaseOnce func()
 }
@@ -56,8 +56,8 @@ func newBodyDeferrer(doneCh <-chan struct{}, body io.ReadCloser) *bodyDeferrer {
 	releaseCh := make(chan struct{})
 
 	return &bodyDeferrer{
-		doneCh:    doneCh,
 		body:      body,
+		doneCh:    doneCh,
 		releaseCh: releaseCh,
 		closeReleaseOnce: sync.OnceFunc(func() {
 			close(releaseCh)

--- a/pkg/server/service/connect.go
+++ b/pkg/server/service/connect.go
@@ -41,7 +41,7 @@ func (h *connectHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	bodyDeferrer := newBodyDeferrer(req.Context().Done(), req.Body)
 	req.Body = bodyDeferrer
 
-	h.next.ServeHTTP(&connectResponseWriter{ResponseWriter: rw, req: req, bodyDeferrer: bodyDeferrer}, req)
+	h.next.ServeHTTP(&connectResponseWriter{ResponseWriter: rw, bodyDeferrer: bodyDeferrer}, req)
 }
 
 // bodyDeferrer holds the body of a CONNECT request until the backend has accepted the tunnel.
@@ -92,7 +92,6 @@ func (bd *bodyDeferrer) Release() {
 type connectResponseWriter struct {
 	http.ResponseWriter
 
-	req          *http.Request
 	bodyDeferrer *bodyDeferrer
 }
 

--- a/pkg/server/service/connect_test.go
+++ b/pkg/server/service/connect_test.go
@@ -122,6 +122,9 @@ func newConnectBackend(t *testing.T, accept bool) *connectBackend {
 	backend.payload.Store(&empty)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// Test that the proxy sets the Connection: close header on CONNECT requests to avoid reusing the connection.
+		assert.True(t, req.Close)
+
 		if !accept {
 			if req.ContentLength > 0 {
 				// A declared body means the proxy forwarded payload; read it to capture what leaked.

--- a/pkg/server/service/proxy.go
+++ b/pkg/server/service/proxy.go
@@ -182,7 +182,7 @@ func statusText(statusCode int) string {
 	return http.StatusText(statusCode)
 }
 
-// copyForwardedHeader copies header that are removed by the reverseProxy when a rewriteRequest is used.
+// copyForwardedHeader copies headers that are removed by ReverseProxy when Rewrite is used.
 func copyForwardedHeader(dst, src http.Header) {
 	prior, ok := src["X-Forwarded-For"]
 	if ok {

--- a/pkg/server/service/proxy.go
+++ b/pkg/server/service/proxy.go
@@ -46,45 +46,67 @@ func buildProxy(passHostHeader *bool, responseForwarding *dynamic.ResponseForwar
 	}
 
 	proxy := &httputil.ReverseProxy{
-		Director: func(outReq *http.Request) {
-			u := outReq.URL
-			if outReq.RequestURI != "" {
-				parsedURL, err := url.ParseRequestURI(outReq.RequestURI)
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			copyForwardedHeader(pr.Out.Header, pr.In.Header)
+
+			if clientIP, _, err := net.SplitHostPort(pr.In.RemoteAddr); err == nil {
+				// If we aren't the first proxy retain prior
+				// X-Forwarded-For information as a comma+space
+				// separated list and fold multiple headers into one.
+				prior, ok := pr.Out.Header["X-Forwarded-For"]
+				omit := ok && prior == nil // Issue 38079: nil now means don't populate the header
+				if len(prior) > 0 {
+					clientIP = strings.Join(prior, ", ") + ", " + clientIP
+				}
+				if !omit {
+					pr.Out.Header.Set("X-Forwarded-For", clientIP)
+				}
+			}
+
+			u := pr.Out.URL
+			if pr.Out.RequestURI != "" {
+				parsedURL, err := url.ParseRequestURI(pr.Out.RequestURI)
 				if err == nil {
 					u = parsedURL
 				}
 			}
 
-			outReq.URL.Path = u.Path
-			outReq.URL.RawPath = u.RawPath
+			pr.Out.URL.Path = u.Path
+			pr.Out.URL.RawPath = u.RawPath
 			// If a plugin/middleware adds semicolons in query params, they should be urlEncoded.
-			outReq.URL.RawQuery = strings.ReplaceAll(u.RawQuery, ";", "&")
-			outReq.RequestURI = "" // Outgoing request should not have RequestURI
+			pr.Out.URL.RawQuery = strings.ReplaceAll(u.RawQuery, ";", "&")
+			pr.Out.RequestURI = "" // Outgoing request should not have RequestURI
 
-			outReq.Proto = "HTTP/1.1"
-			outReq.ProtoMajor = 1
-			outReq.ProtoMinor = 1
+			pr.Out.Proto = "HTTP/1.1"
+			pr.Out.ProtoMajor = 1
+			pr.Out.ProtoMinor = 1
+
+			// Adding the "Connection: close" header to the request ensures that we are not reusing the connection for
+			// subsequent requests in case the backend does not support CONNECT and returns a 2xx response.
+			if pr.Out.Method == http.MethodConnect {
+				pr.Out.Close = true
+			}
 
 			// Do not pass client Host header unless optsetter PassHostHeader is set.
 			if passHostHeader != nil && !*passHostHeader {
-				outReq.Host = outReq.URL.Host
+				pr.Out.Host = pr.Out.URL.Host
 			}
 
 			// Even if the websocket RFC says that headers should be case-insensitive,
 			// some servers need Sec-WebSocket-Key, Sec-WebSocket-Extensions, Sec-WebSocket-Accept,
 			// Sec-WebSocket-Protocol and Sec-WebSocket-Version to be case-sensitive.
 			// https://tools.ietf.org/html/rfc6455#page-20
-			if isWebSocketUpgrade(outReq) {
-				outReq.Header["Sec-WebSocket-Key"] = outReq.Header["Sec-Websocket-Key"]
-				outReq.Header["Sec-WebSocket-Extensions"] = outReq.Header["Sec-Websocket-Extensions"]
-				outReq.Header["Sec-WebSocket-Accept"] = outReq.Header["Sec-Websocket-Accept"]
-				outReq.Header["Sec-WebSocket-Protocol"] = outReq.Header["Sec-Websocket-Protocol"]
-				outReq.Header["Sec-WebSocket-Version"] = outReq.Header["Sec-Websocket-Version"]
-				delete(outReq.Header, "Sec-Websocket-Key")
-				delete(outReq.Header, "Sec-Websocket-Extensions")
-				delete(outReq.Header, "Sec-Websocket-Accept")
-				delete(outReq.Header, "Sec-Websocket-Protocol")
-				delete(outReq.Header, "Sec-Websocket-Version")
+			if isWebSocketUpgrade(pr.Out) {
+				pr.Out.Header["Sec-WebSocket-Key"] = pr.Out.Header["Sec-Websocket-Key"]
+				pr.Out.Header["Sec-WebSocket-Extensions"] = pr.Out.Header["Sec-Websocket-Extensions"]
+				pr.Out.Header["Sec-WebSocket-Accept"] = pr.Out.Header["Sec-Websocket-Accept"]
+				pr.Out.Header["Sec-WebSocket-Protocol"] = pr.Out.Header["Sec-Websocket-Protocol"]
+				pr.Out.Header["Sec-WebSocket-Version"] = pr.Out.Header["Sec-Websocket-Version"]
+				delete(pr.Out.Header, "Sec-Websocket-Key")
+				delete(pr.Out.Header, "Sec-Websocket-Extensions")
+				delete(pr.Out.Header, "Sec-Websocket-Accept")
+				delete(pr.Out.Header, "Sec-Websocket-Protocol")
+				delete(pr.Out.Header, "Sec-Websocket-Version")
 			}
 		},
 		Transport:     roundTripper,
@@ -158,4 +180,24 @@ func statusText(statusCode int) string {
 		return StatusClientClosedRequestText
 	}
 	return http.StatusText(statusCode)
+}
+
+// copyForwardedHeader copies header that are removed by the reverseProxy when a rewriteRequest is used.
+func copyForwardedHeader(dst, src http.Header) {
+	prior, ok := src["X-Forwarded-For"]
+	if ok {
+		dst["X-Forwarded-For"] = prior
+	}
+	prior, ok = src["Forwarded"]
+	if ok {
+		dst["Forwarded"] = prior
+	}
+	prior, ok = src["X-Forwarded-Host"]
+	if ok {
+		dst["X-Forwarded-Host"] = prior
+	}
+	prior, ok = src["X-Forwarded-Proto"]
+	if ok {
+		dst["X-Forwarded-Proto"] = prior
+	}
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request makes sure that CONNECT requests are not added to the pool in case of an error or when the tunnel ends. It also reworks how the CONNECT body is deferred to the backend.


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
