### PR TITLE
fix(job): prevent backoff from permanently stopping provider retries

### DIFF
--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -35,5 +35,17 @@ func (b *BackOff) NextBackOff() time.Duration {
 	if b.GetElapsedTime() >= b.MinJobInterval {
 		b.Reset()
 	}
-	return b.ExponentialBackOff.NextBackOff()
+
+	next := b.ExponentialBackOff.NextBackOff()
+
+	// Defensive guard: if the underlying backoff returns Stop (which can
+	// happen despite MaxElapsedTime=0 under certain edge conditions such as
+	// the wrapped context being cancelled), reset and restart from initial
+	// interval so that long-running jobs never permanently stop retrying.
+	if next == backoff.Stop {
+		b.Reset()
+		return b.InitialInterval
+	}
+
+	return next
 }


### PR DESCRIPTION
### What does this PR do?

Fixes #13549 — providers (Docker, Swarm, Kubernetes, Consul, etc.) use `job.BackOff.NextBackOff()` for their retry loops. Despite setting `MaxElapsedTime = 0`, the underlying exponential backoff can return `Stop` under certain edge conditions (e.g. interactions with the `backOffContext` wrapper that checks context cancellation before delegating). When `Stop` is returned, `doRetryNotify` exits the retry loop, and the provider silently stops retrying forever.

This PR adds a defensive guard in `NextBackOff()`: if the underlying backoff returns `Stop`, we reset and return the initial interval instead, ensuring the retry loop never permanently exits.

### Root cause

- `ExponentialBackOff.NextBackOff()` returns `Stop` when: `MaxElapsedTime != 0 && elapsed+next > MaxElapsedTime`
- `NewBackOff()` sets `MaxElapsedTime = 0`, so this check should never trigger
- However, `backoff.WithContext()` wraps `NextBackOff()` with a context check that can return `Stop` independently
- Combined with the `Reset()` logic in `job.BackOff` (which resets every 30s), there are edge conditions where `Stop` leaks through
- Once `Stop` is returned, `doRetryNotify` exits and the provider's goroutine terminates

### Fix

```go
if next == backoff.Stop {
    b.Reset()
    return b.InitialInterval
}
```

Simple, defensive, and ensures long-running jobs never permanently stop retrying.

### How to verify

Existing tests in `pkg/job/job_test.go` should continue to pass. The fix only activates when `ExponentialBackOff.NextBackOff()` returns `Stop`, which is the exact scenario reported in #13549.