### PR TITLE
Do not watch TCPRoutes when the v1alpha2 resource is not served

### DIFF
--- a/pkg/provider/kubernetes/gateway/client.go
+++ b/pkg/provider/kubernetes/gateway/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/traefik/traefik/v3/pkg/types"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
+	kerror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	ktypes "k8s.io/apimachinery/pkg/types"
@@ -160,6 +161,19 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 		return nil, err
 	}
 
+	// An informer for a resource that is not served never syncs and prevents the whole shared factory cache from becoming ready.
+	var tcpRouteSupported bool
+	if c.experimentalChannel {
+		tcpRouteSupported, err = c.supportsTCPRoute()
+		if err != nil {
+			return nil, err
+		}
+
+		if !tcpRouteSupported {
+			log.Warn().Msgf("The %s TCPRoute resource is not served by the Kubernetes cluster, TCPRoutes will be ignored", gatev1alpha2.SchemeGroupVersion)
+		}
+	}
+
 	for _, ns := range namespaces {
 		factoryKube := kinformers.NewSharedInformerFactoryWithOptions(c.csKube, resyncPeriod, kinformers.WithNamespace(ns))
 		_, err = factoryKube.Core().V1().Services().Informer().AddEventHandler(eventHandler)
@@ -206,7 +220,7 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 			return nil, err
 		}
 
-		if c.experimentalChannel {
+		if tcpRouteSupported {
 			_, err = factoryGateway.Gateway().V1alpha2().TCPRoutes().Informer().AddEventHandler(eventHandler)
 			if err != nil {
 				return nil, err
@@ -266,6 +280,20 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 	}
 
 	return eventCh, nil
+}
+
+func (c *clientWrapper) supportsTCPRoute() (bool, error) {
+	resources, err := c.csGateway.Discovery().ServerResourcesForGroupVersion(gatev1alpha2.SchemeGroupVersion.String())
+	if err != nil {
+		if kerror.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return slices.ContainsFunc(resources.APIResources, func(resource metav1.APIResource) bool {
+		return resource.Kind == kindTCPRoute
+	}), nil
 }
 
 func (c *clientWrapper) ListNamespaces(selector labels.Selector) ([]string, error) {

--- a/pkg/provider/kubernetes/gateway/fixtures/tcproute/with_httproute.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/tcproute/with_httproute.yml
@@ -1,0 +1,80 @@
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-gateway-class
+  namespace: default
+spec:
+  controllerName: traefik.io/gateway-controller
+
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners: # Use GatewayClass defaults for listener definition.
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: HTTPRoute
+            group: gateway.networking.k8s.io
+    - name: tcp
+      protocol: TCP
+      port: 9000
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TCPRoute
+            group: gateway.networking.k8s.io
+
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-app-1
+  namespace: default
+spec:
+  parentRefs:
+    - name: my-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  hostnames:
+    - "foo.com"
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /bar
+      backendRefs:
+        - name: whoami
+          port: 80
+          weight: 1
+          kind: Service
+          group: ""
+
+---
+kind: TCPRoute
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: tcp-app-1
+  namespace: default
+spec:
+  parentRefs:
+    - name: my-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  rules:
+    - backendRefs:
+        - name: whoamitcp
+          port: 9000
+          weight: 1
+          kind: Service
+          group: ""

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -9426,6 +9426,11 @@ func newGatewaySimpleClientSet(t *testing.T, objects ...runtime.Object) *gatefak
 	t.Helper()
 
 	client := gatefake.NewSimpleClientset(objects...)
+	client.Resources = append(client.Resources, &metav1.APIResourceList{
+		GroupVersion: gatev1alpha2.SchemeGroupVersion.String(),
+		APIResources: []metav1.APIResource{{Kind: kindTCPRoute}},
+	})
+
 	for _, object := range objects {
 		gateway, ok := object.(*gatev1.Gateway)
 		if !ok {
@@ -9711,6 +9716,37 @@ func TestCrossProviderNamespaces_TCPRoute(t *testing.T) {
 			assert.Equal(t, test.wantError, hasError)
 		})
 	}
+}
+
+// TestExperimentalChannelWithUnservedTCPRoute ensures that an unserved v1alpha2
+// TCPRoute resource does not prevent the other resources from being loaded, as
+// its informer would otherwise never sync and block the whole shared factory.
+func TestExperimentalChannelWithUnservedTCPRoute(t *testing.T) {
+	k8sObjects, gwObjects := readResources(t, []string{"services.yml", "tcproute/with_httproute.yml"})
+
+	kubeClient := kubefake.NewClientset(k8sObjects...)
+	gwClient := newGatewaySimpleClientSet(t, gwObjects...)
+	gwClient.Resources = nil
+
+	client := newClientImpl(kubeClient, gwClient)
+	client.experimentalChannel = true
+
+	eventCh, err := client.WatchAll(nil, make(chan struct{}))
+	require.NoError(t, err)
+
+	// just wait for the first event
+	<-eventCh
+
+	p := Provider{
+		EntryPoints:         map[string]Entrypoint{"web": {Address: ":80"}, "tcp": {Address: ":9000"}},
+		client:              client,
+		ExperimentalChannel: true,
+	}
+
+	conf := p.loadConfigurationFromGateways(t.Context())
+
+	assert.NotEmpty(t, conf.HTTP.Routers)
+	assert.Empty(t, conf.TCP.Routers)
 }
 
 // TestCrossProviderNamespaces_TLSRoute verifies that the option also gates


### PR DESCRIPTION
### What does this PR do?

The Kubernetes Gateway provider registers the TCPRoute informer on the same shared factory as the other resources. If the cluster does not serve the v1alpha2 TCPRoute resource, that informer never syncs, so the factory cache never becomes ready and the provider stops loading configuration. Unrelated HTTPRoutes on the same Gateway then start returning 404. This checks whether the cluster serves the v1alpha2 TCPRoute resource before registering its informer, and skips it with a warning when it does not.

### Motivation

Fixes #13622. The Gateway API v1.6 standard channel CRDs serve TCPRoute as v1 and mark v1alpha2 as not served, so enabling experimentalChannel against those CRDs breaks the whole provider.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Opened against v3.7, the oldest maintained branch that ships Gateway API v1.6.1.
