### PR TITLE
Fix auth singleflight key collision

### DIFF
--- a/pkg/middlewares/auth/basic_auth.go
+++ b/pkg/middlewares/auth/basic_auth.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
+	"strconv"
 	"strings"
 
 	goauth "github.com/abbot/go-http-auth"
@@ -118,7 +119,9 @@ func (b *basicAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 func (b *basicAuth) checkPassword(user, password string) bool {
 	secret := b.auth.Secrets(user, b.auth.Realm)
 
-	key := password + secret
+	// Prefix the password length so the key unambiguously encodes the
+	// (password, secret) pair and distinct pairs cannot collide.
+	key := strconv.Itoa(len(password)) + ":" + password + secret
 	match, _, _ := b.singleflightGroup.Do(key, func() (any, error) {
 		if secret == "" {
 			_ = b.checkSecret(password, b.notFoundSecret)

--- a/pkg/middlewares/auth/basic_auth_test.go
+++ b/pkg/middlewares/auth/basic_auth_test.go
@@ -254,6 +254,69 @@ func TestBasicAuthConcurrentHashOnce(t *testing.T) {
 	assert.Equal(t, 1, hashCount)
 }
 
+// TestBasicAuthConcurrentNoKeyCollision ensures an unconfigured user cannot inherit
+// a configured user's successful authentication through singleflight deduplication
+// (GHSA-6765-c87h-8mrf).
+func TestBasicAuthConcurrentNoKeyCollision(t *testing.T) {
+	var forwardedUser string
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		forwardedUser = r.Header.Get("X-WebAuth-User")
+		fmt.Fprintln(w, "traefik")
+	})
+
+	const hash = "$2a$04$.8sTYfcxbSplCtoxt5TdJOgpBYkarKtZYsYfYxQ1edbYRuO1DNi0e"
+	auth := dynamic.BasicAuth{
+		Users:       []string{"viewer:" + hash},
+		HeaderField: "X-WebAuth-User",
+	}
+
+	authMiddleware, err := NewBasic(t.Context(), next, auth, "authName")
+	require.NoError(t, err)
+
+	// Validate only the configured pair, and stay in flight long enough for the
+	// attacker request to join a colliding singleflight call.
+	ba := authMiddleware.(*basicAuth)
+	ba.checkSecret = func(password, secret string) bool {
+		time.Sleep(50 * time.Millisecond)
+		return secret == hash && password == "test"
+	}
+
+	ts := httptest.NewServer(authMiddleware)
+	defer ts.Close()
+
+	// The attacker's crafted request must fail on its own.
+	attackerReq := testhelpers.MustNewRequest(http.MethodGet, ts.URL, nil)
+	attackerReq.SetBasicAuth("admin", "test"+hash)
+	baseline, err := http.DefaultClient.Do(attackerReq)
+	require.NoError(t, err)
+	baseline.Body.Close()
+	require.Equal(t, http.StatusUnauthorized, baseline.StatusCode)
+
+	// Fire a valid request, then let the attacker join it concurrently.
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		req := testhelpers.MustNewRequest(http.MethodGet, ts.URL, nil)
+		req.SetBasicAuth("viewer", "test")
+		res, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		res.Body.Close()
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+	})
+
+	time.Sleep(10 * time.Millisecond)
+
+	req := testhelpers.MustNewRequest(http.MethodGet, ts.URL, nil)
+	req.SetBasicAuth("admin", "test"+hash)
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	res.Body.Close()
+
+	wg.Wait()
+
+	assert.Equal(t, http.StatusUnauthorized, res.StatusCode)
+	assert.NotEqual(t, "admin", forwardedUser)
+}
+
 func TestBasicAuthUsersFromFile(t *testing.T) {
 	testCases := []struct {
 		desc            string


### PR DESCRIPTION
### What does this PR do?

Fixes the singleflight deduplication key used by the BasicAuth middleware to verify passwords.

The key was the plain concatenation `password + secret`, which is ambiguous: two different `(password, secret)` pairs can produce the same key. An unconfigured user could therefore share the in-flight result of a configured user's successful check and be authenticated (and, when `headerField` is set, have its chosen username forwarded to the backend).

The key now encodes the pair unambiguously by prefixing the password length, so distinct pairs can no longer collide while legitimate deduplication of identical concurrent requests is preserved.

### Motivation

The concurrent-request deduplication introduced for BasicAuth allowed an authentication bypass through key collision. This restores the guarantee that a request is only ever authenticated against its own user's secret.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes