### PR TITLE
fix: reuse CertificateStore instances to prevent go-cache janitor goroutine leak

### DIFF
--- a/pkg/tls/tlsmanager.go
+++ b/pkg/tls/tlsmanager.go
@@ -173,11 +173,16 @@ func (m *Manager) UpdateConfigs(ctx context.Context, stores map[string]Store, co
 		}
 	}
 
-	m.stores = make(map[string]*CertificateStore)
+	newStores := make(map[string]*CertificateStore)
 
 	for storeName, storeConfig := range m.storesConfig {
-		st := NewCertificateStore(m.ocspStapler)
-		m.stores[storeName] = st
+		st, exists := m.stores[storeName]
+		if !exists {
+			st = NewCertificateStore(m.ocspStapler)
+		} else {
+			st.ResetCache()
+		}
+		newStores[storeName] = st
 
 		if certs, ok := storesCertificates[storeName]; ok {
 			st.DynamicCerts.Set(certs)
@@ -198,6 +203,8 @@ func (m *Manager) UpdateConfigs(ctx context.Context, stores map[string]Store, co
 
 		st.DefaultCertificate = certificate
 	}
+
+	m.stores = newStores
 
 	if m.ocspStapler != nil {
 		m.ocspStapler.ForceStapleUpdates()


### PR DESCRIPTION
## Description

Fixes #13584

When TLS stores are rebuilt on every dynamic-config apply, each `NewCertificateStore` call creates a new go-cache `Cache` with a janitor goroutine (started by `cache.New` when `cleanupInterval > 0`). The old stores are discarded but their janitor goroutines are never stopped, because something holds a reference to the old `CertificateStore`.

With a single store configured, 6411 leaked janitors over 50 days were observed in production, consuming ~200KB of live heap per leaked goroutine (~26MB/day unreclaimable).

## Fix

Reuse existing `CertificateStore` instances when the store name already exists in `m.stores`. Only create a new store for previously unknown store names. Reset the cache on reused stores via `ResetCache()` to clear stale TLS certificate lookup entries.

## Root cause

`m.stores = make(map[string]*CertificateStore)` in `UpdateConfigs` discards all existing stores on every dynamic-config apply, but the go-cache janitor goroutine inside each discarded store is never stopped (the `runtime.SetFinalizer` that would stop it never fires because the old store is still reachable through the janitor's closure).

## Verification

The goroutine leak is eliminated because existing stores are reused instead of destroyed, so no new janitor goroutines are created and no existing ones are orphaned.

## Related

- #4770 (same janitor stack, 2019, closed without a janitor fix)
- #13235 (same class of per-apply resource leak for WASM middleware instances)