### PR TITLE
Reject out-of-range status codes from backends when using FastProxy

### DIFF
--- a/pkg/proxy/fast/connpool.go
+++ b/pkg/proxy/fast/connpool.go
@@ -157,6 +157,11 @@ func (c *conn) handleResponse(r rwWithUpgrade) error {
 		fixPragmaCacheControl(&res.Header)
 
 		resCode := res.StatusCode()
+		// fasthttp does not enforce the 3-digit/100-999 status code range net/http requires,
+		// and WriteHeader panics on an out-of-range code with no way to recover it here.
+		if resCode < 100 || resCode > 999 {
+			return fmt.Errorf("unexpected response code %d", resCode)
+		}
 		is1xx := 100 <= resCode && resCode <= 199
 		// treat 101 as a terminal status, see issue 26161
 		is1xxNonTerminal := is1xx && resCode != http.StatusSwitchingProtocols

--- a/pkg/proxy/fast/proxy_test.go
+++ b/pkg/proxy/fast/proxy_test.go
@@ -329,8 +329,8 @@ func TestHeadRequest(t *testing.T) {
 
 func TestInvalidStatusCode(t *testing.T) {
 	testCases := []struct {
-		desc           string
-		rawStatusLine  string
+		desc          string
+		rawStatusLine string
 	}{
 		{
 			desc:          "status code above 999",
@@ -338,7 +338,7 @@ func TestInvalidStatusCode(t *testing.T) {
 		},
 		{
 			desc:          "status code below 100",
-			rawStatusLine: "HTTP/1.1 0 X",
+			rawStatusLine: "HTTP/1.1 50 X",
 		},
 	}
 

--- a/pkg/proxy/fast/proxy_test.go
+++ b/pkg/proxy/fast/proxy_test.go
@@ -327,6 +327,56 @@ func TestHeadRequest(t *testing.T) {
 	assert.Equal(t, http.StatusOK, res.Code)
 }
 
+func TestInvalidStatusCode(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		rawStatusLine  string
+	}{
+		{
+			desc:          "status code above 999",
+			rawStatusLine: "HTTP/1.1 99999 X",
+		},
+		{
+			desc:          "status code below 100",
+			rawStatusLine: "HTTP/1.1 0 X",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			backendListener, err := net.Listen("tcp", ":0")
+			require.NoError(t, err)
+
+			t.Cleanup(func() {
+				_ = backendListener.Close()
+			})
+
+			go func() {
+				conn, err := backendListener.Accept()
+				if err != nil {
+					return
+				}
+
+				_, _ = conn.Write([]byte(test.rawStatusLine + "\r\n\r\n"))
+			}()
+
+			builder := NewProxyBuilder(&transportManagerMock{}, static.FastProxyConfig{})
+
+			serverURL := "http://" + backendListener.Addr().String()
+
+			proxyHandler, err := builder.Build("", testhelpers.MustParseURL(serverURL), true, true)
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+			res := httptest.NewRecorder()
+
+			proxyHandler.ServeHTTP(res, req)
+
+			assert.Equal(t, http.StatusInternalServerError, res.Code)
+		})
+	}
+}
+
 func TestNoContentLength(t *testing.T) {
 	backendListener, err := net.Listen("tcp", ":0")
 	require.NoError(t, err)


### PR DESCRIPTION
### What does this PR do?

Add a validation for the received status code when using FastProxy.


### Motivation

To avoid panic when an out-of-range status code is received. FastProxy (`experimental.fastProxy`) reads responses from backends using `fasthttp`, whose status-line parser doesn't enforce the 3-digit/100-999 range that `net/http` requires. An out-of-range value from a backend (e.g. HTTP/1.1 99999 ...) flows unchecked into `ResponseWriter.WriteHeader`, which panics.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

