### PR TITLE
Fix genconf generation for recent dynamic configuration types

### DIFF
--- a/cmd/internal/gen/centrifuge.go
+++ b/cmd/internal/gen/centrifuge.go
@@ -175,7 +175,10 @@ func (c Centrifuge) writeStruct(name string, obj *types.Struct, rootPkg string, 
 		fType := c.TypeCleaner(field.Type(), rootPkg)
 
 		if field.Embedded() {
-			fmt.Fprintf(&b, "\t%s\n", fType)
+			// An empty cleaned type means the embedded type is excluded from the generation.
+			if fType != "" {
+				fmt.Fprintf(&b, "\t%s\n", fType)
+			}
 			continue
 		}
 

--- a/cmd/internal/gen/main.go
+++ b/cmd/internal/gen/main.go
@@ -63,7 +63,7 @@ func run(dest string) error {
 
 	centrifuge.ExcludedTypes = []string{
 		// tls
-		"CertificateStore", "Manager",
+		"CertificateStore", "CertificateData", "Manager",
 		// dynamic
 		"Message", "Configurations",
 		// types
@@ -99,6 +99,27 @@ func cleanType(typ types.Type, base string) string {
 		return "string"
 	}
 
+	if typ.String() == "*github.com/traefik/paerser/types.Duration" {
+		return "*string"
+	}
+
+	if typ.String() == "*net/http.Header" {
+		return "*http.Header"
+	}
+
+	if typ.String() == "github.com/traefik/traefik/v3/pkg/observability/types.TracingVerbosity" {
+		return "string"
+	}
+
+	if typ.String() == "google.golang.org/grpc/codes.Code" {
+		return "uint32"
+	}
+
+	// The ext extension points are empty structs, skip them.
+	if strings.HasPrefix(typ.String(), "github.com/traefik/traefik/dynamic/ext.") {
+		return ""
+	}
+
 	if strings.Contains(typ.String(), base) {
 		return strings.ReplaceAll(typ.String(), base+".", "")
 	}
@@ -112,7 +133,10 @@ func cleanType(typ types.Type, base string) string {
 
 func cleanPackage(src string) string {
 	switch src {
-	case "github.com/traefik/paerser/types":
+	case "github.com/traefik/paerser/types",
+		"github.com/traefik/traefik/v3/pkg/observability/types",
+		"github.com/traefik/traefik/dynamic/ext",
+		"google.golang.org/grpc/codes":
 		return ""
 	case "github.com/traefik/traefik/v3/pkg/tls":
 		return path.Join(destModuleName, destPkg, "tls")


### PR DESCRIPTION
### What does this PR do?

Fixes `make generate-genconf`, which currently fails on v3.7. The centrifuge generator emits raw fully-qualified type paths (e.g. `*github.com/traefik/paerser/types.Duration`) for several types added to the dynamic configuration since the last genconf generation, producing Go sources that do not compile and are rejected at the `gofmt` step.

- Map pointer `ptypes.Duration` fields (`UnhealthyInterval`, Redis rate-limiter timeouts) to `*string`, consistently with the existing non-pointer mapping.
- Keep `ErrorPage.NginxHeaders` as `*http.Header`, importing the standard library `net/http`.
- Map `TracingVerbosity` to `string` and gRPC `codes.Code` to `uint32` (their underlying types), to avoid adding external dependencies to the genconf module.
- Skip the `ext.HTTP`/`ext.Router` embedded extension points: they are empty structs with no effect on the configuration shape.
- Exclude `CertificateData` from the generation, like the other TLS runtime types (`CertificateStore`, `Manager`).

### Motivation

The genconf module has not been regenerated for a while, and every type listed above breaks the generation. Since generated files are processed in map iteration order, each failure masks the next one, making the target fail on a seemingly random file on every run.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Publishing the regenerated genconf module requires bumping its `go` directive to at least `1.18`, as the generated `PluginConf` type now uses `any`.
