### PR TITLE
Honor asDefault and exclude internal entrypoints from default selection for ingress-nginx provider

### DIFF
--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -319,8 +319,23 @@ func (c *Configuration) SetEffectiveConfiguration() {
 
 	// Configure Ingress NGINX provider.
 	if c.Providers.KubernetesIngressNGINX != nil {
+		var hasDefinedDefaults bool
+		for _, entryPoint := range c.EntryPoints {
+			if entryPoint.AsDefault {
+				hasDefinedDefaults = true
+				break
+			}
+		}
+
 		var nonTLSEntryPoints []string
 		for epName, entryPoint := range c.EntryPoints {
+			if hasDefinedDefaults && !entryPoint.AsDefault {
+				continue
+			}
+			// Skip internal entrypoint.
+			if epName == DefaultInternalEntryPointName {
+				continue
+			}
 			if entryPoint.HTTP.TLS == nil {
 				nonTLSEntryPoints = append(nonTLSEntryPoints, epName)
 			}

--- a/pkg/config/static/static_config_test.go
+++ b/pkg/config/static/static_config_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/traefik/traefik/v3/pkg/provider/acme"
+	ingressnginx "github.com/traefik/traefik/v3/pkg/provider/kubernetes/ingress-nginx"
 )
 
 func TestHasEntrypoint(t *testing.T) {
@@ -269,6 +270,56 @@ func TestConfiguration_SetEffectiveConfiguration(t *testing.T) {
 							},
 						},
 					},
+				},
+			},
+		},
+		{
+			desc: "Ingress NGINX provider, no asDefault, traefik entrypoint excluded",
+			conf: &Configuration{
+				Providers: &Providers{
+					KubernetesIngressNGINX: &ingressnginx.Provider{},
+				},
+				EntryPoints: EntryPoints{
+					"web":       {Address: ":80"},
+					"traefik":   {Address: ":8080"},
+					"websecure": {Address: ":443", HTTP: HTTPConfig{TLS: &TLSConfig{}}},
+				},
+			},
+			expected: &Configuration{
+				Providers: &Providers{
+					KubernetesIngressNGINX: &ingressnginx.Provider{
+						NonTLSEntryPoints: []string{"web"},
+					},
+				},
+				EntryPoints: EntryPoints{
+					"web":       {Address: ":80"},
+					"traefik":   {Address: ":8080"},
+					"websecure": {Address: ":443", HTTP: HTTPConfig{TLS: &TLSConfig{}}},
+				},
+			},
+		},
+		{
+			desc: "Ingress NGINX provider, asDefault set, only marked entrypoint included",
+			conf: &Configuration{
+				Providers: &Providers{
+					KubernetesIngressNGINX: &ingressnginx.Provider{},
+				},
+				EntryPoints: EntryPoints{
+					"web":     {Address: ":80", AsDefault: true},
+					"admin":   {Address: ":8081"},
+					"traefik": {Address: ":8080"},
+				},
+			},
+			expected: &Configuration{
+				Providers: &Providers{
+					KubernetesIngressNGINX: &ingressnginx.Provider{
+						NonTLSEntryPoints: []string{"web"},
+					},
+				},
+				EntryPoints: EntryPoints{
+					"web":     {Address: ":80", AsDefault: true},
+					"admin":   {Address: ":8081"},
+					"traefik": {Address: ":8080"},
 				},
 			},
 		},

--- a/pkg/config/static/static_config_test.go
+++ b/pkg/config/static/static_config_test.go
@@ -274,13 +274,14 @@ func TestConfiguration_SetEffectiveConfiguration(t *testing.T) {
 			},
 		},
 		{
-			desc: "Ingress NGINX provider, no asDefault, traefik entrypoint excluded",
+			desc: "Ingress NGINX provider, no asDefault, all non-TLS non-internal entrypoints included",
 			conf: &Configuration{
 				Providers: &Providers{
 					KubernetesIngressNGINX: &ingressnginx.Provider{},
 				},
 				EntryPoints: EntryPoints{
 					"web":       {Address: ":80"},
+					"admin":     {Address: ":8081"},
 					"traefik":   {Address: ":8080"},
 					"websecure": {Address: ":443", HTTP: HTTPConfig{TLS: &TLSConfig{}}},
 				},
@@ -288,11 +289,12 @@ func TestConfiguration_SetEffectiveConfiguration(t *testing.T) {
 			expected: &Configuration{
 				Providers: &Providers{
 					KubernetesIngressNGINX: &ingressnginx.Provider{
-						NonTLSEntryPoints: []string{"web"},
+						NonTLSEntryPoints: []string{"admin", "web"},
 					},
 				},
 				EntryPoints: EntryPoints{
 					"web":       {Address: ":80"},
+					"admin":     {Address: ":8081"},
 					"traefik":   {Address: ":8080"},
 					"websecure": {Address: ":443", HTTP: HTTPConfig{TLS: &TLSConfig{}}},
 				},
@@ -305,9 +307,10 @@ func TestConfiguration_SetEffectiveConfiguration(t *testing.T) {
 					KubernetesIngressNGINX: &ingressnginx.Provider{},
 				},
 				EntryPoints: EntryPoints{
-					"web":     {Address: ":80", AsDefault: true},
-					"admin":   {Address: ":8081"},
-					"traefik": {Address: ":8080"},
+					"web":       {Address: ":80", AsDefault: true},
+					"admin":     {Address: ":8081"},
+					"traefik":   {Address: ":8080"},
+					"websecure": {Address: ":443", HTTP: HTTPConfig{TLS: &TLSConfig{}}},
 				},
 			},
 			expected: &Configuration{
@@ -317,9 +320,10 @@ func TestConfiguration_SetEffectiveConfiguration(t *testing.T) {
 					},
 				},
 				EntryPoints: EntryPoints{
-					"web":     {Address: ":80", AsDefault: true},
-					"admin":   {Address: ":8081"},
-					"traefik": {Address: ":8080"},
+					"web":       {Address: ":80", AsDefault: true},
+					"admin":     {Address: ":8081"},
+					"traefik":   {Address: ":8080"},
+					"websecure": {Address: ":443", HTTP: HTTPConfig{TLS: &TLSConfig{}}},
 				},
 			},
 		},
@@ -330,6 +334,13 @@ func TestConfiguration_SetEffectiveConfiguration(t *testing.T) {
 			t.Parallel()
 
 			test.conf.SetEffectiveConfiguration()
+
+			// NonTLSEntryPoints is built from a map iteration, so its order isn't deterministic.
+			if p := test.conf.Providers.KubernetesIngressNGINX; p != nil {
+				assert.ElementsMatch(t, test.expected.Providers.KubernetesIngressNGINX.NonTLSEntryPoints, p.NonTLSEntryPoints)
+				p.NonTLSEntryPoints = nil
+				test.expected.Providers.KubernetesIngressNGINX.NonTLSEntryPoints = nil
+			}
 
 			assert.Equal(t, test.expected, test.conf)
 		})


### PR DESCRIPTION
### What does this PR do?

Honor `asDefault` when at least one entrypoint is marked for the ingress-nginx provider's default entrypoint computation (`NonTLSEntryPoints`), and always exclude the internal `traefik` entrypoint.

### Motivation

Aligns Ingress NGINX with how every other provider computes default entrypoints, honoring `asDefault` and excluding the internal `traefik`entrypoint as per the [documentation](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#asdefault).

### More

- [x] Added/updated tests
- [ ] Added/updated documentation
