### PR TITLE
Keep labeled containers when inspect fails on port ranges

### DIFF
--- a/pkg/provider/docker/pdocker.go
+++ b/pkg/provider/docker/pdocker.go
@@ -168,7 +168,19 @@ func (p *Provider) listContainers(ctx context.Context, dockerClient client.Conta
 	for _, c := range containerList.Items {
 		dData := inspectContainers(ctx, dockerClient, c.ID)
 		if len(dData.Name) == 0 {
-			continue
+			if len(c.Labels) == 0 {
+				continue
+			}
+			name := c.ID
+			if len(c.Names) > 0 {
+				name = c.Names[0]
+			}
+			dData = dockerData{
+				ID:          c.ID,
+				ServiceName: name,
+				Name:        name,
+				Labels:      c.Labels,
+			}
 		}
 
 		extraConf, err := p.extractDockerLabels(dData)

--- a/pkg/provider/docker/shared_test.go
+++ b/pkg/provider/docker/shared_test.go
@@ -1,15 +1,33 @@
 package docker
 
 import (
+	"context"
 	"strconv"
 	"testing"
 
 	containertypes "github.com/moby/moby/api/types/container"
 	networktypes "github.com/moby/moby/api/types/network"
 	swarmtypes "github.com/moby/moby/api/types/swarm"
+	"github.com/moby/moby/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type fakeContainersClient struct {
+	client.APIClient
+
+	containers []containertypes.Summary
+	inspect    containertypes.InspectResponse
+	inspectErr error
+}
+
+func (c *fakeContainersClient) ContainerList(_ context.Context, _ client.ContainerListOptions) (client.ContainerListResult, error) {
+	return client.ContainerListResult{Items: c.containers}, nil
+}
+
+func (c *fakeContainersClient) ContainerInspect(_ context.Context, _ string, _ client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
+	return client.ContainerInspectResult{Container: c.inspect}, c.inspectErr
+}
 
 func Test_getPort_docker(t *testing.T) {
 	testCases := []struct {
@@ -72,6 +90,52 @@ func Test_getPort_docker(t *testing.T) {
 
 			actual := getPort(dData, test.serverPort)
 			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func Test_listContainers_inspectFallback(t *testing.T) {
+	labels := map[string]string{"traefik.http.services.foo.loadbalancer.server.port": "8080"}
+
+	testCases := []struct {
+		desc       string
+		summary    containertypes.Summary
+		expectKeep bool
+	}{
+		{
+			desc:       "inspect error without labels is skipped",
+			summary:    containertypes.Summary{ID: "abc", Names: []string{"/foo"}},
+			expectKeep: false,
+		},
+		{
+			desc:       "inspect error with labels falls back to summary",
+			summary:    containertypes.Summary{ID: "abc", Names: []string{"/foo"}, Labels: labels},
+			expectKeep: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			fake := &fakeContainersClient{
+				containers: []containertypes.Summary{test.summary},
+				inspectErr: assert.AnError,
+			}
+
+			p := &Provider{Shared: Shared{ExposedByDefault: true}}
+			got, err := p.listContainers(t.Context(), fake)
+			require.NoError(t, err)
+
+			if !test.expectKeep {
+				assert.Empty(t, got)
+				return
+			}
+
+			require.Len(t, got, 1)
+			assert.Equal(t, "abc", got[0].ID)
+			assert.Equal(t, "/foo", got[0].Name)
+			assert.Equal(t, labels, got[0].Labels)
 		})
 	}
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->
---

### What does this PR do?

Avoids dropping a container when its inspect response cannot be decoded.

Until now, a decoding failure made `inspectContainers` return an empty `dockerData`, and the container was then discarded by the empty-name guard in `listContainers`. It is now rebuilt from the `ContainerList` summary that has already been fetched, so the rest of the pipeline proceeds as usual.

### Motivation

Fixes #13146.

I have used Traefik as a gateway before. While studying goroutines I was going through the Traefik issue tracker, came across #13146 about port ranges, and wanted to contribute a fix.

While investigating I found the commit that migrated to the moby modules in May. Since that commit, a container whose inspect response contains a port range key disappears from the routing table. The range arrives as a key of `NetworkSettings.Ports`, now typed `map[network.Port][]PortBinding`, and `network.Port.UnmarshalText` rejects it through `strconv.ParseUint`. That fails the decoding of the entire `InspectResponse`, so the labels and the container IP carried by the very same response become unusable as well. An explicit `loadbalancer.server.port` label therefore does not help: the container is gone before its labels are ever read.

Before the migration the decoding succeeded, so such containers stayed in the routing table. This PR restores that behavior at the application level, without changing how ports are parsed.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

The regression came in with e4537f8b0 (#13053), which moved `github.com/docker/docker v28.5.2+incompatible` to `github.com/moby/moby/api v1.54.1`. That bump carries moby/moby#50710 (milestone 29.0.0), which redefined the port types. In `pkg/provider/docker`:

```diff
-	Ports       nat.PortMap
+	Ports       networktypes.PortMap
```

`nat.Port` was a plain string (`type Port string`) and even exposed a `Range() (int, int, error)` method, so a key such as `12000-13000/tcp` was unmarshaled as-is. The new `network.Port` is a `uint16`-based struct with a strict `UnmarshalText`, so the same key now fails to decode.

The `ContainerList` response is used as the fallback because its `PortSummary` stores ports in `uint16` fields, which cannot hold a range in the first place, so the same failure cannot happen there.

Range values reaching the API response are an upstream concern, tracked in moby/moby#52553. The image in that report was built with buildah and kept `33060-33061/tcp` unexpanded in its image config. Images built with `docker build` are unaffected, since the range is expanded into individual ports at build time. Fixes are open upstream but not merged yet.

Even once that is fixed upstream, I think it is safer for Traefik not to drop a container entirely just because one response could not be decoded.

Containers without an explicit port label are not restored to the previous behavior. The old code produced a bogus server URL such as `http://172.18.0.2:12000-13000`, and the new `network.Port` type cannot represent that value. In that case no port is resolved and the service is skipped through the existing "port is missing" path.