### PR TITLE
fix(provider/docker): don't drop container config when an unreferenced auto-created service can't resolve a port

### DIFF
--- a/pkg/provider/docker/config.go
+++ b/pkg/provider/docker/config.go
@@ -166,7 +166,9 @@ func (p *DynConfBuilder) buildUDPServiceConfiguration(ctx context.Context, conta
 func (p *DynConfBuilder) buildServiceConfiguration(ctx context.Context, container dockerData, configuration *dynamic.HTTPConfiguration) error {
 	serviceName := getServiceName(container)
 
+	autoCreatedService := false
 	if len(configuration.Services) == 0 {
+		autoCreatedService = true
 		configuration.Services = make(map[string]*dynamic.Service)
 		lb := &dynamic.ServersLoadBalancer{}
 		lb.SetDefaults()
@@ -187,11 +189,45 @@ func (p *DynConfBuilder) buildServiceConfiguration(ctx context.Context, containe
 	for name, service := range configuration.Services {
 		ctx := log.Ctx(ctx).With().Str(logs.ServiceName, name).Logger().WithContext(ctx)
 		if err := p.addServer(ctx, container, service.LoadBalancer); err != nil {
+			// If this service was auto-created (the user declared no service
+			// via labels) and every declared router already has an explicit
+			// Service set (e.g. pointing at an internal service such as
+			// api@internal), nothing in this container's configuration
+			// actually needs this default service. In that case, don't take
+			// down the whole container's configuration (routers included)
+			// over a backend that was never going to be used; drop the
+			// unusable service and keep going.
+			if autoCreatedService && !p.defaultServiceRequired(configuration) {
+				log.Ctx(ctx).Warn().Err(err).
+					Msgf("Ignoring auto-created service %q: no router references it", name)
+				delete(configuration.Services, name)
+				continue
+			}
 			return fmt.Errorf("service %q error: %w", name, err)
 		}
 	}
 
 	return nil
+}
+
+// defaultServiceRequired reports whether the (as yet unbuilt) default router
+// wiring could still end up depending on the container's auto-created,
+// name-based default service. This is true whenever there are no routers
+// declared at all (provider.BuildRouterConfiguration will create one and
+// auto-assign it the container's sole service), or when at least one
+// declared router has no explicit Service set (same auto-assignment logic
+// applies to it). If every declared router already has an explicit Service,
+// the default service is unreachable dead weight and safe to drop on error.
+func (p *DynConfBuilder) defaultServiceRequired(configuration *dynamic.HTTPConfiguration) bool {
+	if len(configuration.Routers) == 0 {
+		return true
+	}
+	for _, router := range configuration.Routers {
+		if router.Service == "" {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *DynConfBuilder) keepContainer(ctx context.Context, container dockerData) bool {

--- a/pkg/provider/docker/config_test.go
+++ b/pkg/provider/docker/config_test.go
@@ -4749,3 +4749,80 @@ func TestDynConfBuilder_getIPAddress_swarm(t *testing.T) {
 		})
 	}
 }
+
+// TestDynConfBuilder_buildServiceConfiguration_orphanedAutoServicePortFailure
+// covers the fix for the macvlan/no-port-label bug: when a container declares
+// no service label (so a default service gets auto-created from the
+// container name) but every declared router already has an explicit Service
+// set (e.g. a dashboard router pointing at api@internal), a port-resolution
+// failure on that unused auto-created service must not take the router down
+// with it.
+func TestDynConfBuilder_buildServiceConfiguration_orphanedAutoServicePortFailure(t *testing.T) {
+	container := dockerData{
+		ServiceName: "traefik13532",
+		Name:        "traefik13532",
+		NetworkSettings: networkSettings{
+			// Empty Ports mirrors what Docker reports for a macvlan-attached
+			// container even when a port is declared via EXPOSE.
+			Ports: networktypes.PortMap{},
+			Networks: map[string]*networkData{
+				"macvlan01": {
+					Name: "macvlan01",
+					Addr: "192.168.1.231",
+				},
+			},
+		},
+	}
+
+	configuration := &dynamic.HTTPConfiguration{
+		Routers: map[string]*dynamic.Router{
+			"dashboard": {
+				Rule:        "PathPrefix(`/dashboard`)",
+				EntryPoints: []string{"web"},
+				Service:     "api@internal",
+			},
+		},
+	}
+
+	builder := NewDynConfBuilder(Shared{}, nil, false)
+
+	err := builder.buildServiceConfiguration(t.Context(), container, configuration)
+	require.NoError(t, err, "a port failure on an orphaned auto-created service must not error out")
+
+	assert.Empty(t, configuration.Services, "the unusable auto-created service should be dropped")
+
+	require.Contains(t, configuration.Routers, "dashboard")
+	assert.Equal(t, "api@internal", configuration.Routers["dashboard"].Service,
+		"the router pointing at api@internal must survive untouched")
+}
+
+// TestDynConfBuilder_buildServiceConfiguration_requiredAutoServicePortFailure
+// is the regression guard: when there are no router labels at all (so the
+// auto-created service will in fact be the one wired up by
+// provider.BuildRouterConfiguration), a port-resolution failure must still
+// error out exactly as before the fix.
+func TestDynConfBuilder_buildServiceConfiguration_requiredAutoServicePortFailure(t *testing.T) {
+	container := dockerData{
+		ServiceName: "my-app",
+		Name:        "my-app",
+		NetworkSettings: networkSettings{
+			Ports: networktypes.PortMap{},
+			Networks: map[string]*networkData{
+				"macvlan01": {
+					Name: "macvlan01",
+					Addr: "192.168.1.50",
+				},
+			},
+		},
+	}
+
+	// No routers declared via labels: BuildRouterConfiguration would later
+	// create a default router and wire it to this auto-created service.
+	configuration := &dynamic.HTTPConfiguration{}
+
+	builder := NewDynConfBuilder(Shared{}, nil, false)
+
+	err := builder.buildServiceConfiguration(t.Context(), container, configuration)
+	require.Error(t, err, "a port failure on a service that would still be used must fail as before")
+	assert.Contains(t, err.Error(), "port is missing")
+}


### PR DESCRIPTION
### What does this PR do?

When a container declares no service via labels, Traefik auto-creates a default service named after the container and tries to attach a backend server to it. If port resolution fails for that auto-created service, the error is currently treated as fatal for the entire container's HTTP configuration, including routers that never referenced that service at all (for example a router pointing at api@internal).

This PR makes that specific failure non-fatal, but only when it's provably safe: the service must be one Traefik invented on its own (not declared via labels), and every router already declared on the container must already have an explicit Service set. That second check mirrors the same condition BuildRouterConfiguration itself uses to decide whether to auto-wire a router to the default service, so it shouldn't introduce new judgment calls, just reuse an existing one slightly earlier. If either condition doesn't hold, behavior is unchanged and the container still fails loudly as before.

Fixes #13532

### Motivation

On macvlan networks, Docker doesn't populate NetworkSettings.Ports even for ports declared via EXPOSE, so the auto-created service reliably fails to resolve a port, and any router on that container gets silently dropped along with it, even one pointing at an internal service like api@internal that never needed that service to begin with. Full investigation and live repro are in the linked issue.

I verified this end to end against a real macvlan container built from this branch: without the fix, GET /api/http/routers returns nothing for the router and the container logs "port is missing"; with the fix, the router shows up correctly with status enabled and the correct service reference, and the error no longer appears.

### On the approach

I went with fixing this at the point where the service is built (buildServiceConfiguration), since that's the earliest place it's possible to tell whether the failing service is actually needed by anything. Open to other directions if a different layer makes more sense, a couple I considered but didn't take:

- Handling this further up in build(), by inspecting the whole container's config after a failure instead of deciding per-service. Went with the current approach since it keeps the decision local to the function that owns the service map, but happy to move it if that's preferred.
- Being more permissive and just building services with no servers at all rather than dropping them, similar to how allowEmptyServices already works for non-running containers. Didn't go this route since it changes behavior for every unresolvable-port case rather than only the orphaned/unreferenced ones, but wanted to flag it as an alternative in case that's actually closer to the intended semantics here.

Happy to adjust the approach based on what fits the codebase's conventions best, this is more of a starting point for discussion than something I'm attached to.

### More
- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Added two tests in pkg/provider/docker/config_test.go:
- TestDynConfBuilder_buildServiceConfiguration_orphanedAutoServicePortFailure confirms the router survives and the dead service is dropped when nothing references it.
- TestDynConfBuilder_buildServiceConfiguration_requiredAutoServicePortFailure confirms the original fail-hard behavior is unchanged when the default service is genuinely needed.

Ran the full pkg/provider/docker test suite locally, all existing tests pass unchanged.