### PR TITLE
update nginx migration guide hostname retention steps

### DIFF
--- a/docs/content/migrate/nginx-to-traefik.md
+++ b/docs/content/migrate/nginx-to-traefik.md
@@ -111,6 +111,7 @@ Before starting the migration, ensure you have:
 - **Helm**
 - **Cluster admin permissions** to create RBAC resources
 - **Backup of critical configurations** (Ingress resources, ConfigMaps, Secrets)
+- **`helm.sh/resource-policy: keep`** set on the NGINX IngressClass (and Service if using [hostname retention](#option-c-loadbalancer-hostname-retention-orphan-and-adopt)) — see [Preserve the IngressClass and Service](#preserve-the-ingressclass-and-service)
 
 !!! tip "Backup Recommendations"
 
@@ -223,17 +224,16 @@ When you find one of these keys, translate the underlying intent rather than try
 
 ## Step 1: Install Traefik Alongside NGINX
 
-??? info "Install Ingress NGINX Controller"
+??? info "Testing this guide without an existing NGINX installation"
 
-    If you have not installed Ingress NGINX Controller yet, you can set up a fresh Ingress NGINX Controller installation following the instructions below:
-
-    ### Install Ingress NGINX Controller
+    If you want to try this migration guide in a test environment, you can install a fresh Ingress NGINX Controller:
 
     ```bash
     helm upgrade --install ingress-nginx ingress-nginx \
       --repo https://kubernetes.github.io/ingress-nginx \
       --namespace ingress-nginx --create-namespace
     ```
+
 Install Traefik with the Kubernetes Ingress NGINX provider enabled. Both controllers will serve the same Ingress resources simultaneously.
 
 !!! warning "Read the status race condition note first"
@@ -249,40 +249,76 @@ helm repo update
 
 ### Install Traefik
 
-```bash
-helm upgrade --install traefik traefik/traefik \
-  --namespace traefik --create-namespace \
-  --set providers.kubernetesIngressNGINX.enabled=true
-```
+Choose the install configuration based on your migration strategy:
 
-Or using a [values file](https://github.com/traefik/traefik-helm-chart/blob/master/traefik/VALUES.md) for more configuration:
+- **Standard** — Traefik gets its own namespace and LoadBalancer. Traffic is shifted via DNS.
+- **Hostname retention** — Traefik is installed in the same namespace as NGINX with matching port names. Use this if your cloud provider assigns hostnames (not IPs) to LoadBalancer Services (e.g., AWS). See [LoadBalancer Hostname Retention](#option-c-loadbalancer-hostname-retention-orphan-and-adopt) for the full migration flow.
 
-```yaml tab="traefik-values.yaml"
-...
+```yaml tab="Standard"
 providers:
   kubernetesIngressNGINX:
     enabled: true
- ...
 ```
 
-```bash
+```yaml tab="Hostname Retention"
+providers:
+  kubernetesIngressNGINX:
+    enabled: true
+
+# Match NGINX port names so no targetPort patching is needed at traffic split
+ports:
+  web: null
+  websecure: null
+  http:
+    port: 8000
+    expose:
+      default: true
+    exposedPort: 80
+    protocol: TCP
+  https:
+    port: 8443
+    expose:
+      default: true
+    exposedPort: 443
+    protocol: TCP
+    http:
+      tls:
+        enabled: true
+
+service:
+  enabled: true
+```
+
+Save the values for your chosen strategy as `traefik-values.yaml`, then install Traefik:
+
+```bash tab="Standard"
 helm upgrade --install traefik traefik/traefik \
   --namespace traefik --create-namespace \
-  --values traefik-values.yaml
+  -f traefik-values.yaml
+```
+
+```bash tab="Hostname Retention"
+# Install in the SAME namespace as NGINX
+helm upgrade --install traefik traefik/traefik \
+  --namespace ingress-nginx \
+  -f traefik-values.yaml
 ```
 
 ### Verify Both Controllers Are Running
 
 ```bash
+# "traefik" for standard, "ingress-nginx" for hostname retention
+TRAEFIK_NS="traefik"
+
 # Check NGINX pods
 kubectl get pods -n ingress-nginx
 
 # Check Traefik pods
-kubectl get pods -n traefik
+kubectl get pods -n ${TRAEFIK_NS} -l app.kubernetes.io/name=traefik
 
 # Check both services have LoadBalancer IPs
 kubectl get svc -n ingress-nginx ingress-nginx-controller
-kubectl get svc -n traefik traefik
+kubectl get svc -n ${TRAEFIK_NS} traefik
 ```
 
 At this point, both NGINX and Traefik are running and can serve the same Ingress resources. Traffic is still flowing only through NGINX since DNS points to the NGINX LoadBalancer.
@@ -293,25 +329,28 @@ At this point, both NGINX and Traefik are running and can serve the same Ingress
 
 Before adding Traefik to DNS, verify it correctly serves your Ingress resources.
 
-### Test via Traefik's LoadBalancer IP
+### Test via Traefik's LoadBalancer IP or Hostname
 
-Get Traefik's LoadBalancer IP and use `--resolve` to test without changing DNS:
+Get Traefik's LoadBalancer IP or hostname and use `--connect-to` to test without changing DNS:
 
 ```bash
-# Get LoadBalancer IPs
-NGINX_IP=$(kubectl get svc -n ingress-nginx ingress-nginx-controller -o go-template='{{ $ing := index .status.loadBalancer.ingress 0 }}{{ if $ing.ip }}{{ $ing.ip }}{{ else }}{{ $ing.hostname }}{{ end }}')
-TRAEFIK_IP=$(kubectl get svc -n traefik traefik -o go-template='{{ $ing := index .status.loadBalancer.ingress 0 }}{{ if $ing.ip }}{{ $ing.ip }}{{ else }}{{ $ing.hostname }}{{ end }}')
-echo -e "Nginx IP: $NGINX_IP\nTraefik IP: $TRAEFIK_IP"
+# "traefik" for standard, "ingress-nginx" for hostname retention
+TRAEFIK_NS="traefik"
+
+# Get LoadBalancer IPs/hostnames
+NGINX_LB=$(kubectl get svc -n ingress-nginx ingress-nginx-controller -o go-template='{{ $ing := index .status.loadBalancer.ingress 0 }}{{ if $ing.ip }}{{ $ing.ip }}{{ else }}{{ $ing.hostname }}{{ end }}')
+TRAEFIK_LB=$(kubectl get svc -n ${TRAEFIK_NS} traefik -o go-template='{{ $ing := index .status.loadBalancer.ingress 0 }}{{ if $ing.ip }}{{ $ing.ip }}{{ else }}{{ $ing.hostname }}{{ end }}')
+echo -e "NGINX LB: $NGINX_LB\nTraefik LB: $TRAEFIK_LB"
 
 # Test HTTP for both
 FQDN=myapp.example.com
 # Observe HTTPS redirections:
-curl --connect-to "${FQDN}:80:${NGINX_IP}:80" "http://${FQDN}" -D -
-curl --connect-to "${FQDN}:80:${TRAEFIK_IP}:80" "http://${FQDN}" -D - # note X-Forwarded-Server which should be traefik
+curl --connect-to "${FQDN}:80:${NGINX_LB}:80" "http://${FQDN}" -D -
+curl --connect-to "${FQDN}:80:${TRAEFIK_LB}:80" "http://${FQDN}" -D - # note X-Forwarded-Server which should be traefik
 
 # Test HTTPS
-curl --connect-to "${FQDN}:443:${NGINX_IP}:443" "https://${FQDN}"
-curl --connect-to "${FQDN}:443:${TRAEFIK_IP}:443" "https://${FQDN}"
+curl --connect-to "${FQDN}:443:${NGINX_LB}:443" "https://${FQDN}"
+curl --connect-to "${FQDN}:443:${TRAEFIK_LB}:443" "https://${FQDN}"
 ```
 
 !!! warning "TLS Certificates During Migration"
@@ -330,7 +369,7 @@ curl --connect-to "${FQDN}:443:${TRAEFIK_IP}:443" "https://${FQDN}"
 Check Traefik logs to confirm it discovered your Ingress resources:
 
 ```bash
-kubectl logs -n traefik deployment/traefik | grep -i "ingress"
+kubectl logs -n ${TRAEFIK_NS} deployment/traefik | grep -i "ingress"
 ```
 
 ---
@@ -350,7 +389,7 @@ Add the Traefik LoadBalancer IP to your DNS records alongside NGINX. This allows
 echo $(kubectl get svc -n ingress-nginx ingress-nginx-controller -o go-template='{{ $ing := index .status.loadBalancer.ingress 0 }}{{ if $ing.ip }}{{ $ing.ip }}{{ else }}{{ $ing.hostname }}{{ end }}')
 
 # Traefik LoadBalancer
-echo $(kubectl get svc -n traefik traefik -o go-template='{{ $ing := index .status.loadBalancer.ingress 0 }}{{ if $ing.ip }}{{ $ing.ip }}{{ else }}{{ $ing.hostname }}{{ end }}')
+echo $(kubectl get svc -n ${TRAEFIK_NS} traefik -o go-template='{{ $ing := index .status.loadBalancer.ingress 0 }}{{ if $ing.ip }}{{ $ing.ip }}{{ else }}{{ $ing.hostname }}{{ end }}')
 ```
 
 **Progressive DNS migration:**
@@ -385,7 +424,7 @@ echo $(kubectl get svc -n traefik traefik -o go-template='{{ $ing := index .stat
         ```yaml
         # traefik-values.yaml
         providers:
-          kubernetesIngressNginx:
+          kubernetesIngressNGINX:
             enabled: true
             publishService:
               enabled: false  # Disable to prevent status updates
@@ -393,7 +432,7 @@ echo $(kubectl get svc -n traefik traefik -o go-template='{{ $ing := index .stat
 
         Traefik keeps serving the Ingresses normally. It only stops writing the status field, leaving NGINX as the sole writer.
 
-    2. **Test Traefik** using [port-forward](#step-2-verify-traefik-is-handling-traffic) or a separate test hostname.
+    2. **Test Traefik** using its [LoadBalancer](#step-2-verify-traefik-is-handling-traffic) or a separate test hostname.
 
     3. **Switch DNS via NGINX** (ExternalDNS users only). Configure NGINX to publish Traefik's service address so ExternalDNS points traffic to Traefik:
 
@@ -401,7 +440,8 @@ echo $(kubectl get svc -n traefik traefik -o go-template='{{ $ing := index .stat
         # nginx-values.yaml
         controller:
           publishService:
-            pathOverride: "traefik/traefik"  # Points to Traefik's service
+            # Points to Traefik's service ("ingress-nginx/traefik" for a hostname retention install)
+            pathOverride: "traefik/traefik"
         ```
 
     4. **Verify traffic flows through Traefik**. At this point, you can still roll back by removing the `pathOverride`.
@@ -431,7 +471,7 @@ For more control over traffic distribution, use an external load balancer (like 
 **Example weight progression:**
 
 | Phase | NGINX Weight | Traefik Weight | Duration |
-|-------|-------------|----------------|----------|
+| ----- | ----------- | -------------- | -------- |
 | Initial | 100% | 0% | - |
 | Start | 90% | 10% | 1 hour |
 | Increase | 50% | 50% | 2 hour |
@@ -590,18 +630,18 @@ Once DNS is pointing to Traefik and your values are configured with the target I
 
 ```bash
 # Ensure Traefik is already receiving traffic via its current LoadBalancer
-kubectl get svc -n traefik traefik
+kubectl get svc -n ${TRAEFIK_NS} traefik
 
 # Delete NGINX LoadBalancer service to release the IP
 kubectl delete svc -n ingress-nginx ingress-nginx-controller
 
 # Upgrade Traefik to claim the released IP
 helm upgrade traefik traefik/traefik \
-  --namespace traefik \
+  --namespace ${TRAEFIK_NS} \
   --values traefik-values.yaml
 
 # Verify Traefik now has the old NGINX IP
-kubectl get svc -n traefik traefik
+kubectl get svc -n ${TRAEFIK_NS} traefik
 ```
 
 !!! tip "Zero Downtime During Helm Upgrade"
@@ -631,34 +671,240 @@ kubectl get svc -n traefik traefik
 
     With multiple replicas spread across nodes and a PodDisruptionBudget, at least one pod is always running during upgrades and node maintenance.
 
+### Option C: LoadBalancer Hostname Retention (Orphan and Adopt)
+
+Some cloud providers (notably AWS with Classic or Network Load Balancers) assign a **hostname** rather than a static IP to LoadBalancer Services. Since hostnames are tied to the LoadBalancer resource, releasing the Service means losing the hostname — and all DNS records pointing to it.
+
+The **orphan and adopt** approach migrates traffic to Traefik without releasing the LoadBalancer, preserving the hostname throughout.
+
+None of the values in this flow enable `providers.kubernetesIngressNGINX.publishService`, so Traefik never writes Ingress status while both controllers coexist — the [status race](#status-race) does not apply here. Status publishing is restored in [Step 4](#step-4-adopt-the-service-into-the-traefik-helm-release) once NGINX is gone.
+
+!!! warning "Prerequisites"
+
+    Before proceeding, ensure `helm.sh/resource-policy: keep` is set on **both** the NGINX Service and IngressClass. See [Preserve the IngressClass and Service](#preserve-the-ingressclass-and-service) in Step 4.
+
+#### Step 1: Install and Verify Traefik
+
+Install Traefik using the **Hostname Retention** configuration from [Step 1: Install Traefik Alongside NGINX](#step-1-install-traefik-alongside-nginx). This installs Traefik in the same namespace as NGINX with its own LoadBalancer and matching port names.
+
+Verify Traefik is working by testing through its own LoadBalancer:
+
+```bash
+TRAEFIK_LB=$(kubectl get svc -n ingress-nginx traefik \
+  -o go-template='{{ $ing := index .status.loadBalancer.ingress 0 }}{{ if $ing.ip }}{{ $ing.ip }}{{ else }}{{ $ing.hostname }}{{ end }}')
+
+curl -H "Host: your-app.example.com" http://${TRAEFIK_LB}
+```
+
+#### Step 2: Split Traffic — Both Controllers Serve Simultaneously
+
+Once Traefik is verified, upgrade it so its pod labels match the NGINX Service selector. This causes the existing NGINX LoadBalancer Service to send traffic to **both** NGINX and Traefik pods automatically. Traefik's own Service is disabled in this step since traffic now flows through NGINX's LoadBalancer. Note that `nameOverride` also renames the Traefik workload: the upgrade replaces the `traefik` Deployment with `traefik-ingress-nginx`, turning over all Traefik pods — safe at this point, since traffic is still served by the NGINX pods.
+
+```yaml tab="traefik-values-split-traffic.yaml"
+# Match NGINX pod labels so the existing Service selector picks up Traefik pods
+nameOverride: ingress-nginx
+instanceLabelOverride: ingress-nginx
+deployment:
+  podLabels:
+    app.kubernetes.io/component: controller
+
+providers:
+  kubernetesIngressNGINX:
+    enabled: true
+
+# Match NGINX port names
+ports:
+  web: null
+  websecure: null
+  http:
+    port: 8000
+    expose:
+      default: true
+    exposedPort: 80
+    protocol: TCP
+  https:
+    port: 8443
+    expose:
+      default: true
+    exposedPort: 443
+    protocol: TCP
+    http:
+      tls:
+        enabled: true
+
+service:
+  enabled: false
+```
+
+```bash
+helm upgrade traefik traefik/traefik \
+  --namespace ingress-nginx \
+  -f traefik-values-split-traffic.yaml
+```
+
+Validate that both NGINX and Traefik pods appear in the endpoints:
+
+```bash
+# Should show IPs from both NGINX and Traefik pods
+kubectl get endpoints ingress-nginx-controller -n ingress-nginx
+
+# Hostname should be unchanged
+kubectl get svc ingress-nginx-controller -n ingress-nginx \
+  -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
+```
+
+!!! note "Rollback"
+
+    To stop sending traffic to Traefik, upgrade back to the original values (with Traefik's own labels). The NGINX Service selector will no longer match Traefik pods, and traffic returns to NGINX only:
+
+    ```bash
+    helm upgrade traefik traefik/traefik \
+      --namespace ingress-nginx \
+      -f traefik-values.yaml
+    ```
+
+#### Step 3: Uninstall NGINX
+
+Traefik's pods match the NGINX Service selector (from Step 2), so traffic continues flowing through Traefik after NGINX is removed.
+
+Uninstall NGINX. The Service and IngressClass will survive via `helm.sh/resource-policy: keep` (set in the [prerequisites](#preserve-the-ingressclass-and-service)).
+
+```bash
+helm uninstall ingress-nginx -n ingress-nginx
+```
+
+Confirm the LoadBalancer Service survived:
+
+```bash
+# Service should still exist with hostname intact
+LB_HOSTNAME=$(kubectl get svc ingress-nginx-controller -n ingress-nginx \
+  -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+echo ${LB_HOSTNAME}
+
+# Traefik should still be serving traffic
+curl -H "Host: your-app.example.com" http://${LB_HOSTNAME}
+```
+
+#### Step 4: Adopt the Service into the Traefik Helm Release
+
+The Service is now orphaned — no Helm release owns it. Add Traefik ownership and upgrade Traefik to manage it. The `service.nameOverride` field tells the Traefik Helm chart to use the existing Service name instead of generating a new one.
+
+```bash
+NGINX_NS="ingress-nginx"
+NGINX_SVC="ingress-nginx-controller"
+TRAEFIK_RELEASE="traefik"
+
+# Add Traefik Helm ownership metadata
+kubectl annotate svc ${NGINX_SVC} -n ${NGINX_NS} --overwrite \
+  meta.helm.sh/release-name=${TRAEFIK_RELEASE} \
+  meta.helm.sh/release-namespace=${NGINX_NS}
+
+kubectl label svc ${NGINX_SVC} -n ${NGINX_NS} --overwrite \
+  app.kubernetes.io/managed-by=Helm
+```
+
+Upgrade Traefik with Service enabled and `service.nameOverride` set to the existing Service name:
+
+```yaml tab="traefik-values-adopt.yaml"
+# Keep NGINX-matching labels
+nameOverride: ingress-nginx
+instanceLabelOverride: ingress-nginx
+deployment:
+  podLabels:
+    app.kubernetes.io/component: controller
+
+providers:
+  kubernetesIngressNGINX:
+    enabled: true
+    # Restore Ingress status updates now that NGINX no longer publishes them
+    publishService:
+      enabled: true
+      pathOverride: "ingress-nginx/ingress-nginx-controller"
+
+# Match NGINX port names
+ports:
+  web: null
+  websecure: null
+  http:
+    port: 8000
+    expose:
+      default: true
+    exposedPort: 80
+    protocol: TCP
+  https:
+    port: 8443
+    expose:
+      default: true
+    exposedPort: 443
+    protocol: TCP
+    http:
+      tls:
+        enabled: true
+
+service:
+  enabled: true
+  nameOverride: ingress-nginx-controller
+```
+
+```bash
+helm upgrade traefik traefik/traefik \
+  --namespace ingress-nginx \
+  -f traefik-values-adopt.yaml
+```
+
+Validate:
+
+```bash
+# Confirm Service is now part of the Traefik release
+helm get manifest traefik -n ingress-nginx | grep "kind: Service" -A 20
+
+# Confirm hostname is still intact
+kubectl get svc ${NGINX_SVC} -n ${NGINX_NS} \
+  -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
+```
+
+The migration is complete — the LoadBalancer hostname never changed hands. Continue with [Step 4](#step-4-uninstall-ingress-nginx-controller) for the remaining cleanup, with two differences: skip the `helm uninstall` (NGINX was already removed in [Uninstall NGINX](#step-3-uninstall-nginx) above), and keep the `ingress-nginx` namespace since Traefik now runs there. After the traffic split, Traefik's Deployment is named `traefik-ingress-nginx` (a consequence of `nameOverride`) and the adopted Service keeps the name `ingress-nginx-controller` — substitute these names in commands that reference `deployment/traefik` or the `traefik` Service.
+
 ---
 
 ## Step 4: Uninstall Ingress NGINX Controller
 
 Once NGINX is no longer receiving traffic, remove it from your cluster. Before uninstalling, you must ensure the `nginx` IngressClass is preserved. Traefik needs it to continue discovering your Ingresses.
 
-### Preserve the IngressClass
+### Preserve the IngressClass and Service
 
 ??? note "If NGINX Was Installed via Helm"
 
-    Add the `helm.sh/resource-policy: keep` annotation to tell Helm to preserve the IngressClass:
+    The `helm.sh/resource-policy: keep` annotation tells Helm to preserve resources on uninstall. **This annotation must be set through Helm values, not via `kubectl annotate`** — Helm reads annotations from its stored manifest, not the live cluster state.
+
+    **Recommended: Set it in your NGINX install values from the start:**
+
+    ```yaml tab="nginx-values.yaml"
+    controller:
+      service:
+        annotations:
+          helm.sh/resource-policy: keep
+      ingressClassResource:
+        annotations:
+          helm.sh/resource-policy: keep
+    ```
+
+    The `service` annotation is only needed if you are using the [hostname retention](#option-c-loadbalancer-hostname-retention-orphan-and-adopt) approach. The `ingressClassResource` annotation is always required.
+
+    If you didn't set these at install time, run a `helm upgrade` before uninstalling:
 
     ```bash
-    # Add the required annotation
     helm upgrade ingress-nginx ingress-nginx \
       --repo https://kubernetes.github.io/ingress-nginx \
       --namespace ingress-nginx \
       --reuse-values \
+      --set-json 'controller.service.annotations={"helm.sh/resource-policy": "keep"}' \
       --set-json 'controller.ingressClassResource.annotations={"helm.sh/resource-policy": "keep"}'
-    # Check that the annotation is really here
-    kubectl describe ingressclass nginx
     ```
 
-    The `--reuse-values` flag is critical - it preserves all your existing NGINX configuration. Without it, Helm would reset everything to defaults, potentially breaking your setup.
+    !!! info "`kubectl annotate` does not work for this"
 
-    !!! info "kubectl annotate/patch/edit does not work"
-
-        Adding the annotation via `kubectl annotate`, `kubectl patch`, or `kubectl edit` will not preserve the IngressClass. Helm stores its release state internally and checks annotations from its internal manifest, not the live cluster state. Only `helm upgrade` updates Helm's internal state.
+        Adding the annotation via `kubectl annotate`, `kubectl patch`, or `kubectl edit` will **not** prevent Helm from deleting the resource. Helm stores its release state internally and checks annotations from its internal manifest, not the live cluster state. Only `helm upgrade` or setting it in values updates Helm's internal state.
 
 ??? note "If NGINX Was Installed via GitOps (ArgoCD, Flux)"
 
@@ -709,6 +955,7 @@ If you added the `helm.sh/resource-policy: keep` annotation, you should see:
 ```text
 These resources were kept due to the resource policy:
 [IngressClass] nginx
+[Service] ingress-nginx-controller  # Only if hostname retention was used
 
 release "ingress-nginx" uninstalled
 ```
@@ -719,9 +966,13 @@ release "ingress-nginx" uninstalled
 kubectl get ingressclass nginx
 ```
 
-In case, the ingressClass is somehow deleted, you can recreate it using the commands in [Preserve the IngressClass](#preserve-the-ingressclass).
+In case, the ingressClass is somehow deleted, you can recreate it using the commands in [Preserve the IngressClass and Service](#preserve-the-ingressclass-and-service).
 
 ### Clean Up NGINX Namespace
+
+!!! warning "Hostname Retention Users"
+
+    Do **not** delete the `ingress-nginx` namespace if you used the [hostname retention](#option-c-loadbalancer-hostname-retention-orphan-and-adopt) approach — Traefik is running in that namespace.
 
 ```bash
 kubectl delete namespace ingress-nginx
@@ -741,11 +992,14 @@ Refer to the [dedicated documentation](../reference/install-configuration/api-da
 ??? note "Ingresses Not Discovered by Traefik"
 
     ```bash
+    # "traefik" for standard, "ingress-nginx" for hostname retention
+    TRAEFIK_NS="traefik"
+
     # Verify IngressClass exists
     kubectl get ingressclass nginx
 
     # Check Traefik provider configuration
-    kubectl logs -n traefik deployment/traefik | grep -i "nginx\|ingress"
+    kubectl logs -n ${TRAEFIK_NS} deployment/traefik | grep -i "nginx\|ingress"
 
     # Verify Ingress has correct ingressClassName
     kubectl get ingress <name> -o yaml | grep ingressClassName
@@ -774,11 +1028,14 @@ Refer to the [dedicated documentation](../reference/install-configuration/api-da
 ??? note "LoadBalancer IP Not Assigned"
 
     ```bash
+      # "traefik" for standard, "ingress-nginx" for hostname retention
+      TRAEFIK_NS="traefik"
+
       # Check service status
-      kubectl describe svc -n traefik traefik
+      kubectl describe svc -n ${TRAEFIK_NS} traefik
 
       # Check for events
-      kubectl get events -n traefik --sort-by='.lastTimestamp'
+      kubectl get events -n ${TRAEFIK_NS} --sort-by='.lastTimestamp'
     ```
 
 ---


### PR DESCRIPTION
### What does this PR do?

Recovers and supersedes #12929, which was auto-closed when its head branch (`zalbiraw:master`) was force-synced with upstream. The work now lives on a dedicated branch so a fork sync can no longer close it.

Adds a **LoadBalancer Hostname Retention** path to the NGINX-to-Traefik migration guide, for environments where the LoadBalancer provides a hostname (e.g. AWS CLB/NLB) rather than a static IP. Since the hostname is tied to the LoadBalancer resource, releasing the Service loses the hostname — the "orphan and adopt" flow preserves the Service (and its hostname) throughout:

- **Step 1** — the install section now offers a "Hostname Retention" values tab (same namespace as NGINX, matching port names) alongside the standard install
- **Step 2** — verification covers LoadBalancer hostnames as well as IPs (`--connect-to`-based testing)
- **Step 3** — new "Option C: LoadBalancer Hostname Retention (Orphan and Adopt)" subsection: verify Traefik through its own LoadBalancer, split traffic by matching the NGINX Service selector, uninstall NGINX while `helm.sh/resource-policy: keep` preserves the Service, then adopt the Service into the Traefik Helm release via `service.nameOverride`
- **Step 4** — "Preserve the IngressClass" extended to also cover preserving the Service, with per-install-method notes (Helm, GitOps, manual)

Compared to #12929 at the time it was closed:

- applied the review feedback from #12929: `kubernetesIngressNginx` → `kubernetesIngressNGINX` (this also fixes one remaining old-spelling occurrence on `master` that 2c03850b9 missed)
- rebased onto the guide's current structure (Step 0 ConfigMap migration, status race condition warning, X-Forwarded-Scheme note)
- retitled the new subsection to "(Orphan and Adopt)" so the markdownlint MD051 fragment check and the MkDocs slugifier agree on the anchor, and verified every in-page link against the built site
- split the Step 1 values/install code fences into two tab groups (previously the four adjacent `tab=` fences rendered as a single 4-tab group with duplicate labels) and named the `traefik-values.yaml` file the later steps reference
- `TRAEFIK_NS` and the other shell variables are now assigned before first use in each snippet
- added an explicit hand-off from Option C to Step 4 (skip the second `helm uninstall`, keep the `ingress-nginx` namespace, note the `nameOverride`-renamed workload)
- restored Ingress status publishing in the adopt values (`publishService.enabled` + `pathOverride`), since after NGINX is removed nothing else writes `status.loadBalancer` on nginx-class Ingresses, and clarified that the status race does not apply to this flow during coexistence
- dropped a `service.type` key that does not exist in the Helm chart (the type lives at `service.spec.type` and already defaults to `LoadBalancer`)

### Motivation

The existing guide covers LoadBalancer **IP** retention, but some cloud providers (notably AWS) assign hostnames instead of static IPs. Releasing the Service loses the hostname and breaks all DNS records pointing to it. This approach preserves the hostname by never deleting the original Service.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Supersedes #12929. Targets `master` like the original, per the maintainers' guidance on that PR.
