### PR TITLE
Bump github.com/klauspost/compress to v1.18.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/influxdata/influxdb-client-go/v2 v2.7.0
 	github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab // No tag on the repo.
 	github.com/instana/go-sensor v1.38.3
-	github.com/klauspost/compress v1.18.6
+	github.com/klauspost/compress v1.18.7
 	github.com/kvtools/consul v1.0.2
 	github.com/kvtools/etcdv3 v1.0.2
 	github.com/kvtools/redis v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1540,8 +1540,8 @@ github.com/klauspost/asmfmt v1.3.2/go.mod h1:AG8TuvYojzulgDAMCnYn50l/5QV3Bs/tp6j
 github.com/klauspost/compress v1.13.4/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
-github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
-github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/klauspost/compress v1.18.7 h1:aUyZsS4kH3QTKurYhAOwAHxllVPnOthb3vPfnF1Ehjw=
+github.com/klauspost/compress v1.18.7/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=


### PR DESCRIPTION
### What does this PR do?

Upgrade github.com/klauspost/compress to v1.18.7

### Motivation

Having Docker scout happy:

<img width="886" height="683" alt="image" src="https://github.com/user-attachments/assets/dda95244-16cb-4279-8702-45d6c7d12a64" />

Traefik is not impacted by this CVE

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

**Traefik is not impacted** The vulnerability requires calling `s2.NewDict()` with attacker-controlled dictionary data:

- **v3.6 / v3.7**: the `s2` package is not even compiled into the binary.
- **v2.11**: `s2` is compiled in (via dd-trace-go → simdjson-go) but only the stream `Reader`/`Writer` APIs are used — `NewDict()` is never called, so the vulnerable code is unreachable.

Bumping `klauspost/compress` to **v1.18.7** in all branches will make the Scout finding disappear.